### PR TITLE
fix: 移除 search_agent 的重试机制

### DIFF
--- a/src/agents/core/node_utils.py
+++ b/src/agents/core/node_utils.py
@@ -4,10 +4,7 @@ Agent 节点共享工具函数
 从 search_agent/nodes.py 和 fast_agent/nodes.py 中提取的公共逻辑。
 """
 
-import asyncio
-
 from langchain_core.messages import HumanMessage
-from langchain_core.runnables import RunnableConfig
 
 from src.infra.agent import AgentEventProcessor
 from src.infra.logging import get_logger
@@ -93,83 +90,6 @@ def build_human_message(text: str, attachments: list[dict] | None) -> HumanMessa
         enhanced_text += f"\n- 链接: {url}"
 
     return HumanMessage(content=enhanced_text)
-
-
-def is_retryable_error(error: Exception) -> bool:
-    """判断错误是否可重试（429、网络错误等）"""
-    error_str = str(error).lower()
-    error_type = type(error).__name__.lower()
-
-    retryable_patterns = [
-        "429",  # rate limit
-        "503",  # service unavailable
-        "502",  # bad gateway
-        "504",  # gateway timeout
-        "timeout",
-        "connection",
-        "network",
-        "reset",
-        "refused",
-        "overloaded",
-    ]
-
-    retryable_types = [
-        "timeouterror",
-        "connectionerror",
-        "connectionreseterror",
-    ]
-
-    if any(pattern in error_str for pattern in retryable_patterns):
-        return True
-    if any(rt in error_type for rt in retryable_types):
-        return True
-
-    return False
-
-
-async def run_with_retry(
-    graph,
-    input_data: dict,
-    config: RunnableConfig,
-    event_processor: AgentEventProcessor,
-    max_retries: int | None = None,
-    base_delay: float | None = None,
-) -> None:
-    """带重试的 LLM 流式执行（使用 astream_events）"""
-    if max_retries is None:
-        max_retries = getattr(settings, "LLM_MAX_RETRIES", 3)
-    if base_delay is None:
-        base_delay = getattr(settings, "LLM_RETRY_DELAY", 1.0)
-
-    last_error: Exception | None = None
-    for attempt in range(max_retries):
-        try:
-            async for event in graph.astream_events(
-                input_data,
-                config,
-                version="v2",
-            ):
-                await event_processor.process_event(event)
-            # Flush any remaining buffered chunks
-            await event_processor._flush_chunk_buffer()
-            return
-        except Exception as e:
-            last_error = e
-            # Flush any buffered chunks before retrying (avoid data loss)
-            await event_processor._flush_chunk_buffer()
-            if is_retryable_error(e) and attempt < max_retries - 1:
-                delay = base_delay * (2**attempt)
-                logger.warning(
-                    f"LLM call failed (attempt {attempt + 1}/{max_retries}): {e}. "
-                    f"Retrying in {delay}s..."
-                )
-                await asyncio.sleep(delay)
-            else:
-                raise
-
-    if last_error is None:
-        raise RuntimeError("Unexpected state: no error but loop exhausted")
-    raise last_error
 
 
 async def emit_token_usage(

--- a/src/agents/fast_agent/nodes.py
+++ b/src/agents/fast_agent/nodes.py
@@ -16,7 +16,6 @@ from src.agents.core.base import get_presenter
 from src.agents.core.node_utils import (
     build_human_message,
     emit_token_usage,
-    run_with_retry,
     schedule_auto_retain,
 )
 from src.agents.core.subagent_prompts import SUBAGENT_PROMPT
@@ -177,19 +176,17 @@ async def fast_agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict
     logger.info("[FastAgent] Creating AgentEventProcessor")
     event_processor = AgentEventProcessor(presenter)
 
-    logger.info("[FastAgent] Starting run_with_retry (astream_events)")
-    # 流式处理事件（带重试，使用 astream_events）
-    # 注意：不预加载 skill_files，通过 SkillsStoreBackend 实时读写
-    await run_with_retry(
-        graph=inner_graph,
-        input_data={
-            "messages": all_messages,
-            "files": {},  # 不预加载，通过 SkillsStoreBackend 实时读写
-        },
-        config=inner_config,
-        event_processor=event_processor,
-    )
-    logger.info("[FastAgent] run_with_retry completed")
+    logger.info("[FastAgent] Starting astream_events")
+    # 流式处理事件（不重试，直接调用）
+    async for event in inner_graph.astream_events(
+        {"messages": all_messages, "files": {}},
+        inner_config,
+        version="v2",
+    ):
+        await event_processor.process_event(event)
+    # Flush any remaining buffered chunks
+    await event_processor._flush_chunk_buffer()
+    logger.info("[FastAgent] astream_events completed")
 
     # 发送 token 使用统计事件
     await emit_token_usage(event_processor, presenter, start_time)

--- a/src/agents/search_agent/nodes.py
+++ b/src/agents/search_agent/nodes.py
@@ -17,7 +17,6 @@ from src.agents.core.base import get_presenter
 from src.agents.core.node_utils import (
     build_human_message,
     emit_token_usage,
-    run_with_retry,
     schedule_auto_retain,
 )
 from src.agents.core.subagent_prompts import SUBAGENT_PROMPT
@@ -167,16 +166,16 @@ async def agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict[str,
     logger.info("[SearchAgent] Creating AgentEventProcessor")
     event_processor = AgentEventProcessor(presenter)
 
-    logger.info("[SearchAgent] Starting run_with_retry (astream_events)")
-    # 流式处理事件（带重试，使用 astream_events）
-    await run_with_retry(
-        graph=inner_graph,
-        input_data={
-            "messages": all_messages,
-        },
-        config=inner_config,
-        event_processor=event_processor,
-    )
+    logger.info("[SearchAgent] Starting astream_events")
+    # 流式处理事件（不重试，直接调用）
+    async for event in inner_graph.astream_events(
+        {"messages": all_messages},
+        inner_config,
+        version="v2",
+    ):
+        await event_processor.process_event(event)
+    # Flush any remaining buffered chunks
+    await event_processor._flush_chunk_buffer()
 
     # 发送 token 使用统计事件
     await emit_token_usage(event_processor, presenter, start_time)


### PR DESCRIPTION
移除 search_agent/nodes.py 中对 run_with_retry 的调用，改为直接使用 astream_events 流式调用，避免 429 限流时无意义的 subagent 重跑。