### PR TITLE
feat(auth): 未验证用户登录时自动跳转到验证页面

### DIFF
--- a/frontend/src/components/auth/AuthPage.tsx
+++ b/frontend/src/components/auth/AuthPage.tsx
@@ -210,8 +210,26 @@ export function AuthPage({ onSuccess }: AuthPageProps) {
       }
     } catch (err) {
       const errorMessage = (err as Error).message || t("auth.operationFailed");
-      toast.error(errorMessage);
-      setError(errorMessage);
+      
+      // 检查是否是邮箱未验证或账户未激活错误，跳转到验证页面
+      if (errorMessage.includes("请先验证邮箱") || errorMessage.includes("账户未激活")) {
+        // 如果输入的是邮箱，直接跳转
+        const isEmail = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(username);
+        if (isEmail) {
+          toast.error(errorMessage);
+          setTimeout(() => {
+            window.location.href = `/registration-pending?email=${encodeURIComponent(username)}`;
+          }, 1500);
+          return;
+        }
+        // 如果是用户名，提示用户
+        setError(t("auth.pleaseLoginWithEmail") || "请使用注册邮箱登录以完成验证");
+        toast.error(errorMessage);
+      } else {
+        toast.error(errorMessage);
+        setError(errorMessage);
+      }
+      
       // 重置 Turnstile widget
       setTurnstileToken(null);
       setTurnstileKey(prev => prev + 1);

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -47,6 +47,7 @@
     "loginHint": "Sign in to your account",
     "loginNow": "Login now",
     "loginSuccess": "Login successful",
+    "pleaseLoginWithEmail": "Please login with your registered email to complete verification",
     "logout": "Logout",
     "noAccount": "Don't have an account?",
     "oauthLoginFailed": "OAuth login failed, please try again later",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -47,6 +47,7 @@
     "loginHint": "アカウントにログイン",
     "loginNow": "今すぐログイン",
     "loginSuccess": "ログインしました",
+    "pleaseLoginWithEmail": "登録したメールアドレスでログインして認証を完了してください",
     "logout": "ログアウト",
     "noAccount": "アカウントをお持ちでないですか？",
     "oauthLoginFailed": "OAuthログインに失敗しました。もう一度お試しください",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -47,6 +47,7 @@
     "loginHint": "계정에 로그인",
     "loginNow": "지금 로그인",
     "loginSuccess": "로그인 성공",
+    "pleaseLoginWithEmail": "등록한 이메일로 로그인하여 인증을 완료해주세요",
     "logout": "로그아웃",
     "noAccount": "계정이 없으신가요?",
     "oauthLoginFailed": "OAuth 로그인에 실패했습니다. 나중에 다시 시도해 주세요",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -47,6 +47,7 @@
     "loginHint": "登录您的账户",
     "loginNow": "立即登录",
     "loginSuccess": "登录成功",
+    "pleaseLoginWithEmail": "请使用注册邮箱登录以完成验证",
     "logout": "退出登录",
     "noAccount": "还没有账户？",
     "oauthLoginFailed": "OAuth 登录失败，请稍后重试",


### PR DESCRIPTION
## 功能

未验证用户登录时，自动跳转到验证页面而不是只显示错误。

### 用户流程

```
用户登录
    ↓
密码正确但未验证
    ↓
检查输入类型
    ├── 邮箱 → 自动跳转到 registration-pending 页面
    └── 用户名 → 提示"请使用邮箱登录以完成验证"
```

### 实现细节

1. **错误捕获**：在 `AuthPage.tsx` 的 `handleSubmit` 中捕获错误
2. **邮箱检测**：使用正则判断输入是否为邮箱格式
3. **自动跳转**：邮箱格式则跳转到 `/registration-pending?email=xxx`
4. **友好提示**：用户名格式则提示使用邮箱登录
5. **i18n 支持**：添加 4 种语言翻译

### 代码变更

```tsx
// AuthPage.tsx
catch (err) {
  const errorMessage = (err as Error).message;
  
  // 检查是否是验证错误
  if (errorMessage.includes("请先验证邮箱") || errorMessage.includes("账户未激活")) {
    const isEmail = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(username);
    if (isEmail) {
      // 邮箱格式 → 跳转验证页面
      window.location.href = `/registration-pending?email=${username}`;
      return;
    }
    // 用户名格式 → 提示使用邮箱
    setError(t("auth.pleaseLoginWithEmail"));
  }
}
```

### 添加翻译

| 语言 | 键 | 值 |
|------|-----|-----|
| 中文 | pleaseLoginWithEmail | 请使用注册邮箱登录以完成验证 |
| 英文 | pleaseLoginWithEmail | Please login with your registered email to complete verification |
| 日文 | pleaseLoginWithEmail | 登録したメールアドレスでログインして認証を完了してください |
| 韩文 | pleaseLoginWithEmail | 등록한 이메일로 로그인하여 인증을 완료해주세요 |