### PR TITLE
fix: narrow FileCheckResult union type in useFileUpload

### DIFF
--- a/frontend/src/hooks/useFileUpload.ts
+++ b/frontend/src/hooks/useFileUpload.ts
@@ -174,16 +174,17 @@ export function useFileUpload({
           })
           .catch(() => ({ check: { exists: false } }))
           .then(({ check }) => {
-            if (check.exists) {
+            if (check.exists && 'key' in check) {
               abortMapRef.current.delete(tempId);
+              const c = check as FileCheckResult;
               const finalAttachment: MessageAttachment = {
                 id: uuid(),
-                key: check.key ?? "",
-                name: check.name || processedFile.name,
-                type: check.type as FileCategory,
-                mimeType: check.mimeType ?? processedFile.type,
-                size: check.size ?? processedFile.size,
-                url: check.url || `/api/upload/file/${check.key ?? ""}`,
+                key: c.key ?? "",
+                name: c.name || processedFile.name,
+                type: c.type as FileCategory,
+                mimeType: c.mimeType ?? processedFile.type,
+                size: c.size ?? processedFile.size,
+                url: c.url || `/api/upload/file/${c.key ?? ""}`,
               };
               onAttachmentsChange((prev: MessageAttachment[]) =>
                 prev.map((a) =>


### PR DESCRIPTION
Fix TS2339 build errors in  where  union type was not narrowed before accessing , , , , ,  properties.

- Added  type guard to narrow the union
- Used explicit  cast for property access