### PR TITLE
fix: 修复 deep agent 消息重复添加问题

### DIFF
--- a/src/agents/fast_agent/nodes.py
+++ b/src/agents/fast_agent/nodes.py
@@ -158,19 +158,11 @@ async def fast_agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict
         "recursion_limit": config.get("recursion_limit", settings.SESSION_MAX_RUNS_PER_SESSION),
     }
 
-    # 从内层 graph 的 checkpoint 获取历史消息
-    inner_state = await inner_graph.aget_state(inner_config)
-    existing_messages = inner_state.values.get("messages", [])
-
-    # 构建传入的消息列表（包含附件）
+    # 构建传入的新消息（包含附件）
+    # 注意：checkpointer + add_messages reducer 会自动维护历史消息，
+    # 只需传入新消息，避免与 checkpoint 中的历史消息重复。
     user_input = state.get("input", "")
     new_message = build_human_message(user_input, attachments)
-
-    # 消息列表（记忆召回改为由 agent 通过 tool 主动触发）
-    all_messages = existing_messages + [new_message]
-
-    # 传递 messages
-    inner_config["configurable"]["messages"] = existing_messages
 
     # 创建事件处理器（使用 AgentEventProcessor 处理 astream_events）
     logger.info("[FastAgent] Creating AgentEventProcessor")
@@ -179,7 +171,7 @@ async def fast_agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict
     logger.info("[FastAgent] Starting astream_events")
     # 流式处理事件（不重试，直接调用）
     async for event in inner_graph.astream_events(
-        {"messages": all_messages, "files": {}},
+        {"messages": [new_message], "files": {}},
         inner_config,
         version="v2",
     ):
@@ -193,9 +185,7 @@ async def fast_agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict
 
     # 获取内层 graph 的最终状态
     inner_state = await inner_graph.aget_state(inner_config)
-    new_messages = inner_state.values.get("messages", [])
-
-    final_messages = new_messages if len(new_messages) > len(all_messages) else all_messages
+    final_messages = inner_state.values.get("messages", [])
 
     # 自动记忆存储（异步，不阻塞响应）
     schedule_auto_retain(user_input, event_processor.output_text, context.user_id)

--- a/src/agents/search_agent/nodes.py
+++ b/src/agents/search_agent/nodes.py
@@ -148,19 +148,11 @@ async def agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict[str,
         "recursion_limit": config.get("recursion_limit", settings.SESSION_MAX_RUNS_PER_SESSION),
     }
 
-    # 从内层 graph 的 checkpoint 获取历史消息
-    inner_state = await inner_graph.aget_state(inner_config)
-    existing_messages = inner_state.values.get("messages", [])
-
-    # 构建传入的消息列表（包含附件）
+    # 构建传入的新消息（包含附件）
+    # 注意：checkpointer + add_messages reducer 会自动维护历史消息，
+    # 只需传入新消息，避免与 checkpoint 中的历史消息重复。
     user_input = state.get("input", "")
     new_message = build_human_message(user_input, attachments)
-
-    # 消息列表（记忆召回改为由 agent 通过 tool 主动触发）
-    all_messages = existing_messages + [new_message]
-
-    # 传递 messages
-    inner_config["configurable"]["messages"] = existing_messages
 
     # 创建事件处理器（使用 AgentEventProcessor 处理 astream_events）
     logger.info("[SearchAgent] Creating AgentEventProcessor")
@@ -169,7 +161,7 @@ async def agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict[str,
     logger.info("[SearchAgent] Starting astream_events")
     # 流式处理事件（不重试，直接调用）
     async for event in inner_graph.astream_events(
-        {"messages": all_messages},
+        {"messages": [new_message]},
         inner_config,
         version="v2",
     ):
@@ -182,9 +174,7 @@ async def agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict[str,
 
     # 获取内层 graph 的最终状态
     inner_state = await inner_graph.aget_state(inner_config)
-    new_messages = inner_state.values.get("messages", [])
-
-    final_messages = new_messages if len(new_messages) > len(all_messages) else all_messages
+    final_messages = inner_state.values.get("messages", [])
 
     # 自动记忆存储（异步，不阻塞响应）
     schedule_auto_retain(user_input, event_processor.output_text, context.user_id)


### PR DESCRIPTION
## 问题

两个 agent 节点（`fast_agent` 和 `search_agent`）在调用 `astream_events` 时，都会：
1. 从 checkpoint 获取 `existing_messages`
2. 拼接 `existing_messages + [new_message]` 作为输入
3. 将 `existing_messages` 赋值到 `inner_config["configurable"]["messages"]`

由于 LangGraph state 的 `messages` 使用 `add_messages` reducer，输入的消息会**追加**到 checkpoint 已有的消息上。这导致每次调用时历史消息被重复添加。

同时 `configurable["messages"]` 在 deepagents/langchain 中未被任何代码读取，完全无效。

## 修复

- 只传入新消息 `[new_message]`，让 checkpointer + `add_messages` reducer 自动维护历史消息
- 移除无效的 `configurable.messages` 赋值
- 移除不必要的 `final_messages` 对比逻辑，直接取 checkpoint 最终状态

## 影响范围

- `src/agents/fast_agent/nodes.py`
- `src/agents/search_agent/nodes.py`