### PR TITLE
fix(auth): 登录时检查邮箱验证状态

### DIFF
--- a/src/api/routes/auth.py
+++ b/src/api/routes/auth.py
@@ -227,13 +227,25 @@ async def login(credentials: LoginRequest, request: Request):
             )
 
     manager = UserManager()
-    token = await manager.login(credentials.username, credentials.password)
-    if not token:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="用户名或密码错误",
-        )
-    return token
+    try:
+        token = await manager.login(credentials.username, credentials.password)
+        if not token:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="用户名或密码错误",
+            )
+        return token
+    except Exception as e:
+        # 处理邮箱未验证错误
+        if "EmailNotVerifiedError" in type(e).__name__ or "请先验证邮箱" in str(e):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "message": "请先验证邮箱后再登录",
+                    "email": getattr(e, "email", credentials.username),
+                },
+            )
+        raise
 
 
 @router.post("/refresh", response_model=Token)

--- a/src/infra/user/manager.py
+++ b/src/infra/user/manager.py
@@ -61,10 +61,19 @@ class UserManager:
 
         Returns:
             Token 或 None
+
+        Raises:
+            EmailNotVerifiedError: 邮箱未验证（当 REQUIRE_EMAIL_VERIFICATION=true 时）
         """
         user = await self.storage.authenticate(username_or_email, password)
         if not user:
             return None
+
+        # 检查邮箱验证状态
+        if settings.REQUIRE_EMAIL_VERIFICATION and not user.email_verified:
+            from src.kernel.exceptions import EmailNotVerifiedError
+
+            raise EmailNotVerifiedError("请先验证邮箱后再登录", user.email)
 
         # 获取用户的角色和权限
         roles = []

--- a/src/kernel/exceptions.py
+++ b/src/kernel/exceptions.py
@@ -69,3 +69,11 @@ class SessionError(Exception):
     """会话相关错误"""
 
     pass
+
+
+class EmailNotVerifiedError(Exception):
+    """邮箱未验证错误"""
+
+    def __init__(self, message: str, email: str):
+        super().__init__(message)
+        self.email = email


### PR DESCRIPTION
## 问题

开启了 `REQUIRE_EMAIL_VERIFICATION=true` 后，用户注册时虽然会发送验证邮件，但登录时没有检查邮箱验证状态，导致用户可以直接登录成功。

## 修复

1. **添加 `EmailNotVerifiedError` 异常** - `src/kernel/exceptions.py`
2. **修改 `UserManager.login()` 方法** - `src/infra/user/manager.py`
   - 登录时检查 `email_verified` 状态
   - 如果 `REQUIRE_EMAIL_VERIFICATION=true` 且用户未验证，抛出异常
3. **修改登录路由** - `src/api/routes/auth.py`
   - 捕获 `EmailNotVerifiedError` 并返回 403 错误
   - 提示用户需要验证邮箱

## 测试

1. 设置 `REQUIRE_EMAIL_VERIFICATION=true`
2. 注册新用户
3. 尝试登录 → 应返回 403 错误："请先验证邮箱后再登录"
4. 验证邮箱后登录 → 应成功