### PR TITLE
fix: resolve NameError for FeishuChannel in processing emoji loop

### DIFF
--- a/src/infra/channel/feishu/handler.py
+++ b/src/infra/channel/feishu/handler.py
@@ -130,6 +130,8 @@ class FeishuResponseCollector:
         """循环切换 emoji 表示正在处理。"""
         try:
             while self._processing_active:
+                from src.infra.channel.feishu.channel import FeishuChannel
+
                 for emoji in FeishuChannel.PROCESSING_EMOJIS:
                     await asyncio.sleep(3)
                     if not self._processing_active:


### PR DESCRIPTION
## Summary
- Fix `NameError: name 'FeishuChannel' is not defined` in `_processing_emoji_loop`
- `FeishuChannel` was only imported under `TYPE_CHECKING`, causing runtime failure when accessing `FeishuChannel.PROCESSING_EMOJIS`
- Changed to a lazy import inside the method, consistent with other runtime imports in the same file

## Test plan
- [ ] Verify Feishu message processing no longer throws `FeishuChannel is not defined` error
- [ ] Confirm processing emoji indicator still cycles correctly