### PR TITLE
fix(docker): add MongoDB service to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,21 @@ services:
     volumes:
       - redis-data:/data
 
+  mongodb:
+    image: mongo:7
+    container_name: taskagent-mongodb
+    ports:
+      - "27017:27017"
+    restart: unless-stopped
+    volumes:
+      - mongodb-data:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
   app:
     build:
       context: .
@@ -19,8 +34,12 @@ services:
       - "8080:8080"
     environment:
       - REDIS_URL=redis://redis:6379/0
+      - MONGODB_URL=mongodb://mongodb:27017
     depends_on:
-      - redis
+      redis:
+        condition: service_started
+      mongodb:
+        condition: service_healthy
     restart: unless-stopped
     volumes:
       - ./uploads:/app/uploads
@@ -33,3 +52,4 @@ services:
 
 volumes:
   redis-data:
+  mongodb-data:


### PR DESCRIPTION
## 问题

在 WSL2 中使用 Docker Compose 部署时，后端服务启动失败，报错 MongoDB 连接拒绝（`Connection refused` on `localhost:27017`）。原因是 `docker-compose.yml` 未包含 MongoDB 服务。

Fixes #90

## 修改内容

1. **新增 MongoDB 7 服务**：添加 `mongodb` 容器，包含 healthcheck
2. **配置 MONGODB_URL**：App 容器通过环境变量连接 `mongodb://mongodb:27017`
3. **依赖管理**：App 的 `depends_on` 配置了 MongoDB 的 `service_healthy` 条件，确保 MongoDB 就绪后再启动
4. **数据持久化**：新增 `mongodb-data` volume

## 验证

```bash
docker compose up -d
# 三个容器应全部正常运行：
# ✔ Container taskagent-redis   Running
# ✔ Container taskagent-mongodb  Running  
# ✔ Container taskagent-app     Running
```