### PR TITLE
refactor: 移除冗余邮件配置，统一使用 RESEND_ACCOUNTS JSON

### DIFF
--- a/src/infra/email/service.py
+++ b/src/infra/email/service.py
@@ -172,54 +172,33 @@ class EmailService:
         return self._http_client
 
     def _parse_accounts(self) -> list[dict[str, str]]:
-        """Parse account configurations.
-
-        Priority:
-        1. RESEND_ACCOUNTS JSON array
-        2. Fallback to single RESEND_API_KEY + EMAIL_FROM + EMAIL_FROM_NAME
+        """Parse account configurations from RESEND_ACCOUNTS JSON.
 
         Returns:
             List of account dicts with api_key, email_from, email_from_name.
         """
         accounts: list[dict[str, str]] = []
 
-        # Priority 1: Parse JSON accounts config
         resend_accounts = settings.RESEND_ACCOUNTS
-        if resend_accounts:
-            try:
-                if isinstance(resend_accounts, str):
-                    resend_accounts = json.loads(resend_accounts)
+        if not resend_accounts:
+            return accounts
 
-                if isinstance(resend_accounts, list):
-                    for acc in resend_accounts:
-                        if isinstance(acc, dict) and acc.get("api_key"):
-                            accounts.append(
-                                {
-                                    "api_key": str(acc.get("api_key", "")),
-                                    "email_from": str(acc.get("email_from", settings.EMAIL_FROM)),
-                                    "email_from_name": str(
-                                        acc.get(
-                                            "email_from_name",
-                                            settings.EMAIL_FROM_NAME,
-                                        )
-                                    ),
-                                }
-                            )
-            except (json.JSONDecodeError, TypeError) as e:
-                logger.warning("[EmailService] Failed to parse RESEND_ACCOUNTS: %s", e)
+        try:
+            if isinstance(resend_accounts, str):
+                resend_accounts = json.loads(resend_accounts)
 
-        # Priority 2: Fallback to single key config (backward compatible)
-        if not accounts and settings.RESEND_API_KEY:
-            # Support comma-separated keys with same email_from
-            keys = [k.strip() for k in settings.RESEND_API_KEY.split(",") if k.strip()]
-            for key in keys:
-                accounts.append(
-                    {
-                        "api_key": key,
-                        "email_from": settings.EMAIL_FROM,
-                        "email_from_name": settings.EMAIL_FROM_NAME,
-                    }
-                )
+            if isinstance(resend_accounts, list):
+                for acc in resend_accounts:
+                    if isinstance(acc, dict) and acc.get("api_key"):
+                        accounts.append(
+                            {
+                                "api_key": str(acc.get("api_key", "")),
+                                "email_from": str(acc.get("email_from", "noreply@example.com")),
+                                "email_from_name": str(acc.get("email_from_name", "LambChat")),
+                            }
+                        )
+        except (json.JSONDecodeError, TypeError) as e:
+            logger.warning("[EmailService] Failed to parse RESEND_ACCOUNTS: %s", e)
 
         return accounts
 

--- a/src/kernel/config.py
+++ b/src/kernel/config.py
@@ -105,7 +105,7 @@ SENSITIVE_SETTINGS = {
     "OAUTH_GITHUB_CLIENT_SECRET",
     "OAUTH_APPLE_CLIENT_SECRET",
     "TURNSTILE_SECRET_KEY",
-    "RESEND_API_KEY",
+    "RESEND_ACCOUNTS",  # JSON array of email accounts
 }
 
 # ============================================
@@ -756,30 +756,6 @@ SETTING_DEFINITIONS: dict[str, dict] = {
         "depends_on": "EMAIL_ENABLED",
         "frontend_visible": True,
     },
-    "RESEND_API_KEY": {
-        "type": SettingType.STRING,
-        "category": SettingCategory.SECURITY,
-        "description": "Resend API key (fallback if RESEND_ACCOUNTS empty)",
-        "default": "",
-        "depends_on": "EMAIL_ENABLED",
-        "frontend_visible": False,  # Hidden - use RESEND_ACCOUNTS instead
-    },
-    "EMAIL_FROM": {
-        "type": SettingType.STRING,
-        "category": SettingCategory.SECURITY,
-        "description": "Sender email address (fallback if RESEND_ACCOUNTS empty)",
-        "default": "noreply@lambchat.com",
-        "depends_on": "EMAIL_ENABLED",
-        "frontend_visible": False,  # Hidden - use RESEND_ACCOUNTS instead
-    },
-    "EMAIL_FROM_NAME": {
-        "type": SettingType.STRING,
-        "category": SettingCategory.SECURITY,
-        "description": "Sender name displayed in emails (fallback if RESEND_ACCOUNTS empty)",
-        "default": "LambChat",
-        "depends_on": "EMAIL_ENABLED",
-        "frontend_visible": False,  # Hidden - use RESEND_ACCOUNTS instead
-    },
     "PASSWORD_RESET_EXPIRE_HOURS": {
         "type": SettingType.NUMBER,
         "category": SettingCategory.SECURITY,
@@ -1008,9 +984,6 @@ class Settings(BaseSettings):
     # Email Settings (Resend)
     EMAIL_ENABLED: bool = False
     RESEND_ACCOUNTS: Any = Field(default_factory=list)  # JSON array of accounts
-    RESEND_API_KEY: str = ""
-    EMAIL_FROM: str = "noreply@lambchat.com"
-    EMAIL_FROM_NAME: str = "LambChat"
     PASSWORD_RESET_EXPIRE_HOURS: int = 24
     REQUIRE_EMAIL_VERIFICATION: bool = False
 


### PR DESCRIPTION
## 问题

邮件配置项冗余：
- `RESEND_API_KEY`
- `EMAIL_FROM`  
- `EMAIL_FROM_NAME`

与 `RESEND_ACCOUNTS` 功能重复，增加配置复杂度。

## 解决方案

**删除配置项：**
- ❌ `RESEND_API_KEY`
- ❌ `EMAIL_FROM`
- ❌ `EMAIL_FROM_NAME`

**统一使用：**
```env
RESEND_ACCOUNTS=[{"api_key":"re_xxx","email_from":"noreply@domain.com","email_from_name":"LambChat"}]
```

## 优势

1. **配置简洁** - 只需一个 JSON 配置
2. **支持多账号** - 可配置多个邮件账号轮询
3. **易于管理** - 集中配置，避免分散

## 文件变更

- `src/kernel/config.py` - 移除三个配置项定义
- `src/infra/email/service.py` - 移除 fallback 逻辑