### PR TITLE
fix: 移动端登录页面滚动和布局修复

### DIFF
--- a/frontend/src/components/auth/AuthPage.tsx
+++ b/frontend/src/components/auth/AuthPage.tsx
@@ -192,7 +192,7 @@ export function AuthPage({ onSuccess }: AuthPageProps) {
   return (
     <div className="relative min-h-screen overflow-y-auto overflow-x-hidden bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-stone-950 dark:via-stone-900 dark:to-stone-800">
       {/* 左上角 Logo */}
-      <div className="absolute left-3 top-3 z-50 flex items-center gap-2 sm:left-4 sm:top-4">
+      <div className="sticky top-0 z-50 flex items-center gap-2 bg-gradient-to-br from-gray-50/80 via-white/80 to-gray-100/80 p-3 backdrop-blur-sm dark:from-stone-950/80 dark:via-stone-900/80 dark:to-stone-800/80 sm:absolute sm:left-4 sm:top-4 sm:bg-transparent sm:p-0 sm:backdrop-blur-none dark:sm:bg-transparent">
         <div className="flex h-8 w-8 items-center justify-center rounded-lg transition-colors hover:bg-stone-100 dark:hover:bg-stone-800">
           <img
             src="/icons/icon.svg"
@@ -203,20 +203,20 @@ export function AuthPage({ onSuccess }: AuthPageProps) {
       </div>
 
       {/* 右上角按钮 */}
-      <div className="absolute right-3 top-3 z-50 flex items-center gap-1.5 sm:right-4 sm:top-4 sm:gap-2">
+      <div className="sticky top-0 z-50 flex items-center justify-end gap-1.5 bg-gradient-to-br from-gray-50/80 via-white/80 to-gray-100/80 p-3 backdrop-blur-sm dark:from-stone-950/80 dark:via-stone-900/80 dark:to-stone-800/80 sm:absolute sm:right-4 sm:top-4 sm:justify-start sm:bg-transparent sm:backdrop-blur-none dark:sm:bg-transparent">
         <LanguageToggle />
         <ThemeToggle />
       </div>
 
       {/* 背景装饰 */}
-      <div className="absolute inset-0 overflow-hidden">
+      <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
         <div className="absolute -bottom-20 -left-20 h-64 w-64 rounded-full bg-gray-200/50 blur-3xl dark:bg-stone-700/30" />
         <div className="absolute -bottom-20 -right-20 h-80 w-80 rounded-full bg-gray-200/50 blur-3xl dark:bg-stone-700/30" />
       </div>
 
-      <div className="flex min-h-[100dvh] w-full flex-col items-center justify-center px-4 py-6 sm:min-h-screen sm:px-6 sm:py-8">
+      <div className="flex w-full flex-col items-center justify-start px-4 py-4 sm:min-h-screen sm:justify-center sm:px-6 sm:py-8">
         {/* 内容容器 */}
-        <div className="w-full max-w-md pt-12 sm:pt-0">
+        <div className="w-full max-w-md pb-8">
           {/* Logo 和标题 */}
           <div className="mb-6 text-center sm:mb-8">
             <h1 className="text-2xl font-bold text-gray-900 dark:text-stone-100 mb-2 tracking-tight font-serif sm:text-3xl">


### PR DESCRIPTION
## 问题描述

移动端登录/注册页面存在以下问题：
1. 页面内容过长时无法滚动查看全部内容
2. 顶部 Logo 和按钮遮挡了内容
3. 页面布局不适合小屏幕设备

## 修复内容

### 1. 布局改进
- 移除 `justify-center`，移动端使用 `justify-start`
- 添加 `pb-8` 底部内边距确保内容可滚动查看
- 使用 `w-full` 确保宽度适配

### 2. 固定元素优化
- Logo 和主题切换按钮使用 `sticky` 定位（移动端）
- 桌面端保持 `absolute` 定位
- 背景装饰使用 `pointer-events-none` 防止交互干扰

### 3. 滚动支持
- 容器使用 `overflow-y-auto` 允许垂直滚动
- 内容从顶部开始，不会被裁切

## 测试

- [x] TypeScript 编译通过
- [x] 前端构建成功
- [ ] 移动端测试（需要部署后验证）