### PR TITLE
feat: add retry mechanism for OSS upload

### DIFF
--- a/src/infra/storage/s3/service.py
+++ b/src/infra/storage/s3/service.py
@@ -2,15 +2,17 @@
 S3 Storage Service - high-level interface for storage operations.
 
 Supports multiple providers through configuration, with automatic backend selection.
+Includes retry mechanism for transient upload failures.
 """
 
 from __future__ import annotations
 
 import asyncio
+import random
 import re
 import uuid
 from datetime import datetime, timezone
-from typing import BinaryIO, Optional
+from typing import BinaryIO, Callable, Optional, TypeVar
 
 from src.infra.logging import get_logger
 from src.infra.storage.s3.backends import (
@@ -22,6 +24,13 @@ from src.infra.storage.s3.base import S3StorageBackend
 from src.infra.storage.s3.types import S3Config, S3Provider, UploadResult
 
 logger = get_logger(__name__)
+
+T = TypeVar("T")
+
+# Retry configuration
+UPLOAD_MAX_RETRIES = 3
+UPLOAD_RETRY_BACKOFF_BASE = 2  # seconds, exponential backoff base
+UPLOAD_RETRY_BACKOFF_JITTER = 1  # seconds, random jitter
 
 
 class S3StorageService:
@@ -58,6 +67,75 @@ class S3StorageService:
         """Whether the storage backend is local filesystem."""
         return self._config.provider == S3Provider.LOCAL
 
+    @staticmethod
+    async def _retry_async(
+        func: Callable[..., T],
+        max_retries: int = UPLOAD_MAX_RETRIES,
+        label: str = "operation",
+    ) -> T:
+        """
+        Execute an async function with exponential backoff retry on transient errors.
+
+        Retries on network/timeout errors; does NOT retry on validation errors.
+        """
+        last_exc: Exception | None = None
+        for attempt in range(1, max_retries + 1):
+            try:
+                return await func()
+            except (ConnectionError, TimeoutError, OSError) as e:
+                last_exc = e
+                if attempt < max_retries:
+                    backoff = UPLOAD_RETRY_BACKOFF_BASE ** attempt + random.uniform(
+                        0, UPLOAD_RETRY_BACKOFF_JITTER
+                    )
+                    logger.warning(
+                        f"Upload {label} failed (attempt {attempt}/{max_retries}), "
+                        f"retrying in {backoff:.1f}s: {e}"
+                    )
+                    await asyncio.sleep(backoff)
+                else:
+                    logger.error(
+                        f"Upload {label} failed after {max_retries} attempts: {e}"
+                    )
+            except Exception as e:
+                # Non-transient errors (e.g. auth, validation) — raise immediately
+                if "oss2" in type(e).__module__ or "minio" in type(e).__module__:
+                    # Check if it's a server/network error from the SDK
+                    err_lower = str(e).lower()
+                    if any(
+                        kw in err_lower
+                        for kw in (
+                            "connection",
+                            "timeout",
+                            "timed out",
+                            "network",
+                            "temporary",
+                            "service unavailable",
+                            "internal server error",
+                            "503",
+                            "500",
+                            "502",
+                        )
+                    ):
+                        last_exc = e
+                        if attempt < max_retries:
+                            backoff = UPLOAD_RETRY_BACKOFF_BASE ** attempt + random.uniform(
+                                0, UPLOAD_RETRY_BACKOFF_JITTER
+                            )
+                            logger.warning(
+                                f"Upload {label} failed (attempt {attempt}/{max_retries}), "
+                                f"retrying in {backoff:.1f}s: {e}"
+                            )
+                            await asyncio.sleep(backoff)
+                            continue
+                        logger.error(
+                            f"Upload {label} failed after {max_retries} attempts: {e}"
+                        )
+                raise
+
+        raise last_exc  # type: ignore[misc]
+>>>>>>> 54a4e36 (feat: add retry mechanism for OSS upload with exponential backoff)
+
     def _get_backend(self) -> S3StorageBackend:
         """Get or create the storage backend"""
         if self._backend is None:
@@ -89,7 +167,7 @@ class S3StorageService:
         *,
         skip_size_limit: bool = False,
     ) -> UploadResult:
-        """Upload a file to storage."""
+        """Upload a file to storage with retry on transient failures."""
         # Check file size via current position
         if not skip_size_limit:
             current_pos = file.tell()
@@ -109,7 +187,10 @@ class S3StorageService:
         key = f"{folder}/{timestamp}_{unique_suffix}_{safe_filename}"
 
         backend = self._get_backend()
-        return await backend.upload(file, key, content_type, metadata)
+        return await self._retry_async(
+            lambda: backend.upload(file, key, content_type, metadata),
+            label=f"file://{key}",
+        )
 
     async def upload_bytes(
         self,
@@ -121,7 +202,7 @@ class S3StorageService:
         *,
         skip_size_limit: bool = False,
     ) -> UploadResult:
-        """Upload bytes to storage."""
+        """Upload bytes to storage with retry on transient failures."""
         if not skip_size_limit and len(data) > self._config.internal_max_upload_size:
             max_mb = self._config.internal_max_upload_size / (1024 * 1024)
             raise ValueError(
@@ -154,12 +235,18 @@ class S3StorageService:
             )
 
         backend = self._get_backend()
-        result = await backend.upload_bytes(data, key, content_type, metadata)
+        result = await self._retry_async(
+            lambda: backend.upload_bytes(data, key, content_type, metadata),
+            label=f"bytes://{key}",
+        )
 
         if not self._config.public_bucket and "?" not in result.url:
             max_expires = 7 * 24 * 3600
             expires = min(self._config.presigned_url_expires, max_expires)
-            result.url = await backend.get_presigned_url(key, expires)
+            result.url = await self._retry_async(
+                lambda: backend.get_presigned_url(key, expires),
+                label=f"presign://{key}",
+            )
 
         return result
 

--- a/src/infra/storage/s3/service.py
+++ b/src/infra/storage/s3/service.py
@@ -12,6 +12,7 @@ import random
 import re
 import uuid
 from datetime import datetime, timezone
+from collections.abc import Awaitable
 from typing import BinaryIO, Callable, Optional, TypeVar
 
 from src.infra.logging import get_logger
@@ -69,7 +70,7 @@ class S3StorageService:
 
     @staticmethod
     async def _retry_async(
-        func: Callable[..., T],
+        func: Callable[..., "Awaitable[T]"],
         max_retries: int = UPLOAD_MAX_RETRIES,
         label: str = "operation",
     ) -> T:
@@ -134,7 +135,6 @@ class S3StorageService:
                 raise
 
         raise last_exc  # type: ignore[misc]
->>>>>>> 54a4e36 (feat: add retry mechanism for OSS upload with exponential backoff)
 
     def _get_backend(self) -> S3StorageBackend:
         """Get or create the storage backend"""

--- a/src/infra/storage/s3/service.py
+++ b/src/infra/storage/s3/service.py
@@ -86,7 +86,7 @@ class S3StorageService:
             except (ConnectionError, TimeoutError, OSError) as e:
                 last_exc = e
                 if attempt < max_retries:
-                    backoff = UPLOAD_RETRY_BACKOFF_BASE ** attempt + random.uniform(
+                    backoff = UPLOAD_RETRY_BACKOFF_BASE**attempt + random.uniform(
                         0, UPLOAD_RETRY_BACKOFF_JITTER
                     )
                     logger.warning(
@@ -95,9 +95,7 @@ class S3StorageService:
                     )
                     await asyncio.sleep(backoff)
                 else:
-                    logger.error(
-                        f"Upload {label} failed after {max_retries} attempts: {e}"
-                    )
+                    logger.error(f"Upload {label} failed after {max_retries} attempts: {e}")
             except Exception as e:
                 # Non-transient errors (e.g. auth, validation) — raise immediately
                 if "oss2" in type(e).__module__ or "minio" in type(e).__module__:
@@ -120,7 +118,7 @@ class S3StorageService:
                     ):
                         last_exc = e
                         if attempt < max_retries:
-                            backoff = UPLOAD_RETRY_BACKOFF_BASE ** attempt + random.uniform(
+                            backoff = UPLOAD_RETRY_BACKOFF_BASE**attempt + random.uniform(
                                 0, UPLOAD_RETRY_BACKOFF_JITTER
                             )
                             logger.warning(
@@ -129,9 +127,7 @@ class S3StorageService:
                             )
                             await asyncio.sleep(backoff)
                             continue
-                        logger.error(
-                            f"Upload {label} failed after {max_retries} attempts: {e}"
-                        )
+                        logger.error(f"Upload {label} failed after {max_retries} attempts: {e}")
                 raise
 
         raise last_exc  # type: ignore[misc]

--- a/src/infra/storage/s3/service.py
+++ b/src/infra/storage/s3/service.py
@@ -11,8 +11,8 @@ import asyncio
 import random
 import re
 import uuid
-from datetime import datetime, timezone
 from collections.abc import Awaitable
+from datetime import datetime, timezone
 from typing import BinaryIO, Callable, Optional, TypeVar
 
 from src.infra.logging import get_logger


### PR DESCRIPTION
## Summary
- Add `_retry_async` method to `S3StorageService` with exponential backoff + jitter (max 3 retries)
- Wrap `upload_file`, `upload_bytes`, and `get_presigned_url` with automatic retry
- Smart error classification: retries on transient errors (connection/timeout/502/503/500), immediately raises on non-transient errors (auth/validation)

## Retry Strategy
| Attempt | Backoff |
|---------|---------|
| 1st retry | ~2s + 0-1s jitter |
| 2nd retry | ~4s + 0-1s jitter |

All retries are logged with `warning` level; final failure is logged with `error`.

## Impact
All upload paths automatically benefit: frontend file upload, agent tools (reveal_file, reveal_project, binary blocks), Feishu image uploads, and avatar uploads.

## Test plan
- [ ] Test upload succeeds on first attempt (no regression)
- [ ] Simulate network timeout — verify retry kicks in and succeeds on 2nd attempt
- [ ] Simulate persistent 503 — verify fails after 3 retries with proper error log
- [ ] Simulate auth error (403) — verify fails immediately without retry