### PR TITLE
fix: 移动端滚动和 Turnstile UI 改进

### DIFF
--- a/frontend/src/components/auth/AuthPage.tsx
+++ b/frontend/src/components/auth/AuthPage.tsx
@@ -209,14 +209,14 @@ export function AuthPage({ onSuccess }: AuthPageProps) {
       </div>
 
       {/* 背景装饰 */}
-      <div className="absolute inset-0 overflow-hidden">
+      <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
         <div className="absolute -bottom-20 -left-20 h-64 w-64 rounded-full bg-gray-200/50 blur-3xl dark:bg-stone-700/30" />
         <div className="absolute -bottom-20 -right-20 h-80 w-80 rounded-full bg-gray-200/50 blur-3xl dark:bg-stone-700/30" />
       </div>
 
-      <div className="flex min-h-[100dvh] w-full flex-col items-center justify-center px-4 py-6 sm:min-h-screen sm:px-6 sm:py-8">
+      <div className="flex w-full flex-col items-center justify-start px-4 py-16 sm:min-h-screen sm:justify-center sm:px-6 sm:py-8">
         {/* 内容容器 */}
-        <div className="w-full max-w-md pt-12 sm:pt-0">
+        <div className="w-full max-w-md pb-4">
           {/* Logo 和标题 */}
           <div className="mb-6 text-center sm:mb-8">
             <h1 className="text-2xl font-bold text-gray-900 dark:text-stone-100 mb-2 tracking-tight font-serif sm:text-3xl">
@@ -410,19 +410,20 @@ export function AuthPage({ onSuccess }: AuthPageProps) {
 
               {/* Turnstile 人机验证 */}
               {requiresTurnstile() && (
-                <div className="mb-4 flex w-full justify-center sm:mb-6">
-                  <Turnstile
-                    key={turnstileKey}
-                    sitekey={turnstileConfig.site_key}
-                    onSuccess={(token) => setTurnstileToken(token)}
-                    onError={() => {
-                      setTurnstileToken(null);
-                      setError(t("auth.turnstileError"));
-                    }}
-                    onExpire={() => setTurnstileToken(null)}
-                    theme="auto"
-                    style={{ width: "100%" }}
-                  />
+                <div className="mb-4 w-full rounded-xl border border-gray-200/80 bg-white/80 p-3 dark:border-stone-600/60 dark:bg-stone-800/60 sm:mb-6 sm:p-4">
+                  <div className="flex justify-center">
+                    <Turnstile
+                      key={turnstileKey}
+                      sitekey={turnstileConfig.site_key}
+                      onSuccess={(token) => setTurnstileToken(token)}
+                      onError={() => {
+                        setTurnstileToken(null);
+                        setError(t("auth.turnstileError"));
+                      }}
+                      onExpire={() => setTurnstileToken(null)}
+                      theme="auto"
+                    />
+                  </div>
                 </div>
               )}
 

--- a/frontend/src/components/auth/AuthPage.tsx
+++ b/frontend/src/components/auth/AuthPage.tsx
@@ -214,9 +214,9 @@ export function AuthPage({ onSuccess }: AuthPageProps) {
         <div className="absolute -bottom-20 -right-20 h-80 w-80 rounded-full bg-gray-200/50 blur-3xl dark:bg-stone-700/30" />
       </div>
 
-      <div className="flex w-full flex-col items-center justify-start px-4 py-16 sm:min-h-screen sm:justify-center sm:px-6 sm:py-8">
+      <div className="flex min-h-[100dvh] w-full flex-col items-center justify-start overflow-y-auto px-4 py-6 sm:min-h-screen sm:justify-center sm:px-6 sm:py-8">
         {/* 内容容器 */}
-        <div className="w-full max-w-md pb-4">
+        <div className="w-full max-w-md pb-8 sm:pb-0">
           {/* Logo 和标题 */}
           <div className="mb-6 text-center sm:mb-8">
             <h1 className="text-2xl font-bold text-gray-900 dark:text-stone-100 mb-2 tracking-tight font-serif sm:text-3xl">


### PR DESCRIPTION
## 概述

合并 PR #22 和 PR #23 的修改，包含登录页面的移动端布局和 Turnstile 组件样式改进。

## 修复内容

### 1. 移动端布局 (from PR #23)
- 将 `justify-center` 改为 `justify-start`，移动端内容从顶部开始
- 添加 `py-16` 移动端内边距，桌面端 `py-8`
- 添加 `pb-4` 底部内边距确保内容可滚动
- 背景装饰使用 `pointer-events-none` 防止交互干扰

### 2. Turnstile 容器样式 (from PR #22)
- Turnstile 组件包装在与表单输入框相同样式的容器中
- 容器使用 `rounded-xl border border-gray-200/80 bg-white/80`
- Turnstile widget 在容器内居中显示
- 支持暗色模式

## 技术说明

Cloudflare Turnstile widget 是固定宽度（约 300px），由 Cloudflare 托管，无法通过 CSS 强制拉伸。

**解决方案：**
- 使用与表单元素相同样式的容器包裹 Turnstile
- 容器宽度与表单一致
- Turnstile widget 在容器内居中显示

## 关联 PR

- Closes #22 
- Closes #23