### PR TITLE
fix(tool): 修复 reveal_project 无法读取 Daytona 沙箱文件的问题

### DIFF
--- a/src/infra/tool/reveal_project_tool.py
+++ b/src/infra/tool/reveal_project_tool.py
@@ -225,6 +225,9 @@ async def _run_command(backend: Any, command: str) -> Optional[str]:
     if hasattr(backend, "aexecute"):
         try:
             result = await backend.aexecute(command)
+            # ExecuteResponse 对象（有 output 属性）
+            if hasattr(result, "output"):
+                return result.output
             if isinstance(result, dict):
                 return result.get("output", result.get("stdout", ""))
             elif isinstance(result, str):
@@ -235,6 +238,9 @@ async def _run_command(backend: Any, command: str) -> Optional[str]:
     if hasattr(backend, "execute"):
         try:
             result = backend.execute(command)
+            # ExecuteResponse 对象（有 output 属性）
+            if hasattr(result, "output"):
+                return result.output
             if isinstance(result, dict):
                 return result.get("output", result.get("stdout", ""))
             elif isinstance(result, str):


### PR DESCRIPTION
## Summary
- 修复 `_run_command` 函数无法正确处理 Daytona backend `ExecuteResponse` 对象的问题
- Daytona backend 的 `execute()` 返回的是 `ExecuteResponse` 对象（有 `output` 属性），而不是 `dict` 或 `str`
- 原代码只检查了 `dict` 和 `str` 类型，导致返回 `None`，最终报 `no_files_found` 错误

## 修改内容
在 `aexecute` 和 `execute` 处理中添加对带有 `output` 属性对象的检查：
```python
if hasattr(result, "output"):
    return result.output
```

## 测试计划
- [ ] 在 Daytona 沙箱环境中测试 `reveal_project` 工具
- [ ] 验证可以正确读取项目文件并返回给前端预览