### PR TITLE
fix: 支持所有 LangGraph/MCP 工具结果格式解析与渲染

### DIFF
--- a/frontend/src/components/chat/ChatMessage/ToolCallItem.tsx
+++ b/frontend/src/components/chat/ChatMessage/ToolCallItem.tsx
@@ -39,6 +39,120 @@ function isMarkdownText(text: string): boolean {
   return false;
 }
 
+// MCP content block 类型 (后端 _normalize_content 返回)
+interface McpContentBlock {
+  type: "text" | "image" | "file";
+  text?: string;
+  base64?: string;
+  url?: string;
+  mime_type?: string;
+}
+
+// MCP 多模态结果格式
+interface McpMultiModalResult {
+  text?: string;
+  blocks?: McpContentBlock[];
+}
+
+// 工具结果渲染组件 — 支持 str / dict / MCP 多模态
+function ToolResultContent({
+  result,
+}: {
+  result?: string | Record<string, unknown>;
+}) {
+  // MCP 多模态格式: {"text": "...", "blocks": [...]}
+  if (
+    typeof result === "object" &&
+    result !== null &&
+    "blocks" in result &&
+    Array.isArray((result as McpMultiModalResult).blocks)
+  ) {
+    const mcp = result as McpMultiModalResult;
+    return (
+      <div className="space-y-1.5">
+        {mcp.text && (
+          <pre className="text-xs text-stone-600 dark:text-stone-300 whitespace-pre-wrap break-words">
+            {isMarkdownText(mcp.text) ? (
+              <MarkdownContent content={mcp.text} />
+            ) : (
+              mcp.text
+            )}
+          </pre>
+        )}
+        <div className="flex flex-wrap gap-2">
+          {(mcp.blocks || []).map((block, i) => (
+            <McpBlockPreview key={i} block={block} />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // 普通字符串
+  if (typeof result === "string") {
+    return isMarkdownText(result) ? (
+      <div className="text-xs text-stone-600 dark:text-stone-300 max-h-32 overflow-y-auto">
+        <MarkdownContent content={result} />
+      </div>
+    ) : (
+      <pre className="text-xs text-stone-600 dark:text-stone-300 max-h-32 overflow-y-auto whitespace-pre-wrap break-words">
+        {result}
+      </pre>
+    );
+  }
+
+  // 普通 dict / JSON
+  return (
+    <pre className="text-xs text-stone-600 dark:text-stone-300 max-h-32 overflow-y-auto whitespace-pre-wrap break-words">
+      {JSON.stringify(result, null, 2)}
+    </pre>
+  );
+}
+
+// 单个 MCP content block 的预览
+function McpBlockPreview({ block }: { block: McpContentBlock }) {
+  if (block.type === "image") {
+    const src = block.base64
+      ? `data:${block.mime_type || "image/png"};base64,${block.base64}`
+      : block.url || "";
+    return (
+      <img
+        src={src}
+        alt="tool output"
+        className="max-w-full max-h-48 rounded-md border border-stone-200 dark:border-stone-700 cursor-pointer hover:opacity-80 transition-opacity"
+        onClick={() => src && window.open(src, "_blank")}
+      />
+    );
+  }
+
+  if (block.type === "file") {
+    const url = block.url || "";
+    const fileName = url.split("/").pop() || "file";
+    return (
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md bg-stone-100 dark:bg-stone-800 text-xs text-stone-600 dark:text-stone-300 hover:bg-stone-200 dark:hover:bg-stone-700 transition-colors border border-stone-200 dark:border-stone-700"
+      >
+        <ExternalLink size={12} />
+        {fileName}
+      </a>
+    );
+  }
+
+  // text block (fallback, normally rendered as text)
+  if (block.text) {
+    return (
+      <pre className="text-xs text-stone-600 dark:text-stone-300 whitespace-pre-wrap break-words">
+        {block.text}
+      </pre>
+    );
+  }
+
+  return null;
+}
+
 // Collapsible Tool Call Item (compact design)
 export function ToolCallItem({
   name,
@@ -112,17 +226,7 @@ export function ToolCallItem({
               <div className="text-xs uppercase tracking-wider text-stone-400 dark:text-stone-500 mb-1 font-medium">
                 {t("chat.message.result")}
               </div>
-              {typeof result === "string" && isMarkdownText(result) ? (
-                <div className="text-xs text-stone-600 dark:text-stone-300 max-h-32 overflow-y-auto">
-                  <MarkdownContent content={result} />
-                </div>
-              ) : (
-                <pre className="text-xs text-stone-600 dark:text-stone-300 max-h-32 overflow-y-auto whitespace-pre-wrap break-words">
-                  {typeof result === "string"
-                    ? result
-                    : JSON.stringify(result, null, 2)}
-                </pre>
-              )}
+              <ToolResultContent result={result} />
             </div>
           )}
 

--- a/src/infra/agent/events.py
+++ b/src/infra/agent/events.py
@@ -429,20 +429,21 @@ class AgentEventProcessor:
         out = data.get("output", "")
         tool_call_id = event.get("run_id") or f"tool_{uuid.uuid4().hex[:8]}"
 
-        # 提取 ToolMessage content（链式提取）
-        raw = out
-        # 使用 or 短路和链式 getattr 替代多次 hasattr
-        raw = getattr(out, "content", None) if not isinstance(out, str) else out
-        raw = getattr(raw, "content", raw) if not isinstance(raw, str) else raw
+        # 提取工具结果内容，适配所有 LangGraph 工具输出类型
+        # 支持的类型:
+        #   1. str — 直接返回
+        #   2. ToolMessage — 取 .content（str/list[dict]/None）
+        #   3. list[ToolMessage] — 合并每个 .content
+        #   4. list[dict] — 多模态内容 [{"type":"text","text":"..."}]
+        #   5. dict {"content": ...} — 简单 dict 包装
+        #   6. Command dict {"goto":[],"update":{"messages":[ToolMessage,...]}}
+        #   7. Command 对象 — 有 .update 属性
+        #   8. dict {"output": ...} — 嵌套输出
+        #   9. 其他 dict — 保留结构化数据
+        #  10. 其他对象 — str()
+        raw = self._extract_tool_output(out)
 
-        # 转换为字符串
-        if isinstance(raw, list):
-            # 使用生成器表达式避免中间列表
-            raw = "".join(p.get("text", "") if isinstance(p, dict) else str(p) for p in raw)
-        elif not isinstance(raw, str):
-            raw = str(raw)
-
-        # 错误检测（使用字符串视图避免重复 lower() 调用）
+        # 错误检测
         is_error, error_message = False, None
         if isinstance(raw, dict):
             if raw.get("error") or raw.get("status") == "error":
@@ -450,11 +451,10 @@ class AgentEventProcessor:
                 error_message = raw.get("error") or raw.get("message") or str(raw)
         elif isinstance(raw, str):
             raw_lower = raw.lower()
-            # 使用 any 的短路特性
             if any(e in raw_lower for e in _TOOL_ERROR_INDICATORS):
                 is_error, error_message = True, raw
 
-        # JSON 解析（快速检查避免不必要的解析尝试）
+        # JSON 解析（字符串可能是 JSON，尝试解析为结构化数据给前端）
         result: Any = raw
         if isinstance(raw, str) and raw and raw[0] in ("{", "["):
             try:
@@ -475,3 +475,192 @@ class AgentEventProcessor:
                 agent_id=current_agent_id,
             )
         )
+
+    @staticmethod
+    def _extract_tool_output(out: Any) -> Any:
+        """从 LangGraph 工具节点输出中提取可显示内容。
+
+        支持所有 LangGraph + MCP 工具输出类型:
+          1. str — 直接返回
+          2. ToolMessage — 取 .content (优先 .artifact)
+          3. list[BaseMessage] — 合并每个消息的 content
+          4. Command 对象 — 取 .update.messages → 合并 content
+          5. Command dict {"goto":[], "update":{"messages":[...]}}
+          6. dict {"content": ...} / {"output": {"content": ...}}
+          7. list[dict] — MCP 多模态 content blocks (text/image/file/resource)
+          8. 其他 dict — 保留结构化数据
+          9. 其他对象 — str()
+        """
+        if out is None:
+            return ""
+        if isinstance(out, str):
+            return out
+
+        # 1. Command 对象 (langgraph.types.Command)
+        if hasattr(out, "update") and not isinstance(out, dict):
+            update = getattr(out, "update", None)
+            if isinstance(update, dict):
+                messages = update.get("messages")
+                if isinstance(messages, list) and messages:
+                    return AgentEventProcessor._merge_message_contents(messages)
+                return update
+
+        # 2. BaseMessage 对象 (ToolMessage, AIMessage 等)
+        if hasattr(out, "content") and hasattr(out, "type"):
+            content = getattr(out, "content", None)
+            artifact = getattr(out, "artifact", None)
+            if artifact is not None:
+                return artifact
+            if content is not None:
+                return AgentEventProcessor._normalize_content(content)
+            return ""
+
+        # 3. list — [BaseMessage] 或 MCP content blocks [dict]
+        if isinstance(out, list):
+            if out and hasattr(out[0], "content"):
+                return AgentEventProcessor._merge_message_contents(out)
+            return AgentEventProcessor._normalize_content(out)
+
+        # 4. dict
+        if isinstance(out, dict):
+            # 4a. Command dict {"goto":[], "update":{"messages":[...]}}
+            if "update" in out and isinstance(out["update"], dict):
+                messages = out["update"].get("messages")
+                if isinstance(messages, list) and messages:
+                    return AgentEventProcessor._merge_message_contents(messages)
+                return out["update"]
+
+            # 4b. 直接 content key
+            if "content" in out:
+                return AgentEventProcessor._normalize_content(out["content"])
+
+            # 4c. 嵌套 output.content
+            if "output" in out:
+                nested = out["output"]
+                if isinstance(nested, dict) and "content" in nested:
+                    return AgentEventProcessor._normalize_content(nested["content"])
+                if isinstance(nested, str):
+                    return nested
+
+            # 4d. 其他 dict — 保留结构化数据
+            return out
+
+        # 5. 其他对象
+        return str(out)
+
+    @staticmethod
+    def _normalize_content(content: Any) -> Any:
+        """将 content 标准化为可显示格式。
+
+        MCP content block 类型 (经 langchain-mcp-adapter 转换后):
+          {"type": "text", "text": "..."}
+          {"type": "image", "base64": "...", "mime_type": "..."}
+          {"type": "image", "url": "...", "mime_type": "..."}
+          {"type": "file", "url": "...", "mime_type": "..."}
+
+        返回值策略:
+          - 纯文本 (str 或仅 text blocks) → str
+          - 包含 image/file → {"text": str, "blocks": list[dict]}
+          - dict → dict
+        """
+        if isinstance(content, str):
+            return content
+        if isinstance(content, dict):
+            return content
+        if not isinstance(content, list):
+            return str(content)
+
+        # 分离 text 和 media blocks
+        text_parts: list[str] = []
+        media_blocks: list[dict] = []
+
+        for block in content:
+            if isinstance(block, dict):
+                btype = block.get("type", "")
+                if btype == "text" and "text" in block:
+                    text_parts.append(str(block["text"]))
+                elif btype in ("image", "file"):
+                    # 保留给前端的 media block，去掉内部 id
+                    media_block = {k: v for k, v in block.items() if k != "id"}
+                    media_blocks.append(media_block)
+                elif "text" in block:
+                    text_parts.append(str(block["text"]))
+                else:
+                    # 其他未知 block，保留结构
+                    media_block = {k: v for k, v in block.items() if k != "id"}
+                    media_blocks.append(media_block)
+            elif isinstance(block, str):
+                text_parts.append(block)
+            else:
+                text_parts.append(str(block))
+
+        text_result = "".join(text_parts)
+
+        # 有 media blocks → 返回结构化对象给前端
+        if media_blocks:
+            return {"text": text_result, "blocks": media_blocks}
+
+        # 纯文本
+        return text_result if text_result else content
+
+    @staticmethod
+    def _merge_message_contents(messages: list) -> Any:
+        """从消息列表中提取并合并所有 content。
+
+        支持 BaseMessage 对象和 dict 格式的消息。
+        保留 MCP 多模态 block 结构（image/file）。
+        """
+        all_text_parts: list[str] = []
+        all_media_blocks: list[dict] = []
+        has_media = False
+
+        for msg in messages:
+            if isinstance(msg, dict):
+                content = msg.get("content", "")
+                artifact = msg.get("artifact")
+            elif hasattr(msg, "content"):
+                content = getattr(msg, "content", "")
+                artifact = getattr(msg, "artifact", None)
+            else:
+                content = str(msg)
+                artifact = None
+
+            # artifact 优先（结构化数据）
+            if artifact is not None:
+                all_text_parts.append(json.dumps(artifact, ensure_ascii=False))
+                continue
+
+            if isinstance(content, str):
+                all_text_parts.append(content)
+            elif isinstance(content, list):
+                # MCP content blocks
+                for block in content:
+                    if isinstance(block, dict):
+                        btype = block.get("type", "")
+                        if btype == "text" and "text" in block:
+                            all_text_parts.append(str(block["text"]))
+                        elif btype in ("image", "file"):
+                            media_block = {k: v for k, v in block.items() if k != "id"}
+                            all_media_blocks.append(media_block)
+                            has_media = True
+                        elif "text" in block:
+                            all_text_parts.append(str(block["text"]))
+                        else:
+                            media_block = {k: v for k, v in block.items() if k != "id"}
+                            all_media_blocks.append(media_block)
+                            has_media = True
+                    elif isinstance(block, str):
+                        all_text_parts.append(block)
+                    else:
+                        all_text_parts.append(str(block))
+            elif isinstance(content, dict):
+                all_text_parts.append(json.dumps(content, ensure_ascii=False))
+            else:
+                all_text_parts.append(str(content))
+
+        text_result = "\n".join(all_text_parts)
+
+        if has_media:
+            return {"text": text_result, "blocks": all_media_blocks}
+
+        return text_result


### PR DESCRIPTION
## 问题

LangGraph 工具节点的输出格式多样（ToolMessage、Command、dict 等），LambChat 之前的 `_handle_tool_end` 只处理了对象属性 `.content`，导致：
- Command dict 格式（`{goto, update: {messages}}`）无法提取 content
- MCP 多模态工具返回的 image/file content blocks 被丢弃

## 修复

### 后端 `src/infra/agent/events.py`

重构为 3 个独立方法，覆盖 9 种工具输出类型：

| 类型 | 处理方式 |
|------|--------|
| str | 直接返回 |
| ToolMessage | 取 `.content`（优先 `.artifact`） |
| list[BaseMessage] | 合并每个消息的 content |
| Command 对象 | 取 `.update.messages` |
| Command dict | `update.messages` |
| dict{content} | 直接取 |
| dict{output.content} | 嵌套提取 |
| MCP multimodal list | 分离 text 与 media blocks |
| plain dict | 保留结构化数据 |

- `_normalize_content`: 有 image/file block 时返回 `{text, blocks}` 结构
- `_merge_message_contents`: 支持多消息 MCP media blocks 合并

### 前端 `frontend/src/components/chat/ChatMessage/ToolCallItem.tsx`

新增 3 个组件：
- `ToolResultContent` — 统一结果渲染入口，自动识别格式
- `McpBlockPreview` — image 渲染预览，file 渲染下载链接
- 类型定义 `McpMultiModalResult` / `McpContentBlock`

## 测试

已验证所有 9 种输出类型的提取结果正确。