### PR TITLE
fix(auth): 修复旧用户登录问题并添加自动迁移

### DIFF
--- a/src/infra/user/manager.py
+++ b/src/infra/user/manager.py
@@ -70,14 +70,21 @@ class UserManager:
             return None
 
         # 检查邮箱验证状态
-        # 注意：使用 `is False` 而不是 `not`，因为旧用户字段为 None 应该通过检查
-        if settings.REQUIRE_EMAIL_VERIFICATION and user.email_verified is False:
+        # 注意：
+        # 1. 只有当 REQUIRE_EMAIL_VERIFICATION=True 且用户有 email 且 email_verified 明确为 False 时才拦截
+        # 2. 旧用户（字段为 None）通过检查
+        # 3. 没有 email 的用户通过检查
+        if (
+            settings.REQUIRE_EMAIL_VERIFICATION
+            and user.email  # 有邮箱才需要验证
+            and user.email_verified is False  # 明确为 False（不是 None）
+        ):
             from src.kernel.exceptions import EmailNotVerifiedError
 
             raise EmailNotVerifiedError("请先验证邮箱后再登录", user.email)
 
         # 检查账户激活状态
-        # 注意：使用 `is False` 而不是 `not`，因为旧用户字段为 None 应该通过检查
+        # 注意：只有明确为 False 时才拦截，None（旧用户）通过检查
         if user.is_active is False:
             from src.kernel.exceptions import AccountNotActiveError
 

--- a/src/infra/user/storage.py
+++ b/src/infra/user/storage.py
@@ -49,7 +49,7 @@ class UserStorage:
         return self._collection
 
     async def _ensure_indexes(self):
-        """确保必要的索引存在（包括唯一索引）"""
+        """确保必要的索引存在（包括唯一索引）并迁移旧用户数据"""
         try:
             collection = self.collection  # 使用属性而不是直接访问 _collection
             # 创建唯一索引防止并发竞态条件
@@ -59,11 +59,45 @@ class UserStorage:
             await collection.create_index("oauth_provider", background=True)
             await collection.create_index("reset_token", background=True, sparse=True)
             await collection.create_index("verification_token", background=True, sparse=True)
+
+            # 自动迁移旧用户：将 None 改为 True
+            await self._migrate_legacy_users()
         except Exception as e:
             # 索引创建失败不应阻止应用启动
             import logging
 
             logging.getLogger(__name__).warning(f"Failed to create indexes: {e}")
+
+    async def _migrate_legacy_users(self):
+        """迁移旧用户数据：将 email_verified 和 is_active 从 None 改为 True"""
+        try:
+            # 迁移 email_verified: None -> True
+            result1 = await self.collection.update_many(
+                {"email_verified": None},
+                {"$set": {"email_verified": True}},
+            )
+            if result1.modified_count > 0:
+                import logging
+
+                logging.getLogger(__name__).info(
+                    f"[Migration] Updated email_verified for {result1.modified_count} users"
+                )
+
+            # 迁移 is_active: None -> True
+            result2 = await self.collection.update_many(
+                {"is_active": None},
+                {"$set": {"is_active": True}},
+            )
+            if result2.modified_count > 0:
+                import logging
+
+                logging.getLogger(__name__).info(
+                    f"[Migration] Updated is_active for {result2.modified_count} users"
+                )
+        except Exception as e:
+            import logging
+
+            logging.getLogger(__name__).warning(f"[Migration] Failed to migrate legacy users: {e}")
 
     async def create(self, user_data: UserCreate) -> UserInDB:
         """


### PR DESCRIPTION
## 问题

旧用户（在实现邮箱验证功能之前注册的用户）无法登录。

**根本原因：**
- 旧用户的 `email_verified` 和 `is_active` 字段为 `None`
- 即使使用 `is False` 检查，没有 email 的用户也被验证逻辑拦截

## 修复

### 1. 登录检查优化

**修改前：**
```python
if settings.REQUIRE_EMAIL_VERIFICATION and user.email_verified is False:
    # 没有 email 的用户也被拦截 ❌
```

**修改后：**
```python
if (
    settings.REQUIRE_EMAIL_VERIFICATION
    and user.email  # 有邮箱才需要验证
    and user.email_verified is False  # 明确为 False
):
    # 只拦截有邮箱且明确未验证的用户 ✅
```

### 2. 自动迁移功能

应用启动时自动将旧用户的 `None` 改为 `True`：

```python
async def _migrate_legacy_users(self):
    # email_verified: None -> True
    await self.collection.update_many(
        {"email_verified": None},
        {"$set": {"email_verified": True}},
    )
    # is_active: None -> True
    await self.collection.update_many(
        {"is_active": None},
        {"$set": {"is_active": True}},
    )
```

## 测试场景

| 用户类型 | email | email_verified | 能否登录 |
|----------|-------|----------------|----------|
| 旧用户 | 无 | `None` | ✅ 通过 |
| 旧用户 | 有 | `None` | ✅ 通过（自动迁移后） |
| 新注册 | 有 | `False` | ❌ 被拦截 |
| 已验证 | 有 | `True` | ✅ 通过 |
| 无 email | 无 | `None` | ✅ 通过 |

## 关联 PR

- #38 fix(auth): 修复旧用户登录被拦截的问题