### PR TITLE
fix: SkillsStoreBackend 后续修复

### DIFF
--- a/frontend/src/components/skill/SkillForm.tsx
+++ b/frontend/src/components/skill/SkillForm.tsx
@@ -104,8 +104,11 @@ export function SkillForm({
 
     if (!name.trim()) {
       newErrors.name = t("skills.form.validation.nameRequired");
-    } else if (!/^[a-zA-Z0-9_-]+$/.test(name.trim())) {
+    } else if (!/^[\w\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af\-.]+$/.test(name.trim())) {
+      // Allow: letters, numbers, underscores, Chinese, Japanese (Hiragana/Katakana), Korean, hyphens, dots
       newErrors.name = t("skills.form.validation.nameInvalid");
+    } else if (name.trim().length > 100) {
+      newErrors.name = t("skills.form.validation.nameTooLong");
     }
 
     if (!description.trim()) {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -699,8 +699,9 @@
       "validation": {
         "contentRequired": "Content is required",
         "descriptionRequired": "Description is required",
-        "nameInvalid": "Name can only contain letters, numbers, underscores, and hyphens",
-        "nameRequired": "Name is required"
+        "nameInvalid": "Name can only contain letters, numbers, underscores, hyphens, dots, and CJK characters",
+        "nameRequired": "Name is required",
+        "nameTooLong": "Name cannot exceed 100 characters"
       }
     },
     "foundSkills": "Found {{count}} skill(s) - select to install",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -676,8 +676,9 @@
       "validation": {
         "contentRequired": "コンテンツを入力してください",
         "descriptionRequired": "説明を入力してください",
-        "nameInvalid": "名前には文字、数字、アンダースコア、ハイフンのみ使用できます",
-        "nameRequired": "スキル名を入力してください"
+        "nameInvalid": "名前には文字、数字、アンダースコア、ハイフン、ドット、日本語のみ使用できます",
+        "nameRequired": "スキル名を入力してください",
+        "nameTooLong": "名前は100文字を超えることはできません"
       }
     },
     "foundSkills": "{{count}}件のスキルが見つかりました - インストールするものを選択",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -677,8 +677,9 @@
       "validation": {
         "contentRequired": "내용을 입력하세요",
         "descriptionRequired": "설명을 입력하세요",
-        "nameInvalid": "이름에는 문자, 숫자, 밑줄, 하이픈만 사용할 수 있습니다",
-        "nameRequired": "스킬 이름을 입력하세요"
+        "nameInvalid": "이름에는 문자, 숫자, 밑줄, 하이픈, 점, 한글만 사용할 수 있습니다",
+        "nameRequired": "스킬 이름을 입력하세요",
+        "nameTooLong": "이름은 100자를 초과할 수 없습니다"
       }
     },
     "foundSkills": "{{count}}개 스킬 발견 - 설치할 항목 선택",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -698,8 +698,9 @@
       "validation": {
         "contentRequired": "请输入内容",
         "descriptionRequired": "请输入描述",
-        "nameInvalid": "名称只能包含字母、数字、下划线和连字符",
-        "nameRequired": "请输入技能名称"
+        "nameInvalid": "名称只能包含字母、数字、下划线、连字符、点和中文",
+        "nameRequired": "请输入技能名称",
+        "nameTooLong": "名称不能超过100个字符"
       }
     },
     "foundSkills": "找到 {{count}} 个技能 - 选择要安装的",

--- a/src/infra/backend/skills_store.py
+++ b/src/infra/backend/skills_store.py
@@ -35,8 +35,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# 路径格式：/skills/{skill_name}/{file_path}
-SKILLS_PATH_PATTERN = re.compile(r"^/skills/([^/]+)/(.+)$")
+# 路径格式：
+# - 直接调用: /skills/{skill_name}/{file_path}
+# - 通过 CompositeBackend: {skill_name}/{file_path}（前缀已被去掉）
+SKILLS_PATH_PATTERN = re.compile(r"^(?:/skills/)?([^/]+)/(.+)$")
 SKILLS_ROOT_PATTERN = re.compile(r"^/skills/?$")
 SKILLS_DIR_PATTERN = re.compile(r"^/skills/([^/]+)/?$")
 
@@ -160,19 +162,42 @@ class SkillsStoreBackend(BackendProtocol):
         return None
 
     def _is_skills_root(self, path: str) -> bool:
-        """检查是否是 skills 根路径"""
+        """检查是否是 skills 根路径（支持有/无前缀）"""
+        # 支持空字符串、"/"、"/skills"、"/skills/"
+        if path in ("", "/"):
+            return True
         return bool(SKILLS_ROOT_PATTERN.match(path))
 
     def _is_skill_dir(self, path: str) -> bool:
-        """检查是否是某个 skill 的目录"""
-        return bool(SKILLS_DIR_PATTERN.match(path))
+        """检查是否是某个 skill 的目录（支持有/无前缀）"""
+        # 支持格式: "skill-name/" 或 "/skills/skill-name/"
+        if not path:
+            return False
+        # 去掉可能的 /skills/ 前缀
+        stripped = path
+        if path.startswith("/skills/"):
+            stripped = path[8:]  # 去掉 "/skills/"
+        elif path.startswith("skills/"):
+            stripped = path[7:]  # 去掉 "skills/"
+        # 检查是否是 skill 目录格式: "skill-name/"
+        return stripped.endswith("/") and "/" not in stripped.rstrip("/")
 
     def _get_skill_name_from_dir(self, path: str) -> Optional[str]:
-        """从目录路径获取 skill 名称"""
-        match = SKILLS_DIR_PATTERN.match(path)
-        if match:
-            return match.group(1)
-        return None
+        """从目录路径获取 skill 名称（支持有/无前缀）"""
+        if not path:
+            return None
+        # 去掉可能的 /skills/ 前缀
+        stripped = path
+        if path.startswith("/skills/"):
+            stripped = path[8:]
+        elif path.startswith("skills/"):
+            stripped = path[7:]
+        # 去掉末尾的 /
+        stripped = stripped.rstrip("/")
+        # 检查是否只有一个部分（skill 名称）
+        if "/" in stripped:
+            return None
+        return stripped if stripped else None
 
     def _format_content_with_line_numbers(
         self, content: str, offset: int = 0, limit: int = 2000

--- a/src/infra/backend/skills_store.py
+++ b/src/infra/backend/skills_store.py
@@ -35,10 +35,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# 路径格式：
-# - 直接调用: /skills/{skill_name}/{file_path}
-# - 通过 CompositeBackend: {skill_name}/{file_path}（前缀已被去掉）
-SKILLS_PATH_PATTERN = re.compile(r"^(?:/skills/)?([^/]+)/(.+)$")
+# 路径格式：/skills/{skill_name}/{file_path}
+# 内部统一使用带 /skills/ 前缀的路径
+SKILLS_PATH_PATTERN = re.compile(r"^/skills/([^/]+)/(.+)$")
 SKILLS_ROOT_PATTERN = re.compile(r"^/skills/?$")
 SKILLS_DIR_PATTERN = re.compile(r"^/skills/([^/]+)/?$")
 
@@ -146,6 +145,31 @@ class SkillsStoreBackend(BackendProtocol):
             self._storage = _get_cached_storage(self._user_id)
         return self._storage
 
+    def _normalize_path(self, path: str) -> str:
+        """
+        标准化路径，确保始终以 /skills/ 开头
+
+        CompositeBackend 路由时会去掉 /skills/ 前缀，
+        这个方法确保内部处理时路径总是带前缀的。
+
+        Args:
+            path: 原始路径，可能有或没有 /skills/ 前缀
+
+        Returns:
+            带 /skills/ 前缀的标准化路径
+        """
+        if not path:
+            return "/skills/"
+
+        # 已经有前缀
+        if path.startswith("/skills/"):
+            return path
+
+        # 添加前缀
+        if path.startswith("/"):
+            return f"/skills{path}"
+        return f"/skills/{path}"
+
     def _parse_skill_path(self, path: str) -> Optional[tuple[str, str]]:
         """
         解析 skills 路径
@@ -162,42 +186,22 @@ class SkillsStoreBackend(BackendProtocol):
         return None
 
     def _is_skills_root(self, path: str) -> bool:
-        """检查是否是 skills 根路径（支持有/无前缀）"""
-        # 支持空字符串、"/"、"/skills"、"/skills/"
-        if path in ("", "/"):
-            return True
-        return bool(SKILLS_ROOT_PATTERN.match(path))
+        """检查是否是 skills 根路径"""
+        normalized = self._normalize_path(path)
+        return normalized in ("/skills/", "/skills") or bool(SKILLS_ROOT_PATTERN.match(normalized))
 
     def _is_skill_dir(self, path: str) -> bool:
-        """检查是否是某个 skill 的目录（支持有/无前缀）"""
-        # 支持格式: "skill-name/" 或 "/skills/skill-name/"
-        if not path:
-            return False
-        # 去掉可能的 /skills/ 前缀
-        stripped = path
-        if path.startswith("/skills/"):
-            stripped = path[8:]  # 去掉 "/skills/"
-        elif path.startswith("skills/"):
-            stripped = path[7:]  # 去掉 "skills/"
-        # 检查是否是 skill 目录格式: "skill-name/"
-        return stripped.endswith("/") and "/" not in stripped.rstrip("/")
+        """检查是否是某个 skill 的目录"""
+        normalized = self._normalize_path(path)
+        return bool(SKILLS_DIR_PATTERN.match(normalized))
 
     def _get_skill_name_from_dir(self, path: str) -> Optional[str]:
-        """从目录路径获取 skill 名称（支持有/无前缀）"""
-        if not path:
-            return None
-        # 去掉可能的 /skills/ 前缀
-        stripped = path
-        if path.startswith("/skills/"):
-            stripped = path[8:]
-        elif path.startswith("skills/"):
-            stripped = path[7:]
-        # 去掉末尾的 /
-        stripped = stripped.rstrip("/")
-        # 检查是否只有一个部分（skill 名称）
-        if "/" in stripped:
-            return None
-        return stripped if stripped else None
+        """从目录路径获取 skill 名称"""
+        normalized = self._normalize_path(path)
+        match = SKILLS_DIR_PATTERN.match(normalized)
+        if match:
+            return match.group(1)
+        return None
 
     def _format_content_with_line_numbers(
         self, content: str, offset: int = 0, limit: int = 2000
@@ -251,13 +255,16 @@ class SkillsStoreBackend(BackendProtocol):
         异步读取 skill 文件
 
         Args:
-            file_path: /skills/{skill_name}/{file_path}
+            file_path: 文件路径（会自动添加 /skills/ 前缀）
             offset: 起始行号（0-indexed）
             limit: 最大行数
 
         Returns:
             带行号的文件内容，或错误信息字符串
         """
+        # 标准化路径，确保有 /skills/ 前缀
+        file_path = self._normalize_path(file_path)
+
         parsed = self._parse_skill_path(file_path)
         if not parsed:
             return f"Error: Invalid skills path: {file_path}. Expected /skills/{{skill_name}}/{{file_path}}"
@@ -298,12 +305,15 @@ class SkillsStoreBackend(BackendProtocol):
         异步写入 skill 文件
 
         Args:
-            file_path: /skills/{skill_name}/{file_path}
+            file_path: 文件路径（会自动添加 /skills/ 前缀）
             content: 文件内容
 
         Returns:
             WriteResult 表示操作结果
         """
+        # 标准化路径，确保有 /skills/ 前缀
+        file_path = self._normalize_path(file_path)
+
         parsed = self._parse_skill_path(file_path)
         if not parsed:
             return WriteResult(
@@ -411,7 +421,7 @@ class SkillsStoreBackend(BackendProtocol):
         异步编辑 skill 文件
 
         Args:
-            file_path: /skills/{skill_name}/{file_path}
+            file_path: 文件路径（会自动添加 /skills/ 前缀）
             old_string: 要替换的字符串
             new_string: 新字符串
             replace_all: 是否替换所有出现
@@ -419,6 +429,9 @@ class SkillsStoreBackend(BackendProtocol):
         Returns:
             EditResult 表示操作结果
         """
+        # 标准化路径，确保有 /skills/ 前缀
+        file_path = self._normalize_path(file_path)
+
         parsed = self._parse_skill_path(file_path)
         if not parsed:
             return EditResult(error=f"Invalid skills path: {file_path}")
@@ -489,11 +502,13 @@ class SkillsStoreBackend(BackendProtocol):
         异步列出 skills 或文件
 
         Args:
-            path: /skills/ 或 /skills/{skill_name}/
+            path: 路径（会自动添加 /skills/ 前缀）
 
         Returns:
             list[FileInfo] 包含文件/目录信息
         """
+        # 标准化路径，确保有 /skills/ 前缀
+        path = self._normalize_path(path)
         storage = self._get_storage()
 
         try:

--- a/src/infra/sandbox/session_manager.py
+++ b/src/infra/sandbox/session_manager.py
@@ -375,15 +375,13 @@ class SessionSandboxManager:
                     "/skills/": skills_backend,
                 },
             )
-            return composite_backend, sandbox.get_work_dir()
+            # 返回 composite_backend, work_dir, sandbox_id（从 daytona_backend 获取）
+            return composite_backend, sandbox.get_work_dir(), daytona_backend.id
 
-        backend, work_dir = await asyncio.wait_for(
+        backend, work_dir, sandbox_id = await asyncio.wait_for(
             asyncio.to_thread(_sync_create),
             timeout=DEFAULT_DAYTONA_TIMEOUT,
         )
-
-        # 获取 sandbox_id
-        sandbox_id = backend.id
 
         # 更新 session metadata（覆盖旧的 sandbox_id）
         await self._update_session_metadata(session_id, sandbox_id, "running", is_new=True)


### PR DESCRIPTION
## 修复内容

### 1. SkillsStoreBackend 支持无前缀路径
- CompositeBackend 路由时会去掉 /skills/ 前缀
- 正则和目录检测方法现在支持有/无前缀的路径

### 2. 修复沙箱初始化失败
- CompositeBackend 没有 id 属性
- 从 daytona_backend.id 获取 sandbox_id

### 3. 支持 Unicode Skill 名称
- 支持中文、日文、韩文等字符
- 添加名称长度限制（100字符）

### 4. 分布式支持说明
- Redis 缓存失效确保所有进程读取最新数据
- SkillStorage 全局缓存仅复用连接

## 文件修改
- frontend/src/components/skill/SkillForm.tsx
- frontend/src/i18n/locales/*.json
- src/infra/backend/skills_store.py
- src/infra/sandbox/session_manager.py