### PR TITLE
feat(mcp): dynamic tool discovery, per-tool toggle & alphabetical sorting

### DIFF
--- a/frontend/src/components/layout/AppContent/index.tsx
+++ b/frontend/src/components/layout/AppContent/index.tsx
@@ -49,6 +49,15 @@ export function AppContent({ activeTab }: AppContentProps) {
     isLoading: approvalLoading,
   } = useApprovals({ sessionId: null });
 
+  // Auth & permissions (needed before useTools for disabledToolsVersion)
+  const { hasPermission, isAuthenticated, user } = useAuth();
+
+  // Derive a version key from disabled_tools so useTools re-fetches when they change
+  // (e.g. when user toggles a tool in MCPServerCard)
+  const disabledToolsVersion = JSON.stringify(
+    user?.metadata?.disabled_tools ?? [],
+  );
+
   // Tools
   const {
     tools,
@@ -59,7 +68,7 @@ export function AppContent({ activeTab }: AppContentProps) {
     toggleCategory,
     toggleAll,
     getDisabledToolNames,
-  } = useTools();
+  } = useTools(disabledToolsVersion);
 
   // Skills
   const {
@@ -126,8 +135,6 @@ export function AppContent({ activeTab }: AppContentProps) {
   const { agentOptionValues, currentAgentOptions, handleToggleAgentOption } =
     useAgentOptions(agents, currentAgent);
 
-  // Auth & permissions
-  const { hasPermission, isAuthenticated } = useAuth();
   const canSendMessage = hasPermission(Permission.CHAT_WRITE);
 
   // WebSocket notifications

--- a/frontend/src/hooks/useTools.ts
+++ b/frontend/src/hooks/useTools.ts
@@ -10,7 +10,7 @@ import type {
 
 const API_BASE = "/api";
 
-export function useTools() {
+export function useTools(disabledToolsVersion?: string) {
   const [tools, setTools] = useState<ToolState[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -147,12 +147,13 @@ export function useTools() {
   const enabledCount = tools.filter((t) => t.enabled).length;
 
   // 初始加载 — 从 authApi 获取当前 user metadata
+  // disabledToolsVersion 变化时重新获取（当 MCPServerCard 切换工具时触发）
   useEffect(() => {
     authApi
       .getCurrentUser()
       .then((user) => fetchTools(user.metadata))
       .catch(() => fetchTools());
-  }, [fetchTools]);
+  }, [fetchTools, disabledToolsVersion]);
 
   return {
     tools,


### PR DESCRIPTION
## Summary

- **Dynamic tool discovery**: Add `GET /{name}/tools` endpoint to dynamically fetch available tools from each MCP server, with an expandable tools panel in `MCPServerCard`
- **Per-tool toggle control**: Allow users to enable/disable individual MCP tools via toggle switches, using `user.metadata.disabled_tools` as the single source of truth shared between `MCPServerCard` and `ToolSelector`
- **Alphabetical sorting**: Sort MCP tools by name in both backend `GET /api/tools` response and frontend `ToolSelector` UI
- **Server source attribution**: Display which MCP server each tool originates from in the tools list
- **Fix message duplication**: Fix deep agent (fast_agent/search_agent) sending duplicate messages by only passing new messages to `astream_events`, relying on the checkpointer's `add_messages` reducer for history
- **Fix ToolSelector sync**: When a user toggles a tool in MCPServerCard, ToolSelector now automatically re-fetches to reflect the change

## Key changes

### Backend
- `src/api/routes/mcp.py` — New `GET /{name}/tools` and `PATCH /{name}/tools/{tool_name}` endpoints
- `src/api/routes/agent/__init__.py` — `GET /api/tools` reads disabled tools from user metadata, resolves server attribution via tuple-keyed `_tool_server_map`, filters out disabled tools before returning
- `src/infra/mcp/storage.py` — `discover_server_tools()` with proper resource cleanup (try/finally), tool preference storage, strips langchain server prefix from tool names
- `src/infra/tool/mcp_client.py` — `_tool_server_map` uses `(server_name, raw_name)` tuple keys to prevent same-named tool collisions across servers
- `src/kernel/schemas/mcp.py` — New Pydantic schemas for tool discovery/toggle
- `src/agents/*/nodes.py` — Fix message duplication by only passing new messages

### Frontend
- `MCPServerCard` — Expandable tools section with per-tool toggle switches and optimistic UI updates
- `MCPPanel` — Derives `disabledToolNames` from user metadata, triggers `refreshUser()` on toggle
- `AppContent` + `useTools` — Observes `user.metadata.disabled_tools` changes to auto re-fetch tools list
- `ToolSelector` — Sorts tools alphabetically within each category
- i18n — Added keys for all 5 locales (en, zh, ja, ko, ru)

## Bugs fixed during review
- Resource leak in `discover_server_tools` (missing try/finally for manager.close)
- Sorting index calculation error when disabled tools were filtered out
- Tool name double-prefix bug (langchain `server_name:` + frontend `server_name:`)
- `_tool_server_map` type annotation mismatch and no-redef
- `server` variable type narrowing (UserMCPServer | SystemMCPServer union)
- React hooks rule violation (`useAuth()` called inside callback)

## Test plan
- [ ] Verify tool discovery works for both user and system MCP servers
- [ ] Verify per-tool toggle persists across page refreshes
- [ ] Verify toggling a tool in MCPServerCard immediately reflects in ToolSelector
- [ ] Verify disabled tools are filtered out from `GET /api/tools` response
- [ ] Verify tools are sorted alphabetically in ToolSelector and API response
- [ ] Verify deep agent no longer duplicates messages
- [ ] Verify same-named tools from different servers are correctly attributed