### PR TITLE
feat(ui): unify Assistant title font size with message content

### DIFF
--- a/frontend/src/components/chat/ChatMessage/index.tsx
+++ b/frontend/src/components/chat/ChatMessage/index.tsx
@@ -224,7 +224,7 @@ export function ChatMessage({
             <div className="flex size-6 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-amber-500 to-rose-500 text-white shadow-sm">
               <Bot size={16} />
             </div>
-            <span className="text-sm sm:text-base font-semibold text-stone-900 dark:text-stone-100 font-serif">
+            <span className="text-base font-semibold text-stone-900 dark:text-stone-100 font-serif">
               {t("chat.message.assistant")}
             </span>
           </div>


### PR DESCRIPTION
## Changes

### 🔤 Assistant Font Consistency

- Unify Assistant title font size to `text-base`
- Match font size with message content for visual consistency
- Remove mobile small font style (`text-sm`)

## Before
```html
<span class="text-sm sm:text-base ...">
```

## After
```html
<span class="text-base ...">
```

## Modified Files
- `frontend/src/components/chat/ChatMessage/index.tsx`

## Testing
- [ ] Assistant title font size should match message content on all screen sizes