### PR TITLE
fix: Turnstile 主题跟随应用主题切换

### DIFF
--- a/frontend/src/components/auth/AuthPage.tsx
+++ b/frontend/src/components/auth/AuthPage.tsx
@@ -8,6 +8,7 @@ import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { Turnstile } from "react-turnstile";
 import { useAuth } from "../../hooks/useAuth";
+import { useTheme } from "../../contexts/ThemeContext";
 import { LoadingSpinner } from "../common/LoadingSpinner";
 import { ThemeToggle } from "../common/ThemeToggle";
 import { LanguageToggle } from "../common/LanguageToggle";
@@ -63,6 +64,13 @@ export function AuthPage({ onSuccess }: AuthPageProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
   const [turnstileKey, setTurnstileKey] = useState(0); // 用于强制重新渲染 Turnstile
+
+  const { theme } = useTheme();
+
+  // 当主题变化时，强制重新渲染 Turnstile 以更新主题
+  useEffect(() => {
+    setTurnstileKey(prev => prev + 1);
+  }, [theme]);
 
   const { login, register, loginWithOAuth } = useAuth();
   const [oauthProviders, setOauthProviders] = useState<
@@ -446,7 +454,7 @@ export function AuthPage({ onSuccess }: AuthPageProps) {
                         setError(t("auth.turnstileError"));
                       }}
                       onExpire={() => setTurnstileToken(null)}
-                      theme="auto"
+                      theme={theme}
                     />
                   </div>
                 </div>


### PR DESCRIPTION
## 问题
点击白天/黑夜按钮切换主题时，Turnstile 组件不会跟着切换。

## 原因
Turnstile 使用 theme="auto" 不能正确响应应用的主题变化。

## 解决方案
1. 导入 useTheme hook 获取当前主题
2. 当主题变化时更新 turnstileKey 强制重新渲染
3. 将 theme 直接传递给 Turnstile 组件

## 测试
- [x] TypeScript 编译通过
- [x] 前端构建成功