### PR TITLE
fix: filter Sandpack template default files in reveal project

### DIFF
--- a/frontend/src/components/chat/ChatMessage/items/ProjectRevealItem.tsx
+++ b/frontend/src/components/chat/ChatMessage/items/ProjectRevealItem.tsx
@@ -76,30 +76,41 @@ function isV2(result: ProjectRevealResult): result is ProjectRevealResultV2 {
  */
 async function fetchTextFiles(
   textFileEntries: Array<[string, FileManifestEntry]>,
-): Promise<Record<string, string>> {
+): Promise<{ files: Record<string, string>; failed: string[] }> {
   const entries = await Promise.all(
     textFileEntries.map(
       async ([path, entry]): Promise<[string, string] | null> => {
         try {
           const fullUrl = getFullUrl(entry.url) || entry.url;
           const resp = await fetch(fullUrl);
-          if (!resp.ok) return null;
+          if (!resp.ok) {
+            console.warn(`[reveal_project] Failed to fetch ${path}: ${resp.status}`);
+            return null;
+          }
           const text = await resp.text();
           return [path, text];
-        } catch {
+        } catch (e) {
+          console.warn(`[reveal_project] Error fetching ${path}:`, e);
           return null;
         }
       },
     ),
   );
 
-  const result: Record<string, string> = {};
+  const files: Record<string, string> = {};
+  const failed: string[] = [];
   for (const entry of entries) {
     if (entry) {
-      result[entry[0]] = entry[1];
+      files[entry[0]] = entry[1];
     }
   }
-  return result;
+  // 找出哪些文件没加载成功
+  for (const [path] of textFileEntries) {
+    if (!(path in files)) {
+      failed.push(path);
+    }
+  }
+  return { files, failed };
 }
 
 export function ProjectRevealItem({
@@ -183,11 +194,23 @@ export function ProjectRevealItem({
       setBinaryFiles(binMap);
 
       try {
-        const rawFiles = await fetchTextFiles(textEntries);
+        const { files: rawFiles, failed } = await fetchTextFiles(textEntries);
+
+        if (failed.length > 0) {
+          console.warn(
+            `[reveal_project] ${failed.length} files failed to load:`,
+            failed,
+          );
+        }
+
         const resolved = rewriteProjectTextFiles(rawFiles, binMap);
 
         if (!cancelled) {
           setLoadedFiles(resolved);
+          // 如果关键文件（如 index.html）加载失败，标记错误
+          if (Object.keys(resolved).length === 0 && textEntries.length > 0) {
+            setLoadingError(true);
+          }
         }
       } catch {
         if (!cancelled) {

--- a/frontend/src/components/documents/previews/ProjectPreview.tsx
+++ b/frontend/src/components/documents/previews/ProjectPreview.tsx
@@ -58,7 +58,7 @@ function CustomLayout({
       {showExplorer && (
         <SandpackFileExplorer
           className="!w-48 !h-full shrink-0"
-          autoHiddenFiles={false}
+          autoHiddenFiles={true}
         />
       )}
 
@@ -112,12 +112,20 @@ export default function ProjectPreview({
   const [showExplorer, setShowExplorer] = useState(showFileExplorer);
   const isFullscreen = !!externalFullscreen;
 
-  // 检测并转换文件格式
+  // 用户提供的文件路径集合（用于过滤模板默认文件）
+  const userFilePaths = useMemo(() => {
+    const paths = new Set<string>();
+    for (const path of Object.keys(files)) {
+      paths.add(path.startsWith("/") ? path : `/${path}`);
+    }
+    return paths;
+  }, [files]);
+
+  // 检测并转换文件格式，隐藏模板自带的默认文件中用户未覆盖的部分
   const sandpackFiles = useMemo(() => {
     const result: Record<string, string> = {};
 
     for (const [path, content] of Object.entries(files)) {
-      // 确保路径以 / 开头
       const normalizedPath = path.startsWith("/") ? path : `/${path}`;
       result[normalizedPath] = content;
     }
@@ -291,6 +299,7 @@ export default function ProjectPreview({
           theme="dark"
           options={{
             activeFile: entryFile,
+            visibleFiles: [...userFilePaths],
             classes: {
               "sp-wrapper": "!h-full !flex !flex-col",
               "sp-layout": "!h-full !border-0",
@@ -328,6 +337,11 @@ export function ProjectPreviewCompact({
 
   // 获取入口文件
   const entryFile = resolveEntryFile(files);
+
+  // 用户文件路径集合，用于过滤模板默认文件
+  const visibleFiles = Object.keys(files).map((p) =>
+    p.startsWith("/") ? p : `/${p}`,
+  );
 
   return (
     <div className="my-2 sm:my-3">
@@ -373,6 +387,7 @@ export function ProjectPreviewCompact({
             theme="dark"
             options={{
               activeFile: entryFile,
+              visibleFiles,
               classes: {
                 "sp-wrapper": "!h-full",
                 "sp-layout": "!h-full !border-0",


### PR DESCRIPTION
## Summary
- Use `visibleFiles` + `autoHiddenFiles={true}` to hide Sandpack template default files (`/styles.css`, `/package.json`, `/index.html` with "Hello world") that leaked into the file tree when user projects didn't override them
- Add `console.warn` logging to `fetchTextFiles` so OSS load failures are no longer silent — previously a failed `/index.html` fetch caused the template's "Hello world" to render with no error indication
- Track failed file paths in `fetchTextFiles` return value and show loading error when all files fail to load

## Test plan
- [ ] Reveal a static HTML/CSS/JS project and verify file tree only shows user files (no `/styles.css`, `/package.json` from template)
- [ ] Reveal a project with `/index.html` and verify preview renders user content (not "Hello world")
- [ ] Check browser console for `[reveal_project]` warnings if any OSS fetch fails
- [ ] Test both compact preview (in message) and fullscreen preview