### PR TITLE
feat: add Sandpack project preview for multi-file frontend projects

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "lamb-agent-frontend",
       "version": "1.0.0",
       "dependencies": {
+        "@codesandbox/sandpack-react": "^2.20.0",
+        "@codesandbox/sandpack-themes": "^2.0.21",
         "@excalidraw/excalidraw": "^0.18.0",
         "@microsoft/fetch-event-source": "^2.0.1",
         "@types/react-syntax-highlighter": "^15.5.13",
@@ -418,6 +420,188 @@
       "version": "11.1.1",
       "resolved": "https://registry.npmmirror.com/@chevrotain/utils/-/utils-11.1.1.tgz",
       "integrity": "sha512-71eTYMzYXYSFPrbg/ZwftSaSDld7UYlS8OQa3lNnn9jzNtpFbaReRRyghzqS7rI3CDaorqpPJJcXGHK+FE1TVQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
+      "integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.2.tgz",
+      "integrity": "sha512-vvX1fsih9HledO1c9zdotZYUZnE4xV0m6i3m25s5DIfXofuprk6cRcLUZvSk3CASUbwjQX21tOGbkY2BH8TpnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.4.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
+      "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.11.tgz",
+      "integrity": "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.12"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
+      "integrity": "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.2.tgz",
+      "integrity": "sha512-jEPmz2nGGDxhRTg3lTpzmIyGKxz3Gp3SJES4b0nAuE5SWQoKdT5GoQ69cwMmFd+wvFUhYirtDTr0/DRHpQAyWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
+      "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.4.tgz",
+      "integrity": "sha512-8y7xqG/hpB53l25CIoit9/ngxdfoG+fx+V3SHBrinnhOtLvKHRyAJJuHzkWrR4YXXLX8eXBsejgAAxHUOdW1yw==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.39.17",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.39.17.tgz",
+      "integrity": "sha512-Aim4lFqhbijnchl83RLfABWueSGs1oUCSv0mru91QdhpXQeNKprIdRO9LWA4cYkJvuYTKGJN7++9MXx8XW43ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.5.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@codesandbox/nodebox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@codesandbox/nodebox/-/nodebox-0.1.8.tgz",
+      "integrity": "sha512-2VRS6JDSk+M+pg56GA6CryyUSGPjBEe8Pnae0QL3jJF1mJZJVMDKr93gJRtBbLkfZN6LD/DwMtf+2L0bpWrjqg==",
+      "license": "SEE LICENSE IN ./LICENSE",
+      "dependencies": {
+        "outvariant": "^1.4.0",
+        "strict-event-emitter": "^0.4.3"
+      }
+    },
+    "node_modules/@codesandbox/sandpack-client": {
+      "version": "2.19.8",
+      "resolved": "https://registry.npmjs.org/@codesandbox/sandpack-client/-/sandpack-client-2.19.8.tgz",
+      "integrity": "sha512-CMV4nr1zgKzVpx4I3FYvGRM5YT0VaQhALMW9vy4wZRhEyWAtJITQIqZzrTGWqB1JvV7V72dVEUCUPLfYz5hgJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@codesandbox/nodebox": "0.1.8",
+        "buffer": "^6.0.3",
+        "dequal": "^2.0.2",
+        "mime-db": "^1.52.0",
+        "outvariant": "1.4.0",
+        "static-browser-server": "1.0.3"
+      }
+    },
+    "node_modules/@codesandbox/sandpack-react": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/@codesandbox/sandpack-react/-/sandpack-react-2.20.0.tgz",
+      "integrity": "sha512-takd1YpW/PMQ6KPQfvseWLHWklJovGY8QYj8MtWnskGKbjOGJ6uZfyZbcJ6aCFLQMpNyjTqz9AKNbvhCOZ1TUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.4.0",
+        "@codemirror/commands": "^6.1.3",
+        "@codemirror/lang-css": "^6.0.1",
+        "@codemirror/lang-html": "^6.4.0",
+        "@codemirror/lang-javascript": "^6.1.2",
+        "@codemirror/language": "^6.3.2",
+        "@codemirror/state": "^6.2.0",
+        "@codemirror/view": "^6.7.1",
+        "@codesandbox/sandpack-client": "^2.19.8",
+        "@lezer/highlight": "^1.1.3",
+        "@react-hook/intersection-observer": "^3.1.1",
+        "@stitches/core": "^1.2.6",
+        "anser": "^2.1.1",
+        "clean-set": "^1.1.2",
+        "dequal": "^2.0.2",
+        "escape-carriage": "^1.3.1",
+        "lz-string": "^1.4.4",
+        "react-devtools-inline": "4.4.0",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/@codesandbox/sandpack-react/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "license": "MIT"
+    },
+    "node_modules/@codesandbox/sandpack-themes": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/@codesandbox/sandpack-themes/-/sandpack-themes-2.0.21.tgz",
+      "integrity": "sha512-CMH/MO/dh6foPYb/3eSn2Cu/J3+1+/81Fsaj7VggICkCrmRk0qG5dmgjGAearPTnRkOGORIPHuRqwNXgw0E6YQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2154,6 +2338,69 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lezer/common": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
+      "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/css": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.1.tgz",
+      "integrity": "sha512-PYAKeUVBo3HFThruRyp/iK91SwiZJnzXh8QzkQlwijB5y+N5iB28+iLk78o2zmKqqV0uolNhCwFqB8LA7b0Svg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
+      "integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
+      "integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
+    },
     "node_modules/@mermaid-js/parser": {
       "version": "1.0.0",
       "resolved": "https://registry.npmmirror.com/@mermaid-js/parser/-/parser-1.0.0.tgz",
@@ -2456,6 +2703,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "license": "MIT"
     },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.1",
@@ -2867,6 +3120,28 @@
       "integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==",
       "license": "MIT"
     },
+    "node_modules/@react-hook/intersection-observer": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-hook/intersection-observer/-/intersection-observer-3.1.2.tgz",
+      "integrity": "sha512-mWU3BMkmmzyYMSuhO9wu3eJVP21N8TcgYm9bZnTrMwuM818bEk+0NRM3hP+c/TqA9Ln5C7qE53p1H0QMtzYdvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-hook/passive-layout-effect": "^1.2.0",
+        "intersection-observer": "^0.10.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/@react-hook/passive-layout-effect": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@react-hook/passive-layout-effect/-/passive-layout-effect-1.2.1.tgz",
+      "integrity": "sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -3223,6 +3498,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@stitches/core": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@stitches/core/-/core-1.2.8.tgz",
+      "integrity": "sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3998,6 +4279,12 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/anser": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/anser/-/anser-2.3.5.tgz",
+      "integrity": "sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ==",
+      "license": "MIT"
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -4225,6 +4512,30 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -4414,6 +4725,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/clean-set": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/clean-set/-/clean-set-1.1.2.tgz",
+      "integrity": "sha512-cA8uCj0qSoG9e0kevyOWXwPaELRPVg5Pxp6WskLMwerx257Zfnh8Nl0JBH59d7wQzij2CK7qEfJQK3RjuKKIug==",
+      "license": "MIT"
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -4538,6 +4855,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
+    },
     "node_modules/cross-env": {
       "version": "7.0.3",
       "resolved": "https://registry.npmmirror.com/cross-env/-/cross-env-7.0.3.tgz",
@@ -4636,6 +4959,19 @@
       "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
       "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
       "license": "MIT"
+    },
+    "node_modules/d": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
+      "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
+      "license": "ISC",
+      "dependencies": {
+        "es5-ext": "^0.10.64",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
     },
     "node_modules/d3": {
       "version": "7.9.0",
@@ -5215,6 +5551,18 @@
         "@types/trusted-types": "^2.0.7"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/duck": {
       "version": "0.1.12",
       "resolved": "https://registry.npmmirror.com/duck/-/duck-0.1.12.tgz",
@@ -5265,6 +5613,33 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es5-ext": {
+      "version": "0.10.64",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
+      "hasInstallScript": true,
+      "license": "ISC",
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "license": "MIT",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
     "node_modules/es6-promise-pool": {
       "version": "2.5.0",
       "resolved": "https://registry.npmmirror.com/es6-promise-pool/-/es6-promise-pool-2.5.0.tgz",
@@ -5272,6 +5647,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/es6-symbol": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
+      "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.2",
+        "ext": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/esbuild": {
@@ -5325,6 +5713,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-carriage": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/escape-carriage/-/escape-carriage-1.3.1.tgz",
+      "integrity": "sha512-GwBr6yViW3ttx1kb7/Oh+gKQ1/TrhYwxKqVmg5gS+BK+Qe2KrOa/Vh7w3HPBvgGf0LfcDGoY9I6NHKoA5Hozhw==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -5452,6 +5846,21 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/espree": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -5524,6 +5933,25 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "license": "MIT",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "node_modules/ext": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "license": "ISC",
+      "dependencies": {
+        "type": "^2.7.2"
       }
     },
     "node_modules/extend": {
@@ -6144,6 +6572,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -6222,6 +6670,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/intersection-observer": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.10.0.tgz",
+      "integrity": "sha512-fn4bQ0Xq8FTej09YC/jqKZwtijpvARlRp6wxL5WTA6yPe2YWSJ5RJh7Nm79rK2qB0wr6iDQzH60XGq5V/7u8YQ==",
+      "deprecated": "The Intersection Observer polyfill is no longer needed and can safely be removed. Intersection Observer has been Baseline since 2019.",
+      "license": "W3C-20150513"
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
@@ -6695,6 +7150,15 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/make-cancellable-promise": {
@@ -7736,6 +8200,15 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -7834,6 +8307,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+      "license": "ISC"
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -7904,6 +8383,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.0.tgz",
+      "integrity": "sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==",
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -8492,6 +8977,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-devtools-inline": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/react-devtools-inline/-/react-devtools-inline-4.4.0.tgz",
+      "integrity": "sha512-ES0GolSrKO8wsKbsEkVeiR/ZAaHQTY4zDh1UW8DImVmm8oaGLl3ijJDvSGe+qDRKPZdPRnDtWWnSvvrgxXdThQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es6-symbol": "^3"
       }
     },
     "node_modules/react-dom": {
@@ -9286,6 +9780,24 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/static-browser-server": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/static-browser-server/-/static-browser-server-1.0.3.tgz",
+      "integrity": "sha512-ZUyfgGDdFRbZGGJQ1YhiM930Yczz5VlbJObrQLlk24+qNHVQx4OlLcYswEUo3bIyNAbQUIUR9Yr5/Hqjzqb4zA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.1.0",
+        "dotenv": "^16.0.3",
+        "mime-db": "^1.52.0",
+        "outvariant": "^1.3.0"
+      }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.4.6.tgz",
+      "integrity": "sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==",
+      "license": "MIT"
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmmirror.com/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -9321,6 +9833,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
     },
     "node_modules/style-to-js": {
       "version": "1.1.21",
@@ -10071,6 +10589,12 @@
         "zustand": "^4.3.2"
       }
     },
+    "node_modules/type": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
+      "license": "ISC"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -10589,6 +11113,12 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmmirror.com/vscode-uri/-/vscode-uri-3.1.0.tgz",
       "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "license": "MIT"
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
     },
     "node_modules/warning": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,8 @@
     "find-large-files": "tsx scripts/find-large-files.ts"
   },
   "dependencies": {
+    "@codesandbox/sandpack-react": "^2.20.0",
+    "@codesandbox/sandpack-themes": "^2.0.21",
     "@excalidraw/excalidraw": "^0.18.0",
     "@microsoft/fetch-event-source": "^2.0.1",
     "@types/react-syntax-highlighter": "^15.5.13",

--- a/frontend/src/components/chat/ChatMessage/ToolCallItem.tsx
+++ b/frontend/src/components/chat/ChatMessage/ToolCallItem.tsx
@@ -1,12 +1,14 @@
 import { useState } from "react";
+import { createPortal } from "react-dom";
 import { clsx } from "clsx";
-import { Wrench, ExternalLink } from "lucide-react";
+import { Wrench, ExternalLink, Code2, FolderTree } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { LoadingSpinner, CollapsiblePill, ImageViewer } from "../../common";
 import type { CollapsibleStatus } from "../../common";
 import DocumentPreview from "../../documents/DocumentPreview";
 import { getFileTypeInfo } from "../../documents/utils";
 import { getFullUrl } from "../../../services/api";
+import ProjectPreview from "../../documents/previews/ProjectPreview";
 
 // Collapsible Tool Call Item (compact design)
 export function ToolCallItem({
@@ -298,6 +300,193 @@ export function FileRevealItem({
           </div>
         )}
       </button>
+    </div>
+  );
+}
+
+// Project Reveal Item - for showing reveal_project tool results
+interface ProjectRevealResult {
+  type: "project_reveal";
+  name: string;
+  description?: string;
+  template: "react" | "vue" | "vanilla" | "static";
+  files: Record<string, string>;
+  entry?: string;
+  path?: string;
+  file_count?: number;
+  error?: string;
+  message?: string;
+}
+
+export function ProjectRevealItem({
+  args,
+  result,
+  success,
+  isPending,
+}: {
+  args: Record<string, unknown>;
+  result?: string;
+  success?: boolean;
+  isPending?: boolean;
+}) {
+  const { t } = useTranslation();
+  const [showFullPreview, setShowFullPreview] = useState(false);
+
+  // Parse result
+  let projectName = "";
+  let template: "react" | "vue" | "vanilla" | "static" = "vanilla";
+  let files: Record<string, string> = {};
+  let entry: string | undefined;
+  let fileCount = 0;
+  let error = "";
+
+  if (result) {
+    try {
+      const parsed: ProjectRevealResult = JSON.parse(result);
+
+      if (parsed.error) {
+        error = parsed.message || parsed.error;
+      } else {
+        projectName = parsed.name || "";
+        template = parsed.template || "vanilla";
+        files = parsed.files || {};
+        entry = parsed.entry;
+        fileCount = parsed.file_count || Object.keys(files).length;
+      }
+    } catch {
+      error = "Failed to parse project data";
+    }
+  } else {
+    projectName = (args.name as string) || "";
+  }
+
+  // Pending state
+  if (isPending) {
+    return (
+      <div className="my-2 flex items-center gap-3 px-4 py-3 rounded-xl border border-stone-200 dark:border-stone-700 bg-white dark:bg-stone-900">
+        <div className="p-2.5 rounded-lg bg-gradient-to-br from-blue-500 to-purple-500">
+          <LoadingSpinner size="sm" className="text-white" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-medium text-stone-700 dark:text-stone-300 truncate">
+            {projectName || t("project.loading", "加载项目中...")}
+          </div>
+          <div className="text-xs text-stone-500 dark:text-stone-400 truncate mt-0.5">
+            {(args.project_path as string) || ""}
+          </div>
+        </div>
+        <div className="text-xs text-amber-600 dark:text-amber-400">
+          {t("chat.message.running")}
+        </div>
+      </div>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <div className="my-2 flex items-center gap-3 px-4 py-3 rounded-xl border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20">
+        <div className="p-2.5 rounded-lg bg-red-100 dark:bg-red-900/30">
+          <Code2 size={20} className="text-red-500" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-medium text-red-700 dark:text-red-300 truncate">
+            {projectName || t("project.error", "项目加载失败")}
+          </div>
+          <div className="text-xs text-red-500 dark:text-red-400 truncate mt-0.5">
+            {error}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Empty files
+  if (Object.keys(files).length === 0) {
+    return (
+      <div className="my-2 flex items-center gap-3 px-4 py-3 rounded-xl border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20">
+        <div className="p-2.5 rounded-lg bg-amber-100 dark:bg-amber-900/30">
+          <FolderTree size={20} className="text-amber-500" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-medium text-amber-700 dark:text-amber-300 truncate">
+            {projectName || t("project.empty", "空项目")}
+          </div>
+          <div className="text-xs text-amber-500 dark:text-amber-400 truncate mt-0.5">
+            {t("project.noFiles", "没有找到可预览的文件")}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="my-2 sm:my-3">
+      {/* Full screen preview modal */}
+      {showFullPreview && (
+        createPortal(
+          <div
+            className="fixed inset-0 z-[300] flex items-center justify-center bg-black/70 p-4"
+            onClick={() => setShowFullPreview(false)}
+          >
+            <div
+              className="w-full max-w-6xl h-[90vh] bg-white dark:bg-stone-900 rounded-2xl overflow-hidden shadow-2xl"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <ProjectPreview
+                name={projectName}
+                template={template}
+                files={files}
+                entry={entry}
+                onClose={() => setShowFullPreview(false)}
+              />
+            </div>
+          </div>,
+          document.body
+        )
+      )}
+
+      {/* Compact preview card */}
+      <div className="border border-stone-200 dark:border-stone-700 rounded-xl overflow-hidden bg-white dark:bg-stone-900">
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 bg-stone-50 dark:bg-stone-800/50 border-b border-stone-200 dark:border-stone-700">
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-lg bg-gradient-to-br from-blue-500 to-purple-500 text-white">
+              <Code2 size={16} />
+            </div>
+            <div>
+              <h4 className="text-sm font-medium text-stone-900 dark:text-stone-100">
+                {projectName || t("project.untitled", "未命名项目")}
+              </h4>
+              <p className="text-xs text-stone-500 dark:text-stone-400">
+                {t("project.fileCount", "{{count}} 个文件", { count: fileCount })}
+                {template !== "static" && ` · ${template}`}
+              </p>
+            </div>
+          </div>
+
+          <button
+            onClick={() => setShowFullPreview(true)}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-blue-500 hover:bg-blue-600 text-white text-xs font-medium transition-colors"
+          >
+            <ExternalLink size={14} />
+            <span>{t("project.expand", "展开")}</span>
+          </button>
+        </div>
+
+        {/* Preview area - inline Sandpack */}
+        <div className="h-[300px] bg-stone-900">
+          {success && Object.keys(files).length > 0 && (
+            <ProjectPreview
+              name={projectName}
+              template={template}
+              files={files}
+              entry={entry}
+              showHeader={false}
+            />
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/chat/ChatMessage/index.tsx
+++ b/frontend/src/components/chat/ChatMessage/index.tsx
@@ -11,7 +11,7 @@ import type {
 } from "../../../types";
 import { useTranslation } from "react-i18next";
 import { MarkdownContent } from "./MarkdownContent";
-import { ToolCallItem, FileRevealItem } from "./ToolCallItem";
+import { ToolCallItem, FileRevealItem, ProjectRevealItem } from "./ToolCallItem";
 import { ThinkingBlock, SubagentBlock, SandboxItem } from "./SubagentBlocks";
 import { UserMessageBubble } from "./UserMessageBubble";
 import { FeedbackButtons } from "./FeedbackButtons";
@@ -364,6 +364,17 @@ function MessagePartRenderer({
     if (part.name === "reveal_file") {
       return (
         <FileRevealItem
+          args={part.args}
+          result={part.result}
+          success={part.success}
+          isPending={part.isPending}
+        />
+      );
+    }
+    // Detect reveal_project tool, use dedicated component
+    if (part.name === "reveal_project") {
+      return (
+        <ProjectRevealItem
           args={part.args}
           result={part.result}
           success={part.success}

--- a/frontend/src/components/documents/previews/ProjectPreview.tsx
+++ b/frontend/src/components/documents/previews/ProjectPreview.tsx
@@ -1,0 +1,347 @@
+import { useState, useMemo } from "react";
+import {
+  SandpackProvider,
+  SandpackLayout,
+  SandpackPreview,
+  SandpackCodeEditor,
+  SandpackFileExplorer,
+} from "@codesandbox/sandpack-react";
+import { useTranslation } from "react-i18next";
+import {
+  Play,
+  Code2,
+  FolderTree,
+  ExternalLink,
+  Maximize2,
+  Minimize2,
+  X,
+  AlertCircle,
+} from "lucide-react";
+import { clsx } from "clsx";
+
+// Sandpack 支持的模板类型（精简版）
+type SandpackTemplate =
+  | "react"
+  | "vue"
+  | "vanilla"
+  | "angular"
+  | "svelte"
+  | "solid"
+  | "node"
+  | "nextjs";
+
+// 项目模板映射
+const TEMPLATE_MAP: Record<string, SandpackTemplate> = {
+  react: "react",
+  vue: "vue",
+  vanilla: "vanilla",
+  static: "vanilla",
+};
+
+interface ProjectPreviewProps {
+  name: string;
+  template: string;
+  files: Record<string, string>;
+  entry?: string;
+  onClose?: () => void;
+  showHeader?: boolean;
+}
+
+// 自定义布局组件
+function CustomLayout({
+  showExplorer,
+  showEditor,
+  showPreview,
+}: {
+  showExplorer: boolean;
+  showEditor: boolean;
+  showPreview: boolean;
+}) {
+  return (
+    <SandpackLayout className="!h-full !min-h-[400px]">
+      {/* 文件浏览器 */}
+      {showExplorer && (
+        <SandpackFileExplorer
+          className="!w-48 shrink-0"
+          autoHiddenFiles={false}
+        />
+      )}
+
+      {/* 代码编辑器 */}
+      {showEditor && (
+        <SandpackCodeEditor
+          className="flex-1 !min-w-0"
+          showTabs
+          showLineNumbers
+          showInlineErrors
+          showRunButton={false}
+        />
+      )}
+
+      {/* 预览 */}
+      {showPreview && (
+        <SandpackPreview
+          className="flex-1 !min-w-0"
+          showNavigator
+          showRefreshButton
+          showOpenInCodeSandbox={false}
+        />
+      )}
+    </SandpackLayout>
+  );
+}
+
+export default function ProjectPreview({
+  name,
+  template,
+  files,
+  entry,
+  onClose,
+  showHeader = true,
+}: ProjectPreviewProps) {
+  const { t } = useTranslation();
+  const [activeTab, setActiveTab] = useState<"preview" | "code">("preview");
+  const [showExplorer, setShowExplorer] = useState(true);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  // 检测并转换文件格式
+  const sandpackFiles = useMemo(() => {
+    const result: Record<string, string> = {};
+
+    for (const [path, content] of Object.entries(files)) {
+      // 确保路径以 / 开头
+      const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+      result[normalizedPath] = content;
+    }
+
+    return result;
+  }, [files]);
+
+  // 获取 Sandpack 模板
+  const sandpackTemplate = TEMPLATE_MAP[template] || "vanilla";
+
+  // 获取入口文件
+  const entryFile = useMemo(() => {
+    if (entry) return entry;
+    if (sandpackFiles["/index.html"]) return "/index.html";
+    if (sandpackFiles["/App.jsx"]) return "/App.jsx";
+    if (sandpackFiles["/App.tsx"]) return "/App.tsx";
+    if (sandpackFiles["/main.js"]) return "/main.js";
+    return Object.keys(sandpackFiles)[0] || "/index.js";
+  }, [entry, sandpackFiles]);
+
+  // 文件数量
+  const fileCount = Object.keys(sandpackFiles).length;
+
+  if (fileCount === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 gap-4">
+        <AlertCircle size={32} className="text-amber-500" />
+        <p className="text-sm text-stone-500 dark:text-stone-400">
+          {t("project.noFiles", "没有可预览的文件")}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={clsx(
+        "flex flex-col bg-white dark:bg-stone-900 overflow-hidden",
+        isFullscreen
+          ? "fixed inset-0 z-[300]"
+          : "h-full min-h-[500px] rounded-xl border border-stone-200 dark:border-stone-700"
+      )}
+    >
+      {/* 工具栏 */}
+      {showHeader && (
+        <div className="flex items-center justify-between px-4 py-3 border-b border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-900 shrink-0">
+          {/* 左侧：项目信息 */}
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-lg bg-gradient-to-br from-blue-500 to-purple-500 text-white">
+              <Code2 size={18} />
+            </div>
+            <div>
+              <h3 className="text-sm font-semibold text-stone-900 dark:text-stone-100">
+                {name || t("project.untitled", "未命名项目")}
+              </h3>
+              <p className="text-xs text-stone-500 dark:text-stone-400">
+                {t("project.fileCount", "{{count}} 个文件", { count: fileCount })}
+                {template !== "static" && ` · ${template}`}
+              </p>
+            </div>
+          </div>
+
+          {/* 中间：标签切换 */}
+          <div className="flex items-center gap-1 bg-stone-100 dark:bg-stone-800 rounded-lg p-1">
+            <button
+              onClick={() => setActiveTab("preview")}
+              className={clsx(
+                "flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors",
+                activeTab === "preview"
+                  ? "bg-white dark:bg-stone-700 text-stone-900 dark:text-stone-100 shadow-sm"
+                  : "text-stone-500 dark:text-stone-400 hover:text-stone-700 dark:hover:text-stone-300"
+              )}
+            >
+              <Play size={14} />
+              <span>{t("project.preview", "预览")}</span>
+            </button>
+            <button
+              onClick={() => setActiveTab("code")}
+              className={clsx(
+                "flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors",
+                activeTab === "code"
+                  ? "bg-white dark:bg-stone-700 text-stone-900 dark:text-stone-100 shadow-sm"
+                  : "text-stone-500 dark:text-stone-400 hover:text-stone-700 dark:hover:text-stone-300"
+              )}
+            >
+              <Code2 size={14} />
+              <span>{t("project.code", "代码")}</span>
+            </button>
+          </div>
+
+          {/* 右侧：操作按钮 */}
+          <div className="flex items-center gap-1">
+            {/* 文件浏览器切换 */}
+            <button
+              onClick={() => setShowExplorer(!showExplorer)}
+              className={clsx(
+                "p-2 rounded-lg transition-colors",
+                showExplorer
+                  ? "bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400"
+                  : "text-stone-400 dark:text-stone-500 hover:bg-stone-100 dark:hover:bg-stone-800"
+              )}
+              title={t("project.toggleExplorer", "切换文件浏览器")}
+            >
+              <FolderTree size={18} />
+            </button>
+
+            {/* 全屏按钮 */}
+            <button
+              onClick={() => setIsFullscreen(!isFullscreen)}
+              className="p-2 rounded-lg text-stone-400 dark:text-stone-500 hover:bg-stone-100 dark:hover:bg-stone-800 transition-colors"
+              title={isFullscreen ? t("project.exitFullscreen") : t("project.fullscreen")}
+            >
+              {isFullscreen ? <Minimize2 size={18} /> : <Maximize2 size={18} />}
+            </button>
+
+            {/* 关闭按钮 */}
+            {onClose && (
+              <button
+                onClick={onClose}
+                className="p-2 rounded-lg text-stone-400 dark:text-stone-500 hover:bg-stone-100 dark:hover:bg-stone-800 transition-colors"
+                title={t("common.close")}
+              >
+                <X size={18} />
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Sandpack 区域 */}
+      <div className="flex-1 min-h-0">
+        <SandpackProvider
+          template={sandpackTemplate}
+          files={sandpackFiles}
+          theme="dark"
+          options={{
+            activeFile: entryFile,
+            classes: {
+              "sp-wrapper": "!h-full !flex !flex-col",
+              "sp-layout": "!h-full !border-0",
+            },
+          }}
+        >
+          <CustomLayout
+            showExplorer={showExplorer}
+            showEditor={activeTab === "code" || true}
+            showPreview={activeTab === "preview" || true}
+          />
+        </SandpackProvider>
+      </div>
+    </div>
+  );
+}
+
+// 导出一个简化版本，用于嵌入消息
+export function ProjectPreviewCompact({
+  name,
+  template,
+  files,
+  onExpand,
+}: {
+  name: string;
+  template: string;
+  files: Record<string, string>;
+  onExpand?: () => void;
+}) {
+  const { t } = useTranslation();
+  const fileCount = Object.keys(files).length;
+  const sandpackTemplate = TEMPLATE_MAP[template] || "vanilla";
+
+  // 获取入口文件
+  const entryFile = files["/index.html"]
+    ? "/index.html"
+    : files["/App.jsx"]
+      ? "/App.jsx"
+      : Object.keys(files)[0] || "/index.js";
+
+  return (
+    <div className="my-2 sm:my-3">
+      <div className="border border-stone-200 dark:border-stone-700 rounded-xl overflow-hidden bg-white dark:bg-stone-900">
+        {/* 工具栏 */}
+        <div className="flex items-center justify-between px-4 py-3 bg-stone-50 dark:bg-stone-800/50 border-b border-stone-200 dark:border-stone-700">
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-lg bg-gradient-to-br from-blue-500 to-purple-500 text-white">
+              <Code2 size={16} />
+            </div>
+            <div>
+              <h4 className="text-sm font-medium text-stone-900 dark:text-stone-100">
+                {name || t("project.untitled", "未命名项目")}
+              </h4>
+              <p className="text-xs text-stone-500 dark:text-stone-400">
+                {t("project.fileCount", "{{count}} 个文件", { count: fileCount })}
+              </p>
+            </div>
+          </div>
+
+          {onExpand && (
+            <button
+              onClick={onExpand}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-blue-500 hover:bg-blue-600 text-white text-xs font-medium transition-colors"
+            >
+              <ExternalLink size={14} />
+              <span>{t("project.expand", "展开预览")}</span>
+            </button>
+          )}
+        </div>
+
+        {/* 预览区域 */}
+        <div className="h-[400px]">
+          <SandpackProvider
+            template={sandpackTemplate}
+            files={files}
+            theme="dark"
+            options={{
+              activeFile: entryFile,
+              classes: {
+                "sp-wrapper": "!h-full",
+                "sp-layout": "!h-full !border-0",
+              },
+            }}
+          >
+            <SandpackLayout className="!h-full !min-h-[400px]">
+              <SandpackPreview
+                className="flex-1"
+                showNavigator
+                showRefreshButton
+                showOpenInCodeSandbox={false}
+              />
+            </SandpackLayout>
+          </SandpackProvider>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -213,6 +213,22 @@
     "showing": "Showing {{start}}-{{end}}",
     "skip": "Skip"
   },
+  "project": {
+    "untitled": "Untitled Project",
+    "fileCount": "{{count}} files",
+    "preview": "Preview",
+    "code": "Code",
+    "reset": "Reset",
+    "resetFiles": "Reset files",
+    "toggleExplorer": "Toggle file explorer",
+    "fullscreen": "Fullscreen",
+    "exitFullscreen": "Exit fullscreen",
+    "expand": "Expand",
+    "loading": "Loading project...",
+    "error": "Failed to load project",
+    "empty": "Empty project",
+    "noFiles": "No files to preview"
+  },
   "documents": {
     "ascending": "Ascending",
     "binary": "Binary file",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -213,6 +213,22 @@
     "showing": "显示第 {{start}}-{{end}} 条",
     "skip": "跳过"
   },
+  "project": {
+    "untitled": "未命名项目",
+    "fileCount": "{{count}} 个文件",
+    "preview": "预览",
+    "code": "代码",
+    "reset": "重置",
+    "resetFiles": "重置文件",
+    "toggleExplorer": "切换文件浏览器",
+    "fullscreen": "全屏",
+    "exitFullscreen": "退出全屏",
+    "expand": "展开",
+    "loading": "加载项目中...",
+    "error": "项目加载失败",
+    "empty": "空项目",
+    "noFiles": "没有找到可预览的文件"
+  },
   "documents": {
     "ascending": "升序",
     "binary": "二进制文件",

--- a/src/agents/fast_agent/context.py
+++ b/src/agents/fast_agent/context.py
@@ -13,6 +13,7 @@ from src.infra.tool.add_skill_tool import get_add_skill_tool
 from src.infra.tool.human_tool import get_human_tool
 from src.infra.tool.mcp_client import MCPClientManager
 from src.infra.tool.reveal_file_tool import get_reveal_file_tool
+from src.infra.tool.reveal_project_tool import get_reveal_project_tool
 from src.kernel.config import settings
 
 logger = logging.getLogger(__name__)
@@ -102,6 +103,10 @@ class FastAgentContext:
         reveal_file_tool = get_reveal_file_tool()
         self.tools.append(reveal_file_tool)
         logger.info("[FastAgentContext] Added reveal_file tool")
+
+        reveal_project_tool = get_reveal_project_tool()
+        self.tools.append(reveal_project_tool)
+        logger.info("[FastAgentContext] Added reveal_project tool")
 
         add_skill_tool = get_add_skill_tool()
         self.tools.append(add_skill_tool)

--- a/src/agents/search_agent/context.py
+++ b/src/agents/search_agent/context.py
@@ -15,6 +15,7 @@ from src.infra.tool.mcp_client import MCPClientManager
 
 # Reveal File 工具 - 向用户展示文件
 from src.infra.tool.reveal_file_tool import get_reveal_file_tool
+from src.infra.tool.reveal_project_tool import get_reveal_project_tool
 from src.kernel.config import settings
 
 logger = logging.getLogger(__name__)
@@ -109,6 +110,10 @@ class AgentContext:
         reveal_file_tool = get_reveal_file_tool()
         self.tools.append(reveal_file_tool)
         logger.info("[AgentContext] Added reveal_file tool")
+
+        reveal_project_tool = get_reveal_project_tool()
+        self.tools.append(reveal_project_tool)
+        logger.info("[AgentContext] Added reveal_project tool")
 
         add_skill_tool = get_add_skill_tool()
         self.tools.append(add_skill_tool)

--- a/src/infra/tool/reveal_project_tool.py
+++ b/src/infra/tool/reveal_project_tool.py
@@ -230,11 +230,14 @@ async def reveal_project(
 
     if backend is None:
         logger.warning("Backend not available from runtime")
-        return json.dumps({
-            "type": "project_reveal",
-            "error": "backend_not_available",
-            "message": "无法访问文件系统",
-        }, ensure_ascii=False)
+        return json.dumps(
+            {
+                "type": "project_reveal",
+                "error": "backend_not_available",
+                "message": "无法访问文件系统",
+            },
+            ensure_ascii=False,
+        )
 
     # 规范化路径
     project_path = project_path.rstrip("/")
@@ -252,7 +255,7 @@ async def reveal_project(
                 # 计算相对路径
                 rel_path = file_path
                 if rel_path.startswith(project_path):
-                    rel_path = rel_path[len(project_path):]
+                    rel_path = rel_path[len(project_path) :]
                 if not rel_path.startswith("/"):
                     rel_path = "/" + rel_path
 
@@ -286,10 +289,22 @@ async def reveal_project(
         # 方式2: 如果 backend 没有 list，尝试读取常见文件
         else:
             common_files = [
-                "index.html", "index.js", "index.jsx", "index.ts", "index.tsx",
-                "App.js", "App.jsx", "App.ts", "App.tsx",
-                "main.js", "main.jsx", "main.ts", "main.tsx",
-                "styles.css", "style.css", "App.css",
+                "index.html",
+                "index.js",
+                "index.jsx",
+                "index.ts",
+                "index.tsx",
+                "App.js",
+                "App.jsx",
+                "App.ts",
+                "App.tsx",
+                "main.js",
+                "main.jsx",
+                "main.ts",
+                "main.tsx",
+                "styles.css",
+                "style.css",
+                "App.css",
                 "package.json",
             ]
 
@@ -304,11 +319,14 @@ async def reveal_project(
                         continue
 
         if not project_files:
-            return json.dumps({
-                "type": "project_reveal",
-                "error": "no_files_found",
-                "message": f"在 {project_path} 中没有找到前端文件",
-            }, ensure_ascii=False)
+            return json.dumps(
+                {
+                    "type": "project_reveal",
+                    "error": "no_files_found",
+                    "message": f"在 {project_path} 中没有找到前端文件",
+                },
+                ensure_ascii=False,
+            )
 
         # 检测或使用指定的模板
         detected_template = template or detect_template(project_files)
@@ -337,11 +355,14 @@ async def reveal_project(
 
     except Exception as e:
         logger.error(f"Error revealing project {project_path}: {e}")
-        return json.dumps({
-            "type": "project_reveal",
-            "error": str(e),
-            "message": f"读取项目失败: {e}",
-        }, ensure_ascii=False)
+        return json.dumps(
+            {
+                "type": "project_reveal",
+                "error": str(e),
+                "message": f"读取项目失败: {e}",
+            },
+            ensure_ascii=False,
+        )
 
 
 def get_reveal_project_tool() -> BaseTool:

--- a/src/infra/tool/reveal_project_tool.py
+++ b/src/infra/tool/reveal_project_tool.py
@@ -27,7 +27,6 @@ Reveal Project 工具
 import json
 import logging
 import os
-from pathlib import Path
 from typing import Any, Literal, Optional
 
 from langchain.tools import ToolRuntime, tool

--- a/src/infra/tool/reveal_project_tool.py
+++ b/src/infra/tool/reveal_project_tool.py
@@ -1,0 +1,350 @@
+"""
+Reveal Project 工具
+
+让 Agent 可以向用户展示整个前端项目（多文件），前端使用 Sandpack 进行预览。
+支持纯 HTML/CSS/JS 项目和 React/Vue 等框架项目。
+
+工作流程：
+1. Agent 调用 reveal_project 指定项目目录
+2. 后端扫描目录，读取所有文件内容
+3. 上传到 S3（可选，用于持久化）
+4. 返回项目结构给前端
+5. 前端用 Sandpack 渲染
+
+返回格式：
+{
+    "type": "project_reveal",
+    "name": "项目名称",
+    "template": "react" | "vue" | "vanilla" | "static",
+    "files": {
+        "/App.js": "内容...",
+        "/styles.css": "内容...",
+    },
+    "entry": "/index.html"  // 入口文件
+}
+"""
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Literal, Optional
+
+from langchain.tools import ToolRuntime, tool
+from langchain_core.tools import BaseTool
+
+from src.infra.tool.backend_utils import get_backend_from_runtime
+
+logger = logging.getLogger(__name__)
+
+# 支持的项目模板类型
+ProjectTemplate = Literal["react", "vue", "vanilla", "static"]
+
+# 常见的前端文件扩展名
+FRONTEND_EXTENSIONS = {
+    ".html",
+    ".css",
+    ".js",
+    ".jsx",
+    ".ts",
+    ".tsx",
+    ".vue",
+    ".json",
+    ".svg",
+    ".md",
+}
+
+# 需要忽略的目录和文件
+IGNORE_PATTERNS = {
+    "node_modules",
+    ".git",
+    ".venv",
+    "__pycache__",
+    ".DS_Store",
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    ".env",
+    ".env.local",
+    ".env.development",
+    ".env.production",
+}
+
+# 二进制文件扩展名（不读取内容）
+BINARY_EXTENSIONS = {
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".ico",
+    ".woff",
+    ".woff2",
+    ".ttf",
+    ".eot",
+    ".mp3",
+    ".mp4",
+    ".webm",
+    ".zip",
+}
+
+
+def detect_template(files: dict[str, str]) -> ProjectTemplate:
+    """根据文件内容检测项目模板类型"""
+    has_package_json = "/package.json" in files
+    has_index_html = "/index.html" in files
+
+    if has_package_json:
+        package_content = files.get("/package.json", "{}")
+        try:
+            package = json.loads(package_content)
+            deps = package.get("dependencies", {})
+            dev_deps = package.get("devDependencies", {})
+
+            # 检查是否有 React
+            if "react" in deps or "react" in dev_deps:
+                return "react"
+            # 检查是否有 Vue
+            if "vue" in deps or "vue" in dev_deps:
+                return "vue"
+        except json.JSONDecodeError:
+            pass
+
+    # 纯 HTML/CSS/JS 项目
+    if has_index_html:
+        return "vanilla"
+
+    return "static"
+
+
+def should_ignore(name: str) -> bool:
+    """检查是否应该忽略该文件/目录"""
+    if name.startswith("."):
+        return True
+    return name in IGNORE_PATTERNS
+
+
+def is_text_file(ext: str) -> bool:
+    """检查是否是文本文件"""
+    return ext.lower() in FRONTEND_EXTENSIONS or ext.lower() == ".json"
+
+
+def is_binary_file(ext: str) -> bool:
+    """检查是否是二进制文件"""
+    return ext.lower() in BINARY_EXTENSIONS
+
+
+async def _read_file_from_backend(backend: Any, file_path: str) -> Optional[bytes]:
+    """从 backend 读取文件内容（复用 reveal_file_tool 的逻辑）"""
+    # 方式1: 沙箱模式 - 使用 download_files
+    if hasattr(backend, "adownload_files"):
+        try:
+            download_responses = await backend.adownload_files([file_path])
+            if download_responses and download_responses[0].content:
+                return download_responses[0].content
+        except Exception as e:
+            logger.debug(f"adownload_files failed for {file_path}: {e}")
+
+    if hasattr(backend, "download_files"):
+        try:
+            download_responses = backend.download_files([file_path])
+            if download_responses and download_responses[0].content:
+                return download_responses[0].content
+        except Exception as e:
+            logger.debug(f"download_files failed for {file_path}: {e}")
+
+    # 方式2: 非沙箱模式
+    if hasattr(backend, "read"):
+        try:
+            content = backend.read(file_path)
+            if content is not None:
+                if isinstance(content, str):
+                    return content.encode("utf-8")
+                elif isinstance(content, bytes):
+                    return content
+        except Exception as e:
+            logger.debug(f"read failed for {file_path}: {e}")
+
+    # 方式3: 异步读取
+    if hasattr(backend, "aread"):
+        try:
+            content = await backend.aread(file_path)
+            if content is not None:
+                if isinstance(content, str):
+                    return content.encode("utf-8")
+                elif isinstance(content, bytes):
+                    return content
+        except Exception as e:
+            logger.debug(f"aread failed for {file_path}: {e}")
+
+    return None
+
+
+def _list_files_from_backend(backend: Any, dir_path: str) -> list[str]:
+    """列出目录下的所有文件"""
+    files = []
+
+    # 方式1: 使用 list 方法
+    if hasattr(backend, "list"):
+        try:
+            items = backend.list(dir_path)
+            for item in items:
+                if isinstance(item, dict):
+                    path = item.get("path", "")
+                    is_dir = item.get("is_dir", False) or item.get("type") == "directory"
+                else:
+                    path = str(item)
+                    is_dir = False
+
+                if path and not is_dir:
+                    files.append(path)
+        except Exception as e:
+            logger.debug(f"list failed for {dir_path}: {e}")
+
+    return files
+
+
+@tool
+async def reveal_project(
+    project_path: str,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    template: Optional[ProjectTemplate] = None,
+    runtime: ToolRuntime = None,  # type: ignore[assignment]
+) -> str:
+    """
+    向用户展示一个前端项目（多文件预览）
+
+    当 AI 生成了包含多个文件的前端项目（HTML/CSS/JS 或 React/Vue 项目）时，
+    使用此工具让用户可以在沙箱环境中预览整个项目。
+
+    Args:
+        project_path: 项目目录路径（包含 index.html 或 package.json 的目录）
+        name: 项目名称（可选，默认使用目录名）
+        description: 项目描述（可选）
+        template: 项目模板类型（可选，自动检测：react/vue/vanilla/static）
+        runtime: 工具运行时（自动注入）
+
+    Returns:
+        JSON 格式的项目信息，包含所有文件内容
+    """
+    backend = get_backend_from_runtime(runtime)
+
+    if backend is None:
+        logger.warning("Backend not available from runtime")
+        return json.dumps({
+            "type": "project_reveal",
+            "error": "backend_not_available",
+            "message": "无法访问文件系统",
+        }, ensure_ascii=False)
+
+    # 规范化路径
+    project_path = project_path.rstrip("/")
+    project_name = name or os.path.basename(project_path)
+
+    try:
+        # 收集项目文件
+        project_files: dict[str, str] = {}
+
+        # 方式1: 如果 backend 支持 list，递归扫描
+        if hasattr(backend, "list"):
+            files = _list_files_from_backend(backend, project_path)
+
+            for file_path in files:
+                # 计算相对路径
+                rel_path = file_path
+                if rel_path.startswith(project_path):
+                    rel_path = rel_path[len(project_path):]
+                if not rel_path.startswith("/"):
+                    rel_path = "/" + rel_path
+
+                # 检查是否应该忽略
+                parts = rel_path.split("/")
+                if any(should_ignore(part) for part in parts):
+                    continue
+
+                # 检查文件扩展名
+                ext = os.path.splitext(rel_path)[1].lower()
+
+                if is_binary_file(ext):
+                    # 跳过二进制文件
+                    logger.debug(f"Skipping binary file: {rel_path}")
+                    continue
+
+                if not is_text_file(ext):
+                    # 跳过非前端文件
+                    continue
+
+                # 读取文件内容
+                content_bytes = await _read_file_from_backend(backend, file_path)
+                if content_bytes:
+                    try:
+                        content = content_bytes.decode("utf-8")
+                        project_files[rel_path] = content
+                    except UnicodeDecodeError:
+                        logger.debug(f"Failed to decode file as UTF-8: {rel_path}")
+                        continue
+
+        # 方式2: 如果 backend 没有 list，尝试读取常见文件
+        else:
+            common_files = [
+                "index.html", "index.js", "index.jsx", "index.ts", "index.tsx",
+                "App.js", "App.jsx", "App.ts", "App.tsx",
+                "main.js", "main.jsx", "main.ts", "main.tsx",
+                "styles.css", "style.css", "App.css",
+                "package.json",
+            ]
+
+            for filename in common_files:
+                file_path = f"{project_path}/{filename}"
+                content_bytes = await _read_file_from_backend(backend, file_path)
+                if content_bytes:
+                    try:
+                        content = content_bytes.decode("utf-8")
+                        project_files[f"/{filename}"] = content
+                    except UnicodeDecodeError:
+                        continue
+
+        if not project_files:
+            return json.dumps({
+                "type": "project_reveal",
+                "error": "no_files_found",
+                "message": f"在 {project_path} 中没有找到前端文件",
+            }, ensure_ascii=False)
+
+        # 检测或使用指定的模板
+        detected_template = template or detect_template(project_files)
+
+        # 查找入口文件
+        entry = None
+        if "/index.html" in project_files:
+            entry = "/index.html"
+        elif f"/{detected_template == 'react' and 'App.jsx' or 'main.js'}" in project_files:
+            entry = "/App.jsx" if detected_template == "react" else "/main.js"
+
+        # 构建返回结果
+        result = {
+            "type": "project_reveal",
+            "name": project_name,
+            "description": description or "",
+            "template": detected_template,
+            "files": project_files,
+            "entry": entry,
+            "path": project_path,
+            "file_count": len(project_files),
+        }
+
+        logger.info(f"Revealed project {project_name} with {len(project_files)} files")
+        return json.dumps(result, ensure_ascii=False)
+
+    except Exception as e:
+        logger.error(f"Error revealing project {project_path}: {e}")
+        return json.dumps({
+            "type": "project_reveal",
+            "error": str(e),
+            "message": f"读取项目失败: {e}",
+        }, ensure_ascii=False)
+
+
+def get_reveal_project_tool() -> BaseTool:
+    """获取 reveal_project 工具实例"""
+    return reveal_project


### PR DESCRIPTION
## Summary

- Add `reveal_project` tool to scan and return project files
- Add `ProjectPreview` component using Sandpack for in-browser preview
- Add `ProjectRevealItem` to render `reveal_project` results in chat
- Support react/vue/vanilla templates with auto-detection
- Add i18n translations for project preview UI

## Problem

When AI generates multi-file frontend projects (HTML/CSS/JS or React/Vue),
users could not preview them directly. They had to:
1. Download all files
2. Run a local server
3. Or manually open HTML files (which doesn't work for external CSS/JS)

## Solution

Use **Sandpack** (@codesandbox/sandpack-react) to run the project entirely in the browser:
- File explorer + code editor + live preview
- No backend server needed
- Supports React, Vue, vanilla HTML/CSS/JS
- Full-screen expand mode

## Usage

AI calls `reveal_project` tool:

```
reveal_project(
  project_path="/workspace/my-project",
  name="我的项目",
  template="react"  # optional, auto-detected
)
```

Users see an interactive preview with:
- File browser
- Code editor
- Live preview

## Files Changed

### Backend
- `src/infra/tool/reveal_project_tool.py` - New tool to scan projects
- `src/agents/fast_agent/context.py` - Register tool
- `src/agents/search_agent/context.py` - Register tool

### Frontend
- `frontend/src/components/documents/previews/ProjectPreview.tsx` - Sandpack component
- `frontend/src/components/chat/ChatMessage/ToolCallItem.tsx` - ProjectRevealItem
- `frontend/src/components/chat/ChatMessage/index.tsx` - Handle reveal_project
- `frontend/src/i18n/locales/*.json` - Translations

## Dependencies

- Added: @codesandbox/sandpack-react
- Added: @codesandbox/sandpack-themes