### PR TITLE
fix(auth): 修复认证页面垂直居中问题

### DIFF
--- a/frontend/src/components/auth/ForgotPassword.tsx
+++ b/frontend/src/components/auth/ForgotPassword.tsx
@@ -55,9 +55,8 @@ export function ForgotPassword({ onBackToLogin }: ForgotPasswordProps) {
 
   if (isSuccess) {
     return (
-      <div className="flex min-h-screen flex-col overflow-y-auto bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-stone-950 dark:via-stone-900 dark:to-stone-800">
-        {/* 左上角 Logo */}
-        <div className="sticky top-0 z-50 flex items-center justify-between bg-gradient-to-br from-gray-50/90 via-white/90 to-gray-100/90 p-3 backdrop-blur-sm dark:from-stone-950/90 dark:via-stone-900/90 dark:to-stone-800/90 sm:absolute sm:left-4 sm:top-4 sm:bg-transparent sm:p-0 sm:backdrop-blur-none dark:sm:bg-transparent">
+      <div className="min-h-screen overflow-y-auto overflow-x-hidden bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-stone-950 dark:via-stone-900 dark:to-stone-800">
+        <div className="fixed left-3 top-3 z-50 flex items-center gap-2 sm:left-4 sm:top-4">
           <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-white/50 backdrop-blur-sm transition-colors hover:bg-white/80 dark:bg-stone-800/50 dark:hover:bg-stone-800/80">
             <img
               src="/icons/icon.svg"
@@ -65,13 +64,13 @@ export function ForgotPassword({ onBackToLogin }: ForgotPasswordProps) {
               className="h-6 w-6 rounded"
             />
           </div>
-          <div className="flex items-center gap-2">
-            <LanguageToggle />
-            <ThemeToggle />
-          </div>
         </div>
 
-        {/* 背景装饰 */}
+        <div className="fixed right-3 top-3 z-50 flex items-center gap-1.5 rounded-lg bg-white/50 p-1 backdrop-blur-sm dark:bg-stone-800/50 sm:right-4 sm:top-4 sm:gap-2 sm:bg-transparent sm:backdrop-blur-none dark:sm:bg-transparent">
+          <LanguageToggle />
+          <ThemeToggle />
+        </div>
+
         <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
           <div className="absolute -bottom-20 -left-20 h-64 w-64 rounded-full bg-gray-200/50 blur-3xl dark:bg-stone-700/30" />
           <div className="absolute -bottom-20 -right-20 h-80 w-80 rounded-full bg-gray-200/50 blur-3xl dark:bg-stone-700/30" />
@@ -105,9 +104,8 @@ export function ForgotPassword({ onBackToLogin }: ForgotPasswordProps) {
   }
 
   return (
-    <div className="flex min-h-screen flex-col overflow-y-auto bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-stone-950 dark:via-stone-900 dark:to-stone-800">
-      {/* 左上角 Logo */}
-      <div className="sticky top-0 z-50 flex items-center justify-between bg-gradient-to-br from-gray-50/90 via-white/90 to-gray-100/90 p-3 backdrop-blur-sm dark:from-stone-950/90 dark:via-stone-900/90 dark:to-stone-800/90 sm:absolute sm:left-4 sm:top-4 sm:bg-transparent sm:p-0 sm:backdrop-blur-none dark:sm:bg-transparent">
+    <div className="min-h-screen overflow-y-auto overflow-x-hidden bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-stone-950 dark:via-stone-900 dark:to-stone-800">
+      <div className="fixed left-3 top-3 z-50 flex items-center gap-2 sm:left-4 sm:top-4">
         <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-white/50 backdrop-blur-sm transition-colors hover:bg-white/80 dark:bg-stone-800/50 dark:hover:bg-stone-800/80">
           <img
             src="/icons/icon.svg"
@@ -115,13 +113,13 @@ export function ForgotPassword({ onBackToLogin }: ForgotPasswordProps) {
             className="h-6 w-6 rounded"
           />
         </div>
-        <div className="flex items-center gap-2">
-          <LanguageToggle />
-          <ThemeToggle />
-        </div>
       </div>
 
-      {/* 背景装饰 */}
+      <div className="fixed right-3 top-3 z-50 flex items-center gap-1.5 rounded-lg bg-white/50 p-1 backdrop-blur-sm dark:bg-stone-800/50 sm:right-4 sm:top-4 sm:gap-2 sm:bg-transparent sm:backdrop-blur-none dark:sm:bg-transparent">
+        <LanguageToggle />
+        <ThemeToggle />
+      </div>
+
       <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
         <div className="absolute -bottom-20 -left-20 h-64 w-64 rounded-full bg-gray-200/50 blur-3xl dark:bg-stone-700/30" />
         <div className="absolute -bottom-20 -right-20 h-80 w-80 rounded-full bg-gray-200/50 blur-3xl dark:bg-stone-700/30" />

--- a/frontend/src/components/auth/RegistrationPending.tsx
+++ b/frontend/src/components/auth/RegistrationPending.tsx
@@ -54,31 +54,33 @@ export function RegistrationPending() {
   }
 
   return (
-    <div className="flex min-h-screen flex-col overflow-y-auto bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-stone-950 dark:via-stone-900 dark:to-stone-800">
-      {/* Header */}
-      <div className="sticky top-0 z-50 flex items-center justify-between bg-gradient-to-br from-gray-50/90 via-white/90 to-gray-100/90 p-3 backdrop-blur-sm dark:from-stone-950/90 dark:via-stone-900/90 dark:to-stone-800/90 sm:absolute sm:left-4 sm:top-4 sm:bg-transparent sm:p-0 sm:backdrop-blur-none dark:sm:bg-transparent">
+    <div className="min-h-screen overflow-y-auto overflow-x-hidden bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-stone-950 dark:via-stone-900 dark:to-stone-800">
+      {/* 左上角返回按钮 */}
+      <div className="fixed left-3 top-3 z-50 flex items-center gap-2 sm:left-4 sm:top-4">
         <div
           className="flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg bg-white/50 backdrop-blur-sm transition-colors hover:bg-white/80 dark:bg-stone-800/50 dark:hover:bg-stone-800/80"
           onClick={handleGoToLogin}
         >
           <ArrowLeft className="h-5 w-5 text-gray-600 dark:text-stone-400" />
         </div>
-        <div className="flex items-center gap-2">
-          <LanguageToggle />
-          <ThemeToggle />
-        </div>
       </div>
 
-      {/* Background decorations */}
+      {/* 右上角按钮 */}
+      <div className="fixed right-3 top-3 z-50 flex items-center gap-1.5 rounded-lg bg-white/50 p-1 backdrop-blur-sm dark:bg-stone-800/50 sm:right-4 sm:top-4 sm:gap-2 sm:bg-transparent sm:backdrop-blur-none dark:sm:bg-transparent">
+        <LanguageToggle />
+        <ThemeToggle />
+      </div>
+
+      {/* 背景装饰 */}
       <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
         <div className="absolute -bottom-20 -left-20 h-64 w-64 rounded-full bg-gray-200/50 blur-3xl dark:bg-stone-700/30" />
         <div className="absolute -bottom-20 -right-20 h-80 w-80 rounded-full bg-gray-200/50 blur-3xl dark:bg-stone-700/30" />
       </div>
 
-      {/* Main content */}
+      {/* 主内容区域 */}
       <div className="grid min-h-screen place-items-center px-4 py-8 sm:px-6">
         <div className="w-full max-w-md py-8">
-          {/* Success icon */}
+          {/* 成功图标 */}
           <div className="mb-8 text-center">
             <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-green-100 dark:bg-green-900/30">
               <CheckCircle className="h-8 w-8 text-green-600 dark:text-green-400" />
@@ -91,7 +93,7 @@ export function RegistrationPending() {
             </p>
           </div>
 
-          {/* Email info card */}
+          {/* 邮箱信息卡片 */}
           <div className="mb-6 rounded-xl border border-gray-200 bg-white p-4 shadow-sm dark:border-stone-700 dark:bg-stone-800">
             <div className="flex items-center gap-3">
               <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-100 dark:bg-blue-900/30">
@@ -108,7 +110,7 @@ export function RegistrationPending() {
             </div>
           </div>
 
-          {/* Instructions */}
+          {/* 操作指引 */}
           <div className="mb-6 rounded-xl bg-gray-50 p-4 dark:bg-stone-800/50">
             <h2 className="mb-3 font-medium text-gray-900 dark:text-stone-100">
               {t("auth.whatToDoNext")}
@@ -135,7 +137,7 @@ export function RegistrationPending() {
             </ol>
           </div>
 
-          {/* Resend button */}
+          {/* 重发按钮 */}
           {resendSuccess ? (
             <div className="mb-4 rounded-xl border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-900/20">
               <p className="text-center text-sm text-green-700 dark:text-green-400">
@@ -159,7 +161,7 @@ export function RegistrationPending() {
             </button>
           )}
 
-          {/* Back to login */}
+          {/* 返回登录 */}
           <button
             onClick={handleGoToLogin}
             className="w-full rounded-xl bg-gray-900 py-3 text-sm font-medium text-white shadow-lg shadow-gray-900/25 transition-all hover:-translate-y-0.5 hover:bg-gray-800 hover:shadow-xl hover:shadow-gray-900/30 active:translate-y-0 dark:bg-white dark:text-gray-900 dark:shadow-white/10 dark:hover:bg-stone-100 sm:py-3.5"

--- a/frontend/src/components/auth/ResetPassword.tsx
+++ b/frontend/src/components/auth/ResetPassword.tsx
@@ -77,8 +77,8 @@ export function ResetPassword() {
   // 成功状态
   if (isSuccess) {
     return (
-      <div className="flex min-h-screen flex-col overflow-y-auto bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-stone-950 dark:via-stone-900 dark:to-stone-800">
-        <div className="sticky top-0 z-50 flex items-center justify-between bg-gradient-to-br from-gray-50/90 via-white/90 to-gray-100/90 p-3 backdrop-blur-sm dark:from-stone-950/90 dark:via-stone-900/90 dark:to-stone-800/90 sm:absolute sm:left-4 sm:top-4 sm:bg-transparent sm:p-0 sm:backdrop-blur-none dark:sm:bg-transparent">
+      <div className="min-h-screen overflow-y-auto overflow-x-hidden bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-stone-950 dark:via-stone-900 dark:to-stone-800">
+        <div className="fixed left-3 top-3 z-50 flex items-center gap-2 sm:left-4 sm:top-4">
           <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-white/50 backdrop-blur-sm transition-colors hover:bg-white/80 dark:bg-stone-800/50 dark:hover:bg-stone-800/80">
             <img
               src="/icons/icon.svg"
@@ -86,10 +86,11 @@ export function ResetPassword() {
               className="h-6 w-6 rounded"
             />
           </div>
-          <div className="flex items-center gap-2">
-            <LanguageToggle />
-            <ThemeToggle />
-          </div>
+        </div>
+
+        <div className="fixed right-3 top-3 z-50 flex items-center gap-1.5 rounded-lg bg-white/50 p-1 backdrop-blur-sm dark:bg-stone-800/50 sm:right-4 sm:top-4 sm:gap-2 sm:bg-transparent sm:backdrop-blur-none dark:sm:bg-transparent">
+          <LanguageToggle />
+          <ThemeToggle />
         </div>
 
         <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
@@ -126,8 +127,8 @@ export function ResetPassword() {
   // 错误状态
   if (isError) {
     return (
-      <div className="flex min-h-screen flex-col overflow-y-auto bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-stone-950 dark:via-stone-900 dark:to-stone-800">
-        <div className="sticky top-0 z-50 flex items-center justify-between bg-gradient-to-br from-gray-50/90 via-white/90 to-gray-100/90 p-3 backdrop-blur-sm dark:from-stone-950/90 dark:via-stone-900/90 dark:to-stone-800/90 sm:absolute sm:left-4 sm:top-4 sm:bg-transparent sm:p-0 sm:backdrop-blur-none dark:sm:bg-transparent">
+      <div className="min-h-screen overflow-y-auto overflow-x-hidden bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-stone-950 dark:via-stone-900 dark:to-stone-800">
+        <div className="fixed left-3 top-3 z-50 flex items-center gap-2 sm:left-4 sm:top-4">
           <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-white/50 backdrop-blur-sm transition-colors hover:bg-white/80 dark:bg-stone-800/50 dark:hover:bg-stone-800/80">
             <img
               src="/icons/icon.svg"
@@ -135,10 +136,11 @@ export function ResetPassword() {
               className="h-6 w-6 rounded"
             />
           </div>
-          <div className="flex items-center gap-2">
-            <LanguageToggle />
-            <ThemeToggle />
-          </div>
+        </div>
+
+        <div className="fixed right-3 top-3 z-50 flex items-center gap-1.5 rounded-lg bg-white/50 p-1 backdrop-blur-sm dark:bg-stone-800/50 sm:right-4 sm:top-4 sm:gap-2 sm:bg-transparent sm:backdrop-blur-none dark:sm:bg-transparent">
+          <LanguageToggle />
+          <ThemeToggle />
         </div>
 
         <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
@@ -173,8 +175,8 @@ export function ResetPassword() {
   }
 
   return (
-    <div className="flex min-h-screen flex-col overflow-y-auto bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-stone-950 dark:via-stone-900 dark:to-stone-800">
-      <div className="sticky top-0 z-50 flex items-center justify-between bg-gradient-to-br from-gray-50/90 via-white/90 to-gray-100/90 p-3 backdrop-blur-sm dark:from-stone-950/90 dark:via-stone-900/90 dark:to-stone-800/90 sm:absolute sm:left-4 sm:top-4 sm:bg-transparent sm:p-0 sm:backdrop-blur-none dark:sm:bg-transparent">
+    <div className="min-h-screen overflow-y-auto overflow-x-hidden bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-stone-950 dark:via-stone-900 dark:to-stone-800">
+      <div className="fixed left-3 top-3 z-50 flex items-center gap-2 sm:left-4 sm:top-4">
         <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-white/50 backdrop-blur-sm transition-colors hover:bg-white/80 dark:bg-stone-800/50 dark:hover:bg-stone-800/80">
           <img
             src="/icons/icon.svg"
@@ -182,10 +184,11 @@ export function ResetPassword() {
             className="h-6 w-6 rounded"
           />
         </div>
-        <div className="flex items-center gap-2">
-          <LanguageToggle />
-          <ThemeToggle />
-        </div>
+      </div>
+
+      <div className="fixed right-3 top-3 z-50 flex items-center gap-1.5 rounded-lg bg-white/50 p-1 backdrop-blur-sm dark:bg-stone-800/50 sm:right-4 sm:top-4 sm:gap-2 sm:bg-transparent sm:backdrop-blur-none dark:sm:bg-transparent">
+        <LanguageToggle />
+        <ThemeToggle />
       </div>
 
       <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">

--- a/frontend/src/components/auth/VerifyEmail.tsx
+++ b/frontend/src/components/auth/VerifyEmail.tsx
@@ -70,29 +70,34 @@ export function VerifyEmail() {
     }
   };
 
+  // 通用 Header 组件
+  const Header = () => (
+    <>
+      <div className="fixed left-3 top-3 z-50 flex items-center gap-2 sm:left-4 sm:top-4">
+        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-white/50 backdrop-blur-sm transition-colors hover:bg-white/80 dark:bg-stone-800/50 dark:hover:bg-stone-800/80">
+          <img
+            src="/icons/icon.svg"
+            alt="LambChat"
+            className="h-6 w-6 rounded"
+          />
+        </div>
+      </div>
+      <div className="fixed right-3 top-3 z-50 flex items-center gap-1.5 rounded-lg bg-white/50 p-1 backdrop-blur-sm dark:bg-stone-800/50 sm:right-4 sm:top-4 sm:gap-2 sm:bg-transparent sm:backdrop-blur-none dark:sm:bg-transparent">
+        <LanguageToggle />
+        <ThemeToggle />
+      </div>
+      <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+        <div className="absolute -bottom-20 -left-20 h-64 w-64 rounded-full bg-gray-200/50 blur-3xl dark:bg-stone-700/30" />
+        <div className="absolute -bottom-20 -right-20 h-80 w-80 rounded-full bg-gray-200/50 blur-3xl dark:bg-stone-700/30" />
+      </div>
+    </>
+  );
+
   // 加载中状态
   if (status === "loading") {
     return (
-      <div className="flex min-h-screen flex-col overflow-y-auto bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-stone-950 dark:via-stone-900 dark:to-stone-800">
-        <div className="sticky top-0 z-50 flex items-center justify-between bg-gradient-to-br from-gray-50/90 via-white/90 to-gray-100/90 p-3 backdrop-blur-sm dark:from-stone-950/90 dark:via-stone-900/90 dark:to-stone-800/90 sm:absolute sm:left-4 sm:top-4 sm:bg-transparent sm:p-0 sm:backdrop-blur-none dark:sm:bg-transparent">
-          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-white/50 backdrop-blur-sm transition-colors hover:bg-white/80 dark:bg-stone-800/50 dark:hover:bg-stone-800/80">
-            <img
-              src="/icons/icon.svg"
-              alt="LambChat"
-              className="h-6 w-6 rounded"
-            />
-          </div>
-          <div className="flex items-center gap-2">
-            <LanguageToggle />
-            <ThemeToggle />
-          </div>
-        </div>
-
-        <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
-          <div className="absolute -bottom-20 -left-20 h-64 w-64 rounded-full bg-gray-200/50 blur-3xl dark:bg-stone-700/30" />
-          <div className="absolute -bottom-20 -right-20 h-80 w-80 rounded-full bg-gray-200/50 blur-3xl dark:bg-stone-700/30" />
-        </div>
-
+      <div className="min-h-screen overflow-y-auto overflow-x-hidden bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-stone-950 dark:via-stone-900 dark:to-stone-800">
+        <Header />
         <div className="grid min-h-screen place-items-center px-4 py-8 sm:px-6">
           <div className="w-full max-w-md py-8">
             <div className="mb-8 text-center">
@@ -115,26 +120,8 @@ export function VerifyEmail() {
   // 成功状态
   if (status === "success") {
     return (
-      <div className="flex min-h-screen flex-col overflow-y-auto bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-stone-950 dark:via-stone-900 dark:to-stone-800">
-        <div className="sticky top-0 z-50 flex items-center justify-between bg-gradient-to-br from-gray-50/90 via-white/90 to-gray-100/90 p-3 backdrop-blur-sm dark:from-stone-950/90 dark:via-stone-900/90 dark:to-stone-800/90 sm:absolute sm:left-4 sm:top-4 sm:bg-transparent sm:p-0 sm:backdrop-blur-none dark:sm:bg-transparent">
-          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-white/50 backdrop-blur-sm transition-colors hover:bg-white/80 dark:bg-stone-800/50 dark:hover:bg-stone-800/80">
-            <img
-              src="/icons/icon.svg"
-              alt="LambChat"
-              className="h-6 w-6 rounded"
-            />
-          </div>
-          <div className="flex items-center gap-2">
-            <LanguageToggle />
-            <ThemeToggle />
-          </div>
-        </div>
-
-        <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
-          <div className="absolute -bottom-20 -left-20 h-64 w-64 rounded-full bg-gray-200/50 blur-3xl dark:bg-stone-700/30" />
-          <div className="absolute -bottom-20 -right-20 h-80 w-80 rounded-full bg-gray-200/50 blur-3xl dark:bg-stone-700/30" />
-        </div>
-
+      <div className="min-h-screen overflow-y-auto overflow-x-hidden bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-stone-950 dark:via-stone-900 dark:to-stone-800">
+        <Header />
         <div className="grid min-h-screen place-items-center px-4 py-8 sm:px-6">
           <div className="w-full max-w-md py-8">
             <div className="mb-8 text-center">
@@ -166,26 +153,8 @@ export function VerifyEmail() {
     const email = searchParams.get("email");
 
     return (
-      <div className="flex min-h-screen flex-col overflow-y-auto bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-stone-950 dark:via-stone-900 dark:to-stone-800">
-        <div className="sticky top-0 z-50 flex items-center justify-between bg-gradient-to-br from-gray-50/90 via-white/90 to-gray-100/90 p-3 backdrop-blur-sm dark:from-stone-950/90 dark:via-stone-900/90 dark:to-stone-800/90 sm:absolute sm:left-4 sm:top-4 sm:bg-transparent sm:p-0 sm:backdrop-blur-none dark:sm:bg-transparent">
-          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-white/50 backdrop-blur-sm transition-colors hover:bg-white/80 dark:bg-stone-800/50 dark:hover:bg-stone-800/80">
-            <img
-              src="/icons/icon.svg"
-              alt="LambChat"
-              className="h-6 w-6 rounded"
-            />
-          </div>
-          <div className="flex items-center gap-2">
-            <LanguageToggle />
-            <ThemeToggle />
-          </div>
-        </div>
-
-        <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
-          <div className="absolute -bottom-20 -left-20 h-64 w-64 rounded-full bg-gray-200/50 blur-3xl dark:bg-stone-700/30" />
-          <div className="absolute -bottom-20 -right-20 h-80 w-80 rounded-full bg-gray-200/50 blur-3xl dark:bg-stone-700/30" />
-        </div>
-
+      <div className="min-h-screen overflow-y-auto overflow-x-hidden bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-stone-950 dark:via-stone-900 dark:to-stone-800">
+        <Header />
         <div className="grid min-h-screen place-items-center px-4 py-8 sm:px-6">
           <div className="w-full max-w-md py-8">
             <div className="mb-8 text-center">
@@ -232,26 +201,8 @@ export function VerifyEmail() {
 
   // 空闲状态 - 无 token
   return (
-    <div className="flex min-h-screen flex-col overflow-y-auto bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-stone-950 dark:via-stone-900 dark:to-stone-800">
-      <div className="sticky top-0 z-50 flex items-center justify-between bg-gradient-to-br from-gray-50/90 via-white/90 to-gray-100/90 p-3 backdrop-blur-sm dark:from-stone-950/90 dark:via-stone-900/90 dark:to-stone-800/90 sm:absolute sm:left-4 sm:top-4 sm:bg-transparent sm:p-0 sm:backdrop-blur-none dark:sm:bg-transparent">
-        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-white/50 backdrop-blur-sm transition-colors hover:bg-white/80 dark:bg-stone-800/50 dark:hover:bg-stone-800/80">
-          <img
-            src="/icons/icon.svg"
-            alt="LambChat"
-            className="h-6 w-6 rounded"
-          />
-        </div>
-        <div className="flex items-center gap-2">
-          <LanguageToggle />
-          <ThemeToggle />
-        </div>
-      </div>
-
-      <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
-        <div className="absolute -bottom-20 -left-20 h-64 w-64 rounded-full bg-gray-200/50 blur-3xl dark:bg-stone-700/30" />
-        <div className="absolute -bottom-20 -right-20 h-80 w-80 rounded-full bg-gray-200/50 blur-3xl dark:bg-stone-700/30" />
-      </div>
-
+    <div className="min-h-screen overflow-y-auto overflow-x-hidden bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-stone-950 dark:via-stone-900 dark:to-stone-800">
+      <Header />
       <div className="grid min-h-screen place-items-center px-4 py-8 sm:px-6">
         <div className="w-full max-w-md py-8">
           <div className="mb-8 text-center">


### PR DESCRIPTION
## 问题

以下页面内容没有垂直居中：
- 重置密码页面 (ResetPassword)
- 忘记密码页面 (ForgotPassword)
- 验证邮箱页面 (VerifyEmail)
- 注册成功页面 (RegistrationPending)

**根本原因：**
- 使用 `flex min-h-screen flex-col` + `sticky header` 布局
- 在 flex column 容器中的 `grid min-h-screen` 会导致高度计算问题

## 修复

统一使用 `AuthPage` 的布局结构：

```jsx
// 之前（错误）
<div className="flex min-h-screen flex-col">
  <div className="sticky top-0">...</div>
  <div className="grid min-h-screen place-items-center">...</div>
</div>

// 之后（正确）
<div className="min-h-screen">
  <div className="fixed left-3 top-3">...</div>
  <div className="fixed right-3 top-3">...</div>
  <div className="grid min-h-screen place-items-center">...</div>
</div>
```

## 修改文件

| 文件 | 状态数量 |
|------|----------|
| ResetPassword.tsx | 3个状态（成功/错误/表单） |
| ForgotPassword.tsx | 2个状态（成功/表单） |
| VerifyEmail.tsx | 4个状态（加载/成功/错误/空闲） |
| RegistrationPending.tsx | 1个页面 |

## 测试

- ✅ 前端构建成功