### PR TITLE
fix(ui): shared page cannot preview user-uploaded files

### DIFF
--- a/frontend/src/components/common/AttachmentCard.tsx
+++ b/frontend/src/components/common/AttachmentCard.tsx
@@ -3,6 +3,7 @@ import { X, Loader2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import clsx from "clsx";
 import type { MessageAttachment } from "../../types";
+import { getFullUrl } from "../../services/api";
 import {
   getFileTypeInfo,
   formatFileSize as formatFileSizeUtil,
@@ -107,7 +108,7 @@ export const AttachmentCard = memo(function AttachmentCard({
             <Loader2 size={18} className={clsx(iconColor, "animate-spin")} />
           ) : isImage ? (
             <img
-              src={attachment.url}
+              src={getFullUrl(attachment.url)}
               alt={attachment.name}
               className="w-full h-full object-cover"
             />
@@ -210,7 +211,7 @@ export const AttachmentCard = memo(function AttachmentCard({
         ) : isImage ? (
           <>
             <img
-              src={attachment.url}
+              src={getFullUrl(attachment.url)}
               alt={attachment.name}
               className="w-full h-full object-cover"
             />


### PR DESCRIPTION
## Problem

Shared conversations could not preview user-uploaded files (especially images). The `AttachmentCard` component rendered image `<img src>` using the raw `attachment.url` value directly, without resolving relative paths via `getFullUrl()`.

When the backend stores file URLs as relative paths (e.g. `/api/upload/file/{key}`), images fail to load on shared pages because the browser resolves the relative URL against the current page origin instead of the API base.

## Root Cause

In `AttachmentCard.tsx`, two `<img>` tags used `src={attachment.url}` directly:
- Compact mode (line ~111): image thumbnail in ChatInput area
- Default mode (line ~214): image thumbnail in message bubble

Other components like `AttachmentPreviewHost`, `UserMessageBubble` (ImageViewer), and `BinaryFilePreview` already use `getFullUrl()` correctly — only `AttachmentCard` was missed.

## Fix

Import `getFullUrl` from `../../services/api` and use `getFullUrl(attachment.url)` for both image `<img>` elements in `AttachmentCard`.

## Files Changed

- `frontend/src/components/common/AttachmentCard.tsx`: Use `getFullUrl()` for image sources