### PR TITLE
fix(auth): 修复用户注册验证流程的多个问题

### DIFF
--- a/frontend/src/services/api/fetch.ts
+++ b/frontend/src/services/api/fetch.ts
@@ -170,9 +170,15 @@ export async function authFetch<T>(
 
   if (!response.ok) {
     const errorData = await response.json().catch(() => ({}));
-    throw new Error(
-      errorData.detail || `Request failed: ${response.statusText}`,
-    );
+    // 处理 detail 为对象或字符串的情况
+    let errorMessage: string;
+    if (typeof errorData.detail === "object" && errorData.detail !== null) {
+      // 如果 detail 是对象，提取 message 字段
+      errorMessage = errorData.detail.message || JSON.stringify(errorData.detail);
+    } else {
+      errorMessage = errorData.detail || `Request failed: ${response.statusText}`;
+    }
+    throw new Error(errorMessage);
   }
 
   // 处理空响应

--- a/src/api/routes/auth.py
+++ b/src/api/routes/auth.py
@@ -240,10 +240,13 @@ async def login(credentials: LoginRequest, request: Request):
         if "EmailNotVerifiedError" in type(e).__name__ or "请先验证邮箱" in str(e):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
-                detail={
-                    "message": "请先验证邮箱后再登录",
-                    "email": getattr(e, "email", credentials.username),
-                },
+                detail="请先验证邮箱后再登录",
+            )
+        # 处理账户未激活错误
+        if "AccountNotActiveError" in type(e).__name__ or "账户未激活" in str(e):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="账户未激活，请验证邮箱后登录",
             )
         raise
 
@@ -870,7 +873,7 @@ async def verify_email(request_data: VerifyEmailRequest):
     验证成功后：
     - 设置 email_verified=True
     - 设置 is_active=True（激活账户）
-    - 赋予默认角色（从 DEFAULT_USER_ROLE 读取）
+    - 如果用户没有角色，赋予默认角色（从 DEFAULT_USER_ROLE 读取）
     """
     token = request_data.token
 
@@ -885,16 +888,20 @@ async def verify_email(request_data: VerifyEmailRequest):
             detail="无效或过期的验证令牌",
         )
 
-    # 获取默认角色
-    default_role = settings.DEFAULT_USER_ROLE or "user"
+    # 如果用户已有角色（如第一个管理员用户），保留；否则赋予默认角色
+    if not user.roles:
+        default_role = settings.DEFAULT_USER_ROLE or "user"
+        roles = [default_role]
+    else:
+        roles = user.roles
 
-    # 更新用户状态：邮箱验证 + 账户激活 + 赋予角色
+    # 更新用户状态：邮箱验证 + 账户激活
     await manager.storage.update(
         user.id,
         UserUpdate(
             email_verified=True,
             is_active=True,  # 激活账户
-            roles=[default_role],  # 赋予默认角色
+            roles=roles,  # 保留已有角色或赋予默认角色
             verification_token=None,
             verification_token_expires=None,
         ),

--- a/src/infra/user/storage.py
+++ b/src/infra/user/storage.py
@@ -100,7 +100,7 @@ class UserStorage:
             "username": user_data.username,
             "email": user_data.email,
             "password_hash": hash_password(password) if password else None,
-            "roles": [],  # 空角色，验证后赋予默认角色
+            "roles": user_data.roles if user_data.roles else [],  # 使用提供的角色，否则为空
             "avatar_url": user_data.avatar_url,  # Data URI for avatar
             "oauth_provider": user_data.oauth_provider.value if user_data.oauth_provider else None,
             "oauth_id": user_data.oauth_id,


### PR DESCRIPTION
## 修复的问题

### 1. 登录错误处理 (后端)
- 添加对 `AccountNotActiveError` 异常的处理
- 统一错误响应格式，`detail` 使用字符串而不是对象
- 确保用户看到清晰的错误提示

### 2. 前端错误解析
- 修复 `fetch.ts` 无法正确解析 `detail` 为对象的错误
- 当后端返回 `{detail: {message: "..."}}` 时，正确提取 `message` 字段
- 避免显示 `[object Object]` 这样的错误信息

### 3. 第一个用户管理员角色
- 修复 `storage.create()` 忽略 `user_data.roles` 的问题
- 修复 `verify_email()` 覆盖已有角色的问题
- 确保第一个注册的用户在邮箱验证后仍然保持 admin 角色

## 测试场景

1. ✅ 普通用户注册 → 需要验证邮箱 → 验证后获得默认角色
2. ✅ 第一个用户注册 → 验证后成为 admin
3. ✅ 登录未验证账户 → 显示"请先验证邮箱后再登录"
4. ✅ 登录未激活账户 → 显示"账户未激活，请验证邮箱后登录"
5. ✅ OAuth 用户 → 自动激活和验证，获得默认角色

## 关联 PR

- #35 feat(auth): 实现用户 pending 状态功能
- #36 feat(frontend): 添加注册成功等待验证页面