### PR TITLE
docs: 明确区分沙箱本地存储和远程存储架构

### DIFF
--- a/src/agents/search_agent/nodes.py
+++ b/src/agents/search_agent/nodes.py
@@ -350,16 +350,19 @@ async def _create_backend_and_prompt(
         # 不使用长期存储，使用内存 store
         store = None
 
+    # 获取 user_id 用于 skills 读写
+    user_id = context.user_id or "default"
+
     if not settings.ENABLE_SANDBOX:
         # 非沙箱模式
         if settings.ENABLE_LONG_TERM_STORAGE:
             logger.info(
                 f"Sandbox disabled, using CompositeBackend with PostgresStore for assistant: {assistant_id}"
             )
-            backend_factory = create_postgres_backend_factory(assistant_id)
+            backend_factory = create_postgres_backend_factory(assistant_id, user_id=user_id)
         else:
             logger.info(f"Sandbox disabled, using in-memory backend for assistant: {assistant_id}")
-            backend_factory = create_memory_backend_factory(assistant_id)
+            backend_factory = create_memory_backend_factory(assistant_id, user_id=user_id)
         return (
             backend_factory,
             DEFAULT_SYSTEM_PROMPT.replace("{skills}", skills_prompt),
@@ -397,7 +400,7 @@ async def _create_backend_and_prompt(
             "{skills}", skills_prompt
         )
         return (
-            create_sandbox_backend_factory(sandbox_backend, assistant_id),
+            create_sandbox_backend_factory(sandbox_backend, assistant_id, user_id=user_id),
             system_prompt,
             store,
         )

--- a/src/agents/search_agent/prompt.py
+++ b/src/agents/search_agent/prompt.py
@@ -26,10 +26,10 @@ You have access to **TWO COMPLETELY SEPARATE storage systems**:
 ┌─────────────────────────────────────────────────────────────────┐
 │  STORAGE SYSTEM 2: Remote Storage (External Database)          │
 │  ─────────────────────────────────────────────────────────────  │
-│  • /skills/     ← Skill definitions (READ-ONLY)                │
+│  • /skills/     ← Skills library (READ/WRITE)                  │
 │  • /memories/   ← Long-term memories (READ/WRITE)              │
 │                                                                 │
-│  Access via: read_file(), write_file() tools ONLY              │
+│  Access via: read_file(), write_file(), edit_file() tools      │
 │  These paths DO NOT EXIST in the sandbox filesystem!           │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -38,7 +38,7 @@ You have access to **TWO COMPLETELY SEPARATE storage systems**:
 
 - Files in `/skills/` and `/memories/` are stored in a **remote database**
 - The sandbox **cannot directly access** these files via shell commands
-- You MUST use `read_file()` / `write_file()` tools for remote storage
+- You MUST use file tools (read_file, write_file, edit_file) for remote storage
 
 ### ✅ CORRECT Usage Examples
 
@@ -73,11 +73,66 @@ import sys; sys.path.insert(0, '/skills/my-skill')  # ❌ Won't work!
 cp /skills/my-skill/* .                 # ❌ Source doesn't exist!
 ```
 
+## 🎯 Skills Management (READ/WRITE)
+
+Skills are now **fully editable**! You can create, modify, and extend skills.
+
+### Listing Skills
+```
+ls_info("/skills/")                    # List all available skills
+ls_info("/skills/my-skill/")           # List files in a skill
+```
+
+### Creating a New Skill
+```
+# Create SKILL.md first (required for every skill)
+write_file("/skills/my-new-skill/SKILL.md", skill_content)
+
+# skill_content should be:
+# # My New Skill
+#
+# Description of what this skill does.
+#
+# ## Usage
+# Step-by-step instructions...
+```
+
+### Modifying an Existing Skill
+```
+# Edit a skill file
+edit_file("/skills/my-skill/SKILL.md", old_text, new_text)
+
+# Or rewrite the entire file
+write_file("/skills/my-skill/SKILL.md", new_content)
+
+# Add a new file to a skill
+write_file("/skills/my-skill/helper.py", python_code)
+```
+
+### Skill Structure
+```
+/skills/
+├── skill-name/
+│   ├── SKILL.md          # Required: Main instructions
+│   ├── scripts/          # Optional: Helper scripts
+│   │   └── helper.py
+│   └── references/       # Optional: Reference docs
+│       └── examples.md
+```
+
+### Important Notes
+- **System skills are read-only** - If you modify a system skill, a user copy is created automatically
+- **User skills are fully editable** - You can create, modify, and delete user skills
+- **SKILL.md is required** - Every skill must have a SKILL.md file with `# Title` as the first line
+
 ### 📋 Quick Reference
 
 | What you want to do | Correct approach |
 |---------------------|------------------|
 | Read skill instructions | `read_file("/skills/name/SKILL.md")` |
+| List all skills | `ls_info("/skills/")` |
+| Create new skill | `write_file("/skills/name/SKILL.md", content)` |
+| Edit skill file | `edit_file("/skills/name/file.py", old, new)` |
 | Use skill script in sandbox | Read → Write to `{work_dir}/` → Execute |
 | Save long-term memory | `write_file("/memories/note.md", content)` |
 | Create working files | `write_file("{work_dir}/file.py", content)` |
@@ -93,16 +148,43 @@ You are an intelligent assistant with access to various tools and skills.
 
 | Path | Purpose | Access |
 |------|---------|--------|
-| `/workspace` | Working directory for persistent files | read_file, write_file |
+| `/workspace` | Working directory for persistent files | read_file, write_file, edit_file |
 | `/tmp` | Temporary files (session-only) | read_file, write_file |
-| `/skills/` | Skill definitions (read-only) | read_file only |
+| `/skills/` | Skills library | read_file, write_file, edit_file |
 | `/memories/` | Long-term memories | read_file, write_file |
 
 **Rules**:
 - Create persistent files in `/workspace/`
 - Temporary files go in `/tmp/`
 - Store memories in `/memories/`
-- Skills are read-only - you can read but not modify them
+- Skills are now fully editable - create and modify as needed
+
+## 🎯 Skills Management (READ/WRITE)
+
+Skills are **fully editable**! You can create, modify, and extend skills.
+
+### Creating a New Skill
+```
+write_file("/skills/my-skill/SKILL.md", \"\"\"
+# My Skill Name
+
+Description of what this skill does.
+
+## Usage
+Instructions...
+\"\"\")
+```
+
+### Modifying Skills
+```
+edit_file("/skills/my-skill/SKILL.md", old_text, new_text)
+write_file("/skills/my-skill/helper.py", code)
+```
+
+### Skill Structure
+- Every skill must have `SKILL.md` with `# Title` as first line
+- System skills are read-only (user copy created on edit)
+- User skills are fully editable
 
 {skills}
 """

--- a/src/agents/search_agent/prompt.py
+++ b/src/agents/search_agent/prompt.py
@@ -1,80 +1,117 @@
+"""
+Search Agent 系统提示词
+
+包含两种模式的提示词：
+- SANDBOX_SYSTEM_PROMPT: 沙箱模式，有独立的远程存储
+- DEFAULT_SYSTEM_PROMPT: 非沙箱模式，所有路径统一管理
+"""
+
 SANDBOX_SYSTEM_PROMPT = """
 You are an intelligent assistant with access to various tools and skills.
 
-## File System
+## 🔒 Storage Architecture (CRITICAL - Read Carefully)
 
-| Path | Purpose |
-|------|---------|
-| `{work_dir}` | Working directory for current task |
-| `/tmp` | Temporary files |
-| `/skills/` | Skill definitions (read-only) |
-| `/memories/` | Long-term memories |
+You have access to **TWO COMPLETELY SEPARATE storage systems**:
 
-**Rules**: Create files in `{work_dir}/`, temporary files in `/tmp/`, store memories in `/memories/`. Never use root `/`.
-
-## Workflow
-
-### Proactive File Reveal (IMPORTANT)
-
-You MUST proactively use `reveal_file` tool to present files to the user in these situations:
-
-1. **After creating a new file** - Always reveal it immediately
-2. **After modifying an existing file** - Always reveal it to show the changes
-3. **After generating code, documents, or any content** - Always reveal the result
-4. **When the task involves file output** - Reveal the output file automatically
-
-**DO NOT wait for the user to ask**. Proactively showing your work is required, not optional.
-
-Example correct behavior:
-- User: "Create a Python script for X" → You create the file → You immediately call `reveal_file` to show it
-- User: "Write a report" → You write the report → You immediately call `reveal_file` to present it
-
-**Anti-pattern to avoid**: Creating files and only saying "I've created the file" without revealing it.
-
-**IMPORTANT**: Never call `write_file` and `reveal_file` for the same file in one block. Call `write_file` first, wait for completion, then call `reveal_file`.
-
-### Project Preview for Frontend Projects (IMPORTANT)
-
-When you create a **multi-file frontend project** (HTML/CSS/JS, React, Vue, etc.), you MUST use `reveal_project` tool to let the user preview it in browser:
-
-1. **After creating a frontend project with multiple files** - Use `reveal_project` to show the entire project
-2. **The project must have an entry file** - Like `index.html`, `App.jsx`, or `main.js`
-3. **Supported templates**: `react`, `vue`, `vanilla` (plain HTML/CSS/JS), `static`
-
-Example usage:
 ```
-reveal_project(
-    project_path="/workspace/my-react-app",
-    name="My React App",
-    template="react"  # optional, auto-detected from package.json
-)
+┌─────────────────────────────────────────────────────────────────┐
+│  STORAGE SYSTEM 1: Sandbox Local Filesystem (Linux Container)  │
+│  ─────────────────────────────────────────────────────────────  │
+│  • {work_dir}/  ← Your working directory (CREATE FILES HERE)   │
+│  • /tmp/        ← Temporary files (session-only)               │
+│                                                                 │
+│  Access via: shell commands (ls, cat, python, etc.)            │
+└─────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────┐
+│  STORAGE SYSTEM 2: Remote Storage (External Database)          │
+│  ─────────────────────────────────────────────────────────────  │
+│  • /skills/     ← Skill definitions (READ-ONLY)                │
+│  • /memories/   ← Long-term memories (READ/WRITE)              │
+│                                                                 │
+│  Access via: read_file(), write_file() tools ONLY              │
+│  These paths DO NOT EXIST in the sandbox filesystem!           │
+└─────────────────────────────────────────────────────────────────┘
 ```
 
-**This enables in-browser preview** with file explorer, code editor, and live preview - no server deployment needed!
+### ⚠️ THE TWO SYSTEMS ARE NOT CONNECTED!
 
-### Ask Human When Needed
+- Files in `/skills/` and `/memories/` are stored in a **remote database**
+- The sandbox **cannot directly access** these files via shell commands
+- You MUST use `read_file()` / `write_file()` tools for remote storage
 
-When uncertain about the user's intent, missing required information, or need clarification:
-- Use the `ask_human` tool to ask the user directly
-- Don't guess or proceed with incomplete information
-- It's better to ask than to do the wrong thing
+### ✅ CORRECT Usage Examples
+
+**Reading a skill:**
+```
+content = read_file("/skills/my-skill/SKILL.md")  # ✅ Correct - use tool
+```
+
+**Using a skill script in sandbox:**
+```
+# Step 1: Read the skill file from remote storage
+script_content = read_file("/skills/my-skill/helper.py")  # ✅
+
+# Step 2: Write it to sandbox local filesystem
+write_file("{work_dir}/helper.py", script_content)  # ✅
+
+# Step 3: Now you can run it in sandbox
+execute("python {work_dir}/helper.py")  # ✅
+```
+
+**Saving a memory:**
+```
+write_file("/memories/important-note.md", content)  # ✅ Correct
+```
+
+### ❌ WRONG Usage Examples (Will Fail!)
+
+```
+python /skills/my-skill/script.py      # ❌ Path doesn't exist in sandbox!
+cat /skills/my-skill/SKILL.md          # ❌ Not a sandbox file!
+import sys; sys.path.insert(0, '/skills/my-skill')  # ❌ Won't work!
+cp /skills/my-skill/* .                 # ❌ Source doesn't exist!
+```
+
+### 📋 Quick Reference
+
+| What you want to do | Correct approach |
+|---------------------|------------------|
+| Read skill instructions | `read_file("/skills/name/SKILL.md")` |
+| Use skill script in sandbox | Read → Write to `{work_dir}/` → Execute |
+| Save long-term memory | `write_file("/memories/note.md", content)` |
+| Create working files | `write_file("{work_dir}/file.py", content)` |
+| Run Python scripts | `execute("python {work_dir}/script.py")` |
+
 {skills}
 """
-
 
 DEFAULT_SYSTEM_PROMPT = """
 You are an intelligent assistant with access to various tools and skills.
 
-## File System
+## 📁 File System
 
-| Path | Purpose |
-|------|---------|
-| `/workspace` | Working directory for persistent files |
-| `/tmp` | Temporary files (session-only) |
-| `/skills/` | Skill definitions (read-only) |
-| `/memories/` | Long-term memories |
+| Path | Purpose | Access |
+|------|---------|--------|
+| `/workspace` | Working directory for persistent files | read_file, write_file |
+| `/tmp` | Temporary files (session-only) | read_file, write_file |
+| `/skills/` | Skill definitions (read-only) | read_file only |
+| `/memories/` | Long-term memories | read_file, write_file |
 
-**Rules**: Create persistent files in `/workspace/`, temporary files in `/tmp/`, store memories in `/memories/`.
+**Rules**:
+- Create persistent files in `/workspace/`
+- Temporary files go in `/tmp/`
+- Store memories in `/memories/`
+- Skills are read-only - you can read but not modify them
+
+{skills}
+"""
+
+# ============================================================================
+# Shared Workflow Sections (appended to both prompts)
+# ============================================================================
+
+WORKFLOW_SECTION = """
 
 ## Workflow
 
@@ -122,5 +159,8 @@ When uncertain about the user's intent, missing required information, or need cl
 - Use the `ask_human` tool to ask the user directly
 - Don't guess or proceed with incomplete information
 - It's better to ask than to do the wrong thing
-{skills}
 """
+
+# 完整提示词（包含 workflow）
+SANDBOX_SYSTEM_PROMPT = SANDBOX_SYSTEM_PROMPT + WORKFLOW_SECTION
+DEFAULT_SYSTEM_PROMPT = DEFAULT_SYSTEM_PROMPT + WORKFLOW_SECTION

--- a/src/infra/backend/__init__.py
+++ b/src/infra/backend/__init__.py
@@ -11,6 +11,7 @@ from .deepagent import (
     create_postgres_backend_factory,
     create_sandbox_backend_factory,
 )
+from .skills_store import SkillsStoreBackend, create_skills_backend
 
 __all__ = [
     # Context
@@ -22,4 +23,7 @@ __all__ = [
     "create_memory_backend_factory",
     "create_postgres_backend_factory",
     "create_sandbox_backend_factory",
+    # Skills Store Backend
+    "SkillsStoreBackend",
+    "create_skills_backend",
 ]

--- a/src/infra/backend/deepagent.py
+++ b/src/infra/backend/deepagent.py
@@ -2,31 +2,40 @@
 DeepAgent Backend 工厂模块
 
 为 DeepAgent 创建不同模式的 Backend 工厂函数。
+
+Skills 路径现在使用 SkillsStoreBackend，支持 LLM 直接读写 skills 到 MongoDB。
 """
 
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 from deepagents.backends import CompositeBackend, StateBackend, StoreBackend
 
 
 def create_memory_backend_factory(
     assistant_id: str,
+    user_id: Optional[str] = None,
 ) -> Callable[[Any], CompositeBackend]:
     """
     创建基于内存的 Backend 工厂函数（非沙箱模式，不使用长期存储）
 
     Args:
         assistant_id: 助手 ID，用于命名空间隔离
+        user_id: 用户 ID，用于 skills 读写
 
     Returns:
         Backend 工厂函数
     """
 
     def backend_factory(rt: Any) -> CompositeBackend:
+        # Skills 使用 SkillsStoreBackend（读写 MongoDB）
+        from src.infra.backend.skills_store import create_skills_backend
+
+        skills_backend = create_skills_backend(user_id=user_id or "default", runtime=rt)
+
         return CompositeBackend(
             default=StateBackend(rt),  # 默认使用内存状态后端
             routes={
-                "/skills/": StateBackend(rt),
+                "/skills/": skills_backend,
             },
         )
 
@@ -35,12 +44,14 @@ def create_memory_backend_factory(
 
 def create_postgres_backend_factory(
     assistant_id: str,
+    user_id: Optional[str] = None,
 ) -> Callable[[Any], CompositeBackend]:
     """
     创建基于 PostgreSQL 的 Backend 工厂函数（非沙箱模式）
 
     Args:
         assistant_id: 助手 ID，用于命名空间隔离
+        user_id: 用户 ID，用于 skills 读写
 
     Returns:
         Backend 工厂函数
@@ -48,6 +59,8 @@ def create_postgres_backend_factory(
 
     def backend_factory(rt: Any) -> CompositeBackend:
         from deepagents.backends.store import BackendContext
+
+        from src.infra.backend.skills_store import create_skills_backend
 
         def memory_namespace_factory(ctx: BackendContext) -> tuple[str, ...]:
             """Memory 使用 PostgresStore 持久化，按 assistant_id 隔离"""
@@ -57,10 +70,13 @@ def create_postgres_backend_factory(
             """默认文件系统按 assistant_id 隔离"""
             return (assistant_id, "filesystem")
 
+        # Skills 使用 SkillsStoreBackend（读写 MongoDB）
+        skills_backend = create_skills_backend(user_id=user_id or "default", runtime=rt)
+
         return CompositeBackend(
             default=StoreBackend(rt, namespace=default_namespace_factory),
             routes={
-                "/skills/": StateBackend(rt),
+                "/skills/": skills_backend,
                 "/memories/": StoreBackend(rt, namespace=memory_namespace_factory),
             },
         )
@@ -71,6 +87,7 @@ def create_postgres_backend_factory(
 def create_sandbox_backend_factory(
     sandbox_backend: Any,
     assistant_id: str,
+    user_id: Optional[str] = None,
 ) -> Callable[[Any], CompositeBackend]:
     """
     创建基于沙箱的 Backend 工厂函数
@@ -78,6 +95,7 @@ def create_sandbox_backend_factory(
     Args:
         sandbox_backend: 沙箱后端实例（从 SessionSandboxManager 获取）
         assistant_id: 助手 ID，用于命名空间隔离
+        user_id: 用户 ID，用于 skills 读写
 
     Returns:
         Backend 工厂函数
@@ -86,14 +104,19 @@ def create_sandbox_backend_factory(
     def backend_factory(rt: Any) -> CompositeBackend:
         from deepagents.backends.store import BackendContext
 
+        from src.infra.backend.skills_store import create_skills_backend
+
         def memory_namespace_factory(ctx: BackendContext) -> tuple[str, ...]:
             """Memory 使用沙箱持久化，按 assistant_id 隔离"""
             return (assistant_id, "memories")
 
+        # Skills 使用 SkillsStoreBackend（读写 MongoDB）
+        skills_backend = create_skills_backend(user_id=user_id or "default", runtime=rt)
+
         return CompositeBackend(
             default=sandbox_backend,  # 沙箱模式使用沙箱 backend 作为默认
             routes={
-                "/skills/": StateBackend(rt),
+                "/skills/": skills_backend,
                 "/memories/": StoreBackend(rt, namespace=memory_namespace_factory),
             },
         )

--- a/src/infra/backend/skills_store.py
+++ b/src/infra/backend/skills_store.py
@@ -1,0 +1,622 @@
+"""
+Skills Store Backend
+
+为 DeepAgent 提供 Skills 的读写后端，连接到 MongoDB。
+
+路径格式：/skills/{skill_name}/{file_path}
+
+特性：
+- 读取：从 MongoDB 获取 skill 文件的 content
+- 写入：更新 MongoDB 中 skill 的 files 字段
+- 编辑：在 skill 文件中进行字符串替换
+- 列表：列出所有 skills 或某个 skill 下的文件
+"""
+
+import asyncio
+import logging
+import re
+from typing import TYPE_CHECKING, Any, Optional
+
+from deepagents.backends.protocol import (
+    BackendProtocol,
+    EditResult,
+    FileDownloadResponse,
+    FileInfo,
+    FileUploadResponse,
+    GrepMatch,
+    WriteResult,
+)
+
+from src.infra.skill.storage import SkillStorage
+
+if TYPE_CHECKING:
+    from motor.motor_asyncio import AsyncIOMotorClient
+
+logger = logging.getLogger(__name__)
+
+# 路径格式：/skills/{skill_name}/{file_path}
+SKILLS_PATH_PATTERN = re.compile(r"^/skills/([^/]+)/(.+)$")
+SKILLS_ROOT_PATTERN = re.compile(r"^/skills/?$")
+SKILLS_DIR_PATTERN = re.compile(r"^/skills/([^/]+)/?$")
+
+
+class SkillsStoreBackend(BackendProtocol):
+    """
+    Skills 存储后端
+
+    将 /skills/ 路径映射到 MongoDB 中的 skills 集合。
+
+    支持：
+    - 读取：read("/skills/my-skill/SKILL.md")
+    - 写入：write("/skills/my-skill/SKILL.md", content)
+    - 编辑：edit("/skills/my-skill/SKILL.md", old, new)
+    - 列表：ls_info("/skills/") 或 ls_info("/skills/my-skill/")
+    """
+
+    def __init__(self, user_id: str, runtime: Any = None):
+        """
+        初始化 Skills Store Backend
+
+        Args:
+            user_id: 用户 ID，用于获取用户可见的 skills
+            runtime: ToolRuntime 实例（可选，用于兼容性）
+        """
+        self._user_id = user_id
+        self._runtime = runtime
+        self._storage: Optional[SkillStorage] = None
+        self._client: Optional["AsyncIOMotorClient"] = None
+
+    def _get_storage(self) -> SkillStorage:
+        """获取 SkillStorage 实例"""
+        if self._storage is None:
+            self._storage = SkillStorage()
+        return self._storage
+
+    def _parse_skill_path(self, path: str) -> Optional[tuple[str, str]]:
+        """
+        解析 skills 路径
+
+        Args:
+            path: 文件路径，如 /skills/my-skill/SKILL.md
+
+        Returns:
+            (skill_name, file_path) 或 None（如果路径无效）
+        """
+        match = SKILLS_PATH_PATTERN.match(path)
+        if match:
+            return match.group(1), match.group(2)
+        return None
+
+    def _is_skills_root(self, path: str) -> bool:
+        """检查是否是 skills 根路径"""
+        return bool(SKILLS_ROOT_PATTERN.match(path))
+
+    def _is_skill_dir(self, path: str) -> bool:
+        """检查是否是某个 skill 的目录"""
+        return bool(SKILLS_DIR_PATTERN.match(path))
+
+    def _get_skill_name_from_dir(self, path: str) -> Optional[str]:
+        """从目录路径获取 skill 名称"""
+        match = SKILLS_DIR_PATTERN.match(path)
+        if match:
+            return match.group(1)
+        return None
+
+    def _format_content_with_line_numbers(
+        self, content: str, offset: int = 0, limit: int = 2000
+    ) -> str:
+        """
+        格式化内容为带行号的格式（类似 cat -n）
+
+        Args:
+            content: 文件内容
+            offset: 起始行号（0-indexed）
+            limit: 最大行数
+
+        Returns:
+            带行号的格式化内容
+        """
+        lines = content.split("\n")
+        start = offset
+        end = min(offset + limit, len(lines))
+
+        result_lines = []
+        for i in range(start, end):
+            line_num = i + 1  # 1-indexed
+            line_content = lines[i]
+            # 截断超长行
+            if len(line_content) > 2000:
+                line_content = line_content[:2000] + "..."
+            result_lines.append(f"{line_num:6d}\t{line_content}")
+
+        return "\n".join(result_lines)
+
+    # ==========================================
+    # 读取操作
+    # ==========================================
+
+    def read(
+        self,
+        file_path: str,
+        offset: int = 0,
+        limit: int = 2000,
+    ) -> str:
+        """读取 skill 文件内容（同步，内部调用异步）"""
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
+        return loop.run_until_complete(self.aread(file_path, offset, limit))
+
+    async def aread(
+        self,
+        file_path: str,
+        offset: int = 0,
+        limit: int = 2000,
+    ) -> str:
+        """
+        异步读取 skill 文件
+
+        Args:
+            file_path: /skills/{skill_name}/{file_path}
+            offset: 起始行号（0-indexed）
+            limit: 最大行数
+
+        Returns:
+            带行号的文件内容，或错误信息字符串
+        """
+        parsed = self._parse_skill_path(file_path)
+        if not parsed:
+            return f"Error: Invalid skills path: {file_path}. Expected /skills/{{skill_name}}/{{file_path}}"
+
+        skill_name, file_name = parsed
+        storage = self._get_storage()
+
+        try:
+            # 先尝试用户 skill
+            files = await storage.get_skill_files(skill_name, user_id=self._user_id)
+            if not files:
+                # 再尝试系统 skill
+                files = await storage.get_skill_files(skill_name, user_id=None)
+
+            if not files:
+                return f"Error: Skill '{skill_name}' not found"
+
+            if file_name not in files:
+                return f"Error: File '{file_name}' not found in skill '{skill_name}'"
+
+            content = files[file_name]
+            return self._format_content_with_line_numbers(content, offset, limit)
+
+        except Exception as e:
+            logger.error(f"Failed to read {file_path}: {e}")
+            return f"Error: {e}"
+
+    # ==========================================
+    # 写入操作
+    # ==========================================
+
+    def write(self, file_path: str, content: str) -> WriteResult:
+        """写入 skill 文件（同步，内部调用异步）"""
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
+        return loop.run_until_complete(self.awrite(file_path, content))
+
+    async def awrite(self, file_path: str, content: str) -> WriteResult:
+        """
+        异步写入 skill 文件
+
+        Args:
+            file_path: /skills/{skill_name}/{file_path}
+            content: 文件内容
+
+        Returns:
+            WriteResult 表示操作结果
+        """
+        parsed = self._parse_skill_path(file_path)
+        if not parsed:
+            return WriteResult(
+                error=f"Invalid skills path: {file_path}. Expected /skills/{{skill_name}}/{{file_path}}"
+            )
+
+        skill_name, file_name = parsed
+        storage = self._get_storage()
+
+        try:
+            # 检查 skill 是否存在（用户 skill 或系统 skill）
+            user_skill = await storage.get_user_skill(skill_name, self._user_id)
+            system_skill = await storage.get_system_skill(skill_name)
+
+            if user_skill:
+                # 更新用户 skill
+                files = await storage.get_skill_files(skill_name, user_id=self._user_id)
+                files[file_name] = content
+                await storage.sync_skill_files(skill_name, files, user_id=self._user_id)
+                logger.info(f"Updated user skill '{skill_name}' file '{file_name}'")
+
+            elif system_skill:
+                # 系统技能是只读的，创建用户副本
+                logger.info(f"Creating user copy of system skill '{skill_name}'")
+
+                from src.kernel.schemas.skill import SkillCreate, SkillSource
+
+                skill_create = SkillCreate(
+                    name=skill_name,
+                    description=system_skill.description,
+                    content=system_skill.content,
+                    files={**system_skill.files, file_name: content},
+                    enabled=True,
+                    source=SkillSource.MANUAL,
+                )
+                await storage.create_user_skill(skill_create, self._user_id)
+                logger.info(f"Created user skill '{skill_name}' with modified file '{file_name}'")
+
+            else:
+                # Skill 不存在，自动创建新的用户 skill
+                logger.info(f"Creating new user skill '{skill_name}'")
+                from src.kernel.schemas.skill import SkillCreate, SkillSource
+
+                # 尝试从 SKILL.md 解析名称和描述
+                name = skill_name
+                description = "Skill created by LLM"
+
+                if file_name == "SKILL.md":
+                    lines = content.split("\n")
+                    for line in lines:
+                        if line.startswith("# "):
+                            name = line[2:].strip()
+                            desc_lines = []
+                            for desc_line in lines[lines.index(line) + 1 :]:
+                                if desc_line.startswith("#") or desc_line.startswith("```"):
+                                    break
+                                if desc_line.strip():
+                                    desc_lines.append(desc_line.strip())
+                            if desc_lines:
+                                description = " ".join(desc_lines)[:200]
+                            break
+
+                skill_create = SkillCreate(
+                    name=name,
+                    description=description,
+                    content=content if file_name == "SKILL.md" else "",
+                    files={file_name: content},
+                    enabled=True,
+                    source=SkillSource.MANUAL,
+                )
+                await storage.create_user_skill(skill_create, self._user_id)
+                logger.info(f"Created user skill '{name}' with file '{file_name}'")
+
+            # 清除缓存
+            await storage._invalidate_user_skills_cache(self._user_id)
+
+            return WriteResult(path=file_path, files_update=None)
+
+        except Exception as e:
+            logger.error(f"Failed to write {file_path}: {e}", exc_info=True)
+            return WriteResult(error=str(e))
+
+    # ==========================================
+    # 编辑操作
+    # ==========================================
+
+    def edit(
+        self,
+        file_path: str,
+        old_string: str,
+        new_string: str,
+        replace_all: bool = False,
+    ) -> EditResult:
+        """编辑 skill 文件（同步，内部调用异步）"""
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
+        return loop.run_until_complete(self.aedit(file_path, old_string, new_string, replace_all))
+
+    async def aedit(
+        self,
+        file_path: str,
+        old_string: str,
+        new_string: str,
+        replace_all: bool = False,
+    ) -> EditResult:
+        """
+        异步编辑 skill 文件
+
+        Args:
+            file_path: /skills/{skill_name}/{file_path}
+            old_string: 要替换的字符串
+            new_string: 新字符串
+            replace_all: 是否替换所有出现
+
+        Returns:
+            EditResult 表示操作结果
+        """
+        parsed = self._parse_skill_path(file_path)
+        if not parsed:
+            return EditResult(error=f"Invalid skills path: {file_path}")
+
+        skill_name, file_name = parsed
+        storage = self._get_storage()
+
+        try:
+            # 只能编辑用户 skill
+            user_skill = await storage.get_user_skill(skill_name, self._user_id)
+            if not user_skill:
+                return EditResult(
+                    error=f"User skill '{skill_name}' not found. Cannot edit system skill files."
+                )
+
+            files = await storage.get_skill_files(skill_name, user_id=self._user_id)
+            if file_name not in files:
+                return EditResult(error=f"File '{file_name}' not found in skill '{skill_name}'")
+
+            content = files[file_name]
+
+            # 检查 old_string 是否存在
+            if old_string not in content:
+                return EditResult(error=f"String not found in file: {old_string[:50]}...")
+
+            # 检查唯一性（如果不是 replace_all）
+            if not replace_all:
+                count = content.count(old_string)
+                if count > 1:
+                    return EditResult(
+                        error=f"Found {count} occurrences. Use replace_all=True or provide more context."
+                    )
+
+            # 执行替换
+            if replace_all:
+                new_content = content.replace(old_string, new_string)
+                occurrences = content.count(old_string)
+            else:
+                new_content = content.replace(old_string, new_string, 1)
+                occurrences = 1
+
+            # 更新文件
+            files[file_name] = new_content
+            await storage.sync_skill_files(skill_name, files, user_id=self._user_id)
+
+            # 清除缓存
+            await storage._invalidate_user_skills_cache(self._user_id)
+
+            logger.info(
+                f"Edited user skill '{skill_name}' file '{file_name}' ({occurrences} replacements)"
+            )
+            return EditResult(path=file_path, files_update=None, occurrences=occurrences)
+
+        except Exception as e:
+            logger.error(f"Failed to edit {file_path}: {e}")
+            return EditResult(error=str(e))
+
+    # ==========================================
+    # 列表操作
+    # ==========================================
+
+    def ls_info(self, path: str) -> list[FileInfo]:
+        """列出文件（同步，内部调用异步）"""
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
+        return loop.run_until_complete(self.als_info(path))
+
+    async def als_info(self, path: str) -> list[FileInfo]:
+        """
+        异步列出 skills 或文件
+
+        Args:
+            path: /skills/ 或 /skills/{skill_name}/
+
+        Returns:
+            list[FileInfo] 包含文件/目录信息
+        """
+        storage = self._get_storage()
+
+        try:
+            # 列出所有 skills
+            if self._is_skills_root(path):
+                effective_skills = await storage.get_effective_skills(self._user_id)
+                skills = effective_skills.get("skills", {})
+
+                entries: list[FileInfo] = []
+                for skill_name in skills.keys():
+                    entries.append(
+                        FileInfo(
+                            path=f"/skills/{skill_name}/",
+                            is_dir=True,
+                        )
+                    )
+
+                return entries
+
+            # 列出某个 skill 下的文件
+            if self._is_skill_dir(path):
+                skill_name = self._get_skill_name_from_dir(path)
+                if not skill_name:
+                    return []
+
+                # 先尝试用户 skill
+                files = await storage.get_skill_files(skill_name, user_id=self._user_id)
+                if not files:
+                    # 再尝试系统 skill
+                    files = await storage.get_skill_files(skill_name, user_id=None)
+
+                if files is None:
+                    files = {}
+
+                skill_entries: list[FileInfo] = []
+                for file_name in files.keys():
+                    skill_entries.append(
+                        FileInfo(
+                            path=f"/skills/{skill_name}/{file_name}",
+                            is_dir=False,
+                            size=len(files[file_name]),
+                        )
+                    )
+
+                return skill_entries
+
+            return []
+
+        except Exception as e:
+            logger.error(f"Failed to list {path}: {e}")
+            return []
+
+    # ==========================================
+    # 批量操作
+    # ==========================================
+
+    def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
+        """批量读取文件（同步）"""
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
+        return loop.run_until_complete(self.adownload_files(paths))
+
+    async def adownload_files(self, paths: list[str]) -> list[FileDownloadResponse]:
+        """批量读取文件（异步）"""
+        results = []
+        for path in paths:
+            parsed = self._parse_skill_path(path)
+            if not parsed:
+                results.append(FileDownloadResponse(path=path, content=None, error="invalid_path"))
+                continue
+
+            skill_name, file_name = parsed
+            storage = self._get_storage()
+
+            try:
+                # 先尝试用户 skill
+                files = await storage.get_skill_files(skill_name, user_id=self._user_id)
+                if not files:
+                    # 再尝试系统 skill
+                    files = await storage.get_skill_files(skill_name, user_id=None)
+
+                if not files or file_name not in files:
+                    results.append(
+                        FileDownloadResponse(path=path, content=None, error="file_not_found")
+                    )
+                    continue
+
+                content = files[file_name]
+                content_bytes = content.encode("utf-8") if isinstance(content, str) else content
+                results.append(FileDownloadResponse(path=path, content=content_bytes, error=None))
+
+            except Exception:
+                # 使用 permission_denied 表示一般性错误
+                results.append(
+                    FileDownloadResponse(path=path, content=None, error="permission_denied")
+                )
+
+        return results
+
+    def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
+        """批量写入文件（同步）"""
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
+        return loop.run_until_complete(self.aupload_files(files))
+
+    async def aupload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
+        """批量写入文件（异步）"""
+        results = []
+        for path, content in files:
+            content_str = content.decode("utf-8") if isinstance(content, bytes) else content
+            result = await self.awrite(path, content_str)
+            if result.error:
+                # 使用 permission_denied 表示一般性错误
+                results.append(FileUploadResponse(path=path, error="permission_denied"))
+            else:
+                results.append(FileUploadResponse(path=path, error=None))
+
+        return results
+
+    # ==========================================
+    # 搜索操作（grep）
+    # ==========================================
+
+    def grep_raw(
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+    ) -> list[GrepMatch] | str:
+        """在 skill 文件中搜索文本模式"""
+        # Skills backend 不支持 grep，返回提示信息
+        return "grep is not supported for skills backend. Use read() to view file content."
+
+    async def agrep_raw(
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+    ) -> list[GrepMatch] | str:
+        """异步版本"""
+        return self.grep_raw(pattern, path, glob)
+
+    # ==========================================
+    # Glob 操作
+    # ==========================================
+
+    def glob_info(self, pattern: str, path: str = "/") -> list[FileInfo]:
+        """使用 glob 模式查找文件"""
+        # 简化实现：只支持列出所有 skills
+        if path == "/skills/" or path == "/skills":
+            return self.ls_info("/skills/")
+        return []
+
+    async def aglob_info(self, pattern: str, path: str = "/") -> list[FileInfo]:
+        """异步版本"""
+        return self.glob_info(pattern, path)
+
+    # ==========================================
+    # 属性
+    # ==========================================
+
+    @property
+    def id(self) -> str:
+        """Backend ID"""
+        return f"skills-{self._user_id}"
+
+    def close(self) -> None:
+        """关闭连接"""
+        if self._storage:
+            try:
+                # SkillStorage 有 close 方法
+                import asyncio
+
+                loop = asyncio.get_event_loop()
+                loop.run_until_complete(self._storage.close())
+            except Exception:
+                pass
+
+
+def create_skills_backend(user_id: str, runtime: Any = None) -> SkillsStoreBackend:
+    """
+    创建 Skills Store Backend
+
+    Args:
+        user_id: 用户 ID
+        runtime: ToolRuntime 实例（可选）
+
+    Returns:
+        SkillsStoreBackend 实例
+    """
+    return SkillsStoreBackend(user_id=user_id, runtime=runtime)

--- a/src/infra/tool/reveal_project_tool.py
+++ b/src/infra/tool/reveal_project_tool.py
@@ -225,6 +225,9 @@ async def _run_command(backend: Any, command: str) -> Optional[str]:
     if hasattr(backend, "aexecute"):
         try:
             result = await backend.aexecute(command)
+            # ExecuteResponse 对象（有 output 属性）
+            if hasattr(result, "output"):
+                return result.output
             if isinstance(result, dict):
                 return result.get("output", result.get("stdout", ""))
             elif isinstance(result, str):
@@ -235,6 +238,9 @@ async def _run_command(backend: Any, command: str) -> Optional[str]:
     if hasattr(backend, "execute"):
         try:
             result = backend.execute(command)
+            # ExecuteResponse 对象（有 output 属性）
+            if hasattr(result, "output"):
+                return result.output
             if isinstance(result, dict):
                 return result.get("output", result.get("stdout", ""))
             elif isinstance(result, str):


### PR DESCRIPTION
## 问题

Search Agent 的系统提示词没有明确区分两个独立的存储系统：
- 沙箱本地文件系统 (`{work_dir}`, `/tmp`)
- 远程存储 (`/skills/`, `/memories/`)

这导致 LLM 可能会：
- 在 shell 命令中引用 `/skills/` 路径（实际上不存在于沙箱）
- 误以为可以直接 `python /skills/xxx/script.py`

## 解决方案

### 1. ASCII 架构图
直观展示两个独立存储系统：
```
┌─ Sandbox Local ─────────┐   ┌─ Remote Storage ────────┐
│ {work_dir}/, /tmp/      │   │ /skills/, /memories/    │
│ shell commands access   │   │ read_file/write_file    │
└─────────────────────────┘   └─────────────────────────┘
```

### 2. 正确/错误示例对比
- ✅ `read_file("/skills/...")` → 写到沙箱 → 执行
- ❌ `python /skills/xxx/script.py` (路径不存在)

### 3. 快速参考表格
让 LLM 一目了然知道该怎么做

### 4. 代码重构
`WORKFLOW_SECTION` 提取为共享模块，避免重复

## 文件修改
- `src/agents/search_agent/prompt.py`

## 测试
- ✅ ruff format 通过
- ✅ ruff check 通过
- ✅ mypy 通过