### PR TITLE
fix: 修复标题生成时 max_retries 重复参数错误

### DIFF
--- a/src/api/routes/session.py
+++ b/src/api/routes/session.py
@@ -497,7 +497,6 @@ async def generate_session_title(
             api_base=title_api_base,
             api_key=title_api_key,
             max_tokens=100,
-            max_retries=max_retries,
         )
         prompt = prompt_template.replace("{lang}", lang).replace("{message}", message[:800])
 


### PR DESCRIPTION
## 问题描述

`generate_session_title` 接口调用 `LLMClient.get_model` 时传入了 `max_retries` 参数，而 `_create_model` 内部已固定传入 `max_retries=settings.LLM_MAX_RETRIES`，导致参数重复。

## 报错

```
ChatAnthropic() got multiple values for keyword argument max_retries
```

标题生成因此失败，走了 fallback（截取消息前20字）。

## 修复

移除 `get_model` 调用时多余的 `max_retries` 参数。