### PR TITLE
fix(frontend): 修复同类型多文件上传问题

### DIFF
--- a/frontend/src/components/chat/FileUploadButton.tsx
+++ b/frontend/src/components/chat/FileUploadButton.tsx
@@ -48,7 +48,7 @@ function getFileCategory(file: File): FileCategory {
 }
 
 export const FileUploadButton = memo(function FileUploadButton({
-  attachments: externalAttachments = [],
+  attachments: _attachments = [],
   onAttachmentsChange,
 }: FileUploadButtonProps) {
   const { t } = useTranslation();
@@ -111,7 +111,8 @@ export const FileUploadButton = memo(function FileUploadButton({
           url: "",
         };
 
-        onAttachmentsChange?.([...externalAttachments, tempAttachment]);
+        // Use functional update to support multiple file uploads
+        onAttachmentsChange?.((prev) => [...prev, tempAttachment]);
 
         try {
           const result = await uploadApi.uploadFile(file, {
@@ -150,7 +151,7 @@ export const FileUploadButton = memo(function FileUploadButton({
         }
       }
     },
-    [externalAttachments, hasPermission, onAttachmentsChange],
+    [hasPermission, onAttachmentsChange],
   );
 
   // Handle category selection from dropdown


### PR DESCRIPTION
## 问题
选择多个同类型文件（如多张图片）时，只有最后一个文件被添加到附件列表。

## 原因
`handleFiles` 函数使用 `[...externalAttachments, tempAttachment]` 添加临时附件，但 `externalAttachments` 是 props 传入的静态值，在循环中不会更新。

## 修复
改为函数式更新 `(prev) => [...prev, tempAttachment]`，确保每次添加都基于最新状态。

## 测试
1. 点击附件按钮，选择「图片」
2. 在文件选择器中按住 Ctrl/Cmd 同时选择多个图片
3. 确认所有图片都显示上传进度并成功上传