### PR TITLE
feat: add Kimi Coding Plan provider

### DIFF
--- a/frontend/src/components/agent/modelIcon.ts
+++ b/frontend/src/components/agent/modelIcon.ts
@@ -11,6 +11,7 @@ import grok from "@lobehub/icons-static-svg/icons/grok.svg?url";
 import cohere from "@lobehub/icons-static-svg/icons/cohere-color.svg?url";
 import zhipu from "@lobehub/icons-static-svg/icons/zhipu-color.svg?url";
 import moonshot from "@lobehub/icons-static-svg/icons/moonshot.svg?url";
+import kimi from "@lobehub/icons-static-svg/icons/kimi-color.svg?url";
 import ollama from "@lobehub/icons-static-svg/icons/ollama.svg?url";
 import perplexity from "@lobehub/icons-static-svg/icons/perplexity-color.svg?url";
 import minimax from "@lobehub/icons-static-svg/icons/minimax-color.svg?url";
@@ -37,6 +38,7 @@ const providerMap: Record<string, string> = {
   cohere,
   zhipu,
   moonshot,
+  kimi,
   ollama,
   perplexity,
   minimax,
@@ -50,6 +52,7 @@ const providerMap: Record<string, string> = {
   zeroone,
   gemini,
   zai: zhipu,
+  "kimi-coding-plan": kimi,
   alibaba: qwen,
   aliyun: qwen,
   hunyuan: tencent,

--- a/frontend/src/components/panels/AgentPanel/shared/ProviderSelect.tsx
+++ b/frontend/src/components/panels/AgentPanel/shared/ProviderSelect.tsx
@@ -30,6 +30,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   zeroone: "01.AI",
   gemini: "Gemini",
   zai: "ZAI",
+  "kimi-coding-plan": "Kimi Coding Plan",
 };
 
 interface ProviderSelectProps {

--- a/src/infra/llm/client.py
+++ b/src/infra/llm/client.py
@@ -55,6 +55,8 @@ PROVIDER_REGISTRY: dict[str, tuple[str, list[str]]] = {
     "zeroone": ("openai", ["zero"]),
     # zai coding plan → Claude 协议
     "zai": ("anthropic", []),
+    # Kimi Coding Plan → Claude (Anthropic) 协议
+    "kimi-coding-plan": ("anthropic", []),
 }
 
 


### PR DESCRIPTION
## Summary
- 新增 `kimi-coding-plan` 提供商，使用 Anthropic 协议（Claude API 接口）
- 后端：在 `PROVIDER_REGISTRY` 注册，协议为 `anthropic`，无模型前缀（需用户手动配置模型名和 API base）
- 前端：添加 Kimi 图标（`kimi-color.svg`）和显示名 "Kimi Coding Plan"

## 使用方式
1. 在模型配置中选择 Provider 为 "Kimi Coding Plan"
2. 填写模型名（如 `claude-sonnet-4-20250514`）
3. 填写该提供商的 API Base URL 和 API Key
4. 系统会通过 Anthropic 协议（Claude 接口）调用

## Test plan
- [ ] 在模型配置页面能看到 "Kimi Coding Plan" 提供商选项
- [ ] 选择后能正常创建模型配置
- [ ] 使用该提供商的模型能正常发起对话