### PR TITLE
feat: add role-based model management

### DIFF
--- a/frontend/src/components/layout/AppContent/index.tsx
+++ b/frontend/src/components/layout/AppContent/index.tsx
@@ -177,6 +177,7 @@ function ChatAppContent({
     isLoading,
     agents,
     currentAgent,
+    allowedModels: agentAllowedModels,
     newlyCreatedSession,
     sendMessage,
     stopGeneration,
@@ -223,6 +224,13 @@ function ChatAppContent({
       refreshToolsForAgent(currentAgent);
     }
   }, [currentAgent, refreshToolsForAgent]);
+
+  // Filter models by role-based permissions
+  const filteredModels = useMemo(() => {
+    if (!availableModels) return null;
+    if (!agentAllowedModels || agentAllowedModels.length === 0) return availableModels;
+    return availableModels.filter((m) => agentAllowedModels.includes(m.value));
+  }, [availableModels, agentAllowedModels]);
 
   // 现在可以初始化 agentOptions
   const {
@@ -532,7 +540,7 @@ function ChatAppContent({
       projectManager={projectManager}
       onNewSession={handleNewSessionWithReset}
       onShowProfile={onShowProfile}
-      availableModels={availableModels}
+      availableModels={filteredModels}
       currentModel={currentModel}
       onSelectModel={handleSelectModel}
       sidebar={

--- a/frontend/src/components/panels/AgentConfigPanel.tsx
+++ b/frontend/src/components/panels/AgentConfigPanel.tsx
@@ -13,18 +13,26 @@ import {
   ChevronDown,
   Check,
   Settings,
+  Sparkles,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import toast from "react-hot-toast";
 import { PanelHeader } from "../common/PanelHeader";
 import { LoadingSpinner } from "../common/LoadingSpinner";
-import { agentConfigApi, roleApi, agentApi } from "../../services/api";
+import { agentConfigApi, roleApi, agentApi, settingsApi } from "../../services/api";
 import { useAuth } from "../../hooks/useAuth";
 import { Permission } from "../../types";
 import type { AgentConfig, Role, AgentInfo } from "../../types";
 
 // Tab 类型
-type TabType = "global" | "roles";
+type TabType = "global" | "roles" | "models";
+
+// 模型选项类型
+interface ModelOption {
+  value: string;
+  label: string;
+  description?: string;
+}
 
 /**
  * 全局 Agent 配置标签组件
@@ -356,12 +364,224 @@ function RolesAgentTab({
 }
 
 /**
+ * 角色 Model 分配标签组件
+ */
+function RolesModelTab({
+  roles,
+  roleModelsMap,
+  availableModels,
+  onUpdate,
+  isLoading,
+}: {
+  roles: Role[];
+  roleModelsMap: Record<string, string[]>;
+  availableModels: ModelOption[];
+  onUpdate: (roleId: string, modelValues: string[]) => void;
+  isLoading: boolean;
+}) {
+  const { t } = useTranslation();
+  const [selectedRole, setSelectedRole] = useState<string | null>(
+    roles.length > 0 ? roles[0].id : null,
+  );
+  const [localRoleModels, setLocalRoleModels] =
+    useState<Record<string, string[]>>(roleModelsMap);
+  const [roleDropdownOpen, setRoleDropdownOpen] = useState(false);
+
+  useEffect(() => {
+    setLocalRoleModels(roleModelsMap);
+  }, [roleModelsMap]);
+
+  if (isLoading) {
+    return (
+      <div className="flex h-40 items-center justify-center">
+        <LoadingSpinner size="lg" />
+      </div>
+    );
+  }
+
+  const currentRoleModels = selectedRole
+    ? localRoleModels[selectedRole] || []
+    : [];
+
+  const toggleModel = (modelValue: string) => {
+    if (!selectedRole) return;
+    setLocalRoleModels((prev) => {
+      const current = prev[selectedRole] || [];
+      if (current.includes(modelValue)) {
+        return {
+          ...prev,
+          [selectedRole]: current.filter((v) => v !== modelValue),
+        };
+      }
+      return { ...prev, [selectedRole]: [...current, modelValue] };
+    });
+  };
+
+  const handleSave = async () => {
+    if (!selectedRole) return;
+    try {
+      await onUpdate(selectedRole, localRoleModels[selectedRole] || []);
+    } catch (err) {
+      console.error("Failed to save role models:", err);
+    }
+  };
+
+  const selectedRoleData = roles.find((r) => r.id === selectedRole);
+  const hasChanges = selectedRole
+    ? JSON.stringify(localRoleModels[selectedRole]) !==
+      JSON.stringify(roleModelsMap[selectedRole])
+    : false;
+
+  if (availableModels.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-stone-500 dark:text-stone-400">
+        <Sparkles size={32} className="mb-3 opacity-40" />
+        <p className="text-sm">{t("agentConfig.noModelsConfigured")}</p>
+        <p className="text-xs mt-1 opacity-70">{t("agentConfig.noModelsConfiguredHint")}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-stone-500 dark:text-stone-400 px-1">
+        {t("agentConfig.modelsDescription")}
+      </p>
+
+      {/* 角色选择器 - 手机端使用下拉菜单，桌面端使用标签 */}
+      <div className="block sm:hidden">
+        <div className="relative">
+          <button
+            onClick={() => setRoleDropdownOpen(!roleDropdownOpen)}
+            className="flex w-full items-center justify-between rounded-lg border border-stone-300 bg-white px-4 py-3 text-sm font-medium text-stone-900 dark:border-stone-600 dark:bg-stone-800 dark:text-stone-100"
+          >
+            <span className="flex items-center gap-2">
+              <Settings size={16} className="text-stone-500" />
+              {selectedRoleData?.name || t("agentConfig.selectRole")}
+            </span>
+            <ChevronDown
+              size={18}
+              className={`text-stone-500 transition-transform ${
+                roleDropdownOpen ? "rotate-180" : ""
+              }`}
+            />
+          </button>
+
+          {roleDropdownOpen && (
+            <div className="absolute z-10 mt-1 w-full rounded-lg border border-stone-200 bg-white shadow-lg dark:border-stone-700 dark:bg-stone-800">
+              {roles.map((role) => (
+                <button
+                  key={role.id}
+                  onClick={() => {
+                    setSelectedRole(role.id);
+                    setRoleDropdownOpen(false);
+                  }}
+                  className={`flex w-full items-center justify-between px-4 py-3 text-sm transition-colors first:rounded-t-lg last:rounded-b-lg ${
+                    selectedRole === role.id
+                      ? "bg-stone-100 text-stone-900 dark:bg-stone-700 dark:text-stone-100"
+                      : "text-stone-700 hover:bg-stone-50 dark:text-stone-300 dark:hover:bg-stone-700/50"
+                  }`}
+                >
+                  <span>{role.name}</span>
+                  {selectedRole === role.id && (
+                    <Check
+                      size={16}
+                      className="text-stone-600 dark:text-stone-400"
+                    />
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* 桌面端标签选择 */}
+      <div className="hidden sm:flex gap-1.5 overflow-x-auto pb-2">
+        {roles.map((role) => (
+          <button
+            key={role.id}
+            onClick={() => setSelectedRole(role.id)}
+            className={`flex-shrink-0 rounded-lg px-4 py-2 text-sm font-medium transition-all ${
+              selectedRole === role.id
+                ? "bg-gradient-to-r from-stone-500 to-stone-600 text-white shadow-sm dark:from-stone-400 dark:to-stone-500 dark:text-stone-900"
+                : "bg-stone-100 text-stone-600 hover:bg-stone-200 dark:bg-stone-800 dark:text-stone-400 dark:hover:bg-stone-700"
+            }`}
+          >
+            {role.name}
+          </button>
+        ))}
+      </div>
+
+      {selectedRole && (
+        <>
+          {/* 可用 Models 选择 */}
+          <div className="rounded-xl border border-stone-200/60 bg-stone-50/80 p-4 dark:border-stone-700/60 dark:bg-stone-900/50">
+            <h4 className="mb-3 text-sm font-medium text-stone-900 dark:text-stone-100">
+              {t("agentConfig.selectModelsForRole", {
+                roleName: selectedRoleData?.name,
+              })}
+            </h4>
+            <div className="grid gap-2 space-y-1 sm:space-y-2">
+              {availableModels.map((model) => (
+                <label
+                  key={model.value}
+                  className={`flex cursor-pointer items-center gap-3 rounded-lg bg-white p-3 transition-all dark:bg-stone-800 ${
+                    currentRoleModels.includes(model.value)
+                      ? "ring-2 ring-stone-500/50 dark:ring-stone-400/50 shadow-sm"
+                      : "hover:bg-stone-50 dark:hover:bg-stone-700/50"
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={currentRoleModels.includes(model.value)}
+                    onChange={() => toggleModel(model.value)}
+                    className="h-5 w-5"
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm font-medium text-stone-900 dark:text-stone-100 truncate">
+                      {model.label}
+                    </div>
+                    {model.description && (
+                      <div className="text-xs text-stone-500 dark:text-stone-400 truncate hidden sm:block">
+                        {model.description}
+                      </div>
+                    )}
+                  </div>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          {/* 保存按钮 */}
+          {hasChanges && (
+            <div className="flex justify-end pt-2">
+              <button
+                onClick={handleSave}
+                className="btn-primary flex items-center gap-2 px-4 py-2.5 text-sm"
+              >
+                <Save size={16} />
+                {t("common.save")}
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+/**
  * Agent 配置面板主组件
  */
 export function AgentConfigPanel() {
   const { t } = useTranslation();
   const { hasPermission } = useAuth();
-  const [activeTab, setActiveTab] = useState<TabType>("global");
+  const canManageAgents = hasPermission(Permission.AGENT_ADMIN);
+  const canManageModels = hasPermission(Permission.MODEL_ADMIN);
+  const [activeTab, setActiveTab] = useState<TabType>(
+    canManageAgents ? "global" : "models",
+  );
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -372,9 +592,13 @@ export function AgentConfigPanel() {
   const [roleAgentsMap, setRoleAgentsMap] = useState<Record<string, string[]>>(
     {},
   );
+  const [roleModelsMap, setRoleModelsMap] = useState<Record<string, string[]>>(
+    {},
+  );
   const [availableAgents, setAvailableAgents] = useState<AgentInfo[]>([]);
+  const [availableModels, setAvailableModels] = useState<ModelOption[]>([]);
 
-  const canManage = hasPermission(Permission.AGENT_ADMIN);
+  const showTabBar = canManageAgents || canManageModels;
 
   // 加载数据
   const loadData = useCallback(async () => {
@@ -383,15 +607,27 @@ export function AgentConfigPanel() {
 
     try {
       // 并行加载所有数据
-      const [globalConfig, roleList, agentList] = await Promise.all([
-        canManage ? agentConfigApi.getGlobalConfig() : Promise.resolve(null),
+      const [globalConfig, roleList, agentList, settingsData] = await Promise.all([
+        canManageAgents ? agentConfigApi.getGlobalConfig() : Promise.resolve(null),
         roleApi.list(),
         agentApi.list(),
+        (canManageAgents || canManageModels) ? settingsApi.list() : Promise.resolve(null),
       ]);
+
+      // 加载全局可用模型列表
+      if (settingsData?.settings) {
+        const allSettings = Object.values(settingsData.settings).flat();
+        const llmModels = allSettings.find(
+          (s: { key: string }) => s.key === "LLM_AVAILABLE_MODELS",
+        );
+        if (llmModels?.value && Array.isArray(llmModels.value) && llmModels.value.length > 0) {
+          setAvailableModels(llmModels.value as ModelOption[]);
+        }
+      }
 
       // 管理员使用全局配置的全部 agent（用于角色分配），非管理员使用过滤后的列表
       setAvailableAgents(
-        canManage && globalConfig
+        canManageAgents && globalConfig
           ? globalConfig.agents.map((a) => ({
               id: a.id,
               name: a.name,
@@ -420,7 +656,7 @@ export function AgentConfigPanel() {
       setRoles(roleList || []);
 
       // 加载角色-agents 映射
-      if (canManage) {
+      if (canManageAgents) {
         const roleAgentPromises = (roleList || []).map(async (role) => {
           try {
             const assignment = await agentConfigApi.getRoleAgents(role.id);
@@ -436,6 +672,24 @@ export function AgentConfigPanel() {
         });
         setRoleAgentsMap(map);
       }
+
+      // 加载角色-models 映射
+      if (canManageModels) {
+        const roleModelPromises = (roleList || []).map(async (role) => {
+          try {
+            const assignment = await agentConfigApi.getRoleModels(role.id);
+            return { roleId: role.id, models: assignment.allowed_models };
+          } catch {
+            return { roleId: role.id, models: [] };
+          }
+        });
+        const roleModelResults = await Promise.all(roleModelPromises);
+        const modelMap: Record<string, string[]> = {};
+        roleModelResults.forEach(({ roleId, models }) => {
+          modelMap[roleId] = models;
+        });
+        setRoleModelsMap(modelMap);
+      }
     } catch (err) {
       const errorMsg = (err as Error).message || t("agentConfig.loadFailed");
       setError(errorMsg);
@@ -443,7 +697,7 @@ export function AgentConfigPanel() {
     } finally {
       setIsLoading(false);
     }
-  }, [canManage, t]);
+  }, [canManageAgents, canManageModels, t]);
 
   useEffect(() => {
     loadData();
@@ -451,7 +705,7 @@ export function AgentConfigPanel() {
 
   // 更新全局配置
   const handleUpdateGlobalConfig = async (agents: AgentConfig[]) => {
-    if (!canManage) return;
+    if (!canManageAgents) return;
     setIsSaving(true);
     try {
       await agentConfigApi.updateGlobalConfig(agents);
@@ -467,10 +721,23 @@ export function AgentConfigPanel() {
 
   // 更新角色配置
   const handleUpdateRoleAgents = async (roleId: string, agentIds: string[]) => {
-    if (!canManage) return;
+    if (!canManageAgents) return;
     try {
       await agentConfigApi.updateRoleAgents(roleId, agentIds);
       setRoleAgentsMap((prev) => ({ ...prev, [roleId]: agentIds }));
+      toast.success(t("agentConfig.saveSuccess"));
+    } catch (err) {
+      toast.error((err as Error).message || t("agentConfig.saveFailed"));
+      throw err;
+    }
+  };
+
+  // 更新角色模型配置
+  const handleUpdateRoleModels = async (roleId: string, modelValues: string[]) => {
+    if (!canManageModels) return;
+    try {
+      await agentConfigApi.updateRoleModels(roleId, modelValues);
+      setRoleModelsMap((prev) => ({ ...prev, [roleId]: modelValues }));
       toast.success(t("agentConfig.saveSuccess"));
     } catch (err) {
       toast.error((err as Error).message || t("agentConfig.saveFailed"));
@@ -520,40 +787,67 @@ export function AgentConfigPanel() {
       )}
 
       {/* Tab 切换 - 移动端增大触摸区域 */}
-      {canManage && (
+      {showTabBar && (
         <div className="flex border-b border-stone-200 dark:border-stone-800">
-          <button
-            onClick={() => setActiveTab("global")}
-            className={`flex-1 px-3 py-4 sm:px-4 sm:py-3 text-center text-sm font-medium transition-all relative ${
-              activeTab === "global"
-                ? "text-stone-900 dark:text-stone-100"
-                : "text-stone-500 hover:text-stone-700 dark:text-stone-400 dark:hover:text-stone-200"
-            }`}
-          >
-            {activeTab === "global" && (
-              <span className="absolute bottom-0 left-2 right-2 h-0.5 rounded-full bg-gradient-to-r from-stone-500 to-stone-600 dark:from-stone-400 dark:to-stone-500" />
-            )}
-            {t("agentConfig.globalTab")}
-          </button>
-          <button
-            onClick={() => setActiveTab("roles")}
-            className={`flex-1 px-3 py-4 sm:px-4 sm:py-3 text-center text-sm font-medium transition-all relative ${
-              activeTab === "roles"
-                ? "text-stone-900 dark:text-stone-100"
-                : "text-stone-500 hover:text-stone-700 dark:text-stone-400 dark:hover:text-stone-200"
-            }`}
-          >
-            {activeTab === "roles" && (
-              <span className="absolute bottom-0 left-2 right-2 h-0.5 rounded-full bg-gradient-to-r from-stone-500 to-stone-600 dark:from-stone-400 dark:to-stone-500" />
-            )}
-            {t("agentConfig.rolesTab")}
-          </button>
+          {canManageAgents && (
+            <>
+              <button
+                onClick={() => setActiveTab("global")}
+                className={`flex-1 px-3 py-4 sm:px-4 sm:py-3 text-center text-sm font-medium transition-all relative ${
+                  activeTab === "global"
+                    ? "text-stone-900 dark:text-stone-100"
+                    : "text-stone-500 hover:text-stone-700 dark:text-stone-400 dark:hover:text-stone-200"
+                }`}
+              >
+                {activeTab === "global" && (
+                  <span className="absolute bottom-0 left-2 right-2 h-0.5 rounded-full bg-gradient-to-r from-stone-500 to-stone-600 dark:from-stone-400 dark:to-stone-500" />
+                )}
+                {t("agentConfig.globalTab")}
+              </button>
+              <button
+                onClick={() => setActiveTab("roles")}
+                className={`flex-1 px-3 py-4 sm:px-4 sm:py-3 text-center text-sm font-medium transition-all relative ${
+                  activeTab === "roles"
+                    ? "text-stone-900 dark:text-stone-100"
+                    : "text-stone-500 hover:text-stone-700 dark:text-stone-400 dark:hover:text-stone-200"
+                }`}
+              >
+                {activeTab === "roles" && (
+                  <span className="absolute bottom-0 left-2 right-2 h-0.5 rounded-full bg-gradient-to-r from-stone-500 to-stone-600 dark:from-stone-400 dark:to-stone-500" />
+                )}
+                {t("agentConfig.rolesTab")}
+              </button>
+            </>
+          )}
+          {canManageModels && (
+            <button
+              onClick={() => setActiveTab("models")}
+              className={`flex-1 px-3 py-4 sm:px-4 sm:py-3 text-center text-sm font-medium transition-all relative ${
+                activeTab === "models"
+                  ? "text-stone-900 dark:text-stone-100"
+                  : "text-stone-500 hover:text-stone-700 dark:text-stone-400 dark:hover:text-stone-200"
+              }`}
+            >
+              {activeTab === "models" && (
+                <span className="absolute bottom-0 left-2 right-2 h-0.5 rounded-full bg-gradient-to-r from-stone-500 to-stone-600 dark:from-stone-400 dark:to-stone-500" />
+              )}
+              {t("agentConfig.modelsTab")}
+            </button>
+          )}
         </div>
       )}
 
       {/* 内容 */}
       <div className="flex-1 overflow-y-auto px-3 py-4 sm:px-6 sm:py-5">
-        {canManage ? (
+        {showTabBar && activeTab === "models" && canManageModels ? (
+          <RolesModelTab
+            roles={roles}
+            roleModelsMap={roleModelsMap}
+            availableModels={availableModels}
+            onUpdate={handleUpdateRoleModels}
+            isLoading={isLoading}
+          />
+        ) : canManageAgents ? (
           activeTab === "global" ? (
             <GlobalAgentTab
               agents={globalAgents}

--- a/frontend/src/hooks/useAgent.ts
+++ b/frontend/src/hooks/useAgent.ts
@@ -54,6 +54,7 @@ export function useAgent(options?: UseAgentOptions): UseAgentReturn {
   const [agents, setAgents] = useState<AgentInfo[]>([]);
   const [currentAgent, setCurrentAgent] = useState<string>("");
   const [agentsLoading, setAgentsLoading] = useState(false);
+  const [allowedModels, setAllowedModels] = useState<string[] | null>(null);
   const [connectionStatus, setConnectionStatus] =
     useState<ConnectionStatus>("disconnected");
   const [currentRunId, setCurrentRunId] = useState<string | null>(null);
@@ -160,6 +161,7 @@ export function useAgent(options?: UseAgentOptions): UseAgentReturn {
       if (!response.ok) throw new Error("Failed to fetch agents");
       const data: AgentListResponse = await response.json();
       setAgents(data.agents || []);
+      setAllowedModels(data.allowed_models ?? null);
       // Use ref to check currentAgent, avoiding dependency cycle
       if (!currentAgentRef.current && data.agents?.length > 0) {
         const defaultAgentId = data.default_agent || data.agents[0]?.id || "";
@@ -209,6 +211,7 @@ export function useAgent(options?: UseAgentOptions): UseAgentReturn {
 
         // Update agents list
         setAgents(data.agents || []);
+        setAllowedModels(data.allowed_models ?? null);
 
         // Apply the new default agent if user doesn't have an active session
         // (i.e., no current messages means it's a good time to switch)
@@ -792,6 +795,7 @@ export function useAgent(options?: UseAgentOptions): UseAgentReturn {
     agents,
     currentAgent,
     agentsLoading,
+    allowedModels,
     isReconnecting: connectionStatus === "reconnecting",
     connectionStatus,
     newlyCreatedSession,

--- a/frontend/src/hooks/useAgent/types.ts
+++ b/frontend/src/hooks/useAgent/types.ts
@@ -175,6 +175,7 @@ export interface UseAgentReturn {
   agents: AgentInfo[];
   currentAgent: string;
   agentsLoading: boolean;
+  allowedModels: string[] | null;
   isReconnecting: boolean;
   connectionStatus: ConnectionStatus;
   newlyCreatedSession: BackendSession | null;

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -49,9 +49,14 @@
     "saveFailed": "Failed to save configuration",
     "saveSuccess": "Configuration saved successfully",
     "selectAgentsForRole": "Select agents accessible to {{roleName}} role",
+    "selectModelsForRole": "Select models accessible to {{roleName}} role",
     "selectRole": "Select a role",
     "subtitle": "Manage agent availability and role assignments",
-    "title": "Agent Configuration"
+    "title": "Agent Configuration",
+    "modelsTab": "Model Assignments",
+    "modelsDescription": "Configure which models each role can use. Roles without configuration can use all models.",
+    "noModelsConfigured": "No models configured",
+    "noModelsConfiguredHint": "Please configure LLM_AVAILABLE_MODELS in system settings first"
   },
   "agentOptions": {
     "enableThinking": {

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -51,7 +51,12 @@
     "title": "エージェント設定",
     "currentPreference": "現在のデフォルトエージェント：{{agentName}}",
     "defaultAgentDescription": "新しい会話のデフォルトエージェントを選択",
-    "selectAgentsForRole": "{{roleName}} ロールがアクセスできるエージェントを選択"
+    "selectAgentsForRole": "{{roleName}} ロールがアクセスできるエージェントを選択",
+    "selectModelsForRole": "{{roleName}} ロールが使用できるモデルを選択",
+    "modelsTab": "モデル割り当て",
+    "modelsDescription": "各ロールが使用できるモデルを設定します。未設定のロールはすべてのモデルを使用できます。",
+    "noModelsConfigured": "利用可能なモデルが設定されていません",
+    "noModelsConfiguredHint": "システム設定で LLM_AVAILABLE_MODELS を設定してください"
   },
   "agentOptions": {
     "enableThinking": {

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -51,7 +51,12 @@
     "title": "에이전트 구성",
     "currentPreference": "현재 기본 에이전트: {{agentName}}",
     "defaultAgentDescription": "새 대화의 기본 에이전트를 선택하세요",
-    "selectAgentsForRole": "{{roleName}} 역할이 접근할 수 있는 에이전트를 선택하세요"
+    "selectAgentsForRole": "{{roleName}} 역할이 접근할 수 있는 에이전트를 선택하세요",
+    "selectModelsForRole": "{{roleName}} 역할이 사용할 수 있는 모델을 선택하세요",
+    "modelsTab": "모델 할당",
+    "modelsDescription": "각 역할이 사용할 수 있는 모델을 설정합니다. 설정되지 않은 역할은 모든 모델을 사용할 수 있습니다.",
+    "noModelsConfigured": "사용 가능한 모델이 설정되지 않았습니다",
+    "noModelsConfiguredHint": "시스템 설정에서 LLM_AVAILABLE_MODELS를 먼저 설정하세요"
   },
   "agentOptions": {
     "enableThinking": {

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -51,7 +51,12 @@
     "selectAgentsForRole": "Выберите агентов для роли {{roleName}}",
     "selectRole": "Выберите роль",
     "subtitle": "Управление доступностью агентов и назначением ролей",
-    "title": "Конфигурация агентов"
+    "title": "Конфигурация агентов",
+    "selectModelsForRole": "Выберите модели для роли {{roleName}}",
+    "modelsTab": "Назначение моделей",
+    "modelsDescription": "Настройте модели, доступные для каждой роли. Роли без настройки могут использовать все модели.",
+    "noModelsConfigured": "Доступные модели не настроены",
+    "noModelsConfiguredHint": "Сначала настройте LLM_AVAILABLE_MODELS в системных настройках"
   },
   "agentOptions": {
     "enableThinking": {

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -49,9 +49,14 @@
     "saveFailed": "保存配置失败",
     "saveSuccess": "配置保存成功",
     "selectAgentsForRole": "选择 {{roleName}} 角色可访问的助手",
+    "selectModelsForRole": "选择 {{roleName}} 角色可使用的模型",
     "selectRole": "选择角色",
     "subtitle": "管理助手可用性和角色分配",
-    "title": "助手配置"
+    "title": "助手配置",
+    "modelsTab": "模型分配",
+    "modelsDescription": "配置每个角色可以使用的模型。未配置的角色将可以使用所有模型。",
+    "noModelsConfigured": "尚未配置可用模型",
+    "noModelsConfiguredHint": "请先在系统设置中配置 LLM_AVAILABLE_MODELS"
   },
   "agentOptions": {
     "enableThinking": {

--- a/frontend/src/services/api/agent_config.ts
+++ b/frontend/src/services/api/agent_config.ts
@@ -8,6 +8,7 @@ import type {
   GlobalAgentConfigResponse,
   RoleAgentAssignment,
   RoleAgentAssignmentResponse,
+  RoleModelAssignment,
   UserAgentPreference,
   UserAgentPreferenceResponse,
   AgentConfig,
@@ -51,6 +52,27 @@ export const agentConfigApi = {
       {
         method: "PUT",
         body: JSON.stringify({ allowed_agents: allowedAgents }),
+      },
+    );
+  },
+
+  /** 获取角色的可用 Models（需要管理员权限） */
+  async getRoleModels(roleId: string): Promise<RoleModelAssignment> {
+    return authFetch<RoleModelAssignment>(
+      `${API_BASE}/api/agent/config/roles/${roleId}/models`,
+    );
+  },
+
+  /** 设置角色的可用 Models（需要管理员权限） */
+  async updateRoleModels(
+    roleId: string,
+    allowedModels: string[],
+  ): Promise<RoleModelAssignment> {
+    return authFetch<RoleModelAssignment>(
+      `${API_BASE}/api/agent/config/roles/${roleId}/models`,
+      {
+        method: "PUT",
+        body: JSON.stringify({ allowed_models: allowedModels }),
       },
     );
   },

--- a/frontend/src/types/agent.ts
+++ b/frontend/src/types/agent.ts
@@ -27,6 +27,7 @@ export interface AgentListResponse {
   agents: AgentInfo[];
   count: number;
   default_agent?: string;
+  allowed_models?: string[] | null;
 }
 
 // Workflow event types
@@ -78,4 +79,11 @@ export interface UserAgentPreference {
 // Response for user agent preference operations
 export interface UserAgentPreferenceResponse {
   default_agent_id: string | null;
+}
+
+// Role's accessible models
+export interface RoleModelAssignment {
+  role_id: string;
+  role_name: string;
+  allowed_models: string[];
 }

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -52,6 +52,8 @@ export enum Permission {
   // Agent
   AGENT_READ = "agent:read",
   AGENT_ADMIN = "agent:admin",
+  // Model
+  MODEL_ADMIN = "model:admin",
   // Marketplace
   MARKETPLACE_READ = "marketplace:read",
   MARKETPLACE_PUBLISH = "marketplace:publish",

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -76,6 +76,7 @@ export type {
   GlobalAgentConfigResponse,
   RoleAgentAssignment,
   RoleAgentAssignmentResponse,
+  RoleModelAssignment,
   UserAgentPreference,
   UserAgentPreferenceResponse,
 } from "./agent";

--- a/src/api/routes/agent/__init__.py
+++ b/src/api/routes/agent/__init__.py
@@ -270,6 +270,7 @@ async def list_agents(
     # 获取用户角色的可用 agents 映射（使用角色ID作为key）
     role_agent_map = {}
     role_ids = []  # 用户角色ID列表
+    all_allowed_models: list[str] = []
     if user_roles:
         from src.infra.role.manager import get_role_manager
 
@@ -280,18 +281,32 @@ async def list_agents(
             role = await role_manager.get_role_by_name(role_name)
             if role:
                 role_agents = await storage.get_role_agents(role.id)
-                return role.id, role_agents, role_name
+                role_models = await storage.get_role_models(role.id)
+                return role.id, role_agents, role_models, role_name
             return None
 
         role_results = await asyncio.gather(*[_fetch_role(rn) for rn in user_roles])
+        all_allowed_models: list[str] = []
         for result in role_results:
             if result is not None:
-                rid, role_agents, role_name = result
+                rid, role_agents, role_models, role_name = result
                 role_ids.append(rid)
                 role_agent_map[rid] = role_agents
+                # 合并角色的 allowed_models（union）
+                if role_models is not None:
+                    all_allowed_models.extend(role_models)
                 logger.info(
-                    f"[Agents API] role_name={role_name}, role_id={rid}, role_agents={role_agents}"
+                    f"[Agents API] role_name={role_name}, role_id={rid}, role_agents={role_agents}, role_models={role_models}"
                 )
+
+        # 去重并保持顺序
+        seen = set()
+        unique_models = []
+        for m in all_allowed_models:
+            if m not in seen:
+                seen.add(m)
+                unique_models.append(m)
+        all_allowed_models = unique_models
 
     logger.info(f"[Agents API] final role_ids={role_ids}, role_agent_map={role_agent_map}")
 
@@ -306,6 +321,7 @@ async def list_agents(
         "agents": agents,
         "count": len(agents),
         "default_agent": default_agent,
+        "allowed_models": all_allowed_models if all_allowed_models else None,
     }
 
 

--- a/src/api/routes/agent/__init__.py
+++ b/src/api/routes/agent/__init__.py
@@ -286,7 +286,6 @@ async def list_agents(
             return None
 
         role_results = await asyncio.gather(*[_fetch_role(rn) for rn in user_roles])
-        all_allowed_models: list[str] = []
         for result in role_results:
             if result is not None:
                 rid, role_agents, role_models, role_name = result

--- a/src/api/routes/agent/config.py
+++ b/src/api/routes/agent/config.py
@@ -21,6 +21,8 @@ from src.kernel.schemas.agent import (
     RoleAgentAssignment,
     RoleAgentAssignmentResponse,
     RoleAgentAssignmentUpdate,
+    RoleModelAssignment,
+    RoleModelAssignmentUpdate,
     UserAgentPreference,
     UserAgentPreferenceResponse,
     UserAgentPreferenceUpdate,
@@ -144,6 +146,60 @@ async def update_role_agents(
         role_id=role_id,
         role_name=role.name,
         allowed_agents=assignment.allowed_agents,
+    )
+
+
+# ============================================
+# 角色 Models 管理
+# ============================================
+
+
+@router.get("/roles/{role_id}/models", response_model=RoleModelAssignment)
+async def get_role_models(
+    role_id: str,
+    _: TokenPayload = Depends(require_permissions(Permission.MODEL_ADMIN.value)),
+):
+    """获取角色的可用 Models"""
+    storage = get_agent_config_storage()
+    role_manager = get_role_manager()
+
+    role = await role_manager.get_role(role_id)
+    if not role:
+        from src.kernel.exceptions import NotFoundError
+
+        raise NotFoundError(f"角色 '{role_id}' 不存在")
+
+    allowed_models = await storage.get_role_models(role_id) or []
+
+    return RoleModelAssignment(
+        role_id=role_id,
+        role_name=role.name,
+        allowed_models=allowed_models,
+    )
+
+
+@router.put("/roles/{role_id}/models", response_model=RoleModelAssignment)
+async def update_role_models(
+    role_id: str,
+    assignment: RoleModelAssignmentUpdate,
+    _: TokenPayload = Depends(require_permissions(Permission.MODEL_ADMIN.value)),
+):
+    """设置角色的可用 Models"""
+    storage = get_agent_config_storage()
+    role_manager = get_role_manager()
+
+    role = await role_manager.get_role(role_id)
+    if not role:
+        from src.kernel.exceptions import NotFoundError
+
+        raise NotFoundError(f"角色 '{role_id}' 不存在")
+
+    await storage.set_role_models(role_id, role.name, assignment.allowed_models)
+
+    return RoleModelAssignment(
+        role_id=role_id,
+        role_name=role.name,
+        allowed_models=assignment.allowed_models,
     )
 
 

--- a/src/infra/agent/config_storage.py
+++ b/src/infra/agent/config_storage.py
@@ -16,6 +16,7 @@ from src.kernel.schemas.agent import AgentConfig, UserAgentPreference
 # MongoDB 集合名称
 _COLL_AGENT_CONFIG = "agent_config"
 _COLL_ROLE_AGENTS = "role_agents"
+_COLL_ROLE_MODELS = "role_models"
 _COLL_USER_PREFERENCES = "user_agent_preferences"
 
 
@@ -46,6 +47,7 @@ class AgentConfigStorage:
         """创建必要的 MongoDB 索引"""
         await self._get_collection(_COLL_AGENT_CONFIG).create_index("type", unique=True)
         await self._get_collection(_COLL_ROLE_AGENTS).create_index("role_id", unique=True)
+        await self._get_collection(_COLL_ROLE_MODELS).create_index("role_id", unique=True)
         await self._get_collection(_COLL_USER_PREFERENCES).create_index("user_id", unique=True)
 
     # ============================================
@@ -126,6 +128,57 @@ class AgentConfigStorage:
                 "role_id": doc["role_id"],
                 "role_name": doc.get("role_name", ""),
                 "allowed_agents": doc.get("allowed_agents", []),
+            }
+            async for doc in cursor
+        ]
+
+    # ============================================
+    # 角色 Models 映射
+    # ============================================
+
+    async def get_role_models(self, role_id: str) -> Optional[list[str]]:
+        """
+        获取角色的可用 Models
+
+        Returns:
+            可用的 Model value 列表，None 表示未配置（不限制）
+        """
+        doc = await self._get_collection(_COLL_ROLE_MODELS).find_one({"role_id": role_id})
+        if not doc:
+            return None
+        return doc.get("allowed_models") or None
+
+    async def set_role_models(
+        self, role_id: str, role_name: str, model_values: list[str]
+    ) -> list[str]:
+        """设置角色的可用 Models"""
+        now = datetime.now(timezone.utc)
+        await self._get_collection(_COLL_ROLE_MODELS).update_one(
+            {"role_id": role_id},
+            {
+                "$set": {
+                    "role_name": role_name,
+                    "allowed_models": model_values,
+                    "updated_at": now.isoformat(),
+                }
+            },
+            upsert=True,
+        )
+        return model_values
+
+    async def delete_role_models(self, role_id: str) -> bool:
+        """删除角色的 Models 配置"""
+        result = await self._get_collection(_COLL_ROLE_MODELS).delete_one({"role_id": role_id})
+        return result.deleted_count > 0
+
+    async def get_all_role_models(self) -> list[dict]:
+        """获取所有角色的 Models 配置"""
+        cursor = self._get_collection(_COLL_ROLE_MODELS).find()
+        return [
+            {
+                "role_id": doc["role_id"],
+                "role_name": doc.get("role_name", ""),
+                "allowed_models": doc.get("allowed_models", []),
             }
             async for doc in cursor
         ]

--- a/src/kernel/schemas/agent.py
+++ b/src/kernel/schemas/agent.py
@@ -194,6 +194,25 @@ class RoleAgentAssignmentResponse(BaseModel):
 
 
 # ============================================
+# Role Model Schemas
+# ============================================
+
+
+class RoleModelAssignment(BaseModel):
+    """Role's accessible models."""
+
+    role_id: str = Field(..., description="Role ID")
+    role_name: str = Field(..., description="Role name")
+    allowed_models: list[str] = Field(default_factory=list, description="List of allowed model values")
+
+
+class RoleModelAssignmentUpdate(BaseModel):
+    """Update role's accessible models."""
+
+    allowed_models: list[str] = Field(..., description="List of allowed model values")
+
+
+# ============================================
 # User Agent Preference Schemas
 # ============================================
 

--- a/src/kernel/schemas/agent.py
+++ b/src/kernel/schemas/agent.py
@@ -203,7 +203,9 @@ class RoleModelAssignment(BaseModel):
 
     role_id: str = Field(..., description="Role ID")
     role_name: str = Field(..., description="Role name")
-    allowed_models: list[str] = Field(default_factory=list, description="List of allowed model values")
+    allowed_models: list[str] = Field(
+        default_factory=list, description="List of allowed model values"
+    )
 
 
 class RoleModelAssignmentUpdate(BaseModel):

--- a/src/kernel/schemas/permission.py
+++ b/src/kernel/schemas/permission.py
@@ -183,6 +183,11 @@ PERMISSION_METADATA: dict[str, dict[str, str]] = {
         "label": "管理智能体",
         "description": "创建、修改和删除智能体配置（管理员权限）",
     },
+    # Model
+    Permission.MODEL_ADMIN.value: {
+        "label": "管理模型",
+        "description": "管理角色可用的模型分配（管理员权限）",
+    },
     # Channel - Generic
     Permission.CHANNEL_READ.value: {
         "label": "查看渠道",
@@ -312,6 +317,12 @@ PERMISSION_GROUPS_CONFIG: list[PermissionGroupConfig] = [
         "permissions": [
             Permission.AGENT_READ.value,
             Permission.AGENT_ADMIN.value,
+        ],
+    },
+    {
+        "name": "模型管理",
+        "permissions": [
+            Permission.MODEL_ADMIN.value,
         ],
     },
     {

--- a/src/kernel/types.py
+++ b/src/kernel/types.py
@@ -79,6 +79,9 @@ class Permission(str, Enum):
     AGENT_READ = "agent:read"
     AGENT_ADMIN = "agent:admin"
 
+    # Model
+    MODEL_ADMIN = "model:admin"
+
     # Marketplace
     MARKETPLACE_READ = "marketplace:read"
     MARKETPLACE_PUBLISH = "marketplace:publish"


### PR DESCRIPTION
## Summary
- 管理员可以为每个角色分配可用的模型，类似现有的角色-Agent分配功能
- 新增 `model:admin` 权限控制模型管理访问，独立于 `agent:admin`
- 未配置模型限制的角色不限制模型访问（显示所有全局模型）

## Changes

### Backend
- 新增 `role_models` MongoDB 集合及 CRUD 操作（复用 `role_agents` 相同模式）
- 新增 `GET/PUT /api/agent/config/roles/{role_id}/models` 管理端点
- `/agents` 端点新增 `allowed_models` 字段，按用户角色过滤
- 新增 `MODEL_ADMIN` (`model:admin`) 权限，含元数据和分组配置

### Frontend
- AgentConfigPanel 新增 "模型分配" 标签页
- ModelSelector 根据角色权限过滤可用模型
- `useAgent` hook 暴露 `allowedModels` 状态
- 补全 5 种语言的 i18n 翻译 (zh, en, ja, ko, ru)

## Test plan
- [ ] 以管理员登录，进入助手配置面板，切换到"模型分配"标签
- [ ] 选择角色，勾选可用模型，保存
- [ ] 以该角色用户登录，验证 ModelSelector 只显示被允许的模型
- [ ] 未配置模型限制的角色应显示所有模型
- [ ] 只有 `model:admin` 权限（无 `agent:admin`）的用户只能看到"模型分配"标签
- [ ] 在角色管理页面验证 `model:admin` 权限可被正确分配