### PR TITLE
fix: 使用 CSS Grid 修复所有设备的登录页面滚动问题

### DIFF
--- a/frontend/src/components/auth/AuthPage.tsx
+++ b/frontend/src/components/auth/AuthPage.tsx
@@ -190,10 +190,10 @@ export function AuthPage({ onSuccess }: AuthPageProps) {
   };
 
   return (
-    <div className="flex min-h-screen flex-col overflow-y-auto bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-stone-950 dark:via-stone-900 dark:to-stone-800">
+    <div className="min-h-screen overflow-y-auto overflow-x-hidden bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-stone-950 dark:via-stone-900 dark:to-stone-800">
       {/* 左上角 Logo */}
-      <div className="sticky top-0 z-50 flex items-center gap-2 bg-gradient-to-br from-gray-50/90 via-white/90 to-gray-100/90 p-3 backdrop-blur-sm dark:from-stone-950/90 dark:via-stone-900/90 dark:to-stone-800/90 sm:absolute sm:left-4 sm:top-4 sm:bg-transparent sm:p-0 sm:backdrop-blur-none dark:sm:bg-transparent">
-        <div className="flex h-8 w-8 items-center justify-center rounded-lg transition-colors hover:bg-stone-100 dark:hover:bg-stone-800">
+      <div className="fixed left-3 top-3 z-50 flex items-center gap-2 sm:left-4 sm:top-4">
+        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-white/50 backdrop-blur-sm transition-colors hover:bg-white/80 dark:bg-stone-800/50 dark:hover:bg-stone-800/80">
           <img
             src="/icons/icon.svg"
             alt="LambChat"
@@ -203,7 +203,7 @@ export function AuthPage({ onSuccess }: AuthPageProps) {
       </div>
 
       {/* 右上角按钮 */}
-      <div className="sticky top-0 z-50 flex items-center justify-end gap-1.5 bg-gradient-to-br from-gray-50/90 via-white/90 to-gray-100/90 p-3 backdrop-blur-sm dark:from-stone-950/90 dark:via-stone-900/90 dark:to-stone-800/90 sm:absolute sm:right-4 sm:top-4 sm:justify-start sm:bg-transparent sm:backdrop-blur-none dark:sm:bg-transparent">
+      <div className="fixed right-3 top-3 z-50 flex items-center gap-1.5 rounded-lg bg-white/50 p-1 backdrop-blur-sm dark:bg-stone-800/50 sm:right-4 sm:top-4 sm:gap-2 sm:bg-transparent sm:backdrop-blur-none dark:sm:bg-transparent">
         <LanguageToggle />
         <ThemeToggle />
       </div>
@@ -214,9 +214,9 @@ export function AuthPage({ onSuccess }: AuthPageProps) {
         <div className="absolute -bottom-20 -right-20 h-80 w-80 rounded-full bg-gray-200/50 blur-3xl dark:bg-stone-700/30" />
       </div>
 
-      <div className="flex flex-1 flex-col items-center justify-center px-4 py-8 sm:px-6">
-        {/* 内容容器 */}
-        <div className="w-full max-w-md pb-8">
+      {/* 主内容区域 - CSS Grid 实现居中且可滚动 */}
+      <div className="grid min-h-screen place-items-center px-4 py-8 sm:px-6">
+        <div className="w-full max-w-md py-8">
           {/* Logo 和标题 */}
           <div className="mb-6 text-center sm:mb-8">
             <h1 className="text-2xl font-bold text-gray-900 dark:text-stone-100 mb-2 tracking-tight font-serif sm:text-3xl">


### PR DESCRIPTION
## 问题描述

移动端和桌面端登录/注册页面在内容超出屏幕高度时都无法滚动，用户无法看到完整内容。

## 解决方案

使用 CSS Grid 的 place-items-center 替代 Flexbox。CSS Grid 可以在保持居中的同时正确支持滚动。

## 技术变更

1. 外层容器: min-h-screen overflow-y-auto
2. 内容区域: grid min-h-screen place-items-center
3. Logo 和主题按钮: fixed 定位

## 效果

- 内容小于视口：表单垂直居中
- 内容超出视口：可以正常滚动
- 适用于移动端和桌面端

## 测试

- [x] TypeScript 编译通过
- [x] 前端构建成功