### PR TITLE
fix: 修复 ls_info 返回路径重复 /skills/ 的问题

### DIFF
--- a/src/infra/backend/skills_store.py
+++ b/src/infra/backend/skills_store.py
@@ -161,13 +161,19 @@ class SkillsStoreBackend(BackendProtocol):
         if not path:
             return "/skills/"
 
-        # 已经有前缀
+        # 已经有正确前缀
         if path.startswith("/skills/"):
             return path
 
-        # 添加前缀
+        # skills/ 开头（CompositeBackend 去掉前导 / 后的情况）
+        if path.startswith("skills/"):
+            return f"/{path}"
+
+        # 其他 / 开头的路径
         if path.startswith("/"):
             return f"/skills{path}"
+
+        # 相对路径，添加前缀
         return f"/skills/{path}"
 
     def _parse_skill_path(self, path: str) -> Optional[tuple[str, str]]:


### PR DESCRIPTION
## 问题

传入 `skills/` 时，`_normalize_path` 返回 `/skills/skills/`，导致 ls_info 结果错误。

## 修复

在 `_normalize_path` 中处理 `skills/` 开头的路径：
- `skills/` → `/skills/`
- `skills/xxx/` → `/skills/xxx/`

## 测试

```python
_normalize_path("skills/")  # → "/skills/"
_normalize_path("/skills/")  # → "/skills/"
_normalize_path("my-skill/SKILL.md")  # → "/skills/my-skill/SKILL.md"
```