### PR TITLE
fix: remove redundant _id index creation

### DIFF
--- a/src/infra/storage/mongodb.py
+++ b/src/infra/storage/mongodb.py
@@ -186,7 +186,8 @@ class ApprovalStorage:
         if self._indexes_created:
             return
         coll = self.collection
-        await coll.create_index("_id", unique=True, background=True)
+        # _id already has a unique index by default, no need to recreate
+
         await coll.create_index(
             [("status", 1), ("expires_at", 1), ("user_id", 1)],
             background=True,


### PR DESCRIPTION
MongoDB `_id` field already has a unique index by default. Creating another with `unique=True` causes `OperationFailure: The field 'unique' is not valid for an _id index specification` (error code 197).

This removes the redundant `create_index("_id", unique=True)` call.