### PR TITLE
fix: 第一个用户（管理员）注册时跳过邮箱验证

### DIFF
--- a/src/infra/user/manager.py
+++ b/src/infra/user/manager.py
@@ -41,8 +41,9 @@ class UserManager:
             # 检查是否已有用户
             existing_users = await self.storage.list_users(limit=1)
             if not existing_users:
-                # 第一个用户设为管理员
+                # 第一个用户设为管理员，并跳过邮箱验证
                 user_data.roles = ["admin"]
+                user_data.skip_verification = True
             else:
                 # 从设置中读取默认角色
                 default_role = await self.settings_service.get("DEFAULT_USER_ROLE")


### PR DESCRIPTION
## 问题

当 `REQUIRE_EMAIL_VERIFICATION=true` 时，即使是第一个注册的用户（自动成为管理员），也需要邮箱验证才能登录。

## 修复

在 `manager.register()` 中，检测到是第一个用户时：
1. 设置 `roles = ["admin"]`（原有逻辑）
2. 设置 `skip_verification = True`（新增）

## 效果

- 第一个用户自动成为管理员，无需邮箱验证
- 后续普通用户仍受 `REQUIRE_EMAIL_VERIFICATION` 配置控制

## 测试

✅ ruff format + ruff check + mypy 全部通过