### PR TITLE
fix: WebSocket auth failure infinite reconnect and reliability improvements

### DIFF
--- a/frontend/src/components/layout/AppContent/index.tsx
+++ b/frontend/src/components/layout/AppContent/index.tsx
@@ -127,11 +127,11 @@ export function AppContent({ activeTab }: AppContentProps) {
     useAgentOptions(agents, currentAgent);
 
   // Auth & permissions
-  const { hasPermission } = useAuth();
+  const { hasPermission, isAuthenticated } = useAuth();
   const canSendMessage = hasPermission(Permission.CHAT_WRITE);
 
   // WebSocket notifications
-  useWebSocketNotifications({ sessionId });
+  useWebSocketNotifications({ sessionId, enabled: isAuthenticated });
 
   // Session name
   const [sessionName, setSessionName] = useState<string | null>(null);

--- a/frontend/src/components/layout/AppContent/useWebSocketNotifications.tsx
+++ b/frontend/src/components/layout/AppContent/useWebSocketNotifications.tsx
@@ -9,10 +9,12 @@ import { sessionApi } from "../../../services/api";
 
 interface UseWebSocketNotificationsOptions {
   sessionId: string | null;
+  enabled?: boolean;
 }
 
 export function useWebSocketNotifications({
   sessionId,
+  enabled = true,
 }: UseWebSocketNotificationsOptions) {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -28,7 +30,7 @@ export function useWebSocketNotifications({
 
   // WebSocket for task completion notifications
   useWebSocket({
-    enabled: true,
+    enabled,
     onTaskComplete: async (notification: {
       data: { session_id: string; status: string; message?: string };
     }) => {

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -11,8 +11,6 @@ export interface TaskCompleteNotification {
   };
 }
 
-type WebSocketMessage = TaskCompleteNotification;
-
 interface UseWebSocketOptions {
   onTaskComplete?: (notification: TaskCompleteNotification) => void;
   enabled?: boolean;

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -110,17 +110,23 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
       // Send authentication after connection is established
       ws.onopen = () => {
         console.log("[WebSocket] Connected, sending auth");
-        // Send auth token after connection
         ws.send(JSON.stringify({ type: "auth", token }));
-        isConnectingRef.current = false;
-        setIsConnected(true);
-        // Reset reconnect attempt counter on successful connection
-        reconnectAttemptRef.current = 0;
+        // Don't set isConnected yet — wait for auth:ok from server
       };
 
       ws.onmessage = (event) => {
         try {
-          const message: WebSocketMessage = JSON.parse(event.data);
+          const message = JSON.parse(event.data);
+
+          if (message.type === "auth:ok") {
+            // Auth confirmed by server — now truly connected
+            isConnectingRef.current = false;
+            setIsConnected(true);
+            reconnectAttemptRef.current = 0;
+            console.log("[WebSocket] Auth confirmed");
+            return;
+          }
+
           console.log("[WebSocket] Received:", message);
 
           if (message.type === "task:complete" && onTaskCompleteRef.current) {
@@ -141,6 +147,13 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
         isDisconnectingRef.current = false; // Reset here after socket is fully closed
 
         wsRef.current = null;
+
+        // Don't reconnect on auth failure - token is invalid/expired
+        // 4001: server explicitly rejects auth; 1006: abnormal close (proxy/browser may map 4001 to 1006)
+        if (event.code === 4001 || event.reason === "Unauthorized") {
+          console.warn("[WebSocket] Auth failed, stopping reconnect");
+          return;
+        }
 
         // Only attempt to reconnect if still enabled and not manually closed
         if (

--- a/src/api/routes/websocket.py
+++ b/src/api/routes/websocket.py
@@ -4,6 +4,8 @@ WebSocket 路由
 提供 WebSocket 连接用于实时任务通知。
 """
 
+import json
+
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
 
 from src.api.deps import get_current_user_from_websocket
@@ -61,8 +63,6 @@ async def websocket_endpoint(
             logger.info("[WebSocket] Waiting for auth message from client")
             try:
                 auth_message = await websocket.receive_text()
-                import json
-
                 auth_data = json.loads(auth_message)
                 if auth_data.get("type") == "auth":
                     auth_token = auth_data.get("token")
@@ -80,6 +80,9 @@ async def websocket_endpoint(
         # 如果还没有accept（URL有token的情况），现在accept
         if not needs_accept:
             await websocket.accept()
+
+        # Send auth confirmation to client
+        await websocket.send_text(json.dumps({"type": "auth:ok"}))
     except WebSocketDisconnect:
         logger.info("[WebSocket] Client disconnected during auth")
         return

--- a/src/infra/storage/s3/service.py
+++ b/src/infra/storage/s3/service.py
@@ -2,15 +2,17 @@
 S3 Storage Service - high-level interface for storage operations.
 
 Supports multiple providers through configuration, with automatic backend selection.
+Includes retry mechanism for transient upload failures.
 """
 
 from __future__ import annotations
 
 import asyncio
+import random
 import re
 import uuid
 from datetime import datetime, timezone
-from typing import BinaryIO, Optional
+from typing import BinaryIO, Callable, Optional, TypeVar
 
 from src.infra.logging import get_logger
 from src.infra.storage.s3.backends import (
@@ -22,6 +24,13 @@ from src.infra.storage.s3.base import S3StorageBackend
 from src.infra.storage.s3.types import S3Config, S3Provider, UploadResult
 
 logger = get_logger(__name__)
+
+T = TypeVar("T")
+
+# Retry configuration
+UPLOAD_MAX_RETRIES = 3
+UPLOAD_RETRY_BACKOFF_BASE = 2  # seconds, exponential backoff base
+UPLOAD_RETRY_BACKOFF_JITTER = 1  # seconds, random jitter
 
 
 class S3StorageService:
@@ -58,6 +67,75 @@ class S3StorageService:
         """Whether the storage backend is local filesystem."""
         return self._config.provider == S3Provider.LOCAL
 
+    @staticmethod
+    async def _retry_async(
+        func: Callable[..., T],
+        max_retries: int = UPLOAD_MAX_RETRIES,
+        label: str = "operation",
+    ) -> T:
+        """
+        Execute an async function with exponential backoff retry on transient errors.
+
+        Retries on network/timeout errors; does NOT retry on validation errors.
+        """
+        last_exc: Exception | None = None
+        for attempt in range(1, max_retries + 1):
+            try:
+                return await func()
+            except (ConnectionError, TimeoutError, OSError) as e:
+                last_exc = e
+                if attempt < max_retries:
+                    backoff = UPLOAD_RETRY_BACKOFF_BASE ** attempt + random.uniform(
+                        0, UPLOAD_RETRY_BACKOFF_JITTER
+                    )
+                    logger.warning(
+                        f"Upload {label} failed (attempt {attempt}/{max_retries}), "
+                        f"retrying in {backoff:.1f}s: {e}"
+                    )
+                    await asyncio.sleep(backoff)
+                else:
+                    logger.error(
+                        f"Upload {label} failed after {max_retries} attempts: {e}"
+                    )
+            except Exception as e:
+                # Non-transient errors (e.g. auth, validation) — raise immediately
+                if "oss2" in type(e).__module__ or "minio" in type(e).__module__:
+                    # Check if it's a server/network error from the SDK
+                    err_lower = str(e).lower()
+                    if any(
+                        kw in err_lower
+                        for kw in (
+                            "connection",
+                            "timeout",
+                            "timed out",
+                            "network",
+                            "temporary",
+                            "service unavailable",
+                            "internal server error",
+                            "503",
+                            "500",
+                            "502",
+                        )
+                    ):
+                        last_exc = e
+                        if attempt < max_retries:
+                            backoff = UPLOAD_RETRY_BACKOFF_BASE ** attempt + random.uniform(
+                                0, UPLOAD_RETRY_BACKOFF_JITTER
+                            )
+                            logger.warning(
+                                f"Upload {label} failed (attempt {attempt}/{max_retries}), "
+                                f"retrying in {backoff:.1f}s: {e}"
+                            )
+                            await asyncio.sleep(backoff)
+                            continue
+                        logger.error(
+                            f"Upload {label} failed after {max_retries} attempts: {e}"
+                        )
+                raise
+
+        raise last_exc  # type: ignore[misc]
+>>>>>>> 54a4e36 (feat: add retry mechanism for OSS upload with exponential backoff)
+
     def _get_backend(self) -> S3StorageBackend:
         """Get or create the storage backend"""
         if self._backend is None:
@@ -89,7 +167,7 @@ class S3StorageService:
         *,
         skip_size_limit: bool = False,
     ) -> UploadResult:
-        """Upload a file to storage."""
+        """Upload a file to storage with retry on transient failures."""
         # Check file size via current position
         if not skip_size_limit:
             current_pos = file.tell()
@@ -109,7 +187,10 @@ class S3StorageService:
         key = f"{folder}/{timestamp}_{unique_suffix}_{safe_filename}"
 
         backend = self._get_backend()
-        return await backend.upload(file, key, content_type, metadata)
+        return await self._retry_async(
+            lambda: backend.upload(file, key, content_type, metadata),
+            label=f"file://{key}",
+        )
 
     async def upload_bytes(
         self,
@@ -121,7 +202,7 @@ class S3StorageService:
         *,
         skip_size_limit: bool = False,
     ) -> UploadResult:
-        """Upload bytes to storage."""
+        """Upload bytes to storage with retry on transient failures."""
         if not skip_size_limit and len(data) > self._config.internal_max_upload_size:
             max_mb = self._config.internal_max_upload_size / (1024 * 1024)
             raise ValueError(
@@ -154,12 +235,18 @@ class S3StorageService:
             )
 
         backend = self._get_backend()
-        result = await backend.upload_bytes(data, key, content_type, metadata)
+        result = await self._retry_async(
+            lambda: backend.upload_bytes(data, key, content_type, metadata),
+            label=f"bytes://{key}",
+        )
 
         if not self._config.public_bucket and "?" not in result.url:
             max_expires = 7 * 24 * 3600
             expires = min(self._config.presigned_url_expires, max_expires)
-            result.url = await backend.get_presigned_url(key, expires)
+            result.url = await self._retry_async(
+                lambda: backend.get_presigned_url(key, expires),
+                label=f"presign://{key}",
+            )
 
         return result
 

--- a/src/infra/storage/s3/service.py
+++ b/src/infra/storage/s3/service.py
@@ -12,6 +12,7 @@ import random
 import re
 import uuid
 from datetime import datetime, timezone
+from collections.abc import Awaitable
 from typing import BinaryIO, Callable, Optional, TypeVar
 
 from src.infra.logging import get_logger
@@ -69,7 +70,7 @@ class S3StorageService:
 
     @staticmethod
     async def _retry_async(
-        func: Callable[..., T],
+        func: Callable[..., "Awaitable[T]"],
         max_retries: int = UPLOAD_MAX_RETRIES,
         label: str = "operation",
     ) -> T:
@@ -134,7 +135,6 @@ class S3StorageService:
                 raise
 
         raise last_exc  # type: ignore[misc]
->>>>>>> 54a4e36 (feat: add retry mechanism for OSS upload with exponential backoff)
 
     def _get_backend(self) -> S3StorageBackend:
         """Get or create the storage backend"""

--- a/src/infra/storage/s3/service.py
+++ b/src/infra/storage/s3/service.py
@@ -86,7 +86,7 @@ class S3StorageService:
             except (ConnectionError, TimeoutError, OSError) as e:
                 last_exc = e
                 if attempt < max_retries:
-                    backoff = UPLOAD_RETRY_BACKOFF_BASE ** attempt + random.uniform(
+                    backoff = UPLOAD_RETRY_BACKOFF_BASE**attempt + random.uniform(
                         0, UPLOAD_RETRY_BACKOFF_JITTER
                     )
                     logger.warning(
@@ -95,9 +95,7 @@ class S3StorageService:
                     )
                     await asyncio.sleep(backoff)
                 else:
-                    logger.error(
-                        f"Upload {label} failed after {max_retries} attempts: {e}"
-                    )
+                    logger.error(f"Upload {label} failed after {max_retries} attempts: {e}")
             except Exception as e:
                 # Non-transient errors (e.g. auth, validation) — raise immediately
                 if "oss2" in type(e).__module__ or "minio" in type(e).__module__:
@@ -120,7 +118,7 @@ class S3StorageService:
                     ):
                         last_exc = e
                         if attempt < max_retries:
-                            backoff = UPLOAD_RETRY_BACKOFF_BASE ** attempt + random.uniform(
+                            backoff = UPLOAD_RETRY_BACKOFF_BASE**attempt + random.uniform(
                                 0, UPLOAD_RETRY_BACKOFF_JITTER
                             )
                             logger.warning(
@@ -129,9 +127,7 @@ class S3StorageService:
                             )
                             await asyncio.sleep(backoff)
                             continue
-                        logger.error(
-                            f"Upload {label} failed after {max_retries} attempts: {e}"
-                        )
+                        logger.error(f"Upload {label} failed after {max_retries} attempts: {e}")
                 raise
 
         raise last_exc  # type: ignore[misc]

--- a/src/infra/storage/s3/service.py
+++ b/src/infra/storage/s3/service.py
@@ -11,8 +11,8 @@ import asyncio
 import random
 import re
 import uuid
-from datetime import datetime, timezone
 from collections.abc import Awaitable
+from datetime import datetime, timezone
 from typing import BinaryIO, Callable, Optional, TypeVar
 
 from src.infra.logging import get_logger

--- a/src/infra/task/executor.py
+++ b/src/infra/task/executor.py
@@ -352,7 +352,7 @@ class TaskExecutor:
             if message:
                 notification["data"]["message"] = message
 
-            await manager.send_to_user(user_id, notification)
+            await manager.send_to_user_with_broadcast(user_id, notification)
             logger.info(
                 f"Task notification sent: user_id={user_id}, session={session_id}, status={status.value}"
             )

--- a/src/infra/websocket.py
+++ b/src/infra/websocket.py
@@ -62,52 +62,6 @@ class ConnectionManager:
                     del self._connections[user_id]
         logger.info(f"WebSocket disconnected: user_id={user_id}")
 
-    async def send_to_user(self, user_id: str, message: dict) -> int:
-        """
-        向指定用户发送消息
-
-        Args:
-            user_id: 用户 ID
-            message: 消息内容（dict，会被序列化为 JSON）
-
-        Returns:
-            成功发送的连接数
-        """
-        if not message:
-            return 0
-
-        json_str = json.dumps(message, ensure_ascii=False)
-        sent_count = 0
-
-        logger.info(
-            f"[WebSocket] send_to_user: user_id={user_id}, connections={list(self._connections.keys())}"
-        )
-
-        async with self._lock:
-            connections = self._connections.get(user_id, set()).copy()
-
-        logger.info(f"[WebSocket] Sending to {len(connections)} connections: {json_str}")
-
-        # 遍历副本以避免在发送时修改集合
-        disconnected = set()
-        for ws in connections:
-            try:
-                await ws.send_text(json_str)
-                sent_count += 1
-                logger.info("[WebSocket] Sent successfully to one connection")
-            except Exception as e:
-                logger.warning(f"Failed to send to WebSocket: {e}")
-                disconnected.add(ws)
-
-        # 清理断开的连接
-        if disconnected:
-            async with self._lock:
-                for ws in disconnected:
-                    if user_id in self._connections:
-                        self._connections[user_id].discard(ws)
-
-        return sent_count
-
     async def broadcast(self, message: dict) -> int:
         """
         向所有用户广播消息


### PR DESCRIPTION
## Summary

- **Stop reconnecting on auth failure**: Frontend `onclose` now checks for close code `4001` / reason `"Unauthorized"` and stops the exponential backoff loop, preventing infinite reconnection attempts with expired tokens
- **Auth confirmation handshake**: Server sends `auth:ok` message after successful auth; frontend only marks `isConnected=true` after receiving it, instead of prematurely on `onopen`
- **Auth-aware connection control**: WebSocket is only enabled when user is authenticated (`isAuthenticated`), preventing unnecessary connections for logged-out users
- **Fix distributed broadcast**: `executor.py` now calls `send_to_user_with_broadcast` instead of `send_to_user`, ensuring task notifications reach users across multiple instances
- **Remove dead code and log leaks**: Deleted unused `send_to_user` method, removed INFO logs that exposed all online user IDs and full message payloads

## Test plan

- [ ] Verify WebSocket connects successfully with a valid token and receives `auth:ok`
- [ ] Verify WebSocket stops reconnecting after 401 auth failure (expired token)
- [ ] Verify WebSocket does not connect when user is logged out
- [ ] Verify task completion notifications are delivered in multi-instance deployment
- [ ] Verify `isConnected` state reflects actual auth-confirmed connection status