### PR TITLE
fix: adapt to deepagents 0.5.x API rename

### DIFF
--- a/src/infra/backend/skills_store.py
+++ b/src/infra/backend/skills_store.py
@@ -15,7 +15,7 @@ Skills Store Backend
 import fnmatch
 from typing import TYPE_CHECKING, Any, Optional
 
-from deepagents.backends.utils import create_file_data, format_read_response
+from deepagents.backends.utils import create_file_data, slice_read_response as format_read_response
 
 from src.infra.backend._skills_path_utils import (
     SKILL_NAME_PATTERN,


### PR DESCRIPTION
## Problem

`deepagents` upgraded from 0.4.x to 0.5.x renamed `format_read_response` to `slice_read_response`, causing import error:

```
ImportError: cannot import name "format_read_response" from "deepagents.backends.utils"
```

## Fix

- Use `slice_read_response` aliased as `format_read_response` in `skills_store.py` to maintain backward compatibility