### PR TITLE
fix(auth): 未激活用户登录时应显示正确的错误信息

### DIFF
--- a/src/infra/user/storage.py
+++ b/src/infra/user/storage.py
@@ -407,6 +407,9 @@ class UserStorage:
         """
         验证用户凭据（支持用户名或邮箱登录）
 
+        注意：此方法只验证密码，不检查激活状态。
+        激活状态检查由 UserManager.login() 处理，以便返回正确的错误信息。
+
         Args:
             username_or_email: 用户名或邮箱
             password: 密码
@@ -423,9 +426,8 @@ class UserStorage:
         if not user:
             return None
 
-        if not user.is_active:
-            return None
-
+        # 只验证密码，不检查 is_active
+        # is_active 检查由 UserManager.login() 处理，以便返回正确的错误信息
         if not verify_password(password, user.password_hash):
             return None
 


### PR DESCRIPTION
## 问题

未激活用户登录时显示"用户名或密码错误"，应该显示"账户未激活，请验证邮箱"。

**根本原因：**
- `storage.authenticate()` 中检查 `is_active=False` 直接返回 `None`
- 密码正确但未激活的用户被当作"用户名或密码错误"处理

## 修复

### 流程变化

| 步骤 | 之前 | 之后 |
|------|------|------|
| 1 | authenticate() 检查 is_active | authenticate() 只验证密码 |
| 2 | 返回 None | 返回 user 对象 |
| 3 | login() 返回 None | login() 检查 is_active |
| 4 | API 返回"用户名或密码错误" | 抛出 AccountNotActiveError |
| 5 | - | API 返回"账户未激活，请验证邮箱" |

### 代码修改

```python
# storage.py - authenticate() 移除 is_active 检查
# 之前
if not user.is_active:
    return None

# 之后
# 只验证密码，is_active 检查由 UserManager.login() 处理
```

## 用户体验

| 用户类型 | 密码正确 | 之前显示 | 之后显示 |
|----------|----------|----------|----------|
| 未激活 | ✅ | 用户名或密码错误 | 账户未激活，请验证邮箱 |
| 已激活 | ✅ | 登录成功 | 登录成功 |
| 不存在 | - | 用户名或密码错误 | 用户名或密码错误 |
| 密码错误 | - | 用户名或密码错误 | 用户名或密码错误 |