### PR TITLE
fix: Turnstile UI 改进 - 组件宽度适配

### DIFF
--- a/frontend/src/components/auth/AuthPage.tsx
+++ b/frontend/src/components/auth/AuthPage.tsx
@@ -410,7 +410,7 @@ export function AuthPage({ onSuccess }: AuthPageProps) {
 
               {/* Turnstile 人机验证 */}
               {requiresTurnstile() && (
-                <div className="mb-4 flex justify-center sm:mb-6">
+                <div className="mb-4 flex w-full justify-center sm:mb-6">
                   <Turnstile
                     key={turnstileKey}
                     sitekey={turnstileConfig.site_key}
@@ -421,6 +421,7 @@ export function AuthPage({ onSuccess }: AuthPageProps) {
                     }}
                     onExpire={() => setTurnstileToken(null)}
                     theme="auto"
+                    style={{ width: "100%" }}
                   />
                 </div>
               )}


### PR DESCRIPTION
## 问题描述

Turnstile 组件宽度没有和其他表单元素对齐，影响 UI 一致性。

## 修复内容

1. **Turnstile 组件宽度适配**
   - 添加 `w-full` 类到容器
   - 添加 `style={{ width: "100%" }}` 确保组件占满宽度
   - 与其他表单元素（输入框、按钮）保持一致的宽度

## 技术细节

- react-turnstile 组件支持 `style` 属性
- 使用 `flex` 布局居中显示
- 保持响应式设计 (`mb-4 sm:mb-6`)

## 测试

- [x] TypeScript 编译通过
- [x] 前端构建成功

## 截图

修复前：Turnstile 组件宽度固定，不与其他元素对齐
修复后：Turnstile 组件宽度与表单一致