### PR TITLE
fix: export collectSessionImageGalleryItems

### DIFF
--- a/frontend/src/components/chat/ChatMessage/sessionImageGallery.tsx
+++ b/frontend/src/components/chat/ChatMessage/sessionImageGallery.tsx
@@ -150,7 +150,7 @@ function collectPartImages(
   return [];
 }
 
-function collectSessionImageGalleryItems(
+export function collectSessionImageGalleryItems(
   messages: Message[],
 ): SessionImageGalleryItem[] {
   return messages.flatMap((message) => {


### PR DESCRIPTION
The function `collectSessionImageGalleryItems` was not exported, causing TypeScript build error:

```
error TS2724: has no exported member named collectSessionImageGalleryItems
```

Added `export` keyword to fix the build.