### PR TITLE
fix(auth): 修复旧用户登录被拦截的问题

### DIFF
--- a/src/infra/user/manager.py
+++ b/src/infra/user/manager.py
@@ -70,13 +70,15 @@ class UserManager:
             return None
 
         # 检查邮箱验证状态
-        if settings.REQUIRE_EMAIL_VERIFICATION and not user.email_verified:
+        # 注意：使用 `is False` 而不是 `not`，因为旧用户字段为 None 应该通过检查
+        if settings.REQUIRE_EMAIL_VERIFICATION and user.email_verified is False:
             from src.kernel.exceptions import EmailNotVerifiedError
 
             raise EmailNotVerifiedError("请先验证邮箱后再登录", user.email)
 
         # 检查账户激活状态
-        if not user.is_active:
+        # 注意：使用 `is False` 而不是 `not`，因为旧用户字段为 None 应该通过检查
+        if user.is_active is False:
             from src.kernel.exceptions import AccountNotActiveError
 
             raise AccountNotActiveError("账户未激活，请验证邮箱后登录", user.email)


### PR DESCRIPTION
## 问题

旧用户（在实现邮箱验证功能之前注册的用户）无法登录，被错误拦截。

**根本原因：**
- 旧用户的 `email_verified` 和 `is_active` 字段为 `None`
- 使用 `not user.email_verified` 检查时，`not None = True`
- 导致旧用户被错误拦截

## 修复

**修改前：**
```python
if settings.REQUIRE_EMAIL_VERIFICATION and not user.email_verified:
    # not None = True，旧用户被错误拦截 ❌
```

**修改后：**
```python
if settings.REQUIRE_EMAIL_VERIFICATION and user.email_verified is False:
    # None is False = False，旧用户通过 ✅
    # False is False = True，新用户被拦截 ✅
```

## 影响范围

| 用户类型 | email_verified | 修改前 | 修改后 |
|----------|----------------|--------|--------|
| 旧用户 | `None` | ❌ 被拦截 | ✅ 通过 |
| 新注册未验证 | `False` | ✅ 被拦截 | ✅ 被拦截 |
| 已验证 | `True` | ✅ 通过 | ✅ 通过 |

## 测试

- ✅ 旧用户可以正常登录
- ✅ 新注册未验证用户仍被拦截
- ✅ 已验证用户正常登录