### PR TITLE
fix: resolve role initialization cache, update fields, and error handling

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -55,11 +55,14 @@ async def lifespan(app: FastAPI):
     setup_logging()
 
     # 初始化默认角色（更新系统角色权限）
-    from src.infra.role.storage import RoleStorage
+    try:
+        from src.infra.role.storage import RoleStorage
 
-    role_storage = RoleStorage()
-    await role_storage.init_default_roles()
-    logger.info("Default roles initialized")
+        role_storage = RoleStorage()
+        await role_storage.init_default_roles()
+        logger.info("Default roles initialized")
+    except Exception as e:
+        logger.error("Failed to initialize default roles: %s", e)
 
     # 配置 uvicorn 访问日志格式，与项目日志完全统一
     import logging

--- a/src/infra/role/storage.py
+++ b/src/infra/role/storage.py
@@ -416,14 +416,18 @@ class RoleStorage:
                         "updated_at": now,
                     }
                 )
+                # 清除 get_by_name 可能缓存的 None，避免新建角色后查询命中空缓存
+                await self.invalidate_cache(role_data["name"])
             elif role_data.get("is_system", False):
-                # 系统角色：更新权限列表和is_system标记
+                # 系统角色：更新权限列表、描述、限制和is_system标记
                 now = datetime.now()
                 await self.collection.update_one(
                     {"name": role_data["name"]},
                     {
                         "$set": {
                             "permissions": role_data["permissions"],
+                            "description": role_data.get("description"),
+                            "limits": role_data.get("limits"),
                             "is_system": True,  # 确保is_system被更新
                             "updated_at": now,
                         }


### PR DESCRIPTION
## Summary
- Fix Redis caching `None` after inserting new default roles, preventing zero-permission state for up to 5 minutes on fresh deployments
- Include `description` and `limits` fields in system role `$set` updates so they stay in sync with code definitions
- Wrap `init_default_roles()` in try/except to prevent app startup failure on transient DB errors

## Test plan
- [ ] Fresh deploy: verify all three default roles are created and immediately queryable (no None cache hit)
- [ ] Existing deploy: verify admin role's `description` and `limits` are updated on restart
- [ ] Simulate MongoDB connection failure during startup: verify app still starts and logs error