### PR TITLE
fix: MCP 结果渲染优化 + Todo/工具名截断

### DIFF
--- a/frontend/src/components/chat/ChatMessage/TodoBlock.tsx
+++ b/frontend/src/components/chat/ChatMessage/TodoBlock.tsx
@@ -116,11 +116,12 @@ function TodoItemRow({ item }: { item: TodoItem }) {
       <div className="min-w-0 flex-1">
         <p
           className={clsx(
-            "text-[13px] leading-snug",
+            "text-[13px] leading-snug truncate",
             config.textClass,
             item.status === "in_progress" &&
               "text-stone-800 dark:text-stone-100",
           )}
+          title={item.content}
         >
           {item.content}
         </p>

--- a/frontend/src/components/chat/ChatMessage/items/McpBlockPreview.tsx
+++ b/frontend/src/components/chat/ChatMessage/items/McpBlockPreview.tsx
@@ -1,4 +1,5 @@
-import { ExternalLink } from "lucide-react";
+import { ChevronDown, ChevronUp, ExternalLink, FileText } from "lucide-react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { MarkdownContent } from "../MarkdownContent";
 import type { McpContentBlock, McpMultiModalResult } from "./toolUtils";
@@ -67,13 +68,15 @@ export function ToolResultContent({
     return (
       <div className="space-y-1.5">
         {mcp.text && (
-          <pre className="text-xs text-stone-600 dark:text-stone-300 whitespace-pre-wrap break-words">
-            {isMarkdownText(mcp.text) ? (
+          isMarkdownText(mcp.text) ? (
+            <div className="text-xs text-stone-600 dark:text-stone-300">
               <MarkdownContent content={mcp.text} />
-            ) : (
-              mcp.text
-            )}
-          </pre>
+            </div>
+          ) : (
+            <pre className="text-xs text-stone-600 dark:text-stone-300 whitespace-pre-wrap break-words">
+              {mcp.text}
+            </pre>
+          )
         )}
         <div className="flex flex-wrap gap-2">
           {(mcp.blocks || []).map((block, i) => (
@@ -84,9 +87,49 @@ export function ToolResultContent({
     );
   }
 
+  // 富文本结果：dict 含 title/url/content 结构
+  if (
+    typeof result === "object" &&
+    result !== null &&
+    typeof result.content === "string" &&
+    (typeof result.title === "string" || typeof result.url === "string")
+  ) {
+    const title = typeof result.title === "string" ? result.title : "";
+    const url = typeof result.url === "string" ? result.url : "";
+    return (
+      <div className="rounded-md border border-stone-200 dark:border-stone-700 overflow-hidden">
+        {(title || url) && (
+          <div className="flex items-center gap-2 px-3 py-2 bg-stone-100 dark:bg-stone-800 border-b border-stone-200 dark:border-stone-700">
+            <FileText size={14} className="shrink-0 text-stone-500 dark:text-stone-400" />
+            {url ? (
+              <a
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs font-medium text-stone-700 dark:text-stone-200 hover:underline truncate"
+              >
+                {title || url}
+              </a>
+            ) : (
+              <span className="text-xs font-medium text-stone-700 dark:text-stone-200 truncate">
+                {title}
+              </span>
+            )}
+            {url && (
+              <ExternalLink size={12} className="shrink-0 text-stone-400 dark:text-stone-500 ml-auto" />
+            )}
+          </div>
+        )}
+        <div className="p-3 text-xs text-stone-600 dark:text-stone-300 max-h-96 overflow-y-auto">
+          <MarkdownContent content={result.content} />
+        </div>
+      </div>
+    );
+  }
+
   if (textContent) {
     return isMarkdownText(textContent) ? (
-      <div className="text-xs text-stone-600 dark:text-stone-300 max-h-32 overflow-y-auto">
+      <div className="text-xs text-stone-600 dark:text-stone-300 max-h-64 overflow-y-auto">
         <MarkdownContent content={textContent} />
       </div>
     ) : (
@@ -96,9 +139,31 @@ export function ToolResultContent({
     );
   }
 
+  return <JsonFallback data={result} />;
+}
+
+const MAX_JSON_COLLAPSED = 640;
+
+function JsonFallback({ data }: { data: unknown }) {
+  const [expanded, setExpanded] = useState(false);
+  const str = JSON.stringify(data, null, 2);
+  const needsTruncation = str.length > MAX_JSON_COLLAPSED;
+  const display = needsTruncation && !expanded ? str.slice(0, MAX_JSON_COLLAPSED) + "\n…" : str;
+
   return (
-    <pre className="text-xs text-stone-600 dark:text-stone-300 max-h-32 overflow-y-auto whitespace-pre-wrap break-words">
-      {JSON.stringify(result, null, 2)}
-    </pre>
+    <div>
+      <pre className="text-xs text-stone-600 dark:text-stone-300 max-h-32 overflow-y-auto whitespace-pre-wrap break-words">
+        {display}
+      </pre>
+      {needsTruncation && (
+        <button
+          onClick={() => setExpanded((v) => !v)}
+          className="flex items-center gap-1 mt-1 text-xs text-stone-500 dark:text-stone-400 hover:text-stone-700 dark:hover:text-stone-200 transition-colors"
+        >
+          {expanded ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+          {expanded ? "收起" : "展开全部"}
+        </button>
+      )}
+    </div>
   );
 }

--- a/frontend/src/components/common/CollapsiblePill.tsx
+++ b/frontend/src/components/common/CollapsiblePill.tsx
@@ -151,7 +151,7 @@ export function CollapsiblePill({
       >
         <StatusIndicator status={status} variant={variant} />
         {icon}
-        <span className="font-mono">{formattedLabel}</span>
+        <span className="font-mono truncate max-w-[200px] sm:max-w-[400px]">{formattedLabel}</span>
         {suffix}
         {canExpand && (
           <ChevronRight

--- a/frontend/src/hooks/useAgent/messageParts.ts
+++ b/frontend/src/hooks/useAgent/messageParts.ts
@@ -184,6 +184,15 @@ export function addPartToDepth(
         } else {
           newSubagentParts = [...existingParts, part];
         }
+      } else if (part.type === "todo") {
+        // Upsert: replace existing todo or append — each subagent gets at most one todo
+        const todoIdx = existingParts.findIndex((p) => p.type === "todo");
+        if (todoIdx >= 0) {
+          newSubagentParts = [...existingParts];
+          newSubagentParts[todoIdx] = part;
+        } else {
+          newSubagentParts = [...existingParts, part];
+        }
       } else {
         newSubagentParts = [...existingParts, part];
       }


### PR DESCRIPTION
## 概述

修复前端 MCP 工具结果渲染和 UI 显示问题。

## 改动

### MCP 结果渲染 (McpBlockPreview.tsx)
- 修复多模态分支中 Markdown 被 `<pre>` 包裹导致排版错乱
- 新增富文本卡片：dict 结果含 title/url/content 时渲染为标题+链接+Markdown
- 增大 Markdown 容器高度
- JSON fallback 添加截断

### 工具名截断 (CollapsiblePill.tsx)
- 长命令/文件名不换行，使用 truncate + max-w 截断

### Todo 项截断 (TodoBlock.tsx)
- todo item 内容不换行，truncate + hover 显示全文

### Todo 去重 (messageParts.ts)
- 子代理中 todo upsert 而非 append，每个子代理最多一个 todo

## 验证
- ✅ TypeScript 无错误