### PR TITLE
fix: Turnstile 容器样式与表单元素对齐

### DIFF
--- a/frontend/src/components/auth/AuthPage.tsx
+++ b/frontend/src/components/auth/AuthPage.tsx
@@ -410,19 +410,20 @@ export function AuthPage({ onSuccess }: AuthPageProps) {
 
               {/* Turnstile 人机验证 */}
               {requiresTurnstile() && (
-                <div className="mb-4 flex w-full justify-center sm:mb-6">
-                  <Turnstile
-                    key={turnstileKey}
-                    sitekey={turnstileConfig.site_key}
-                    onSuccess={(token) => setTurnstileToken(token)}
-                    onError={() => {
-                      setTurnstileToken(null);
-                      setError(t("auth.turnstileError"));
-                    }}
-                    onExpire={() => setTurnstileToken(null)}
-                    theme="auto"
-                    style={{ width: "100%" }}
-                  />
+                <div className="mb-4 w-full rounded-xl border border-gray-200/80 bg-white/80 p-3 dark:border-stone-600/60 dark:bg-stone-800/60 sm:mb-6 sm:p-4">
+                  <div className="flex justify-center">
+                    <Turnstile
+                      key={turnstileKey}
+                      sitekey={turnstileConfig.site_key}
+                      onSuccess={(token) => setTurnstileToken(token)}
+                      onError={() => {
+                        setTurnstileToken(null);
+                        setError(t("auth.turnstileError"));
+                      }}
+                      onExpire={() => setTurnstileToken(null)}
+                      theme="auto"
+                    />
+                  </div>
                 </div>
               )}
 


### PR DESCRIPTION
## 问题描述

Turnstile 组件容器宽度没有与其他表单元素对齐，视觉上不协调。

## 修复内容

1. **容器样式优化**
   - 使用与表单输入框相同的边框样式（`rounded-xl border border-gray-200/80`）
   - 容器宽度设为 `w-full`，与表单元素一致
   - Turnstile widget 在容器内居中显示
   - 支持暗色模式（`dark:border-stone-600/60 dark:bg-stone-800/60`）

2. **布局结构**
   ```tsx
   <div className="w-full rounded-xl border... p-3 sm:p-4">
     <div className="flex justify-center">
       <Turnstile ... />
     </div>
   </div>
   ```

## 技术说明

Cloudflare Turnstile widget 本身是固定宽度（约 300px），由 Cloudflare 托管，无法通过 CSS 强制拉伸。因此采用外层容器与表单元素宽度一致、内部 widget 居中的方案。

## 测试

- [x] TypeScript 编译通过
- [x] 前端构建成功
- [x] 暗色模式样式正确