### PR TITLE
feat: 添加详细的性能监控日志

### DIFF
--- a/src/agents/fast_agent/nodes.py
+++ b/src/agents/fast_agent/nodes.py
@@ -173,6 +173,7 @@ async def fast_agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict
     attachments = state.get("attachments", [])
 
     # 创建 LLM
+    llm_start = time.time()
     llm = LLMClient.get_deep_agent_model(
         api_base=settings.LLM_API_BASE,
         api_key=settings.LLM_API_KEY,
@@ -181,6 +182,8 @@ async def fast_agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict
         max_tokens=settings.LLM_MAX_TOKENS,
         thinking={"type": "enabled"} if enable_thinking else None,
     )
+    llm_init_time = time.time() - llm_start
+    logger.debug(f"[FastAgent] LLM init: {llm_init_time * 1000:.3f}ms")
 
     # 多租户隔离
     tenant_id = context.user_id or "default"
@@ -190,7 +193,10 @@ async def fast_agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict
     skills_prompt = ""
     if settings.ENABLE_SKILLS and context.skills:
         try:
+            skills_start = time.time()
             skills_prompt = await build_skills_prompt(context.skills)
+            skills_init_time = time.time() - skills_start
+            logger.debug(f"[FastAgent] Skills prompt init: {skills_init_time * 1000:.3f}ms")
         except Exception as e:
             logger.warning(f"Failed to build skills prompt: {e}")
 
@@ -198,9 +204,12 @@ async def fast_agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict
     system_prompt = FAST_SYSTEM_PROMPT.replace("{skills}", skills_prompt)
 
     # 使用内存 backend（无沙箱）
+    backend_start = time.time()
     backend_factory = create_memory_backend_factory(
         assistant_id=assistant_id, user_id=context.user_id
     )
+    backend_init_time = time.time() - backend_start
+    logger.debug(f"[FastAgent] Backend init: {backend_init_time * 1000:.3f}ms")
     logger.info(f"[FastAgent] Using in-memory backend for assistant: {assistant_id}")
 
     # 过滤工具
@@ -209,8 +218,12 @@ async def fast_agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict
         filtered_tools = context.filter_tools()
 
     # 创建内层 graph (deep agent)
+    checkpointer_start = time.time()
     inner_checkpointer = await get_async_checkpointer()
+    checkpointer_init_time = time.time() - checkpointer_start
+    logger.debug(f"[FastAgent] Checkpointer init: {checkpointer_init_time * 1000:.3f}ms")
 
+    graph_compile_start = time.time()
     inner_graph = create_deep_agent(
         model=llm,
         system_prompt=system_prompt,
@@ -220,6 +233,8 @@ async def fast_agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict
         store=None,  # Fast Agent 不使用长期存储
         skills=None,
     ).with_config({"recursion_limit": settings.SESSION_MAX_RUNS_PER_SESSION})
+    graph_compile_time = time.time() - graph_compile_start
+    logger.debug(f"[FastAgent] Graph compile: {graph_compile_time * 1000:.3f}ms")
 
     inner_config: RunnableConfig = {
         "configurable": {

--- a/src/agents/search_agent/nodes.py
+++ b/src/agents/search_agent/nodes.py
@@ -208,6 +208,7 @@ async def agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict[str,
     attachments = state.get("attachments", [])
 
     # 创建 LLM
+    llm_start = time.time()
     llm = LLMClient.get_deep_agent_model(
         api_base=settings.LLM_API_BASE,
         api_key=settings.LLM_API_KEY,
@@ -216,12 +217,16 @@ async def agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict[str,
         max_tokens=settings.LLM_MAX_TOKENS,
         thinking={"type": "enabled"} if enable_thinking else None,
     )
+    llm_init_time = time.time() - llm_start
+    logger.debug(f"[Agent] LLM init: {llm_init_time * 1000:.3f}ms")
 
     # 多租户隔离
     tenant_id = context.user_id or "default"
     assistant_id = f"assistant-{tenant_id}"
+    logger.info(f"tenant_id: {tenant_id}")
 
     # 创建 Backend 工厂和获取系统提示
+    backend_start = time.time()
     backend_factory, system_prompt, store = await _create_backend_and_prompt(
         state=state,
         context=context,
@@ -229,6 +234,8 @@ async def agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict[str,
         assistant_id=assistant_id,
         skills=context.skills,
     )
+    backend_init_time = time.time() - backend_start
+    logger.debug(f"[Agent] Backend init: {backend_init_time * 1000:.3f}ms")
 
     # 过滤工具
     filtered_tools = None
@@ -236,12 +243,17 @@ async def agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict[str,
         filtered_tools = context.filter_tools()
 
     # 创建内层 graph (deep agent)
+    checkpointer_start = time.time()
     inner_checkpointer = await get_async_checkpointer()
+    checkpointer_init_time = time.time() - checkpointer_start
+    logger.debug(f"[Agent] Checkpointer init: {checkpointer_init_time * 1000:.3f}ms")
 
     # 注意：不使用 SkillsMiddleware（skills=None）
     # SkillsStoreBackend 直接连接 MongoDB，LLM 可以通过 read_file/write_file 实时读写 skills
     # build_skills_prompt 只用于构建 skills 列表提示，告诉 LLM 有哪些 skills 可用
 
+    # 创建 graph（带计时）
+    graph_compile_start = time.time()
     inner_graph = create_deep_agent(
         model=llm,
         system_prompt=system_prompt,
@@ -251,6 +263,8 @@ async def agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict[str,
         store=store,  # 传递 PostgresStore
         skills=None,  # 禁用 SkillsMiddleware，使用 build_skills_prompt 代替
     ).with_config({"recursion_limit": settings.SESSION_MAX_RUNS_PER_SESSION})
+    graph_compile_time = time.time() - graph_compile_start
+    logger.debug(f"[Agent] Graph compile: {graph_compile_time * 1000:.3f}ms")
 
     inner_config: RunnableConfig = {
         "configurable": {

--- a/src/infra/tool/mcp_global.py
+++ b/src/infra/tool/mcp_global.py
@@ -1,7 +1,8 @@
 """
-全局 MCP 管理器 - 分布式优化版（安全锁 + 内存管理）
+全局 MCP 管理器 - 分布式优化版（安全锁 + 内存管理 + Pub/Sub 缓存同步）
 
 使用全局单例 + Redis 分布式锁（Lua 脚本），避免重复初始化。
+使用 Redis Pub/Sub 实现跨实例缓存失效通知。
 """
 
 import asyncio
@@ -36,6 +37,12 @@ MAX_GLOBAL_ENTRIES = 500
 # Redis 键前缀
 LOCK_KEY_PREFIX = "mcp_init_lock:"
 DONE_KEY_PREFIX = "mcp_init_done:"
+
+# MCP 缓存失效 Pub/Sub 频道
+MCP_CACHE_INVALIDATE_CHANNEL = "mcp:cache:invalidate"
+
+# 当前实例的唯一标识（用于避免处理自己发送的消息）
+_INSTANCE_ID = str(uuid.uuid4())[:8]
 
 # Lua 脚本：安全释放锁
 RELEASE_LOCK_SCRIPT = """


### PR DESCRIPTION
## 功能

添加详细的性能监控日志，用于诊断首次响应延迟。

## 新增计时日志

| 步骤 | 日志 |
|------|------|
| LLM 初始化 | `[Agent] LLM init: {time}ms` |
| Backend 初始化 | `[Agent] Backend init: {time}ms` |
| Checkpointer 初始化 | `[Agent] Checkpointer init: {time}ms` |
| Graph 编译 | `[Agent] Graph compile: {time}ms` |
| tenant_id | `logger.info(f"tenant_id: {tenant_id}")` |

## MCP 优化准备

- 添加 Redis Pub/Sub 缓存同步频道
- 添加实例唯一标识

## 下一步优化建议

1. LLM 客户端缓存 - 使用 @lru_cache
2. 预热初始化 - 启动时预热 MongoDB/PostgreSQL
3. 异步并行加载 - 并行执行 build_skills_prompt 和 get_async_checkpointer
4. 预热 checkpointer - 减少重复创建
5. 缓存 Backend - 使用单例缓存
6. 优化流式输出启动
7. 优化 state 加载 - 使用 aget_state
8. 预热数据库连接