### PR TITLE
fix(chat): prevent race conditions in session loading

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -923,17 +923,20 @@ function AppContent({ activeTab }: { activeTab: TabType }) {
 
   // Handle session selection from sidebar
   const handleSelectSession = useCallback(
-    (selectedSessionId: string) => {
+    async (selectedSessionId: string) => {
+      // Prevent duplicate calls while syncing
+      if (isSyncingRef.current) return;
       // Directly load history without going through URL sync
       isSyncingRef.current = true;
-      loadHistory(selectedSessionId);
-      // Update URL
-      navigate(`/chat/${selectedSessionId}`);
-      // Scroll to top after loading history
-      setTimeout(() => {
+      try {
+        await loadHistory(selectedSessionId);
+        // Update URL
+        navigate(`/chat/${selectedSessionId}`);
+        // Scroll to top after loading history
         messagesContainerRef.current?.scrollTo({ top: 0, behavior: "smooth" });
+      } finally {
         isSyncingRef.current = false;
-      }, 100);
+      }
     },
     [navigate, loadHistory],
   );

--- a/frontend/src/hooks/useAgent.ts
+++ b/frontend/src/hooks/useAgent.ts
@@ -63,6 +63,7 @@ export function useAgent(options?: UseAgentOptions) {
   // Refs for connection management
   const abortControllerRef = useRef<AbortController | null>(null);
   const isConnectingRef = useRef(false);
+  const isLoadingHistoryRef = useRef(false);
   const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
@@ -799,6 +800,13 @@ export function useAgent(options?: UseAgentOptions) {
   // Load message history from backend
   const loadHistory = useCallback(
     async (targetSessionId: string, targetRunId?: string) => {
+      // Prevent concurrent loadHistory calls
+      if (isLoadingHistoryRef.current) {
+        console.log("[loadHistory] Already loading, skipping...");
+        return;
+      }
+      isLoadingHistoryRef.current = true;
+
       if (abortControllerRef.current) {
         abortControllerRef.current.abort();
         abortControllerRef.current = null;
@@ -908,6 +916,7 @@ export function useAgent(options?: UseAgentOptions) {
         setError("Failed to load session");
       } finally {
         setIsLoading(false);
+        isLoadingHistoryRef.current = false;
       }
     },
     [connectToSSE, clearReconnectTimeout, options],


### PR DESCRIPTION
Add guards to prevent duplicate/concurrent calls to loadHistory when rapidly switching sessions. Use isLoadingHistoryRef in useAgent hook and proper async/await pattern in handleSelectSession with try/finally to ensure ref cleanup on completion.