### PR TITLE
fix: 修复三个前端 bug

### DIFF
--- a/frontend/src/components/panels/RolesPanel.tsx
+++ b/frontend/src/components/panels/RolesPanel.tsx
@@ -69,8 +69,11 @@ function RoleFormModal({
 
     try {
       const limits: RoleLimits = {};
-      if (maxChannels !== "") {
-        limits.max_channels = maxChannels as number;
+      if (maxChannels !== "" && maxChannels !== null && maxChannels !== undefined) {
+        const numValue = Number(maxChannels);
+        if (!isNaN(numValue) && numValue >= 0) {
+          limits.max_channels = numValue;
+        }
       }
       const data: RoleCreate | RoleUpdate = {
         name: name.trim(),

--- a/frontend/src/components/share/ShareDialog.tsx
+++ b/frontend/src/components/share/ShareDialog.tsx
@@ -184,15 +184,17 @@ export function ShareDialog({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center">
+    <div className="fixed inset-0 z-[100] sm:flex sm:items-center sm:justify-center">
       {/* Backdrop - using solid color instead of backdrop-blur for better performance */}
       <div className="absolute inset-0 bg-black/60" onClick={onClose} />
 
-      {/* Dialog */}
-      <div className="relative z-10 w-full max-w-lg mx-4 bg-white dark:bg-stone-800 rounded-xl shadow-xl border border-gray-200 dark:border-stone-700 overflow-hidden animate-in fade-in zoom-in-95 duration-200 max-h-[90vh] max-h-[90dvh] flex flex-col">
+      {/* Dialog - bottom sheet on mobile, centered on desktop */}
+      <div className="relative z-10 w-full sm:max-w-lg sm:mx-4 bg-white dark:bg-stone-800 sm:rounded-xl rounded-t-xl shadow-xl border border-gray-200 dark:border-stone-700 overflow-hidden animate-in fade-in zoom-in-95 sm:duration-200 duration-300 max-h-[90vh] max-h-[90dvh] flex flex-col fixed bottom-0 left-0 right-0 sm:static animate-slide-up-sheet sm:animate-in">
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-gray-200 dark:border-stone-700">
-          <div className="flex items-center gap-2">
+          {/* Mobile drag handle */}
+          <div className="sm:hidden absolute top-2 left-1/2 -translate-x-1/2 w-9 h-1 bg-gray-300 dark:bg-stone-600 rounded-full" />
+          <div className="flex items-center gap-2 pt-2 sm:pt-0">
             <Share2 size={20} className="text-stone-500 dark:text-stone-400" />
             <h3 className="text-lg font-semibold text-gray-900 dark:text-stone-100">
               {t("share.title")}

--- a/frontend/src/hooks/useAgent.ts
+++ b/frontend/src/hooks/useAgent.ts
@@ -169,6 +169,20 @@ export function useAgent(options?: UseAgentOptions): UseAgentReturn {
     fetchAgents();
   }, [fetchAgents]);
 
+  // Refresh agents when page becomes visible (e.g., switching back to /chat tab)
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        fetchAgents();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [fetchAgents]);
+
   // Listen for agent preference updates to refresh agents list and apply new default
   useEffect(() => {
     const handleAgentPreferenceUpdated = async () => {


### PR DESCRIPTION
## 修复内容

### Bug 1: 消息弹窗在手机端变形
- **问题**: 点击分享弹窗后，手机端界面变形，不显示 header
- **修复**: ShareDialog 现在在手机端使用底部弹出样式 (bottom sheet)，在桌面端保持居中弹窗样式

### Bug 2: 切换页面后 /agents 不重新请求
- **问题**: 切换到其他页面再切回 /chat 后，不会重新请求 /agents 接口
- **修复**: 添加 `visibilitychange` 事件监听，当页面重新可见时自动刷新 agents 列表

### Bug 3: 更改角色 max_channels 报错
- **问题**: 更改角色的最大渠道数量时会报错
- **修复**: 添加更严格的数值验证，确保 limits 数据格式正确传递给后端

## 测试
- [x] 手机端分享弹窗显示正常
- [x] 切换页面后 agents 列表能正确刷新
- [x] 更改角色 max_channels 不再报错