### PR TITLE
feat(memory): add NATIVE_MEMORY_RECALL_MIN_SCORE for memory recall filtering

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -187,6 +187,7 @@ ENABLE_MEMORY=false
 # NATIVE_MEMORY_INDEX_ENABLED=true
 # NATIVE_MEMORY_INDEX_CACHE_TTL=300
 # NATIVE_MEMORY_MAX_AUTO_RETAIN_PER_DAY=20
+# NATIVE_MEMORY_RECALL_MIN_SCORE=0.3  # Minimum relevance score (0.0-1.0) for recalled memories
 
 # ============================================
 # Frontend Settings

--- a/src/infra/memory/client/native/search.py
+++ b/src/infra/memory/client/native/search.py
@@ -429,6 +429,12 @@ async def recall_memories(
         memories = list(
             await asyncio.gather(*(hydrate_formatted_memory(backend, m) for m in memories))
         )
+
+        # Filter out low-scoring memories
+        min_score = getattr(settings, "NATIVE_MEMORY_RECALL_MIN_SCORE", 0.3)
+        if min_score > 0:
+            memories = [m for m in memories if m.get("score", 0) >= min_score]
+
         if touch_access:
             await backend._update_access_stats([m["memory_id"] for m in memories], user_id)
 

--- a/src/kernel/config/_definitions_extra.py
+++ b/src/kernel/config/_definitions_extra.py
@@ -677,4 +677,12 @@ EXTRA_SETTING_DEFINITIONS: dict[str, dict] = {
         "default": 90,
         "depends_on": "ENABLE_MEMORY",
     },
+    "NATIVE_MEMORY_RECALL_MIN_SCORE": {
+        "type": SettingType.NUMBER,
+        "category": SettingCategory.MEMORY_STORAGE,
+        "subcategory": "policy",
+        "description": "settingDesc.NATIVE_MEMORY_RECALL_MIN_SCORE",
+        "default": 0.3,
+        "depends_on": "ENABLE_MEMORY",
+    },
 }

--- a/src/kernel/config/base.py
+++ b/src/kernel/config/base.py
@@ -247,6 +247,7 @@ class Settings(BaseSettings):
     NATIVE_MEMORY_INLINE_CONTENT_MAX_CHARS: int = 1200
     NATIVE_MEMORY_STORE_NAMESPACE: str = "memories"
     NATIVE_MEMORY_APPEND_MAX_DETAILS: int = 8
+    NATIVE_MEMORY_RECALL_MIN_SCORE: float = 0.3
 
     model_config = {
         "env_file": str(PROJECT_ROOT / ".env"),


### PR DESCRIPTION
## Summary
- Add `NATIVE_MEMORY_RECALL_MIN_SCORE` environment variable (default `0.3`) to filter out low-relevance memory recall results
- Memories with score below the threshold are excluded from recall results, reducing noise
- Set to `0.0` to disable filtering

## Changes
- `src/kernel/config/base.py` - Add setting default
- `src/kernel/config/definitions.py` - Add setting definition
- `src/infra/memory/client/native/search.py` - Apply score filter after rerank/hydrate
- `.env.example` - Document new setting

## Test plan
- [ ] Set `NATIVE_MEMORY_RECALL_MIN_SCORE=0.3`, verify low-score memories are filtered
- [ ] Set `NATIVE_MEMORY_RECALL_MIN_SCORE=0.0`, verify all memories are returned
- [ ] Verify high-score memories (>= 0.3) are still returned normally