### PR TITLE
fix: remove duplicate max_retries kwarg in ChatAnthropic/ChatOpenAI

### DIFF
--- a/src/infra/llm/client.py
+++ b/src/infra/llm/client.py
@@ -135,6 +135,8 @@ class LLMClient:
         api_key = api_key or settings.LLM_API_KEY
         api_base = api_base or settings.LLM_API_BASE
 
+        kwargs.pop("max_retries", None)
+
         if provider in _ANTHROPIC_PROVIDERS:
             return ChatAnthropic(
                 model_name=model_name,


### PR DESCRIPTION
## 问题

调用 `_create_model` 时 `**kwargs` 中可能包含 `max_retries`，而函数内部又显式传了 `max_retries=settings.LLM_MAX_RETRIES`，导致：

```
ChatAnthropic() got multiple values for keyword argument 'max_retries'
```

## 修复

在构造模型前先 `kwargs.pop("max_retries", None)`，避免重复传参。