### PR TITLE
fix: bypass Sandpack template merging for static projects

### DIFF
--- a/frontend/src/components/documents/previews/ProjectPreview.tsx
+++ b/frontend/src/components/documents/previews/ProjectPreview.tsx
@@ -18,10 +18,7 @@ import {
 } from "lucide-react";
 import { clsx } from "clsx";
 import { exportProjectZip } from "../../../utils/exportProjectZip";
-import {
-  resolveEntryFile,
-  resolveSandpackTemplate,
-} from "./projectPreviewUtils";
+import { buildSandpackConfig } from "./projectPreviewUtils";
 
 interface ProjectPreviewProps {
   name: string;
@@ -54,7 +51,6 @@ function CustomLayout({
         isFullscreen ? "!min-h-[calc(100vh-120px)]" : "!min-h-[400px]",
       )}
     >
-      {/* 文件浏览器 */}
       {showExplorer && (
         <SandpackFileExplorer
           className="!w-48 !h-full shrink-0"
@@ -62,7 +58,6 @@ function CustomLayout({
         />
       )}
 
-      {/* 代码编辑器 - 始终渲染，用 CSS 控制显示/隐藏 */}
       <div
         className={clsx(
           "flex-1 !min-w-0 !h-full overflow-hidden",
@@ -78,7 +73,6 @@ function CustomLayout({
         />
       </div>
 
-      {/* 预览 - 始终渲染，用 CSS 控制显示/隐藏 */}
       <div
         className={clsx(
           "flex-1 !min-w-0 !h-full overflow-hidden",
@@ -112,42 +106,12 @@ export default function ProjectPreview({
   const [showExplorer, setShowExplorer] = useState(showFileExplorer);
   const isFullscreen = !!externalFullscreen;
 
-  // 用户提供的文件路径集合（用于过滤模板默认文件）
-  const userFilePaths = useMemo(() => {
-    const paths = new Set<string>();
-    for (const path of Object.keys(files)) {
-      paths.add(path.startsWith("/") ? path : `/${path}`);
-    }
-    return paths;
-  }, [files]);
+  const config = useMemo(
+    () => buildSandpackConfig(template, files, entry),
+    [template, files, entry],
+  );
 
-  // 检测并转换文件格式，隐藏模板自带的默认文件中用户未覆盖的部分
-  const sandpackFiles = useMemo(() => {
-    const result: Record<string, string> = {};
-
-    for (const [path, content] of Object.entries(files)) {
-      const normalizedPath = path.startsWith("/") ? path : `/${path}`;
-      result[normalizedPath] = content;
-    }
-
-    return result;
-  }, [files]);
-
-  // 获取入口文件
-  const entryFile = useMemo(() => {
-    return resolveEntryFile(sandpackFiles, entry);
-  }, [entry, sandpackFiles]);
-
-  // 获取 Sandpack 模板 - 如果入口是 HTML 用 static，否则用传入的模板
-  const sandpackTemplate = useMemo(() => {
-    return resolveSandpackTemplate(template, sandpackFiles);
-  }, [template, sandpackFiles]);
-  const resolvedTemplateLabel = sandpackTemplate;
-
-  // 文件数量
-  const fileCount = Object.keys(sandpackFiles).length;
-
-  if (fileCount === 0) {
+  if (Object.keys(config.files).length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-16 gap-4">
         <AlertCircle size={32} className="text-amber-500" />
@@ -181,20 +145,18 @@ export default function ProjectPreview({
               </h3>
               <p className="text-xs text-stone-500 dark:text-stone-400 hidden sm:block">
                 {t("project.fileCount", "{{count}} 个文件", {
-                  count: fileCount,
+                  count: Object.keys(config.files).length,
                 })}
-                {resolvedTemplateLabel !== "static" &&
-                  ` · ${resolvedTemplateLabel}`}
+                {config.template && config.template !== "static" &&
+                  ` · ${config.template}`}
               </p>
             </div>
           </div>
 
           {/* 右侧：标签切换 + 操作按钮 */}
           <div className="flex items-center gap-0.5 sm:gap-1 shrink-0 flex-nowrap">
-            {/* 手机端：单个切换按钮 | 桌面端：双按钮组 */}
             {showTabs && (
               <>
-                {/* 手机切换按钮 */}
                 <button
                   onClick={() =>
                     setActiveTab(activeTab === "preview" ? "code" : "preview")
@@ -213,7 +175,6 @@ export default function ProjectPreview({
                   )}
                 </button>
 
-                {/* 桌面双按钮组 */}
                 <div className="hidden sm:flex items-center bg-stone-100 dark:bg-stone-800 rounded-lg p-0.5">
                   <button
                     onClick={() => setActiveTab("preview")}
@@ -243,7 +204,6 @@ export default function ProjectPreview({
               </>
             )}
 
-            {/* 文件浏览器切换 */}
             {showFileExplorer && (
               <button
                 onClick={() => setShowExplorer(!showExplorer)}
@@ -259,7 +219,6 @@ export default function ProjectPreview({
               </button>
             )}
 
-            {/* 导出 ZIP — 仅全屏模式 */}
             {isFullscreen && (
               <button
                 onClick={() => exportProjectZip(files, name)}
@@ -272,7 +231,6 @@ export default function ProjectPreview({
               </button>
             )}
 
-            {/* 关闭按钮 */}
             {onClose && (
               <button
                 onClick={onClose}
@@ -294,12 +252,13 @@ export default function ProjectPreview({
         )}
       >
         <SandpackProvider
-          template={sandpackTemplate}
-          files={sandpackFiles}
+          template={config.template}
+          customSetup={config.customSetup}
+          files={config.files}
           theme="dark"
           options={{
-            activeFile: entryFile,
-            visibleFiles: [...userFilePaths],
+            activeFile: config.entryFile,
+            visibleFiles: config.visibleFiles,
             classes: {
               "sp-wrapper": "!h-full !flex !flex-col",
               "sp-layout": "!h-full !border-0",
@@ -331,16 +290,9 @@ export function ProjectPreviewCompact({
   onExpand?: () => void;
 }) {
   const { t } = useTranslation();
-  const fileCount = Object.keys(files).length;
-  const sandpackTemplate = resolveSandpackTemplate(template, files);
-  const resolvedTemplateLabel = sandpackTemplate;
-
-  // 获取入口文件
-  const entryFile = resolveEntryFile(files);
-
-  // 用户文件路径集合，用于过滤模板默认文件
-  const visibleFiles = Object.keys(files).map((p) =>
-    p.startsWith("/") ? p : `/${p}`,
+  const config = useMemo(
+    () => buildSandpackConfig(template, files),
+    [template, files],
   );
 
   return (
@@ -358,10 +310,10 @@ export function ProjectPreviewCompact({
               </h4>
               <p className="text-xs text-stone-500 dark:text-stone-400 hidden sm:block">
                 {t("project.fileCount", "{{count}} 个文件", {
-                  count: fileCount,
+                  count: Object.keys(config.files).length,
                 })}
-                {resolvedTemplateLabel !== "static" &&
-                  ` · ${resolvedTemplateLabel}`}
+                {config.template && config.template !== "static" &&
+                  ` · ${config.template}`}
               </p>
             </div>
           </div>
@@ -382,12 +334,13 @@ export function ProjectPreviewCompact({
         {/* 预览区域 */}
         <div className="h-[250px] sm:h-[400px]">
           <SandpackProvider
-            template={sandpackTemplate}
-            files={files}
+            template={config.template}
+            customSetup={config.customSetup}
+            files={config.files}
             theme="dark"
             options={{
-              activeFile: entryFile,
-              visibleFiles,
+              activeFile: config.entryFile,
+              visibleFiles: config.visibleFiles,
               classes: {
                 "sp-wrapper": "!h-full",
                 "sp-layout": "!h-full !border-0",

--- a/frontend/src/components/documents/previews/projectPreviewUtils.ts
+++ b/frontend/src/components/documents/previews/projectPreviewUtils.ts
@@ -176,3 +176,62 @@ export function resolveEntryFile(
   const matched = ENTRY_CANDIDATES.find((path) => path in files);
   return matched || Object.keys(files)[0] || "/index.js";
 }
+
+/** normalizePaths: 确保所有文件路径以 / 开头 */
+function normalizePaths(
+  files: Record<string, string>,
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [path, content] of Object.entries(files)) {
+    result[path.startsWith("/") ? path : `/${path}`] = content;
+  }
+  return result;
+}
+
+export interface SandpackConfig {
+  /** 传给 SandpackProvider 的 template（static 模板时为 undefined） */
+  template?: SandpackTemplate;
+  /** 传给 SandpackProvider 的 customSetup（仅 static 模板使用） */
+  customSetup?: { entry: string; environment: "static" };
+  /** 规范化后的用户文件 */
+  files: Record<string, string>;
+  /** 入口文件路径 */
+  entryFile: string;
+  /** 文件浏览器可见的文件列表 */
+  visibleFiles: string[];
+}
+
+/**
+ * 构建完整的 Sandpack 配置
+ *
+ * 核心设计：
+ * - static 模板：不使用 Sandpack 内置模板，改用 customSetup 避免模板默认文件
+ *   （Hello world、/styles.css、/package.json）通过 Object.assign 污染用户项目
+ * - 框架模板（react/vue 等）：正常使用内置模板以获取依赖和构建配置
+ */
+export function buildSandpackConfig(
+  template: string,
+  files: Record<string, string>,
+  entry?: string,
+): SandpackConfig {
+  const normalized = normalizePaths(files);
+  const detected = resolveSandpackTemplate(template, normalized);
+  const entryFile = resolveEntryFile(normalized, entry);
+  const visibleFiles = Object.keys(normalized);
+
+  if (detected === "static") {
+    return {
+      customSetup: { entry: entryFile, environment: "static" },
+      files: normalized,
+      entryFile,
+      visibleFiles,
+    };
+  }
+
+  return {
+    template: detected,
+    files: normalized,
+    entryFile,
+    visibleFiles,
+  };
+}


### PR DESCRIPTION
## Summary
- Extract Sandpack config into `buildSandpackConfig()` in `projectPreviewUtils.ts`, eliminating duplicated template detection / path normalization logic across `ProjectPreview` and `ProjectPreviewCompact`
- For `static` template, use `customSetup` instead of the built-in template to prevent `Object.assign` from merging template defaults (Hello world `/index.html`, `/styles.css`, `/package.json`) into the bundler
- Framework templates (react/vue/etc.) continue using the built-in template for dependencies and build configuration
- Add `console.warn` logging to `fetchTextFiles` so V2 OSS load failures are no longer silent

## Test plan
- [ ] Reveal a static HTML/CSS/JS project — file tree shows only user files, preview renders user content (not Hello world)
- [ ] Reveal a React/Vue project — template dependencies still work correctly
- [ ] Check browser console for `[reveal_project]` warnings if any OSS fetch fails
- [ ] Existing tests pass: `npx tsx --test src/components/documents/previews/projectPreviewUtils.test.ts`