### PR TITLE
fix(ui): 优化邮件配置显示，隐藏冗余配置项

### DIFF
--- a/src/kernel/config.py
+++ b/src/kernel/config.py
@@ -751,7 +751,7 @@ SETTING_DEFINITIONS: dict[str, dict] = {
     "RESEND_ACCOUNTS": {
         "type": SettingType.JSON,
         "category": SettingCategory.SECURITY,
-        "description": 'Resend accounts JSON config: [{"api_key":"re_xxx","email_from":"noreply@domain.com","email_from_name":"LambChat"}]',
+        "description": "Resend accounts config (supports multiple accounts with round-robin)",
         "default": [],
         "depends_on": "EMAIL_ENABLED",
         "frontend_visible": True,
@@ -762,6 +762,7 @@ SETTING_DEFINITIONS: dict[str, dict] = {
         "description": "Resend API key (fallback if RESEND_ACCOUNTS empty)",
         "default": "",
         "depends_on": "EMAIL_ENABLED",
+        "frontend_visible": False,  # Hidden - use RESEND_ACCOUNTS instead
     },
     "EMAIL_FROM": {
         "type": SettingType.STRING,
@@ -769,7 +770,7 @@ SETTING_DEFINITIONS: dict[str, dict] = {
         "description": "Sender email address (fallback if RESEND_ACCOUNTS empty)",
         "default": "noreply@lambchat.com",
         "depends_on": "EMAIL_ENABLED",
-        "frontend_visible": True,
+        "frontend_visible": False,  # Hidden - use RESEND_ACCOUNTS instead
     },
     "EMAIL_FROM_NAME": {
         "type": SettingType.STRING,
@@ -777,7 +778,7 @@ SETTING_DEFINITIONS: dict[str, dict] = {
         "description": "Sender name displayed in emails (fallback if RESEND_ACCOUNTS empty)",
         "default": "LambChat",
         "depends_on": "EMAIL_ENABLED",
-        "frontend_visible": True,
+        "frontend_visible": False,  # Hidden - use RESEND_ACCOUNTS instead
     },
     "PASSWORD_RESET_EXPIRE_HOURS": {
         "type": SettingType.NUMBER,


### PR DESCRIPTION
## 问题描述

前端设置页面中邮件配置显示有以下问题：
1. `RESEND_ACCOUNTS` 描述过长导致布局溢出
2. `RESEND_API_KEY`, `EMAIL_FROM`, `EMAIL_FROM_NAME` 与 `RESEND_ACCOUNTS` 功能重复

## 修复内容

1. **缩短描述**
   - 原：`Resend accounts JSON config: [{"api_key":"re_xxx","email_from":"noreply@domain.com","email_from_name":"LambChat"}]`
   - 新：`Resend accounts config (supports multiple accounts with round-robin)`

2. **隐藏冗余配置**
   - `RESEND_API_KEY`: `frontend_visible = False`
   - `EMAIL_FROM`: `frontend_visible = False`
   - `EMAIL_FROM_NAME`: `frontend_visible = False`

## 使用方式

用户只需配置 `RESEND_ACCOUNTS`：
```json
[
  {"api_key": "re_xxx", "email_from": "noreply@domain.com", "email_from_name": "LambChat"}
]
```

fallback 配置仍然可用，但不再在前端显示。