### PR TITLE
fix: 修复 MCP 加密密钥派生导致的解密失败

### DIFF
--- a/src/infra/mcp/encryption.py
+++ b/src/infra/mcp/encryption.py
@@ -30,6 +30,18 @@ class DecryptionError(Exception):
     pass
 
 
+def _get_fernet_legacy() -> Fernet:
+    """
+    获取旧版Fernet加密实例（向后兼容）
+    
+    使用单次 SHA256 哈希派生密钥（PR #52 之前的方式）
+    仅用于解密旧数据，不用于新加密。
+    """
+    key = hashlib.sha256(settings.JWT_SECRET_KEY.encode()).digest()
+    fernet_key = base64.urlsafe_b64encode(key)
+    return Fernet(fernet_key)
+
+
 def _get_fernet() -> Fernet:
     """
     获取Fernet加密实例，使用PBKDF2从JWT_SECRET_KEY派生密钥
@@ -94,6 +106,10 @@ def decrypt_value(value: Any) -> Any:
     1. 加密格式: {"__encrypted__": "base64_encoded_data"}
     2. 明文格式: {"key": "value"}
 
+    支持向后兼容：
+    - 先尝试新密钥（PBKDF2）解密
+    - 失败后尝试旧密钥（SHA256）解密
+
     Args:
         value: 要解密的值
 
@@ -115,19 +131,24 @@ def decrypt_value(value: Any) -> Any:
         if not encrypted_str:
             return value
 
+        encrypted_bytes = base64.b64decode(encrypted_str.encode("utf-8"))
+
+        # 先尝试新密钥（PBKDF2）
         try:
             fernet = _get_fernet()
-            # 解码
-            encrypted_bytes = base64.b64decode(encrypted_str.encode("utf-8"))
-            # 解密
             decrypted_bytes = fernet.decrypt(encrypted_bytes)
-            # 反序列化为dict
             return json.loads(decrypted_bytes.decode("utf-8"))
-        except Exception as e:
-            # 解密失败 - 抛出异常让调用方决定如何处理
-            # 不再静默返回空字典，避免调用方误以为配置为空
-            logger.error(f"解密失败: {e}")
-            raise DecryptionError(f"解密失败: {e}") from e
+        except Exception:
+            # 新密钥失败，尝试旧密钥（SHA256）向后兼容
+            try:
+                fernet_legacy = _get_fernet_legacy()
+                decrypted_bytes = fernet_legacy.decrypt(encrypted_bytes)
+                logger.info("使用旧版密钥解密成功，建议重新保存配置以使用新密钥")
+                return json.loads(decrypted_bytes.decode("utf-8"))
+            except Exception as e:
+                # 两种密钥都失败
+                logger.error(f"解密失败（尝试了新旧密钥）: {e}")
+                raise DecryptionError(f"解密失败: {e}") from e
 
     # 明文格式（向后兼容）
     return value

--- a/src/infra/mcp/encryption.py
+++ b/src/infra/mcp/encryption.py
@@ -33,7 +33,7 @@ class DecryptionError(Exception):
 def _get_fernet_legacy() -> Fernet:
     """
     获取旧版Fernet加密实例（向后兼容）
-    
+
     使用单次 SHA256 哈希派生密钥（PR #52 之前的方式）
     仅用于解密旧数据，不用于新加密。
     """


### PR DESCRIPTION
## 问题
PR #52 修改了密钥派生方式（从 SHA256 改为 PBKDF2），导致无法解密数据库中已存在的旧数据，引发 `DecryptionError`。

```
2026-03-11 12:21:33.904 [ERROR] src.infra.mcp.encryption - 解密失败: 
src.infra.mcp.encryption.DecryptionError: 解密失败: 
```

## 解决方案
1. **添加 `_get_fernet_legacy()` 函数**
   - 保留旧版 SHA256 密钥派生
   - 仅用于解密旧数据，不用于新加密

2. **修改 `decrypt_value()` 支持向后兼容**
   - 先尝试新密钥（PBKDF2）解密
   - 失败后尝试旧密钥（SHA256）解密
   - 新加密数据继续使用 PBKDF2

## 代码变更
**文件**: `src/infra/mcp/encryption.py`

**新增函数**:
```python
def _get_fernet_legacy() -> Fernet:
    """旧版 SHA256 密钥派生（向后兼容）"""
    key = hashlib.sha256(settings.JWT_SECRET_KEY.encode()).digest()
    ...
```

**修改逻辑**:
```python
def decrypt_value(value: Any) -> Any:
    # 先尝试新密钥（PBKDF2）
    try:
        fernet = _get_fernet()
        decrypted_bytes = fernet.decrypt(encrypted_bytes)
        return json.loads(decrypted_bytes.decode("utf-8"))
    except Exception:
        # 新密钥失败，尝试旧密钥（SHA256）
        fernet_legacy = _get_fernet_legacy()
        decrypted_bytes = fernet_legacy.decrypt(encrypted_bytes)
        logger.info("使用旧版密钥解密成功")
        ...
```

## 影响
- ✅ **旧数据可以正常解密**（使用 SHA256 密钥）
- ✅ **新数据使用更安全的 PBKDF2 密钥**
- ✅ **无需手动迁移数据库**
- ✅ **零停机时间**

## 测试
- ✅ 语法检查通过
- ✅ 向后兼容验证
- ✅ 新旧密钥双重支持

## 相关 Issue
用户报告：2026-03-11 12:21 后端日志显示解密失败