### PR TITLE
fix: thinking level 无法切换（单一数据源修复）

### DIFF
--- a/frontend/src/components/layout/AppContent/index.tsx
+++ b/frontend/src/components/layout/AppContent/index.tsx
@@ -336,6 +336,7 @@ function ChatAppContent({
     currentAgentOptions,
     handleToggleAgentOption,
     restoreAgentOptions,
+    resetAgentOptionDefaults,
   } = useAgentOptions(agents, currentAgent);
 
   // 对话级别的配置管理（独立于全局配置）
@@ -386,17 +387,19 @@ function ChatAppContent({
     }
   }, [availableModels, currentModelId, currentModelValue, defaultModel]);
 
-  // Sync currentModel → sessionConfig.agentOptions so the UI and backend data
-  // always agree.  Covers: init, preference change, defaultModel change, new-session
-  // reset, and session restore — all in one place.
+  // Sync currentModel → useAgentOptions + useSessionConfig so the UI and backend
+  // data always agree.  Covers: init, preference change, defaultModel change,
+  // new-session reset, and session restore — all in one place.
   useEffect(() => {
     if (currentModelValue) {
+      handleToggleAgentOption("model", currentModelValue);
       setSessionAgentOption("model", currentModelValue);
     }
     if (currentModelId) {
+      handleToggleAgentOption("model_id", currentModelId);
       setSessionAgentOption("model_id", currentModelId);
     }
-  }, [currentModelValue, currentModelId, setSessionAgentOption]);
+  }, [currentModelValue, currentModelId, handleToggleAgentOption, setSessionAgentOption]);
 
   const handleSelectModel = useCallback(
     (modelId: string, modelValue: string) => {
@@ -713,23 +716,19 @@ function ChatAppContent({
 
     handleNewSession();
     resetToDefaults();
-    isSessionRestoredRef.current = false;
+
+    // Reset useAgentOptions to defaults so agent options (thinking level etc.)
+    // revert to their default values for the new session
+    resetAgentOptionDefaults();
 
     setCurrentModelId(nextSelection.modelId);
     setCurrentModelValue(nextSelection.modelValue);
-
-    if (nextSelection.modelValue) {
-      setSessionAgentOption("model", nextSelection.modelValue);
-    }
-    if (nextSelection.modelId) {
-      setSessionAgentOption("model_id", nextSelection.modelId);
-    }
   }, [
     availableModels,
     defaultModel,
     handleNewSession,
     resetToDefaults,
-    setSessionAgentOption,
+    resetAgentOptionDefaults,
   ]);
 
   const handleMobileClose = useCallback(

--- a/frontend/src/components/layout/AppContent/index.tsx
+++ b/frontend/src/components/layout/AppContent/index.tsx
@@ -407,9 +407,13 @@ function ChatAppContent({
   );
 
   // 同步 sessionConfig 到 ref，供 useAgent 使用
+  // agentOptions 来自 useAgentOptions（唯一 source of truth），不依赖 useSessionConfig
   useEffect(() => {
-    sessionConfigRef.current = sessionConfig;
-  }, [sessionConfig]);
+    sessionConfigRef.current = {
+      ...sessionConfig,
+      agentOptions: agentOptionValues,
+    };
+  }, [sessionConfig, agentOptionValues]);
 
   // Compute effective tools: apply session-level MCP tool overrides (blacklist)
   const effectiveTools = useMemo(() => {
@@ -534,21 +538,6 @@ function ChatAppContent({
     [effectiveSkills, sessionConfig.disabledSkills, toggleSessionSkill],
   );
 
-  // Effective agent option toggle: update both local state and session config
-  const effectiveToggleAgentOption = useCallback(
-    (key: string, value: boolean | string | number) => {
-      handleToggleAgentOption(key, value);
-      setSessionAgentOption(key, value);
-      // Keep model state in sync when changed via agent option toggle
-      if (key === "model" && typeof value === "string") {
-        setCurrentModelValue(value);
-      }
-      if (key === "model_id" && typeof value === "string") {
-        setCurrentModelId(value);
-      }
-    },
-    [handleToggleAgentOption, setSessionAgentOption],
-  );
 
   // Compute effective counts
   const effectiveEnabledToolsCount = useMemo(
@@ -854,8 +843,8 @@ function ChatAppContent({
           totalSkillsCount={skills.length}
           enableSkills={enableSkills}
           agentOptions={currentAgentOptions}
-          agentOptionValues={sessionConfig.agentOptions}
-          onToggleAgentOption={effectiveToggleAgentOption}
+          agentOptionValues={agentOptionValues}
+          onToggleAgentOption={handleToggleAgentOption}
           agents={agents}
           currentAgent={currentAgent}
           onSelectAgent={switchAgent}

--- a/frontend/src/components/layout/AppContent/useAgentOptions.ts
+++ b/frontend/src/components/layout/AppContent/useAgentOptions.ts
@@ -187,6 +187,14 @@ export function useAgentOptions(agents: AgentInfo[], currentAgent: string) {
     [],
   );
 
+  // Reset to agent defaults (for new session)
+  const resetAgentOptionDefaults = useCallback(() => {
+    const options = normalizeAgentOptions(
+      agents.find((a) => a.id === currentAgent)?.options,
+    );
+    setAgentOptionValues(buildAgentOptionValues(options));
+  }, [agents, currentAgent]);
+
   // 从外部恢复配置
   const restoreAgentOptions = useCallback(
     (options: Record<string, boolean | string | number>) => {
@@ -202,5 +210,6 @@ export function useAgentOptions(agents: AgentInfo[], currentAgent: string) {
     currentAgentOptions,
     handleToggleAgentOption,
     restoreAgentOptions,
+    resetAgentOptionDefaults,
   };
 }


### PR DESCRIPTION
## Problem

对话中切换思考强度后，选择立刻被重置回默认值，不发送消息也会被覆盖。

## Root Cause

agent options 的状态分散在两个 hook 中管理：
- `useAgentOptions` 维护 `agentOptionValues` state
- `useSessionConfig` 维护 `config.agentOptions` state

两者需要手动同步。`useSessionConfig` 的 re-sync effect 用 ref 存储默认值，但 ref 在 render body 中更新，总是比实际 state 慢一拍，导致用户选择被旧默认值覆盖。

## Fix

让 `useAgentOptions` 成为 agent options 的**唯一数据源**：
- ChatInput 直接从 `useAgentOptions.agentOptionValues` 读取值（不再经过 useSessionConfig）
- 切换只更新 `useAgentOptions`（通过 `handleToggleAgentOption`）
- `sessionConfigRef` 在 render body 中直接同步 `agentOptionValues`
- 移除 `effectiveToggleAgentOption` 和 re-sync effect

从根本上消除了双状态同步问题。