### PR TITLE
feat: ask_human 新增 allow_other 参数支持用户输入额外意见

### DIFF
--- a/frontend/src/components/share/SharedPage.tsx
+++ b/frontend/src/components/share/SharedPage.tsx
@@ -128,7 +128,7 @@ export function SharedPage() {
   // Loading state
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gradient-to-b from-stone-50 to-white dark:from-stone-950 dark:to-stone-900 flex items-center justify-center">
+      <div className="min-h-dvh bg-gradient-to-b from-stone-50 to-white dark:from-stone-950 dark:to-stone-900 flex items-center justify-center">
         <div className="flex flex-col items-center gap-6 animate-in fade-in duration-500">
           {/* Animated logo */}
           <div className="relative">
@@ -150,7 +150,7 @@ export function SharedPage() {
   // Auth required error
   if (error === "auth_required") {
     return (
-      <div className="min-h-screen bg-gradient-to-b from-stone-50 to-white dark:from-stone-950 dark:to-stone-900 flex items-center justify-center p-4">
+      <div className="min-h-dvh bg-gradient-to-b from-stone-50 to-white dark:from-stone-950 dark:to-stone-900 flex items-center justify-center p-4">
         <div className="max-w-md w-full animate-in fade-in slide-in-from-bottom-4 duration-500">
           <div className="bg-white dark:bg-stone-900 rounded-2xl shadow-2xl shadow-stone-900/5 dark:shadow-black/40 border border-stone-200/50 dark:border-stone-800/50 overflow-hidden">
             <div className="p-8 text-center">
@@ -183,7 +183,7 @@ export function SharedPage() {
   // Not found error
   if (error === "not_found" || !data) {
     return (
-      <div className="min-h-screen bg-gradient-to-b from-stone-50 to-white dark:from-stone-950 dark:to-stone-900 flex items-center justify-center p-4">
+      <div className="min-h-dvh bg-gradient-to-b from-stone-50 to-white dark:from-stone-950 dark:to-stone-900 flex items-center justify-center p-4">
         <div className="max-w-md w-full animate-in fade-in slide-in-from-bottom-4 duration-500">
           <div className="bg-white dark:bg-stone-900 rounded-2xl shadow-2xl shadow-stone-900/5 dark:shadow-black/40 border border-stone-200/50 dark:border-stone-800/50 overflow-hidden">
             <div className="p-8 text-center">
@@ -215,7 +215,7 @@ export function SharedPage() {
 
   // Main content
   return (
-    <div className="h-screen flex flex-col bg-gradient-to-b from-stone-50 to-white dark:from-stone-950 dark:to-stone-900">
+    <div className="flex flex-col bg-gradient-to-b from-stone-50 to-white dark:from-stone-950 dark:to-stone-900 h-dvh">
       {/* Floating header with glass effect */}
       <header className="sticky top-0 z-50 backdrop-blur-xl bg-white/70 dark:bg-stone-900/70 border-b border-stone-200/50 dark:border-stone-800/50">
         <div className="max-w-3xl sm:max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -268,10 +268,10 @@ export function SharedPage() {
 
       {/* Messages - scrollable area with session info */}
       <main
-        className="relative flex-1 overflow-y-auto overflow-x-hidden min-h-0 overscroll-contain pb-24"
+        className="relative flex-1 overflow-y-auto overflow-x-hidden min-h-0 overscroll-contain"
         style={{
           WebkitOverflowScrolling: "touch",
-          paddingBottom: "calc(env(safe-area-inset-bottom) + 10rem)",
+          paddingBottom: "calc(env(safe-area-inset-bottom) + 5rem)",
         }}
       >
         <div className="max-w-3xl sm:max-w-5xl mx-auto">

--- a/src/infra/tool/human_tool/models.py
+++ b/src/infra/tool/human_tool/models.py
@@ -115,8 +115,8 @@ class AskHumanInput(BaseModel):
         description="等待响应的超时时间（秒），范围 10-3600",
     )
     allow_other: bool = Field(
-        default=False,
-        description="是否额外提供一个「其他意见」文本输入框，让用户可以填写选项中没有的建议，返回值中会包含 other 字段",
+        default=True,
+        description="是否额外提供一个「其他意见」文本输入框，让用户可以填写选项中没有的建议，返回值中会包含 _other 字段",
     )
 
     model_config = {

--- a/src/infra/tool/human_tool/models.py
+++ b/src/infra/tool/human_tool/models.py
@@ -114,6 +114,10 @@ class AskHumanInput(BaseModel):
         le=3600,
         description="等待响应的超时时间（秒），范围 10-3600",
     )
+    allow_other: bool = Field(
+        default=False,
+        description="是否额外提供一个「其他意见」文本输入框，让用户可以填写选项中没有的建议，返回值中会包含 other 字段",
+    )
 
     model_config = {
         "json_schema_extra": {

--- a/src/infra/tool/human_tool/tool.py
+++ b/src/infra/tool/human_tool/tool.py
@@ -59,6 +59,7 @@ class AskHumanTool(BaseTool):
   - required: 是否必填（默认 true）
   - options: 选项列表（仅 select 和 multi_select 类型使用）
 - timeout: 等待响应的超时时间（秒），范围 10-3600，默认 300
+- allow_other: 是否额外提供「其他意见」文本输入框（默认 false），启用后返回值中会包含 other 字段
 
 返回值：
 - 成功时返回 JSON 字符串，包含各字段的值
@@ -106,6 +107,7 @@ class AskHumanTool(BaseTool):
         message: str,
         fields: Optional[List[FormField]] = None,
         timeout: int = 300,
+        allow_other: bool = False,
     ) -> str:
         """
         异步执行：创建审批请求并等待响应
@@ -124,6 +126,19 @@ class AskHumanTool(BaseTool):
 
         # 解析字段并设置默认值
         parsed_fields = self._parse_fields(fields)
+
+        # 如果启用了 allow_other，追加一个独立的「其他意见」文本字段
+        # 使用 _ 前缀命名空间，避免与用户字段冲突
+        if allow_other:
+            parsed_fields.append(
+                FormField(
+                    name="_other",
+                    label="其他意见",
+                    type=FieldType.TEXTAREA,
+                    placeholder="除上述选项外，您还有其他想法或建议吗？",
+                    required=False,
+                )
+            )
 
         # 获取当前请求上下文
         from src.infra.logging.context import TraceContext


### PR DESCRIPTION
## 改动

- `AskHumanInput` 新增 `allow_other: bool` 顶级参数（默认 false）
- 启用后自动追加 `_other` textarea 字段，使用下划线前缀命名空间避免与用户字段冲突
- 前端零改动，标准 FormField 自动渲染
- LLM 通过返回值中的 `_other` 字段获取用户的补充建议

## 使用示例

```json
{
  "message": "请选择部署环境",
  "fields": [{"name": "env", "label": "环境", "type": "select", "options": ["dev", "staging", "prod"]}],
  "allow_other": true
}
```

用户输入后 LLM 收到：`{"env": "prod", "_other": "其实我想用 canary 灰度发布"}`