### PR TITLE
fix: 覆盖全局 overflow:hidden 允许登录页面滚动

### DIFF
--- a/frontend/src/components/auth/AuthPage.tsx
+++ b/frontend/src/components/auth/AuthPage.tsx
@@ -29,6 +29,31 @@ interface AuthPageProps {
 
 export function AuthPage({ onSuccess }: AuthPageProps) {
   const { t } = useTranslation();
+
+  // 覆盖全局 overflow: hidden，允许登录页面滚动
+  useEffect(() => {
+    const html = document.documentElement;
+    const body = document.body;
+    const root = document.getElementById('root');
+    
+    // 保存原始样式
+    const originalHtmlOverflow = html.style.overflow;
+    const originalBodyOverflow = body.style.overflow;
+    const originalRootOverflow = root?.style.overflow;
+    
+    // 设置允许滚动
+    html.style.overflow = 'auto';
+    body.style.overflow = 'auto';
+    if (root) root.style.overflow = 'auto';
+    
+    // 组件卸载时恢复原始样式
+    return () => {
+      html.style.overflow = originalHtmlOverflow;
+      body.style.overflow = originalBodyOverflow;
+      if (root) root.style.overflow = originalRootOverflow || '';
+    };
+  }, []);
+
   const [mode, setMode] = useState<AuthMode>("login");
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");


### PR DESCRIPTION
## 问题
全局 CSS 设置了 overflow:hidden 在 html, body, #root 上，阻止了所有页面滚动。

## 解决方案
添加 useEffect 钩子在组件挂载时临时覆盖为 overflow:auto，组件卸载时恢复。

## 测试
- [x] TypeScript 编译通过
- [x] 前端构建成功