### PR TITLE
fix: 登录页面所有设备居中显示，支持滚动

### DIFF
--- a/frontend/src/components/auth/AuthPage.tsx
+++ b/frontend/src/components/auth/AuthPage.tsx
@@ -214,9 +214,9 @@ export function AuthPage({ onSuccess }: AuthPageProps) {
         <div className="absolute -bottom-20 -right-20 h-80 w-80 rounded-full bg-gray-200/50 blur-3xl dark:bg-stone-700/30" />
       </div>
 
-      <div className="flex min-h-[100dvh] w-full flex-col items-center justify-start overflow-y-auto px-4 py-6 sm:min-h-screen sm:justify-center sm:px-6 sm:py-8">
+      <div className="flex min-h-[100dvh] w-full flex-col items-center justify-center overflow-y-auto px-4 py-6 sm:min-h-screen sm:px-6 sm:py-8">
         {/* 内容容器 */}
-        <div className="w-full max-w-md pb-8 sm:pb-0">
+        <div className="w-full max-w-md py-4">
           {/* Logo 和标题 */}
           <div className="mb-6 text-center sm:mb-8">
             <h1 className="text-2xl font-bold text-gray-900 dark:text-stone-100 mb-2 tracking-tight font-serif sm:text-3xl">


### PR DESCRIPTION
## 问题描述

移动端和桌面端都需要表单居中显示，同时当内容超出屏幕高度时需要支持滚动。

## 修复内容

### 布局策略
- **移动端和桌面端都使用 `justify-center`**：表单始终垂直居中
- **保持 `overflow-y-auto`**：内容超出时可以上下滚动
- **`min-h-[100dvh]`**：使用动态视口高度，确保正确计算

### 代码变更
```tsx
// 之前：移动端从顶部开始，桌面端居中
<div className="... justify-start ... sm:justify-center ...">

// 现在：所有设备都居中，支持滚动
<div className="... justify-center overflow-y-auto ...">
```

## 效果

| 场景 | 表现 |
|------|------|
| 内容少于屏幕高度 | 表单垂直居中显示 ✨ |
| 内容超出屏幕高度 | 可以上下滚动查看 📜 |
| 移动端/桌面端 | 一致的美观体验 🎨 |

## 测试

- [x] TypeScript 编译通过
- [x] 前端构建成功