### PR TITLE
fix: 修复项目配置和入口点问题

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,11 +90,6 @@ SANDBOX_AUTO_ARCHIVE_INTERVAL=5  # Auto-archive interval in minutes
 SANDBOX_AUTO_DELETE_INTERVAL=1440  # Auto-delete interval in minutes after being archived
 
 # ============================================
-# Skills Configuration
-# ============================================
-ENABLE_SKILLS=true
-
-# ============================================
 # LangSmith Tracing
 # ============================================
 LANGSMITH_TRACING=false

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
-if __name__ == "__main__":
+def run() -> None:
+    """Start the application server."""
     import uvicorn
 
     from src.kernel.config import settings
@@ -10,3 +11,7 @@ if __name__ == "__main__":
         reload=settings.DEBUG,
         log_level="info",
     )
+
+
+if __name__ == "__main__":
+    run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/omni_agent"]
+packages = ["src/agents", "src/api", "src/infra", "src/kernel", "src/skills"]
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
## 修复内容

- **main.py**: 添加 `run()` 函数解决 mypy 类型错误 (`Module "main" has no attribute "run"`)
- **pyproject.toml**: 修复 hatch 构建配置，将 `packages` 从不存在的 `src/omni_agent` 改为正确的包路径
- **.env.example**: 删除重复的 `ENABLE_SKILLS=true` 配置项
- **tests/**: 添加空的测试目录（pytest 配置需要）

## 检查

- ✅ ruff: 全部通过
- ✅ mypy: 全部通过（修复后）