### PR TITLE
feat(ui): 视频预览居中美化 & 文件上传未完成禁止发送

### DIFF
--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -361,7 +361,9 @@ export const ChatInput = memo(function ChatInput({
   };
 
   const hasContent = input.trim() && !disabled;
-  const canSubmit = hasContent && canSend && !isLoading;
+  // Check if any attachment is still uploading
+  const hasUploadingAttachment = attachments.some((a) => a.isUploading);
+  const canSubmit = hasContent && canSend && !isLoading && !hasUploadingAttachment;
 
   // Drag and drop handlers
   const handleDragOver = (e: React.DragEvent) => {
@@ -597,7 +599,11 @@ export const ChatInput = memo(function ChatInput({
                       ? "bg-stone-900 dark:bg-stone-600 text-white dark:text-stone-100 hover:scale-105"
                       : "bg-gray-100 text-gray-400 dark:bg-stone-700 dark:text-stone-500"
                   }`}
-                  title={t("chat.send")}
+                  title={
+                    hasUploadingAttachment
+                      ? t("chat.waitingForUpload", "请等待文件上传完成")
+                      : t("chat.send")
+                  }
                 >
                   <ArrowUp size={18} />
                 </button>

--- a/frontend/src/components/documents/DocumentPreview.tsx
+++ b/frontend/src/components/documents/DocumentPreview.tsx
@@ -594,16 +594,19 @@ export default function DocumentPreview({
               {pdfUrl && <PdfPreview url={pdfUrl} />}
             </div>
           ) : videoFile && videoUrl ? (
-            <div className="flex items-center justify-center p-4 sm:p-8 bg-stone-950 min-h-[300px]">
-              <video
-                controls
-                autoPlay={false}
-                className="max-w-full max-h-[60vh] rounded-lg shadow-lg"
-                src={videoUrl}
-              >
-                <track kind="captions" />
-                {t("documents.videoNotSupported")}
-              </video>
+            <div className="flex items-center justify-center h-full bg-gradient-to-b from-stone-900 to-stone-950 min-h-[400px] p-4 sm:p-8">
+              <div className="relative w-full max-w-4xl mx-auto">
+                <video
+                  controls
+                  autoPlay={false}
+                  className="w-full max-h-[65vh] rounded-xl shadow-2xl ring-1 ring-white/10"
+                  src={videoUrl}
+                  style={{ margin: "0 auto", display: "block" }}
+                >
+                  <track kind="captions" />
+                  {t("documents.videoNotSupported")}
+                </video>
+              </div>
             </div>
           ) : pptFile && (pptUrl || pptxBuffer) ? (
             <div className="h-full min-h-[400px]">

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -134,7 +134,8 @@
     "send": "Send message",
     "shiftEnterNewLine": "for new line",
     "stop": "Stop generating",
-    "title": "Chat"
+    "title": "Chat",
+    "waitingForUpload": "Please wait for file upload to complete"
   },
   "common": {
     "about": "About",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -133,7 +133,8 @@
     "send": "メッセージを送信",
     "shiftEnterNewLine": "で改行",
     "stop": "生成を停止",
-    "title": "チャット"
+    "title": "チャット",
+    "waitingForUpload": "ファイルのアップロードが完了するまでお待ちください"
   },
   "common": {
     "about": "について",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -133,7 +133,8 @@
     "send": "메시지 보내기",
     "shiftEnterNewLine": "로 줄바꿈",
     "stop": "생성 중지",
-    "title": "채팅"
+    "title": "채팅",
+    "waitingForUpload": "파일 업로드가 완료될 때까지 기다려 주세요"
   },
   "common": {
     "about": "정보",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -134,7 +134,8 @@
     "send": "发送消息",
     "shiftEnterNewLine": "换行",
     "stop": "停止生成",
-    "title": "对话"
+    "title": "对话",
+    "waitingForUpload": "请等待文件上传完成"
   },
   "common": {
     "about": "关于",


### PR DESCRIPTION
## 改动内容

### 1. 🎬 视频预览居中美化
- 视频播放器完全居中显示
- 添加渐变背景 (`from-stone-900 to-stone-950`)
- 阴影效果 (`shadow-2xl`) 和边框高光 (`ring-1 ring-white/10`)
- 响应式最大宽度限制 (`max-w-4xl`)
- 圆角边框 (`rounded-xl`)

### 2. 📤 文件上传未完成禁止发送
- 检测附件上传状态 (`hasUploadingAttachment`)
- 上传中时禁用发送按钮
- 添加提示文案："请等待文件上传完成"
- ✅ 支持 4 种语言翻译（中/英/日/韩）

## 修改文件
| 文件 | 改动 |
|------|------|
| `DocumentPreview.tsx` | 视频预览样式优化 |
| `ChatInput.tsx` | 上传状态检测 + 发送验证 |
| `zh.json` | 中文翻译 |
| `en.json` | 英文翻译 |
| `ja.json` | 日文翻译 |
| `ko.json` | 韩文翻译 |

## 测试建议
- [ ] 上传文件时，发送按钮应禁用并显示提示
- [ ] 文件上传完成后，发送按钮应恢复可用
- [ ] 预览 MP4 视频时，播放器应居中显示
- [ ] 切换语言后，提示文案应正确显示对应语言