### PR TITLE
fix: 修复分享对话组件在手机端显示位置错误

### DIFF
--- a/frontend/src/components/share/ShareDialog.tsx
+++ b/frontend/src/components/share/ShareDialog.tsx
@@ -189,7 +189,7 @@ export function ShareDialog({
       <div className="absolute inset-0 bg-black/60" onClick={onClose} />
 
       {/* Dialog - bottom sheet on mobile, centered on desktop */}
-      <div className="relative z-10 w-full sm:max-w-lg sm:mx-4 bg-white dark:bg-stone-800 sm:rounded-xl rounded-t-xl shadow-xl border border-gray-200 dark:border-stone-700 overflow-hidden animate-in fade-in zoom-in-95 sm:duration-200 duration-300 max-h-[90vh] max-h-[90dvh] flex flex-col fixed bottom-0 left-0 right-0 sm:static animate-slide-up-sheet sm:animate-in">
+      <div className="relative z-10 w-full sm:max-w-lg sm:mx-4 bg-white dark:bg-stone-800 sm:rounded-xl rounded-t-xl shadow-xl border border-gray-200 dark:border-stone-700 overflow-hidden duration-300 max-h-[90vh] max-h-[90dvh] flex flex-col fixed bottom-0 left-0 right-0 sm:static animate-slide-up-sheet sm:animate-in sm:fade-in sm:zoom-in-95 sm:duration-200">
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-gray-200 dark:border-stone-700">
           {/* Mobile drag handle */}

--- a/src/infra/channel/feishu/handler.py
+++ b/src/infra/channel/feishu/handler.py
@@ -323,7 +323,9 @@ def create_feishu_message_handler(
                 ch_config = await ch_storage.get_config(user_id, ChannelType.FEISHU, instance_id)
                 if ch_config and ch_config.get("agent_id"):
                     agent_to_use = ch_config["agent_id"]
-                    logger.info(f"[Feishu] Using channel agent: {agent_to_use} for instance {instance_id}")
+                    logger.info(
+                        f"[Feishu] Using channel agent: {agent_to_use} for instance {instance_id}"
+                    )
 
             collector = FeishuResponseCollector(
                 manager=manager,


### PR DESCRIPTION
## 问题
手机端分享对话框出现在屏幕顶部，而不是从底部展开

## 原因
动画类冲突：同时使用了 `animate-in fade-in zoom-in-95`（从中心缩放）和 `animate-slide-up-sheet`（从底部滑出）

## 修复
- 手机端：只用 `animate-slide-up-sheet`
- 桌面端：用 `sm:animate-in sm:fade-in sm:zoom-in-95`