### PR TITLE
fix(auth): 修复返回登录按钮无响应问题

### DIFF
--- a/frontend/src/components/auth/ForgotPassword.tsx
+++ b/frontend/src/components/auth/ForgotPassword.tsx
@@ -3,6 +3,7 @@
  */
 
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { Mail, ArrowLeft, CheckCircle } from "lucide-react";
 import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
@@ -17,9 +18,18 @@ interface ForgotPasswordProps {
 
 export function ForgotPassword({ onBackToLogin }: ForgotPasswordProps) {
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const [email, setEmail] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
+
+  const handleBackToLogin = () => {
+    if (onBackToLogin) {
+      onBackToLogin();
+    } else {
+      navigate("/");
+    }
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -82,7 +92,7 @@ export function ForgotPassword({ onBackToLogin }: ForgotPasswordProps) {
             </div>
 
             <button
-              onClick={onBackToLogin}
+              onClick={handleBackToLogin}
               className="flex w-full items-center justify-center gap-2 rounded-xl border border-gray-200 bg-white py-3 text-sm font-medium text-gray-700 shadow-sm transition-all hover:bg-gray-50 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-300 dark:hover:bg-stone-700"
             >
               <ArrowLeft size={16} />
@@ -175,7 +185,7 @@ export function ForgotPassword({ onBackToLogin }: ForgotPasswordProps) {
           {/* 返回登录链接 */}
           <div className="mt-6 text-center">
             <button
-              onClick={onBackToLogin}
+              onClick={handleBackToLogin}
               className="inline-flex items-center gap-1.5 text-sm text-gray-600 transition-colors hover:text-gray-900 dark:text-stone-400 dark:hover:text-stone-200"
             >
               <ArrowLeft size={14} />

--- a/frontend/src/components/auth/RegistrationPending.tsx
+++ b/frontend/src/components/auth/RegistrationPending.tsx
@@ -24,8 +24,8 @@ export function RegistrationPending() {
 
   useEffect(() => {
     if (!email) {
-      // 如果没有 email 参数，跳转到登录页
-      navigate("/login");
+      // 如果没有 email 参数，跳转到首页（会自动显示登录页）
+      navigate("/");
     }
   }, [email, navigate]);
 
@@ -46,7 +46,7 @@ export function RegistrationPending() {
   };
 
   const handleGoToLogin = () => {
-    navigate("/login");
+    navigate("/");
   };
 
   if (!email) {

--- a/frontend/src/components/auth/ResetPassword.tsx
+++ b/frontend/src/components/auth/ResetPassword.tsx
@@ -71,7 +71,7 @@ export function ResetPassword() {
   };
 
   const handleBackToLogin = () => {
-    navigate("/login");
+    navigate("/");
   };
 
   // 成功状态

--- a/frontend/src/components/auth/VerifyEmail.tsx
+++ b/frontend/src/components/auth/VerifyEmail.tsx
@@ -48,7 +48,7 @@ export function VerifyEmail() {
   };
 
   const handleGoToLogin = () => {
-    navigate("/login");
+    navigate("/");
   };
 
   const handleResend = async () => {


### PR DESCRIPTION
## 问题

多个页面的"返回登录"按钮点击无反应。

**根本原因：**
- 使用 `navigate("/login")` 但该路由不存在
- 应用没有独立的 `/login` 路由
- 登录页面通过 `ProtectedRoute` 在未认证时自动显示

## 修复

| 文件 | 修改 |
|------|------|
| RegistrationPending.tsx | `navigate("/login")` → `navigate("/")` |
| VerifyEmail.tsx | `navigate("/login")` → `navigate("/")` |
| ResetPassword.tsx | `navigate("/login")` → `navigate("/")` |
| ForgotPassword.tsx | 添加 `useNavigate` 并提供默认导航 |

## 说明

- 导航到 `/` 或 `/chat` 时，`ProtectedRoute` 检测到未认证会自动显示 `AuthPage`
- 这是应用的设计模式：没有独立的登录路由

## 测试

- ✅ 前端构建成功