### PR TITLE
feat(chat): prepend user messages with localized timestamps

### DIFF
--- a/docs/superpowers/plans/2026-04-28-assistant-system-prompt-marketplace.md
+++ b/docs/superpowers/plans/2026-04-28-assistant-system-prompt-marketplace.md
@@ -1,0 +1,643 @@
+# Assistant System Prompt Marketplace Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a first-class assistant marketplace and personal assistant library where each assistant stores a `system_prompt`, can be selected for a chat session, and injects a session-stable prompt snapshot into the agent runtime.
+
+**Architecture:** Introduce a dedicated assistant domain on the backend with storage, manager, and REST routes. Persist assistant selection in session metadata as both `assistant_id` and `assistant_prompt_snapshot`, then inject that snapshot into the existing prompt middleware chain before skills and memory. Add a lightweight frontend assistant page plus a chat header selector that reuses current session config and panel patterns.
+
+**Tech Stack:** FastAPI, MongoDB/Motor, Pydantic, existing session/chat APIs, React, TypeScript, existing panel/hook architecture, pytest, Node `node:test`.
+
+---
+
+## File Structure
+
+- Create: `src/infra/assistant/__init__.py`
+  Re-export assistant storage/manager helpers.
+- Create: `src/infra/assistant/types.py`
+  Backend Pydantic models for assistant create/update/list/select payloads and response objects.
+- Create: `src/infra/assistant/storage.py`
+  MongoDB persistence, indexes, ownership-aware CRUD, list/filter helpers, clone helper.
+- Create: `src/infra/assistant/manager.py`
+  Marketplace visibility rules, clone semantics, session snapshot preparation, runtime lookup helper.
+- Create: `src/api/routes/assistant.py`
+  Authenticated CRUD/list/select/clone routes for assistants.
+- Create: `tests/infra/assistant/test_storage.py`
+  Unit tests for assistant storage behavior and clone semantics.
+- Create: `tests/infra/assistant/test_manager.py`
+  Unit tests for prompt snapshot resolution and visibility rules.
+- Create: `tests/api/routes/test_assistant_routes.py`
+  Route-level tests with fakes for list/create/select/clone permission and ownership flows.
+- Modify: `src/api/main.py`
+  Mount assistant routes and initialize assistant indexes on startup.
+- Modify: `src/kernel/schemas/agent.py`
+  Add optional `assistant_id` to chat requests.
+- Modify: `src/api/routes/chat.py`
+  Accept `assistant_id`, persist assistant snapshot into session metadata during submit.
+- Modify: `frontend/src/hooks/useAgent/types.ts`
+  Extend restored session config shape with assistant metadata.
+- Modify: `src/agents/search_agent/nodes.py`
+  Append assistant prompt section before skills and memory.
+- Modify: `src/agents/fast_agent/nodes.py`
+  Mirror assistant prompt injection if fast agent shares the same middleware chain.
+- Create: `tests/agents/search_agent/test_assistant_prompt_injection.py`
+  Focused tests for prompt section ordering and snapshot precedence.
+- Modify: `src/kernel/schemas/session.py`
+  No schema shape change is required, but update typing/comments if helpful when exposing assistant metadata.
+- Modify: `frontend/src/types/index.ts`
+  Re-export assistant types.
+- Create: `frontend/src/types/assistant.ts`
+  Frontend assistant list/detail/request types.
+- Create: `frontend/src/services/api/assistant.ts`
+  REST client for assistant APIs.
+- Create: `frontend/src/services/api/assistant.test.ts`
+  Small URL/build contract tests for assistant API helper functions.
+- Create: `frontend/src/hooks/useAssistants.ts`
+  Fetch/search/filter/create/update/delete/clone/select hook.
+- Create: `frontend/src/components/assistant/AssistantSelector.tsx`
+  Chat header selector for the current session assistant.
+- Create: `frontend/src/components/panels/AssistantsPanel.tsx`
+  Public + personal assistant browser/editor panel.
+- Modify: `frontend/src/components/layout/AppContent/Header.tsx`
+  Render the assistant selector next to the model selector in chat view.
+- Modify: `frontend/src/components/layout/AppContent/TabContent.tsx`
+  Register the assistants panel.
+- Modify: `frontend/src/components/layout/AppContent/types.ts`
+  Add `assistants` tab.
+- Modify: `frontend/src/components/layout/UserMenu.tsx`
+  Add navigation entry for assistants.
+- Modify: `frontend/src/App.tsx`
+  Register `/assistants` page route.
+- Modify: `frontend/src/hooks/useSessionConfig.ts`
+  Track current `assistantId`, `assistantName`, and restore them from session metadata.
+- Modify: `frontend/src/components/layout/AppContent/sessionState.ts`
+  Add helper coverage for restored assistant metadata if needed.
+- Modify: `frontend/src/components/layout/AppContent/index.tsx`
+  Wire selected assistant into chat submit flow and restore it when loading a session.
+- Modify: `frontend/src/services/api/session.ts`
+  Send `assistant_id` with chat submissions if selected.
+- Modify: `frontend/src/types/session.ts`
+  Narrow metadata typing if needed for assistant fields in frontend consumers.
+- Modify: `frontend/src/types/auth.ts`
+  Add assistant permissions if this implementation chooses explicit assistant permission enums.
+- Modify: `src/kernel/types.py`
+  Add matching backend assistant permissions if explicit permissions are added.
+- Modify: `src/kernel/schemas/permission.py`
+  Register new permission metadata and group placement if explicit assistant permissions are added.
+
+## Implementation Choice Lock-Ins
+
+- Use a dedicated `/assistants` route and frontend page, not the existing skill marketplace route.
+- Keep assistants phase-1-only: `system_prompt` plus display metadata.
+- Store `assistant_prompt_snapshot` in `session.metadata` and prefer it over live assistant lookup.
+- Allow direct use of public assistants without cloning.
+- Allow cloning a public assistant into a private assistant record with `cloned_from_assistant_id`.
+- Use one `assistants` collection with `scope = "public" | "private"`.
+- Prefer explicit assistant permissions if the team is comfortable updating role metadata now; otherwise fall back to authenticated-user access for private CRUD and admin-only checks for public writes. Make this decision once before implementation starts and apply it consistently across backend and frontend.
+
+### Task 1: Assistant Domain Tests and Models
+
+**Files:**
+- Create: `src/infra/assistant/types.py`
+- Create: `tests/infra/assistant/test_storage.py`
+- Create: `tests/infra/assistant/test_manager.py`
+
+- [ ] **Step 1: Write the failing backend domain tests**
+
+Create tests that cover:
+
+- `AssistantCreate` defaults `scope="private"` and `version="1.0.0"`.
+- storage list helpers separate public assistants from a user's private assistants.
+- cloning copies `name`, `description`, `system_prompt`, and `tags` while setting `cloned_from_assistant_id`.
+- manager runtime resolution prefers `assistant_prompt_snapshot` over re-reading the source assistant.
+- manager runtime resolution snapshots the live `system_prompt` when only `assistant_id` is present.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/infra/assistant/test_storage.py tests/infra/assistant/test_manager.py -q`
+
+Expected: FAIL because the assistant domain modules do not exist yet.
+
+- [ ] **Step 3: Add minimal assistant schema module**
+
+Define backend models similar to:
+
+```python
+class AssistantScope(str, Enum):
+    PUBLIC = "public"
+    PRIVATE = "private"
+
+
+class AssistantRecord(BaseModel):
+    assistant_id: str
+    name: str
+    description: str = ""
+    system_prompt: str
+    scope: AssistantScope
+    created_by: str | None = None
+    is_active: bool = True
+    tags: list[str] = Field(default_factory=list)
+    avatar_url: str | None = None
+    cloned_from_assistant_id: str | None = None
+    version: str = "1.0.0"
+    bound_skill_names: list[str] = Field(default_factory=list)
+    default_model: str | None = None
+    default_agent_options: dict[str, Any] = Field(default_factory=dict)
+    default_disabled_tools: list[str] = Field(default_factory=list)
+    default_disabled_skills: list[str] = Field(default_factory=list)
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+```
+
+Also add request/response models:
+
+- `AssistantCreate`
+- `AssistantUpdate`
+- `AssistantResponse`
+- `AssistantSelectRequest`
+
+- [ ] **Step 4: Add minimal manager contracts to satisfy test imports**
+
+Define signatures only:
+
+```python
+class AssistantManager:
+    async def resolve_session_prompt_snapshot(...): ...
+    async def clone_public_assistant(...): ...
+```
+
+- [ ] **Step 5: Run tests again**
+
+Run: `pytest tests/infra/assistant/test_storage.py tests/infra/assistant/test_manager.py -q`
+
+Expected: still FAIL, now on missing storage and manager behavior instead of missing imports.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/infra/assistant/types.py tests/infra/assistant/test_storage.py tests/infra/assistant/test_manager.py
+git commit -m "test: scaffold assistant domain coverage"
+```
+
+### Task 2: Assistant Storage, Manager, and Startup Wiring
+
+**Files:**
+- Create: `src/infra/assistant/__init__.py`
+- Create: `src/infra/assistant/storage.py`
+- Create: `src/infra/assistant/manager.py`
+- Modify: `src/api/main.py`
+- Test: `tests/infra/assistant/test_storage.py`
+- Test: `tests/infra/assistant/test_manager.py`
+
+- [ ] **Step 1: Implement assistant storage**
+
+Add:
+
+- `ensure_indexes()`
+- `create_assistant()`
+- `get_assistant()`
+- `list_public_assistants()`
+- `list_user_assistants()`
+- `update_assistant()`
+- `delete_assistant()`
+- `clone_assistant()`
+
+Use `assistant_id` as the stable external key and store reserved future fields even if empty.
+
+- [ ] **Step 2: Implement assistant manager**
+
+Add logic for:
+
+- public visibility filtering
+- ownership checks
+- cloning from public assistants only
+- session snapshot preparation
+- runtime assistant lookup
+
+Minimal runtime helper:
+
+```python
+async def resolve_session_prompt_snapshot(
+    self,
+    session_metadata: Mapping[str, Any],
+    assistant_id: str | None,
+) -> tuple[str | None, dict[str, Any]]:
+    ...
+```
+
+Return the resolved prompt plus any session metadata fields that should be written back.
+
+- [ ] **Step 3: Initialize indexes at app startup**
+
+In `src/api/main.py`, create the assistant storage instance and call `ensure_indexes()` during lifespan, near the existing skill/revealed-file index initialization.
+
+- [ ] **Step 4: Run backend domain tests**
+
+Run: `pytest tests/infra/assistant/test_storage.py tests/infra/assistant/test_manager.py -q`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/infra/assistant/__init__.py src/infra/assistant/storage.py src/infra/assistant/manager.py src/api/main.py
+git commit -m "feat: add assistant storage and manager"
+```
+
+### Task 3: Assistant API and Permission Surface
+
+**Files:**
+- Create: `src/api/routes/assistant.py`
+- Modify: `src/kernel/types.py`
+- Modify: `src/kernel/schemas/permission.py`
+- Modify: `frontend/src/types/auth.ts`
+- Test: `tests/api/routes/test_assistant_routes.py`
+
+- [ ] **Step 1: Write the failing assistant route tests**
+
+Add tests for:
+
+- listing public assistants hides inactive public records from ordinary users
+- listing `scope=mine` returns only private assistants owned by the current user
+- selecting an assistant writes `assistant_id`, `assistant_name`, and `assistant_prompt_snapshot`
+- cloning a public assistant creates a private copy for the current user
+- editing/deleting another user's private assistant returns 403
+
+- [ ] **Step 2: Run route tests to verify they fail**
+
+Run: `pytest tests/api/routes/test_assistant_routes.py -q`
+
+Expected: FAIL because the assistant route module does not exist.
+
+- [ ] **Step 3: Decide and implement permission strategy**
+
+Choose one:
+
+- explicit assistant permissions:
+  - `assistant:read`
+  - `assistant:write`
+  - `assistant:marketplace_admin`
+- or authenticated-user + admin checks only
+
+If using explicit permissions, add them to:
+
+- `src/kernel/types.py`
+- `src/kernel/schemas/permission.py`
+- `frontend/src/types/auth.ts`
+
+If using the lighter strategy, skip enum churn and make the route use `get_current_user_required` plus manager ownership checks.
+
+- [ ] **Step 4: Implement assistant routes**
+
+Add endpoints:
+
+- `GET /api/assistants`
+- `GET /api/assistants/{assistant_id}`
+- `POST /api/assistants`
+- `PATCH /api/assistants/{assistant_id}`
+- `DELETE /api/assistants/{assistant_id}`
+- `POST /api/assistants/{assistant_id}/clone`
+- `POST /api/assistants/{assistant_id}/select`
+
+Mount the router in `src/api/main.py`.
+
+- [ ] **Step 5: Run route tests**
+
+Run: `pytest tests/api/routes/test_assistant_routes.py -q`
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/api/routes/assistant.py src/kernel/types.py src/kernel/schemas/permission.py frontend/src/types/auth.ts tests/api/routes/test_assistant_routes.py src/api/main.py
+git commit -m "feat: add assistant marketplace api"
+```
+
+### Task 4: Session Snapshot Plumbing Through Chat and Session Restore
+
+**Files:**
+- Modify: `src/kernel/schemas/agent.py`
+- Modify: `src/api/routes/chat.py`
+- Modify: `frontend/src/hooks/useAgent/types.ts`
+- Modify: `frontend/src/services/api/session.ts`
+- Modify: `frontend/src/hooks/useSessionConfig.ts`
+- Modify: `frontend/src/components/layout/AppContent/index.tsx`
+- Modify: `frontend/src/components/layout/AppContent/sessionState.ts`
+- Test: `frontend/src/services/api/assistant.test.ts`
+- Test: `frontend/src/components/layout/AppContent/sessionState.test.ts`
+
+- [ ] **Step 1: Write the failing frontend contract tests**
+
+Add tests that assert:
+
+- assistant list/detail/select URLs are built correctly in `assistantApi`
+- restored session config can safely extract `assistant_id` and `assistant_name`
+- chat submit includes `assistant_id` when present
+
+- [ ] **Step 2: Run the focused frontend tests**
+
+Run: `node --test frontend/src/services/api/assistant.test.ts frontend/src/components/layout/AppContent/sessionState.test.ts`
+
+Expected: FAIL because assistant API helpers and session restore helpers do not exist yet.
+
+- [ ] **Step 3: Extend backend request/restore typing**
+
+Update `src/kernel/schemas/agent.py`:
+
+```python
+assistant_id: Optional[str] = Field(
+    None,
+    description="Assistant ID to snapshot into the session for this conversation",
+)
+```
+
+Update `frontend/src/hooks/useAgent/types.ts` session config typing:
+
+```ts
+assistant_id?: string;
+assistant_name?: string;
+assistant_prompt_snapshot?: string;
+```
+
+- [ ] **Step 4: Persist assistant selection during chat submit**
+
+In `src/api/routes/chat.py`:
+
+- accept `assistant_id`
+- resolve and snapshot the assistant before updating the session config
+- write:
+  - `assistant_id`
+  - `assistant_name`
+  - `assistant_prompt_snapshot`
+
+In `frontend/src/services/api/session.ts`:
+
+- extend `submitChat(...)` to accept `assistantId`
+- include `assistant_id` in the request body
+
+In `frontend/src/hooks/useSessionConfig.ts` and `frontend/src/components/layout/AppContent/index.tsx`:
+
+- track selected assistant state
+- restore it from loaded session metadata
+- pass it into chat submit calls
+
+- [ ] **Step 5: Add helper for restored assistant metadata**
+
+In `frontend/src/components/layout/AppContent/sessionState.ts`, add a small extractor similar to `getRestoredModelSelection()`:
+
+```ts
+export function getRestoredAssistantSelection(config: SessionConfig) {
+  return {
+    assistantId:
+      typeof config.assistant_id === "string" ? config.assistant_id : "",
+    assistantName:
+      typeof config.assistant_name === "string" ? config.assistant_name : "",
+  };
+}
+```
+
+- [ ] **Step 6: Run frontend tests again**
+
+Run: `node --test frontend/src/services/api/assistant.test.ts frontend/src/components/layout/AppContent/sessionState.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/kernel/schemas/agent.py src/api/routes/chat.py frontend/src/services/api/session.ts frontend/src/hooks/useAgent/types.ts frontend/src/hooks/useSessionConfig.ts frontend/src/components/layout/AppContent/index.tsx frontend/src/components/layout/AppContent/sessionState.ts frontend/src/services/api/assistant.test.ts frontend/src/components/layout/AppContent/sessionState.test.ts
+git commit -m "feat: persist assistant snapshots in chat sessions"
+```
+
+### Task 5: Assistant Prompt Injection in Search and Fast Agents
+
+**Files:**
+- Modify: `src/agents/search_agent/nodes.py`
+- Modify: `src/agents/fast_agent/nodes.py`
+- Test: `tests/agents/search_agent/test_assistant_prompt_injection.py`
+
+- [ ] **Step 1: Write the failing prompt injection tests**
+
+Test:
+
+- assistant prompt section is added when `assistant_prompt_snapshot` exists in session metadata or request config
+- assistant prompt appears before skills and memory in `_prompt_sections`
+- no assistant section is injected when no assistant is selected
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/agents/search_agent/test_assistant_prompt_injection.py -q`
+
+Expected: FAIL because no assistant prompt section exists yet.
+
+- [ ] **Step 3: Implement assistant prompt resolution in agent nodes**
+
+Add a helper inside each node flow, or a shared helper if that stays focused:
+
+```python
+assistant_prompt = configurable.get("assistant_prompt", "")
+if not assistant_prompt:
+    metadata = await _load_session_metadata(...)
+    assistant_prompt = metadata.get("assistant_prompt_snapshot", "")
+```
+
+Then build prompt sections in this order:
+
+```python
+_prompt_sections = [
+    s for s in (assistant_prompt, skills_prompt, memory_guide) if s
+]
+```
+
+Do not place the assistant prompt after memory or after prompt caching.
+
+- [ ] **Step 4: Run prompt injection tests**
+
+Run: `pytest tests/agents/search_agent/test_assistant_prompt_injection.py -q`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agents/search_agent/nodes.py src/agents/fast_agent/nodes.py tests/agents/search_agent/test_assistant_prompt_injection.py
+git commit -m "feat: inject assistant system prompts into agent runtime"
+```
+
+### Task 6: Frontend Assistant Types, API, and Hook
+
+**Files:**
+- Create: `frontend/src/types/assistant.ts`
+- Create: `frontend/src/services/api/assistant.ts`
+- Create: `frontend/src/hooks/useAssistants.ts`
+- Modify: `frontend/src/types/index.ts`
+- Test: `frontend/src/services/api/assistant.test.ts`
+
+- [ ] **Step 1: Implement frontend assistant types**
+
+Add:
+
+- `AssistantScope`
+- `AssistantSummary`
+- `AssistantDetail`
+- `AssistantCreateRequest`
+- `AssistantUpdateRequest`
+- `AssistantSelectRequest`
+
+- [ ] **Step 2: Implement assistant API client**
+
+Add helpers for:
+
+- `list(params)`
+- `get(assistantId)`
+- `create(data)`
+- `update(assistantId, data)`
+- `delete(assistantId)`
+- `clone(assistantId)`
+- `select(assistantId, sessionId)`
+
+Mirror the style used in `frontend/src/services/api/marketplace.ts`.
+
+- [ ] **Step 3: Implement `useAssistants`**
+
+Track:
+
+- marketplace list
+- personal list
+- search query
+- selected tags
+- loading/error state
+- create/update/delete/clone/select actions
+
+Keep the hook narrow; avoid adding preview modal complexity in phase 1.
+
+- [ ] **Step 4: Run assistant frontend tests**
+
+Run: `node --test frontend/src/services/api/assistant.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/types/assistant.ts frontend/src/services/api/assistant.ts frontend/src/hooks/useAssistants.ts frontend/src/types/index.ts frontend/src/services/api/assistant.test.ts
+git commit -m "feat: add frontend assistant data layer"
+```
+
+### Task 7: Assistants Panel and Chat Header Selector
+
+**Files:**
+- Create: `frontend/src/components/assistant/AssistantSelector.tsx`
+- Create: `frontend/src/components/panels/AssistantsPanel.tsx`
+- Modify: `frontend/src/components/layout/AppContent/Header.tsx`
+- Modify: `frontend/src/components/layout/AppContent/TabContent.tsx`
+- Modify: `frontend/src/components/layout/AppContent/types.ts`
+- Modify: `frontend/src/components/layout/UserMenu.tsx`
+- Modify: `frontend/src/App.tsx`
+- Modify: `frontend/src/components/layout/AppContent/index.tsx`
+
+- [ ] **Step 1: Build a simple chat header selector**
+
+Model it on the existing agent/model selector pattern:
+
+- show current assistant name or a fallback like `"Default Assistant"`
+- list public + personal assistants in one dropdown
+- selecting an assistant updates local session config immediately
+
+Do not block chat on a network round-trip; selection should be optimistic and the backend snapshot happens on submit or explicit select.
+
+- [ ] **Step 2: Build the assistants panel**
+
+Keep it phase-1 simple:
+
+- tabs or segmented buttons for `Marketplace` and `My Assistants`
+- search
+- tag filters
+- create/edit modal with:
+  - name
+  - description
+  - tags
+  - system prompt
+- clone button on public assistants
+- delete button on owned assistants
+
+Reuse existing panel styling and form patterns from `MarketplacePanel` and `SkillsPanel`.
+
+- [ ] **Step 3: Wire the new tab into app navigation**
+
+Update:
+
+- `frontend/src/components/layout/AppContent/types.ts`
+- `frontend/src/components/layout/AppContent/TabContent.tsx`
+- `frontend/src/components/layout/UserMenu.tsx`
+- `frontend/src/App.tsx`
+
+Recommended route: `/assistants`
+
+- [ ] **Step 4: Ensure loaded sessions restore the selected assistant in chat**
+
+In `frontend/src/components/layout/AppContent/index.tsx`:
+
+- when `loadHistory()` returns session metadata with `assistant_id` and `assistant_name`, restore them into local state
+- clear assistant selection on `onNewSession()` reset if you want new chats to start neutral by default, or keep the last local assistant selection if that matches current UX expectations; pick one behavior and document it in code comments
+
+- [ ] **Step 5: Run targeted frontend verification**
+
+Run: `node --test frontend/src/services/api/assistant.test.ts frontend/src/components/layout/AppContent/sessionState.test.ts frontend/src/components/layout/AppContent/useSessionSync.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/assistant/AssistantSelector.tsx frontend/src/components/panels/AssistantsPanel.tsx frontend/src/components/layout/AppContent/Header.tsx frontend/src/components/layout/AppContent/TabContent.tsx frontend/src/components/layout/AppContent/types.ts frontend/src/components/layout/UserMenu.tsx frontend/src/App.tsx frontend/src/components/layout/AppContent/index.tsx
+git commit -m "feat: add assistants panel and chat selector"
+```
+
+### Task 8: End-to-End Verification and Cleanup
+
+**Files:**
+- No intended source edits unless fixes are required.
+
+- [ ] **Step 1: Run backend assistant test suite**
+
+Run: `pytest tests/infra/assistant/test_storage.py tests/infra/assistant/test_manager.py tests/api/routes/test_assistant_routes.py tests/agents/search_agent/test_assistant_prompt_injection.py -q`
+
+Expected: PASS
+
+- [ ] **Step 2: Run existing related backend tests for regression coverage**
+
+Run: `pytest tests/infra/backend/test_skills_store_backend.py tests/api/routes/test_session_runs.py tests/api/routes/test_session_favorites.py -q`
+
+Expected: PASS
+
+- [ ] **Step 3: Run targeted frontend tests**
+
+Run: `node --test frontend/src/services/api/assistant.test.ts frontend/src/components/layout/AppContent/sessionState.test.ts frontend/src/components/layout/AppContent/useSessionSync.test.ts frontend/src/services/api/session.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 4: Manual smoke-test checklist**
+
+Verify in the browser:
+
+- create a private assistant
+- browse public assistants
+- clone a public assistant
+- select an assistant in chat
+- send a message and confirm the session metadata stores assistant snapshot fields
+- edit the public assistant and confirm an old session still uses the old snapshot
+
+- [ ] **Step 5: Run final repo status check**
+
+Run: `git status --short`
+
+Expected: only intended assistant-related files changed.
+
+- [ ] **Step 6: Final commit**
+
+```bash
+git add .
+git commit -m "feat: add assistant system prompt marketplace"
+```

--- a/docs/superpowers/specs/2026-04-28-assistant-system-prompt-marketplace-design.md
+++ b/docs/superpowers/specs/2026-04-28-assistant-system-prompt-marketplace-design.md
@@ -1,0 +1,328 @@
+# Assistant System Prompt Marketplace Design
+
+## Summary
+
+Add a first-class `assistant` entity that powers a public assistant marketplace and a user's private assistant library. In phase 1, each assistant only carries presentation metadata and a `system_prompt`, which is injected into the agent at runtime. The design reserves fields for future assistant-bound skills, model defaults, and tool preferences without implementing those behaviors yet.
+
+## Problem
+
+The current system has `skills`, which tell the agent what capabilities and workflows are available, but it does not have a stable assistant layer that defines how the agent should behave for a specific use case. Users want something closer to an assistant plaza:
+
+- Admins can publish shared assistants.
+- Users can browse and use those assistants.
+- Users can create and save their own assistants.
+- Users can copy a public assistant into their own library and customize it.
+
+At the same time, phase 1 should stay lightweight. We do not want to build a full bundled assistant runtime yet. We only need an assistant record that can inject a system prompt into the existing agent prompt chain.
+
+## Goals
+
+- Create a durable `assistant` data model in the database.
+- Support both public marketplace assistants and user-private assistants.
+- Allow users to clone a public assistant into their own library.
+- Inject the selected assistant's `system_prompt` into the agent prompt chain.
+- Store a session-level prompt snapshot so old conversations stay stable even if the source assistant changes later.
+- Reuse the existing chat, session, and prompt middleware architecture.
+
+## Non-Goals
+
+- No assistant-bound skill installation or activation in phase 1.
+- No assistant-specific model enforcement in phase 1.
+- No automatic sync from a public assistant to user clones.
+- No assistant recommendation engine.
+- No version diff or historical rollback UI.
+
+## Data Model
+
+Use a dedicated MongoDB collection, `assistants`.
+
+### Document Shape
+
+```python
+{
+    "_id": ObjectId,
+    "assistant_id": str,                # stable external id
+    "name": str,
+    "description": str,
+    "system_prompt": str,
+
+    "scope": str,                      # "public" | "private"
+    "created_by": str | None,          # admin id for public, user id for private
+    "is_active": bool,
+
+    "tags": list[str],
+    "avatar_url": str | None,
+
+    "cloned_from_assistant_id": str | None,
+    "version": str,                    # default "1.0.0"
+
+    # Reserved for future phases
+    "bound_skill_names": list[str],
+    "default_model": str | None,
+    "default_agent_options": dict,
+    "default_disabled_tools": list[str],
+    "default_disabled_skills": list[str],
+
+    "created_at": datetime,
+    "updated_at": datetime,
+}
+```
+
+### Phase 1 Required Fields
+
+Phase 1 logic only depends on:
+
+- `assistant_id`
+- `name`
+- `description`
+- `system_prompt`
+- `scope`
+- `created_by`
+- `is_active`
+- `tags`
+- `cloned_from_assistant_id`
+- `created_at`
+- `updated_at`
+
+The reserved fields should still be stored so the schema grows forward cleanly.
+
+### Indexes
+
+- Unique: `assistant_id`
+- Query: `(scope, is_active, updated_at DESC)`
+- Query: `(created_by, updated_at DESC)`
+- Query: `tags`
+- Query: `cloned_from_assistant_id`
+
+If search remains regex-based in phase 1, no extra text index is required yet.
+
+## Ownership Model
+
+Use one collection with two scopes:
+
+- `public`: marketplace assistants managed by admins
+- `private`: user-owned assistants
+
+This keeps storage simple while still supporting both use cases.
+
+### Public Assistants
+
+- Created and updated by admins.
+- Visible in the marketplace.
+- Can be used directly in a session.
+- Can be cloned by users.
+
+### Private Assistants
+
+- Created by a user or cloned from a public assistant.
+- Visible only to the owner.
+- Fully editable by the owner.
+
+### Cloning
+
+Cloning creates a new `private` assistant document with:
+
+- copied `name`, `description`, `system_prompt`, and `tags`
+- `created_by = current_user`
+- `scope = "private"`
+- `cloned_from_assistant_id = source.assistant_id`
+
+There is no automatic downstream sync after cloning.
+
+## Session Integration
+
+The session should store both assistant identity and the exact prompt snapshot used by the conversation.
+
+### Session Metadata Fields
+
+Store these under `session.metadata`:
+
+```python
+{
+    "assistant_id": str | None,
+    "assistant_name": str | None,
+    "assistant_prompt_snapshot": str | None,
+}
+```
+
+### Why Snapshot the Prompt
+
+The source assistant can change over time, especially for public assistants maintained by admins. Without a snapshot, an old session could behave differently after an assistant edit. The snapshot makes each conversation stable.
+
+### Runtime Resolution Rule
+
+When a run starts:
+
+1. If `session.metadata.assistant_prompt_snapshot` exists, use it.
+2. Otherwise, if an `assistant_id` is provided, load the assistant and snapshot its current `system_prompt` into the session.
+3. If neither exists, no assistant prompt is injected.
+
+This rule supports both stable existing sessions and newly selected assistants.
+
+## Prompt Injection Architecture
+
+Phase 1 should reuse the existing prompt middleware pattern in `search_agent`.
+
+### Injection Order
+
+Recommended order:
+
+1. Base system prompt
+2. Workflow and subagent guide
+3. Assistant system prompt
+4. Skills prompt
+5. Memory guide
+
+This preserves platform guardrails while allowing the assistant to shape task style and persona before skills and memory add capabilities and context.
+
+### Backend Changes
+
+Add assistant loading into the request/session path, then append a new assistant prompt section during graph construction.
+
+Expected touch points:
+
+- session/chat request handling: resolve selected assistant and update session metadata
+- `src/agents/search_agent/nodes.py`: append `assistant_prompt` to `_prompt_sections`
+- matching fast agent path if it shares the same prompt architecture
+
+The assistant prompt should be injected with the same middleware style already used for skills and memory so it stays cache-friendly and easy to reason about.
+
+## Backend Architecture
+
+### Storage Layer
+
+Add a dedicated storage module, for example:
+
+- `src/infra/assistant/storage.py`
+
+Responsibilities:
+
+- create assistant
+- update assistant
+- soft-validate ownership and scope rules
+- list marketplace assistants
+- list a user's assistants
+- clone assistant
+- get assistant by id
+- optional activate/deactivate for admin moderation
+
+### Manager Layer
+
+Add a thin service layer if needed:
+
+- `src/infra/assistant/manager.py`
+
+This layer should handle:
+
+- marketplace visibility rules
+- clone semantics
+- runtime assistant lookup for chat requests
+- snapshot preparation
+
+### API Surface
+
+Phase 1 API should stay small:
+
+- `GET /api/assistants`
+  - supports `scope=public|mine|all`, `search`, `tags`
+- `GET /api/assistants/{assistant_id}`
+- `POST /api/assistants`
+  - create private assistant
+- `PATCH /api/assistants/{assistant_id}`
+  - owner edits private assistant, admin edits public assistant
+- `DELETE /api/assistants/{assistant_id}`
+- `POST /api/assistants/{assistant_id}/clone`
+  - create a private copy from a public assistant
+- `POST /api/assistants/{assistant_id}/select`
+  - attach assistant to a session and write the snapshot
+
+`/select` can accept `session_id` and update:
+
+- `assistant_id`
+- `assistant_name`
+- `assistant_prompt_snapshot`
+
+An alternative is to pass `assistant_id` through the existing chat request and let the chat route perform the snapshot write. Either is valid. The simpler implementation is whichever reuses existing session update code with the fewest moving parts.
+
+## Frontend Shape
+
+Phase 1 frontend does not need a heavy standalone experience yet.
+
+### Minimum UX
+
+- A marketplace view for public assistants
+- A "My Assistants" view for private assistants
+- A selector in chat to choose the current session assistant
+- A lightweight create/edit form with:
+  - name
+  - description
+  - tags
+  - system prompt
+
+### Marketplace Behavior
+
+- Browse public assistants
+- Search and filter by tags
+- Use directly in a chat session
+- Clone to personal library
+
+### My Assistants Behavior
+
+- Create private assistants
+- Edit private assistants
+- Delete private assistants
+- Start chat with a selected assistant
+
+This is enough to support the YubbChat-inspired assistant plaza flow without building a complex detail page in phase 1.
+
+## Permissions
+
+Suggested permission split:
+
+- `assistant:read`
+- `assistant:write`
+- `assistant:marketplace_read`
+- `assistant:marketplace_admin`
+
+If the project prefers to avoid new permission types in phase 1, marketplace read can reuse ordinary authenticated access and admin mutation can follow existing admin checks.
+
+## Migration and Rollout
+
+### Initial Rollout
+
+1. Add assistant collection and indexes.
+2. Add storage and API.
+3. Add session metadata fields and selection flow.
+4. Inject assistant prompt into the agent prompt chain.
+5. Add minimal marketplace and personal assistant UI.
+
+### Backward Compatibility
+
+Existing sessions without assistant metadata continue to work unchanged.
+
+Existing chat flows without an assistant selection behave exactly as they do now.
+
+## Testing
+
+Add focused tests for:
+
+- storage CRUD and visibility filtering
+- clone behavior preserves source link and copies prompt fields
+- chat/session selection writes `assistant_prompt_snapshot`
+- runtime resolution prefers snapshot over live assistant lookup
+- prompt injection order includes assistant prompt before skills and memory
+- permissions for public vs private mutations
+
+Frontend coverage can stay focused on selector and create/edit flows.
+
+## Future Phases
+
+Once phase 1 is stable, the same assistant model can expand to:
+
+- bind selected skills to an assistant
+- bind default model and tool preferences
+- richer marketplace detail pages
+- assistant import/export
+- usage stats and recommendations
+
+Because the collection already reserves these fields, those upgrades should not require a schema reset.

--- a/frontend/src/hooks/useAgent/eventHandlers.ts
+++ b/frontend/src/hooks/useAgent/eventHandlers.ts
@@ -291,8 +291,12 @@ function handleUserMessage(
   eventTimestamp: string | undefined,
   ctx: EventHandlerContext,
 ): void {
+  const extractOptimisticContent = (content: string): string | null => {
+    const match = content.match(/^\[[^\]]+\]\s([\s\S]*)$/);
+    return match ? match[1] : null;
+  };
   const userContent = data.content || "";
-  const userAttachments = convertAttachments(data.attachments);
+  const userAttachments = convertAttachments(data.attachments) || [];
 
   if (userContent) {
     ctx.setMessages((prev) => {
@@ -310,6 +314,28 @@ function handleUserMessage(
         (m) => m.role === "user" && m.content === userContent,
       );
       if (existingUserMsg) return prev;
+
+      const optimisticContent = extractOptimisticContent(userContent);
+      if (optimisticContent) {
+        for (let index = prev.length - 1; index >= 0; index -= 1) {
+          const candidate = prev[index];
+          if (
+            candidate?.role === "user" &&
+            candidate.content === optimisticContent
+          ) {
+            const updatedMessages = [...prev];
+            updatedMessages[index] = {
+              ...candidate,
+              content: userContent,
+              attachments:
+                userAttachments.length > 0
+                  ? userAttachments
+                  : candidate.attachments,
+            };
+            return updatedMessages;
+          }
+        }
+      }
 
       const newUserMessage: Message = {
         id: crypto.randomUUID(),

--- a/frontend/src/hooks/useAgent/eventHandlers.userMessageTimestamp.test.ts
+++ b/frontend/src/hooks/useAgent/eventHandlers.userMessageTimestamp.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { Message } from "../../types";
+import { handleStreamEvent } from "./eventHandlers.ts";
+import type { EventHandlerContext } from "./eventHandlers.ts";
+import type { StreamEvent } from "./types.ts";
+
+function createContext(messages: Message[]): {
+  ctx: EventHandlerContext;
+  getMessages: () => Message[];
+} {
+  let currentMessages = messages;
+
+  return {
+    ctx: {
+      sessionIdRef: { current: "session-1" },
+      processedEventIdsRef: { current: new Set<string>() },
+      lastHistoryTimestampRef: { current: null },
+      activeSubagentStackRef: { current: [] },
+      streamVersionRef: { current: 0 },
+      setSessionId: () => undefined,
+      setMessages: (updater: React.SetStateAction<Message[]>) => {
+        currentMessages =
+          typeof updater === "function" ? updater(currentMessages) : updater;
+      },
+      setConnectionStatus: () => undefined,
+      setIsInitializingSandbox: () => undefined,
+      setSandboxError: () => undefined,
+    },
+    getMessages: () => currentMessages,
+  };
+}
+
+test("replaces the optimistic user message when the backend adds a timestamp prefix", () => {
+  const { ctx, getMessages } = createContext([
+    {
+      id: "user-1",
+      role: "user",
+      content: "hello world",
+      timestamp: new Date("2026-04-28T12:00:00.000Z"),
+    },
+    {
+      id: "assistant-1",
+      role: "assistant",
+      content: "",
+      timestamp: new Date("2026-04-28T12:00:00.000Z"),
+      isStreaming: true,
+      parts: [],
+    },
+  ]);
+
+  const event: StreamEvent = {
+    event: "user:message",
+    data: JSON.stringify({
+      content: "[2026-04-28 20:00:00 +08:00 Asia/Shanghai] hello world",
+      attachments: [],
+    }),
+  };
+
+  handleStreamEvent(
+    event,
+    "assistant-1",
+    "redis-event-1",
+    "2026-04-28T12:00:01.000Z",
+    ctx,
+  );
+
+  const messages = getMessages();
+  assert.equal(messages.length, 2);
+  assert.equal(
+    messages[0]?.content,
+    "[2026-04-28 20:00:00 +08:00 Asia/Shanghai] hello world",
+  );
+});

--- a/frontend/src/services/api/session.test.ts
+++ b/frontend/src/services/api/session.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { buildSessionRunsUrl } from "./session.ts";
+import { buildSessionRunsUrl, buildSubmitChatBody } from "./session.ts";
 
 test("builds a session list url with favorites_only", () => {
   const searchParams = new URLSearchParams();
@@ -22,5 +22,24 @@ test("includes trace_id when looking up a specific run by trace", () => {
   assert.equal(
     buildSessionRunsUrl("session-1", { trace_id: "trace-123" }),
     "/api/sessions/session-1/runs?trace_id=trace-123",
+  );
+});
+
+test("includes user_timezone in the submit chat body when available", () => {
+  assert.deepEqual(
+    buildSubmitChatBody({
+      message: "hello",
+      sessionId: "session-1",
+      userTimezone: "Asia/Shanghai",
+    }),
+    {
+      message: "hello",
+      session_id: "session-1",
+      agent_options: undefined,
+      attachments: undefined,
+      disabled_skills: undefined,
+      disabled_mcp_tools: undefined,
+      user_timezone: "Asia/Shanghai",
+    },
   );
 });

--- a/frontend/src/services/api/session.ts
+++ b/frontend/src/services/api/session.ts
@@ -37,6 +37,48 @@ export interface SessionRunsQuery {
   trace_id?: string;
 }
 
+function getBrowserTimezone(): string | undefined {
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  return typeof timezone === "string" && timezone.trim() ? timezone : undefined;
+}
+
+export function buildSubmitChatBody({
+  message,
+  sessionId,
+  agentOptions,
+  attachments,
+  projectId,
+  disabledSkills,
+  disabledMcpTools,
+  userTimezone,
+}: {
+  message: string;
+  sessionId?: string;
+  agentOptions?: Record<string, boolean | string | number>;
+  attachments?: MessageAttachment[];
+  projectId?: string;
+  disabledSkills?: string[];
+  disabledMcpTools?: string[];
+  userTimezone?: string;
+}): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    message,
+    session_id: sessionId,
+    agent_options: agentOptions,
+    attachments,
+    disabled_skills: disabledSkills,
+    disabled_mcp_tools: disabledMcpTools,
+  };
+
+  if (userTimezone) {
+    body.user_timezone = userTimezone;
+  }
+  if (projectId) {
+    body.project_id = projectId;
+  }
+  return body;
+}
+
 export function buildSessionRunsUrl(
   sessionId: string,
   options?: SessionRunsQuery,
@@ -231,17 +273,16 @@ export const sessionApi = {
     trace_id: string;
     status: string;
   }> {
-    const body: Record<string, unknown> = {
+    const body = buildSubmitChatBody({
       message,
-      session_id: sessionId,
-      agent_options: agentOptions,
+      sessionId,
+      agentOptions,
       attachments,
-      disabled_skills: disabledSkills,
-      disabled_mcp_tools: disabledMcpTools,
-    };
-    if (projectId) {
-      body.project_id = projectId;
-    }
+      projectId,
+      disabledSkills,
+      disabledMcpTools,
+      userTimezone: getBrowserTimezone(),
+    });
     return authFetch(`${API_BASE}/api/chat/stream?agent_id=${agentId}`, {
       method: "POST",
       body: JSON.stringify(body),

--- a/src/api/routes/chat.py
+++ b/src/api/routes/chat.py
@@ -16,6 +16,7 @@ from src.agents.core.base import AgentFactory
 from src.api.deps import get_current_user_required, require_permissions
 from src.api.routes.auth.utils import _get_language
 from src.api.routes.session import verify_session_ownership
+from src.infra.chat.user_message_timestamp import format_user_message_with_timestamp
 from src.infra.logging import get_logger
 from src.infra.session.manager import SessionManager
 from src.infra.task.concurrency import register_executor
@@ -126,6 +127,10 @@ async def chat_stream(
     from src.infra.task.manager import _generate_run_id
 
     session_id = request.session_id or str(uuid.uuid4())
+    formatted_message = format_user_message_with_timestamp(
+        request.message,
+        request.user_timezone,
+    )
 
     # 如果用户传入了 session_id，验证所有权
     if request.session_id:
@@ -163,7 +168,7 @@ async def chat_stream(
     task_context = {
         "executor_key": "agent_stream",
         "agent_id": agent_id,
-        "message": request.message,
+        "message": formatted_message,
         "disabled_tools": request.disabled_tools,
         "agent_options": request.agent_options,
         "attachments": attachments_data,
@@ -225,7 +230,7 @@ async def chat_stream(
         )
         await presenter._ensure_trace()
         await presenter.emit_user_message(
-            request.message,
+            formatted_message,
             attachments=[a.model_dump() for a in request.attachments]
             if request.attachments
             else None,
@@ -261,7 +266,7 @@ async def chat_stream(
     _, _ = await task_manager.submit(
         session_id=session_id,
         agent_id=agent_id,
-        message=request.message,
+        message=formatted_message,
         user_id=user.sub,
         executor=_execute_agent_stream,
         disabled_tools=request.disabled_tools,

--- a/src/infra/chat/__init__.py
+++ b/src/infra/chat/__init__.py
@@ -1,0 +1,1 @@
+"""Chat-related infrastructure helpers."""

--- a/src/infra/chat/user_message_timestamp.py
+++ b/src/infra/chat/user_message_timestamp.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone, tzinfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+
+def _coerce_now(now: datetime | None) -> datetime:
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        return current.replace(tzinfo=timezone.utc)
+    return current
+
+
+def _resolve_timezone(user_timezone: str | None) -> tuple[tzinfo, str]:
+    timezone_name = (user_timezone or "").strip()
+    if timezone_name:
+        try:
+            return ZoneInfo(timezone_name), timezone_name
+        except ZoneInfoNotFoundError:
+            pass
+    return timezone.utc, "UTC"
+
+
+def _format_offset(current: datetime) -> str:
+    offset = current.strftime("%z")
+    if len(offset) == 5:
+        return f"{offset[:3]}:{offset[3:]}"
+    return "+00:00"
+
+
+def format_user_message_with_timestamp(
+    content: str,
+    user_timezone: str | None,
+    now: datetime | None = None,
+) -> str:
+    current = _coerce_now(now)
+    tz, timezone_label = _resolve_timezone(user_timezone)
+    localized = current.astimezone(tz)
+    timestamp = localized.strftime("%Y-%m-%d %H:%M:%S")
+    return f"[{timestamp} {_format_offset(localized)} {timezone_label}] {content}"

--- a/src/kernel/schemas/agent.py
+++ b/src/kernel/schemas/agent.py
@@ -41,6 +41,9 @@ class AgentRequest(BaseModel):
     disabled_mcp_tools: Optional[list[str]] = Field(
         None, description="MCP tools to disable for this conversation"
     )
+    user_timezone: Optional[str] = Field(
+        None, description="User IANA timezone for timestamping chat messages"
+    )
     attachments: Optional[list[AttachmentSchema]] = Field(None, description="File attachments")
     context: dict[str, Any] = Field(default_factory=dict, description="Additional context")
     project_id: Optional[str] = Field(None, description="Project ID to assign to new session")

--- a/tests/infra/test_user_message_timestamp.py
+++ b/tests/infra/test_user_message_timestamp.py
@@ -1,0 +1,23 @@
+from datetime import datetime, timezone
+
+from src.infra.chat.user_message_timestamp import format_user_message_with_timestamp
+
+
+def test_format_user_message_with_timestamp_uses_user_timezone() -> None:
+    formatted = format_user_message_with_timestamp(
+        "hello",
+        user_timezone="Asia/Shanghai",
+        now=datetime(2026, 4, 28, 12, 34, 56, tzinfo=timezone.utc),
+    )
+
+    assert formatted == "[2026-04-28 20:34:56 +08:00 Asia/Shanghai] hello"
+
+
+def test_format_user_message_with_timestamp_falls_back_to_utc() -> None:
+    formatted = format_user_message_with_timestamp(
+        "hello",
+        user_timezone="Mars/Olympus",
+        now=datetime(2026, 4, 28, 12, 34, 56, tzinfo=timezone.utc),
+    )
+
+    assert formatted == "[2026-04-28 12:34:56 +00:00 UTC] hello"


### PR DESCRIPTION
## Summary
- prepend each user chat message on the backend with a localized timestamp including UTC offset and IANA timezone
- send the browser timezone from the frontend when submitting chat messages
- replace the optimistic user message in the UI when the timestamped backend `user:message` event arrives to avoid duplicates

## Test Plan
- `npx tsx --test frontend/src/services/api/session.test.ts frontend/src/hooks/useAgent/eventHandlers.userMessageTimestamp.test.ts`
- `pytest -q tests/infra/test_task_executor_trace_context.py tests/infra/test_user_message_timestamp.py`
- `cd frontend && npx tsc --noEmit`
