### PR TITLE
fix: 支持LangChain嵌套数组的工具结果渲染

### DIFF
--- a/frontend/src/components/chat/ChatMessage/items/McpBlockPreview.tsx
+++ b/frontend/src/components/chat/ChatMessage/items/McpBlockPreview.tsx
@@ -5,6 +5,19 @@ import { MarkdownContent } from "../MarkdownContent";
 import type { McpContentBlock, McpMultiModalResult } from "./toolUtils";
 import { isMarkdownText, extractText } from "./toolUtils";
 
+// LangChain content blocks 数组: [{"type": "text", "text": "..."}, ...]
+function isContentBlocksArray(
+  result: unknown,
+): result is McpContentBlock[] {
+  return (
+    Array.isArray(result) &&
+    result.length > 0 &&
+    typeof result[0] === "object" &&
+    result[0] !== null &&
+    "type" in result[0]
+  );
+}
+
 // 单个 MCP content block 的预览
 function McpBlockPreview({ block }: { block: McpContentBlock }) {
   const { t } = useTranslation();
@@ -57,6 +70,43 @@ export function ToolResultContent({
   result?: string | Record<string, unknown>;
 }) {
   const textContent = extractText(result);
+
+  // LangChain content blocks 数组: [{"type": "text", "text": "..."}, ...]
+  if (isContentBlocksArray(result)) {
+    const blocks = result as McpContentBlock[];
+    const textParts: string[] = [];
+    const mediaBlocks: McpContentBlock[] = [];
+
+    for (const block of blocks) {
+      if (block.type === "text" && block.text) {
+        textParts.push(block.text);
+      } else if (block.type === "image" || block.type === "file") {
+        mediaBlocks.push(block);
+      }
+    }
+
+    const combinedText = textParts.join("\n");
+    return (
+      <div className="space-y-1.5">
+        {combinedText && (
+          <div className="text-xs text-stone-600 dark:text-stone-300 max-h-64 overflow-y-auto">
+            {isMarkdownText(combinedText) ? (
+              <MarkdownContent content={combinedText} />
+            ) : (
+              combinedText
+            )}
+          </div>
+        )}
+        {mediaBlocks.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {mediaBlocks.map((block, i) => (
+              <McpBlockPreview key={i} block={block} />
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
 
   if (
     typeof result === "object" &&

--- a/src/infra/agent/events.py
+++ b/src/infra/agent/events.py
@@ -664,6 +664,17 @@ class AgentEventProcessor:
         _media = AgentEventProcessor._MCP_MEDIA_TYPES
 
         for block in content:
+            # 嵌套数组 (LangChain 双层包装)：递归展平
+            if isinstance(block, list):
+                nested = AgentEventProcessor._normalize_content(block)
+                if isinstance(nested, str):
+                    text_parts.append(nested)
+                elif isinstance(nested, dict):
+                    if "text" in nested:
+                        text_parts.append(nested["text"])
+                    if "blocks" in nested:
+                        media_blocks.extend(nested["blocks"])
+                continue
             if not isinstance(block, dict):
                 text_parts.append(str(block) if block is not None else "")
                 continue
@@ -723,6 +734,18 @@ class AgentEventProcessor:
                 text_parts.append(content)
             elif isinstance(content, list):
                 for block in content:
+                    # 嵌套数组：递归展平
+                    if isinstance(block, list):
+                        nested = AgentEventProcessor._normalize_content(block)
+                        if isinstance(nested, str):
+                            text_parts.append(nested)
+                        elif isinstance(nested, dict):
+                            if "text" in nested:
+                                text_parts.append(nested["text"])
+                            if "blocks" in nested:
+                                media_blocks.extend(nested["blocks"])
+                                has_media = True
+                        continue
                     if not isinstance(block, dict):
                         text_parts.append(str(block) if block is not None else "")
                         continue


### PR DESCRIPTION
## 问题

LangChain MCP 工具返回结果为嵌套数组 `[[{"type":"text","text":"..."}]]`，内层 list 被 `str()` 序列化为 JSON 字符串而非正确解析。

## 修复

**后端** `src/infra/agent/events.py`
- `_normalize_content`: block 为 list 时递归展平
- `_process_messages`: 同样处理嵌套 content blocks

**前端** `items/McpBlockPreview.tsx`
- `ToolResultContent` 支持 LangChain content blocks 数组格式
- 自动检测 markdown 并正确渲染

## 支持格式

| 格式 | 状态 |
|------|------|
| `"plain text"` | ✅ 已有 |
| `[{"type":"text","text":"..."}]` | ✅ 新增 |
| `[[{"type":"text","text":"..."}]]` | ✅ 新增 |
| `{"text":"...","blocks":[...]}` | ✅ 已有 |