### PR TITLE
feat(auth): 实现用户 pending 状态功能

### DIFF
--- a/src/api/routes/auth.py
+++ b/src/api/routes/auth.py
@@ -864,8 +864,13 @@ async def reset_password(request_data: ResetPasswordRequest):
 async def verify_email(request_data: VerifyEmailRequest):
     """验证邮箱
 
-    使用验证令牌验证用户邮箱。
+    使用验证令牌验证用户邮箱并激活账户。
     令牌过期检查已在 storage.get_by_verification_token 中处理。
+
+    验证成功后：
+    - 设置 email_verified=True
+    - 设置 is_active=True（激活账户）
+    - 赋予默认角色（从 DEFAULT_USER_ROLE 读取）
     """
     token = request_data.token
 
@@ -880,19 +885,28 @@ async def verify_email(request_data: VerifyEmailRequest):
             detail="无效或过期的验证令牌",
         )
 
-    # 更新邮箱验证状态
+    # 获取默认角色
+    default_role = settings.DEFAULT_USER_ROLE or "user"
+
+    # 更新用户状态：邮箱验证 + 账户激活 + 赋予角色
     await manager.storage.update(
         user.id,
         UserUpdate(
             email_verified=True,
+            is_active=True,  # 激活账户
+            roles=[default_role],  # 赋予默认角色
             verification_token=None,
             verification_token_expires=None,
         ),
     )
 
-    logger.info("[Auth] Email verified for user %s", user.username)
+    logger.info(
+        "[Auth] Email verified and account activated for user %s with role %s",
+        user.username,
+        default_role,
+    )
 
-    return {"message": "邮箱验证成功"}
+    return {"message": "邮箱验证成功，账户已激活"}
 
 
 @router.post("/resend-verification")

--- a/src/infra/user/manager.py
+++ b/src/infra/user/manager.py
@@ -75,6 +75,12 @@ class UserManager:
 
             raise EmailNotVerifiedError("请先验证邮箱后再登录", user.email)
 
+        # 检查账户激活状态
+        if not user.is_active:
+            from src.kernel.exceptions import AccountNotActiveError
+
+            raise AccountNotActiveError("账户未激活，请验证邮箱后登录", user.email)
+
         # 获取用户的角色和权限
         roles = []
         permissions = set()

--- a/src/infra/user/storage.py
+++ b/src/infra/user/storage.py
@@ -72,6 +72,9 @@ class UserStorage:
         使用 MongoDB unique index 防止并发竞态条件。
         不再使用"先检查后插入"模式，而是直接插入并捕获 duplicate key error。
 
+        注册时设置 is_active=False (pending 状态)，需要邮箱验证后激活。
+        OAuth 用户自动激活。
+
         Args:
             user_data: 用户创建数据
 
@@ -86,21 +89,23 @@ class UserStorage:
         now = datetime.now()
         # For OAuth users, generate a random password if not provided
         password = user_data.password
-        if not password and (user_data.oauth_provider and user_data.oauth_id):
+        is_oauth_user = bool(user_data.oauth_provider and user_data.oauth_id)
+        if not password and is_oauth_user:
             import secrets
 
             password = secrets.token_urlsafe(32)
 
+        # OAuth 用户自动激活和验证，普通用户需要邮箱验证
         user_dict: dict[str, Any] = {
             "username": user_data.username,
             "email": user_data.email,
             "password_hash": hash_password(password) if password else None,
-            "roles": user_data.roles,
+            "roles": [],  # 空角色，验证后赋予默认角色
             "avatar_url": user_data.avatar_url,  # Data URI for avatar
             "oauth_provider": user_data.oauth_provider.value if user_data.oauth_provider else None,
             "oauth_id": user_data.oauth_id,
-            "is_active": True,
-            "email_verified": False,  # 默认未验证
+            "is_active": is_oauth_user,  # OAuth 用户自动激活，普通用户 pending
+            "email_verified": is_oauth_user,  # OAuth 用户自动验证
             "verification_token": None,
             "verification_token_expires": None,
             "reset_token": None,

--- a/src/kernel/exceptions.py
+++ b/src/kernel/exceptions.py
@@ -77,3 +77,11 @@ class EmailNotVerifiedError(Exception):
     def __init__(self, message: str, email: str):
         super().__init__(message)
         self.email = email
+
+
+class AccountNotActiveError(Exception):
+    """账户未激活错误"""
+
+    def __init__(self, message: str, email: str):
+        super().__init__(message)
+        self.email = email


### PR DESCRIPTION
## 功能概述

实现用户注册后的 pending 状态和邮箱验证激活流程。

## 实现细节

### 1. 注册流程 (`storage.py`)
- 普通用户注册时设置 `is_active=False` (pending 状态)
- 设置 `roles=[]` (空角色，验证后赋予)
- OAuth 用户自动激活和验证

### 2. 验证流程 (`auth.py`)
- `verify_email()` 端点更新：
  - 设置 `email_verified=True`
  - 设置 `is_active=True` (激活账户)
  - 赋予 `DEFAULT_USER_ROLE` 角色

### 3. 登录检查 (`manager.py`)
- 检查 `email_verified` 状态
- 检查 `is_active` 状态
- 未验证/未激活账户返回错误

### 4. 异常定义 (`exceptions.py`)
- `EmailNotVerifiedError` - 邮箱未验证
- `AccountNotActiveError` - 账户未激活

## 用户流程

```
用户注册 -> pending 状态 (is_active=False, roles=[])
    ↓
发送验证邮件
    ↓
用户点击验证链接
    ↓
账户激活 (is_active=True, roles=[DEFAULT_USER_ROLE])
    ↓
用户可以登录
```

## 向后兼容

- 已有用户不受影响（is_active 默认为 True）
- OAuth 用户自动激活