### PR TITLE
fix: 修复移动端登录页面无法滚动的问题

### DIFF
--- a/frontend/src/components/auth/AuthPage.tsx
+++ b/frontend/src/components/auth/AuthPage.tsx
@@ -190,9 +190,9 @@ export function AuthPage({ onSuccess }: AuthPageProps) {
   };
 
   return (
-    <div className="relative min-h-screen overflow-y-auto overflow-x-hidden bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-stone-950 dark:via-stone-900 dark:to-stone-800">
+    <div className="flex min-h-screen flex-col overflow-y-auto bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-stone-950 dark:via-stone-900 dark:to-stone-800">
       {/* 左上角 Logo */}
-      <div className="absolute left-3 top-3 z-50 flex items-center gap-2 sm:left-4 sm:top-4">
+      <div className="sticky top-0 z-50 flex items-center gap-2 bg-gradient-to-br from-gray-50/90 via-white/90 to-gray-100/90 p-3 backdrop-blur-sm dark:from-stone-950/90 dark:via-stone-900/90 dark:to-stone-800/90 sm:absolute sm:left-4 sm:top-4 sm:bg-transparent sm:p-0 sm:backdrop-blur-none dark:sm:bg-transparent">
         <div className="flex h-8 w-8 items-center justify-center rounded-lg transition-colors hover:bg-stone-100 dark:hover:bg-stone-800">
           <img
             src="/icons/icon.svg"
@@ -203,20 +203,20 @@ export function AuthPage({ onSuccess }: AuthPageProps) {
       </div>
 
       {/* 右上角按钮 */}
-      <div className="absolute right-3 top-3 z-50 flex items-center gap-1.5 sm:right-4 sm:top-4 sm:gap-2">
+      <div className="sticky top-0 z-50 flex items-center justify-end gap-1.5 bg-gradient-to-br from-gray-50/90 via-white/90 to-gray-100/90 p-3 backdrop-blur-sm dark:from-stone-950/90 dark:via-stone-900/90 dark:to-stone-800/90 sm:absolute sm:right-4 sm:top-4 sm:justify-start sm:bg-transparent sm:backdrop-blur-none dark:sm:bg-transparent">
         <LanguageToggle />
         <ThemeToggle />
       </div>
 
       {/* 背景装饰 */}
-      <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
+      <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
         <div className="absolute -bottom-20 -left-20 h-64 w-64 rounded-full bg-gray-200/50 blur-3xl dark:bg-stone-700/30" />
         <div className="absolute -bottom-20 -right-20 h-80 w-80 rounded-full bg-gray-200/50 blur-3xl dark:bg-stone-700/30" />
       </div>
 
-      <div className="flex min-h-[100dvh] w-full flex-col items-center justify-center overflow-y-auto px-4 py-6 sm:min-h-screen sm:px-6 sm:py-8">
+      <div className="flex flex-1 flex-col items-center justify-center px-4 py-8 sm:px-6">
         {/* 内容容器 */}
-        <div className="w-full max-w-md py-4">
+        <div className="w-full max-w-md pb-8">
           {/* Logo 和标题 */}
           <div className="mb-6 text-center sm:mb-8">
             <h1 className="text-2xl font-bold text-gray-900 dark:text-stone-100 mb-2 tracking-tight font-serif sm:text-3xl">


### PR DESCRIPTION
## 问题描述

移动端登录/注册页面在内容超出屏幕高度时无法滚动，页面被冻住，用户无法看到完整内容。

## 解决方案

### 布局结构调整

外层容器使用 flex min-h-screen flex-col overflow-y-auto 创建单一滚动容器。

Logo 和主题按钮：移动端 sticky top-0，桌面端 sm:absolute。

内容区域使用 flex-1 flex-col items-center justify-center 塂充剩余空间并居中。

## 效果

- 内容少于屏幕高度：表单垂直居中
- 内容超出屏幕高度：可以正常滚动
- 移动端滚动时 Logo 和主题按钮保持可见
- 桌面端原有美观布局保持不变

## 测试

- [x] TypeScript 编译通过
- [x] 前端构建成功