### PR TITLE
fix(e2b): detect binary content in read() and return error instead of garbled text

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ dependencies = [
     "langchain-mcp-adapters>=0.1.0", # MCP integration
     "langgraph>=1.0.9",
     "langsmith>=0.2.0",
-    "deepagents>=0.4.0", # Deep Agent framework
-    "deepagents-backends>=0.1.0",
+    "deepagents>=0.5.3", # Deep Agent framework
+    "deepagents-backends>=0.2.0",
     "tiktoken>=0.9.0",
     # Async & Streaming
     "sse-starlette>=2.2.0",


### PR DESCRIPTION
## Problem
When  encounters binary files (images, videos, PDFs, etc.), E2B's  returns garbled text like  that pollutes the LLM context.

## Root Cause
Commit  refactored  to return  but removed the old line-number formatting. Binary files are now passed through as raw garbled text.

## Fix
Add  detection in :
- Check for null bytes ()
- Check non-printable character ratio in first 4KB (>30% = binary)
- Return a clear error message instead of garbled text

This is a minimal, backend-only fix — no middleware changes needed.