### PR TITLE
fix(frontend): skill editor improvements & markdown fixes

### DIFF
--- a/frontend/src/components/chat/ChatMessage/MarkdownContent.tsx
+++ b/frontend/src/components/chat/ChatMessage/MarkdownContent.tsx
@@ -118,12 +118,12 @@ function CodeBlock({
           background: "transparent",
         }}
         lineNumberStyle={{
-          minWidth: "2.5em",
+          minWidth: "3em",
           paddingRight: "1em",
-          marginRight: "1em",
+          marginRight: "0.75em",
           textAlign: "right",
           color: isDark ? "#71717a" : "#a1a1aa",
-          borderRight: isDark ? "1px solid #44403c" : "1px solid #e7e5e4",
+          borderRight: isDark ? "1px solid #3e4451" : "1px solid #e1e4e8",
         }}
         codeTagProps={{
           style: {

--- a/frontend/src/components/chat/ChatMessage/MarkdownContent.tsx
+++ b/frontend/src/components/chat/ChatMessage/MarkdownContent.tsx
@@ -105,6 +105,12 @@ function CodeBlock({
       </div>
 
       {/* Code content with syntax highlighting and line numbers */}
+      {/* Dynamic line number width based on actual line count */}
+      {(() => {
+        const lines = codeString.split("\n").length;
+        const digits = String(lines).length;
+        const lineNumMinWidth = `${Math.max(digits, 3) + 1}em`;
+        return (
       <SyntaxHighlighter
         language={language || "text"}
         style={isDark ? oneDark : oneLight}
@@ -118,7 +124,7 @@ function CodeBlock({
           background: "transparent",
         }}
         lineNumberStyle={{
-          minWidth: "3em",
+          minWidth: lineNumMinWidth,
           paddingRight: "1em",
           marginRight: "0.75em",
           textAlign: "right",
@@ -134,6 +140,8 @@ function CodeBlock({
       >
         {codeString}
       </SyntaxHighlighter>
+        );
+      })()}
     </div>
   );
 }

--- a/frontend/src/components/documents/DocumentPreview.tsx
+++ b/frontend/src/components/documents/DocumentPreview.tsx
@@ -38,6 +38,7 @@ import {
 // Import preview components
 import CodeRenderer from "./previews/CodeRenderer";
 import MarkdownRenderer from "./previews/MarkdownRenderer";
+import MarkdownPreview from "./previews/MarkdownPreview";
 import PdfPreview from "./previews/PdfPreview";
 import PptPreview from "./previews/PptPreview";
 import WordPreview from "./previews/WordPreview";
@@ -69,6 +70,7 @@ export {
 // Export components for external use
 export { default as CodeRenderer } from "./previews/CodeRenderer";
 export { default as MarkdownRenderer } from "./previews/MarkdownRenderer";
+export { default as MarkdownPreview } from "./previews/MarkdownPreview";
 export { default as PdfPreview } from "./previews/PdfPreview";
 export { default as PptPreview } from "./previews/PptPreview";
 export { default as WordPreview } from "./previews/WordPreview";
@@ -663,9 +665,7 @@ export default function DocumentPreview({
               </div>
             </Suspense>
           ) : markdownFile ? (
-            <div className="p-4 sm:p-6 lg:p-8">
-              <MarkdownRenderer content={data?.content || ""} t={t} />
-            </div>
+            <MarkdownPreview content={data?.content || ""} t={t} />
           ) : (
             <CodeRenderer
               content={data?.content || ""}

--- a/frontend/src/components/documents/previews/CodeRenderer.tsx
+++ b/frontend/src/components/documents/previews/CodeRenderer.tsx
@@ -62,11 +62,13 @@ const CodeRenderer = memo(function CodeRenderer({
         }}
         showLineNumbers
         lineNumberStyle={{
-          minWidth: "3em",
+          minWidth: "3.5em",
           paddingRight: "1em",
+          marginRight: "0.75em",
           textAlign: "right",
           color: isDark ? "#6b7280" : "#9ca3af",
           userSelect: "none",
+          borderRight: isDark ? "1px solid #3e4451" : "1px solid #e1e4e8",
         }}
         codeTagProps={{
           style: {

--- a/frontend/src/components/documents/previews/CodeRenderer.tsx
+++ b/frontend/src/components/documents/previews/CodeRenderer.tsx
@@ -48,6 +48,11 @@ const CodeRenderer = memo(function CodeRenderer({
     return content;
   }, [content, t]);
 
+  // Dynamic line number width based on total line count
+  const lineCount = useMemo(() => displayContent.split("\n").length, [displayContent]);
+  const digitCount = String(lineCount).length;
+  const lineNumMinWidth = `${Math.max(digitCount, 3) + 1}em`;
+
   return (
     <div className="relative h-full overflow-auto bg-stone-100 dark:bg-[#282c34]">
       <SyntaxHighlighter
@@ -62,7 +67,7 @@ const CodeRenderer = memo(function CodeRenderer({
         }}
         showLineNumbers
         lineNumberStyle={{
-          minWidth: "3.5em",
+          minWidth: lineNumMinWidth,
           paddingRight: "1em",
           marginRight: "0.75em",
           textAlign: "right",

--- a/frontend/src/components/documents/previews/MarkdownPreview.tsx
+++ b/frontend/src/components/documents/previews/MarkdownPreview.tsx
@@ -125,43 +125,53 @@ function SourceView({
   }, []);
 
   const lines = content.split("\n");
-  const lineNumWidth = String(lines.length).length;
-  const padWidth = Math.max(lineNumWidth, 3); // minimum 3 chars for alignment
+  // Calculate fixed pixel width: ~8px per digit, minimum 3 digits (24px)
+  const lineCount = lines.length;
+  const digitCount = String(lineCount).length;
+  const lineNumWidthPx = Math.max(digitCount, 3) * 8 + 32; // digits + padding
 
   return (
     <div className="w-full h-full overflow-auto bg-stone-100 dark:bg-[#282c34]">
-      <pre className="text-sm leading-relaxed" style={{ fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace', margin: 0, padding: "1rem 1rem 1rem 0" }}>
-        <code>
-          {lines.map((line, i) => (
-            <div key={i} className="flex hover:bg-stone-200/50 dark:hover:bg-white/5">
-              {/* Fixed-width line number column */}
-              <span
-                className="inline-block shrink-0 select-none text-right pr-4 pl-4"
-                style={{
-                  minWidth: `${padWidth + 2}ch`,
-                  color: isDark ? "#6b7280" : "#9ca3af",
-                  fontSize: "0.75rem",
-                  lineHeight: "1.6",
-                  // Add a vertical separator line
-                  borderRight: `1px solid ${isDark ? "#3e4451" : "#e1e4e8"}`,
-                  marginRight: "1rem",
-                }}
-              >
-                {i + 1}
-              </span>
-              {/* Code content */}
-              <span
-                className="flex-1 whitespace-pre"
-                style={{
-                  color: isDark ? "#abb2bf" : "#24292e",
-                  lineHeight: "1.6",
-                }}
-              >
-                {line || " "}
-              </span>
-            </div>
-          ))}
-        </code>
+      <pre
+        className="text-sm leading-relaxed flex flex-col"
+        style={{
+          fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
+          margin: 0,
+          padding: "1rem 0",
+        }}
+      >
+        {lines.map((line, i) => (
+          <div
+            key={i}
+            className="flex hover:bg-stone-200/50 dark:hover:bg-white/5"
+          >
+            {/* Fixed-width line number column */}
+            <span
+              className="inline-block shrink-0 select-none text-right"
+              style={{
+                width: `${lineNumWidthPx}px`,
+                color: isDark ? "#6b7280" : "#9ca3af",
+                fontSize: "0.75rem",
+                lineHeight: "1.6",
+                paddingRight: "0.75em",
+                borderRight: `1px solid ${isDark ? "#3e4451" : "#e1e4e8"}`,
+                marginRight: "0.75em",
+              }}
+            >
+              {i + 1}
+            </span>
+            {/* Code content */}
+            <span
+              className="flex-1 whitespace-pre"
+              style={{
+                color: isDark ? "#abb2bf" : "#24292e",
+                lineHeight: "1.6",
+              }}
+            >
+              {line || " "}
+            </span>
+          </div>
+        ))}
       </pre>
     </div>
   );

--- a/frontend/src/components/documents/previews/MarkdownPreview.tsx
+++ b/frontend/src/components/documents/previews/MarkdownPreview.tsx
@@ -1,0 +1,170 @@
+import { memo, useState, useEffect } from "react";
+import { Code, Eye } from "lucide-react";
+import { LoadingSpinner } from "../../common/LoadingSpinner";
+import { useTranslation } from "react-i18next";
+import MarkdownRenderer from "./MarkdownRenderer";
+
+interface MarkdownPreviewProps {
+  content: string;
+  t: (key: string, options?: Record<string, unknown>) => string;
+}
+
+const MarkdownPreview = memo(function MarkdownPreview({
+  content,
+  t,
+}: MarkdownPreviewProps) {
+  const { t: t2 } = useTranslation();
+  const [loading, setLoading] = useState(true);
+  const [showSource, setShowSource] = useState(false);
+
+  useEffect(() => {
+    if (content) {
+      setLoading(false);
+    }
+  }, [content]);
+
+  const toggleSource = () => {
+    setShowSource(!showSource);
+  };
+
+  if (loading) {
+    return (
+      <div className="h-full w-full flex flex-col bg-white dark:bg-stone-900">
+        <div className="flex-1 flex items-center justify-center">
+          <LoadingSpinner size="lg" className="text-blue-500" />
+          <span className="ml-2 text-stone-500 dark:text-stone-400">
+            {t("documents.loadingFileContent")}
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full w-full flex flex-col bg-white dark:bg-stone-900">
+      {/* Toolbar */}
+      <div className="flex items-center justify-between px-4 py-2 bg-white dark:bg-stone-900 border-b border-stone-200 dark:border-stone-700 shrink-0">
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-stone-500 dark:text-stone-400">
+            Markdown
+          </span>
+          <span className="text-xs text-stone-400 dark:text-stone-500">
+            ({t("documents.chars", { count: content.length })})
+          </span>
+        </div>
+
+        <div className="flex items-center gap-1">
+          <button
+            onClick={toggleSource}
+            className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+              showSource
+                ? "bg-stone-100 dark:bg-stone-800 text-stone-700 dark:text-stone-300"
+                : "hover:bg-stone-100 dark:hover:bg-stone-800 text-stone-500 dark:text-stone-400"
+            }`}
+            title={
+              showSource
+                ? t("documents.previewMode")
+                : t("documents.viewSource")
+            }
+          >
+            {showSource ? (
+              <>
+                <Eye size={14} />
+                <span>{t("documents.preview")}</span>
+              </>
+            ) : (
+              <>
+                <Code size={14} />
+                <span>{t("documents.source")}</span>
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-hidden">
+        {showSource ? (
+          <SourceView content={content} t={t} />
+        ) : (
+          <div className="p-4 sm:p-6 lg:p-8 overflow-auto h-full">
+            <MarkdownRenderer content={content} t={t} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+});
+
+/**
+ * Source code view with fixed-width line number column
+ * so all content stays aligned regardless of digit count.
+ */
+function SourceView({
+  content,
+  t,
+}: {
+  content: string;
+  t: (key: string, options?: Record<string, unknown>) => string;
+}) {
+  const [isDark, setIsDark] = useState(() =>
+    typeof window !== "undefined"
+      ? document.documentElement.classList.contains("dark")
+      : true,
+  );
+
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      setIsDark(document.documentElement.classList.contains("dark"));
+    });
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  const lines = content.split("\n");
+  const lineNumWidth = String(lines.length).length;
+  const padWidth = Math.max(lineNumWidth, 3); // minimum 3 chars for alignment
+
+  return (
+    <div className="w-full h-full overflow-auto bg-stone-100 dark:bg-[#282c34]">
+      <pre className="text-sm leading-relaxed" style={{ fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace', margin: 0, padding: "1rem 1rem 1rem 0" }}>
+        <code>
+          {lines.map((line, i) => (
+            <div key={i} className="flex hover:bg-stone-200/50 dark:hover:bg-white/5">
+              {/* Fixed-width line number column */}
+              <span
+                className="inline-block shrink-0 select-none text-right pr-4 pl-4"
+                style={{
+                  minWidth: `${padWidth + 2}ch`,
+                  color: isDark ? "#6b7280" : "#9ca3af",
+                  fontSize: "0.75rem",
+                  lineHeight: "1.6",
+                  // Add a vertical separator line
+                  borderRight: `1px solid ${isDark ? "#3e4451" : "#e1e4e8"}`,
+                  marginRight: "1rem",
+                }}
+              >
+                {i + 1}
+              </span>
+              {/* Code content */}
+              <span
+                className="flex-1 whitespace-pre"
+                style={{
+                  color: isDark ? "#abb2bf" : "#24292e",
+                  lineHeight: "1.6",
+                }}
+              >
+                {line || " "}
+              </span>
+            </div>
+          ))}
+        </code>
+      </pre>
+    </div>
+  );
+}
+
+export default MarkdownPreview;

--- a/frontend/src/components/documents/previews/MarkdownRenderer.tsx
+++ b/frontend/src/components/documents/previews/MarkdownRenderer.tsx
@@ -119,7 +119,7 @@ const MarkdownRenderer = memo(function MarkdownRenderer({
           ),
           // Horizontal rule
           hr: () => (
-            <hr className="my-6 border-0 h-px bg-gradient-to-r from-transparent via-stone-300 dark:via-stone-600 to-transparent" />
+            <hr className="my-6 border-0 h-px bg-stone-300 dark:bg-stone-600" />
           ),
           // Strong and emphasis
           strong: ({ children }) => (

--- a/frontend/src/components/documents/previews/MarkdownRenderer.tsx
+++ b/frontend/src/components/documents/previews/MarkdownRenderer.tsx
@@ -157,6 +157,10 @@ const MarkdownRenderer = memo(function MarkdownRenderer({
             }
 
             // Code block with syntax highlighting
+            const lineCount = codeContent.split("\n").length;
+            const digits = String(lineCount).length;
+            const lineNumMinWidth = `${Math.max(digits, 3) + 1}em`;
+
             return (
               <div className="my-4 rounded-xl overflow-hidden shadow-lg ring-1 ring-stone-200 dark:ring-stone-700">
                 {language && (
@@ -181,7 +185,7 @@ const MarkdownRenderer = memo(function MarkdownRenderer({
                   }}
                   showLineNumbers
                   lineNumberStyle={{
-                    minWidth: "3.5em",
+                    minWidth: lineNumMinWidth,
                     paddingRight: "1em",
                     marginRight: "0.75em",
                     textAlign: "right",

--- a/frontend/src/components/documents/previews/MarkdownRenderer.tsx
+++ b/frontend/src/components/documents/previews/MarkdownRenderer.tsx
@@ -181,12 +181,14 @@ const MarkdownRenderer = memo(function MarkdownRenderer({
                   }}
                   showLineNumbers
                   lineNumberStyle={{
-                    minWidth: "2.5em",
+                    minWidth: "3.5em",
                     paddingRight: "1em",
+                    marginRight: "0.75em",
                     textAlign: "right",
                     color: isDark ? "#6b7280" : "#9ca3af",
                     userSelect: "none",
                     fontSize: "0.75rem",
+                    borderRight: isDark ? "1px solid #3e4451" : "1px solid #e1e4e8",
                   }}
                   wrapLines={false}
                   wrapLongLines={false}

--- a/frontend/src/components/panels/SkillsPanel.tsx
+++ b/frontend/src/components/panels/SkillsPanel.tsx
@@ -9,6 +9,8 @@ import {
   Check,
   Github,
   PackageX,
+  Maximize2,
+  Minimize2,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import toast from "react-hot-toast";
@@ -61,6 +63,7 @@ export function SkillsPanel() {
     message: string;
   } | null>(null);
   const [showGithubModal, setShowGithubModal] = useState(false);
+  const [isEditorFullscreen, setIsEditorFullscreen] = useState(false);
   const [githubUrl, setGithubUrl] = useState("");
   const [githubBranch, setGithubBranch] = useState("main");
   const [githubSkills, setGithubSkills] = useState<GitHubSkillPreview[]>([]);
@@ -187,6 +190,7 @@ export function SkillsPanel() {
         setShowModal(false);
         setEditingSkill(null);
         setIsCreating(false);
+        setIsEditorFullscreen(false);
       }
     } catch (error) {
       toast.error((error as Error).message || t("skills.operationFailed"));
@@ -200,6 +204,7 @@ export function SkillsPanel() {
     setShowModal(false);
     setEditingSkill(null);
     setIsCreating(false);
+    setIsEditorFullscreen(false);
   };
 
   const handleDelete = async (name: string, isSystem: boolean = false) => {
@@ -511,19 +516,54 @@ export function SkillsPanel() {
       {showModal && (
         <>
           <div className="fixed inset-0 " onClick={handleCancel} />
-          <div className="modal-bottom-sheet sm:modal-centered-wrapper">
-            <div className="modal-bottom-sheet-content sm:modal-centered-content">
-              <div className="bottom-sheet-handle sm:hidden" />
+          <div
+            className={`${
+              isEditorFullscreen
+                ? "fixed inset-0 z-[200] flex items-stretch"
+                : "modal-bottom-sheet sm:modal-centered-wrapper"
+            }`}
+          >
+            <div
+              className={`${
+                isEditorFullscreen
+                  ? "w-full h-full flex flex-col bg-white dark:bg-stone-900 shadow-2xl"
+                  : "modal-bottom-sheet-content sm:modal-centered-content"
+              }`}
+            >
+              {!isEditorFullscreen && <div className="bottom-sheet-handle sm:hidden" />}
               {/* Header */}
-              <div className="flex items-center justify-between border-b border-stone-200 px-6 py-4 dark:border-stone-800">
+              <div className="flex items-center justify-between border-b border-stone-200 px-6 py-4 dark:border-stone-800 shrink-0">
                 <h3 className="text-xl font-semibold text-stone-900 dark:text-stone-100 font-serif">
                   {isCreating
                     ? t("skills.createNew")
                     : t("skills.editSkill", { name: editingSkill?.name })}
                 </h3>
-                <button onClick={handleCancel} className="btn-icon">
-                  <X size={20} />
-                </button>
+                <div className="flex items-center gap-1">
+                  <button
+                    onClick={() => setIsEditorFullscreen(!isEditorFullscreen)}
+                    className="flex items-center justify-center w-9 h-9 rounded-xl hover:bg-stone-100 dark:hover:bg-stone-800 transition-all duration-200 active:scale-95 cursor-pointer"
+                    title={
+                      isEditorFullscreen
+                        ? t("documents.exitFullscreen")
+                        : t("documents.fullscreen")
+                    }
+                  >
+                    {isEditorFullscreen ? (
+                      <Minimize2
+                        size={18}
+                        className="text-stone-500 dark:text-stone-400"
+                      />
+                    ) : (
+                      <Maximize2
+                        size={18}
+                        className="text-stone-500 dark:text-stone-400"
+                      />
+                    )}
+                  </button>
+                  <button onClick={handleCancel} className="btn-icon">
+                    <X size={20} />
+                  </button>
+                </div>
               </div>
               {/* Content */}
               <div className="flex-1 overflow-y-auto px-2 sm:px-6 py-4 space-y-2">

--- a/frontend/src/components/skill/CodeEditor.tsx
+++ b/frontend/src/components/skill/CodeEditor.tsx
@@ -1,0 +1,135 @@
+import { useRef, useCallback, useEffect, useState, memo } from "react";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import {
+  oneDark,
+  oneLight,
+} from "react-syntax-highlighter/dist/esm/styles/prism";
+import { detectLanguage } from "../documents/utils/detectLanguage";
+
+interface CodeEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  filePath?: string;
+  placeholder?: string;
+  className?: string;
+}
+
+const CodeEditor = memo(function CodeEditor({
+  value,
+  onChange,
+  filePath,
+  placeholder,
+  className = "",
+}: CodeEditorProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const highlightRef = useRef<HTMLPreElement>(null);
+  const [isDark, setIsDark] = useState(() =>
+    typeof window !== "undefined"
+      ? document.documentElement.classList.contains("dark")
+      : true,
+  );
+
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      setIsDark(document.documentElement.classList.contains("dark"));
+    });
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  const language = filePath ? detectLanguage(filePath) : "markdown";
+
+  const handleScroll = useCallback(() => {
+    if (textareaRef.current && highlightRef.current) {
+      highlightRef.current.scrollTop = textareaRef.current.scrollTop;
+      highlightRef.current.scrollLeft = textareaRef.current.scrollLeft;
+    }
+  }, []);
+
+  // Sync scroll from highlight to textarea
+  const handleHighlightScroll = useCallback(() => {
+    if (textareaRef.current && highlightRef.current) {
+      textareaRef.current.scrollTop = highlightRef.current.scrollTop;
+      textareaRef.current.scrollLeft = highlightRef.current.scrollLeft;
+    }
+  }, []);
+
+  const codeStyle = isDark ? oneDark : oneLight;
+  const bgColor = isDark ? "#282c34" : "#fafafa";
+
+  return (
+    <div className={`relative ${className}`}>
+      {/* Syntax highlighted background */}
+      <div
+        className="absolute inset-0 overflow-hidden pointer-events-none"
+        onScroll={handleHighlightScroll}
+        ref={(el) => {
+          if (el) {
+            // Store the scroll container ref
+            (highlightRef as React.MutableRefObject<HTMLPreElement | HTMLDivElement>).current = el as HTMLDivElement;
+          }
+        }}
+      >
+        <SyntaxHighlighter
+          language={language}
+          style={codeStyle}
+          customStyle={{
+            margin: 0,
+            padding: "1rem",
+            background: bgColor,
+            fontSize: "0.875rem",
+            lineHeight: "1.6",
+            minHeight: "100%",
+          }}
+          showLineNumbers
+          lineNumberStyle={{
+            minWidth: "2.5em",
+            paddingRight: "1em",
+            textAlign: "right" as const,
+            color: isDark ? "#6b7280" : "#9ca3af",
+            userSelect: "none" as const,
+            fontSize: "0.75rem",
+          }}
+          codeTagProps={{
+            style: {
+              fontFamily:
+                'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
+            },
+          }}
+          wrapLines={false}
+          wrapLongLines={false}
+        >
+          {value || " "}
+        </SyntaxHighlighter>
+      </div>
+
+      {/* Transparent textarea overlay */}
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onScroll={handleScroll}
+        placeholder={placeholder}
+        spellCheck={false}
+        className="absolute inset-0 w-full h-full resize-none bg-transparent text-transparent caret-stone-300 dark:caret-stone-400 font-mono text-sm focus:outline-none"
+        style={{
+          padding: "1rem",
+          paddingLeft: "2.5rem + 1rem",
+          fontSize: "0.875rem",
+          lineHeight: "1.6",
+          tabSize: 2,
+          fontFamily:
+            'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
+          // Ensure textarea matches highlighter layout
+          letterSpacing: "normal",
+          wordSpacing: "normal",
+        }}
+      />
+    </div>
+  );
+});
+
+export default CodeEditor;

--- a/frontend/src/components/skill/SkillForm.tsx
+++ b/frontend/src/components/skill/SkillForm.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import type { SkillResponse, SkillCreate } from "../../types";
+import CodeEditor from "./CodeEditor";
 
 interface FileEntry {
   path: string;
@@ -307,17 +308,19 @@ export function SkillForm({
         </div>
 
         {/* File content editor */}
-        <textarea
-          value={files[activeFileIndex]?.content || ""}
-          onChange={(e) => updateFileContent(activeFileIndex, e.target.value)}
-          rows={12}
-          placeholder={t("skills.form.contentPlaceholder")}
-          className={`w-full rounded-lg border px-3 py-2 font-mono text-sm focus:border-stone-500 focus:outline-none focus:ring-1 focus:ring-stone-500 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-100 dark:focus:border-amber-500 dark:focus:ring-amber-500 ${
-            errors.content
-              ? "border-red-300 focus:border-red-500 focus:ring-red-500 dark:border-red-700"
-              : ""
+        <div
+          className={`rounded-lg overflow-hidden border ${
+            errors.content ? "border-red-300 dark:border-red-700" : ""
           }`}
-        />
+        >
+          <CodeEditor
+            value={files[activeFileIndex]?.content || ""}
+            onChange={(content) => updateFileContent(activeFileIndex, content)}
+            filePath={files[activeFileIndex]?.path}
+            placeholder={t("skills.form.contentPlaceholder")}
+            className="h-[28rem]"
+          />
+        </div>
         {errors.content && (
           <p className="mt-1 text-xs text-red-600 dark:text-red-400">
             {errors.content}


### PR DESCRIPTION
## Changes

1. **Skill 文件编辑器语法高亮** — 替换 textarea 为 CodeEditor 组件（react-syntax-highlighter + 透明 textarea 覆盖），根据文件路径自动检测语言
2. **Skill 编辑器全屏切换** — Modal 头部新增 Maximize2/Minimize2 按钮，全屏时占满整个屏幕
3. **Markdown hr 分割线** — 渐变改为实线（`bg-stone-300`）
4. **Markdown 源码视图** — 新增 MarkdownPreview 组件，支持预览/源码切换（与 HtmlPreview 风格一致）
5. **行号分割线对齐** — 所有代码块添加 borderRight 分割线，minWidth 根据实际行数动态计算，支持任意行数（10000+）