### PR TITLE
fix(agent): add instruction to separate write_file and reveal_file calls

### DIFF
--- a/frontend/src/components/chat/ChatMessage/SubagentBlocks.tsx
+++ b/frontend/src/components/chat/ChatMessage/SubagentBlocks.tsx
@@ -339,7 +339,7 @@ export function SandboxItem({
   return (
     <CollapsiblePill
       status={pillStatus}
-      icon={<Box size={10} className="shrink-0 opacity-50" />}
+      icon={<Box size={12} className="shrink-0 opacity-50" />}
       label={t("chat.sandbox.name")}
       expandable={!!hasDetails}
       onExpandChange={setIsExpanded}

--- a/src/agents/search_agent/prompt.py
+++ b/src/agents/search_agent/prompt.py
@@ -30,6 +30,8 @@ Example correct behavior:
 - User: "Write a report" → You write the report → You immediately call `reveal_file` to present it
 
 **Anti-pattern to avoid**: Creating files and only saying "I've created the file" without revealing it.
+
+**IMPORTANT**: Never call `write_file` and `reveal_file` for the same file in one block. Call `write_file` first, wait for completion, then call `reveal_file`.
 """
 
 
@@ -65,4 +67,6 @@ Example correct behavior:
 - User: "Write a report" → You write the report → You immediately call `reveal_file` to present it
 
 **Anti-pattern to avoid**: Creating files and only saying "I've created the file" without revealing it.
+
+**IMPORTANT**: Never call `write_file` and `reveal_file` for the same file in one block. Call `write_file` first, wait for completion, then call `reveal_file`.
 """


### PR DESCRIPTION
Add explicit instruction to wait for write_file completion before calling reveal_file to prevent potential issues with concurrent calls. Also increase sandbox icon size from 10 to 12.