### PR TITLE
docs: 美化 README 末尾部分（Star History / Contributors / Footer）

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,8 @@ pnpm run docs:build
 
 ## Star History
 
+<div align="center">
+
 <a href="https://star-history.com/#Yanyutin753/LambChat&Date">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Yanyutin753/LambChat&type=Date&theme=dark" />
@@ -334,32 +336,73 @@ pnpm run docs:build
  </picture>
 </a>
 
+</div>
+
+## Contributors
+
+<div align="center">
+
+<a href="https://github.com/Yanyutin753/LambChat/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=Yanyutin753/LambChat" alt="Contributors">
+</a>
+
+</div>
+
 ## License
 
-[MIT](LICENSE) — Project name "LambChat" and its logo may not be changed or removed.
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](LICENSE)
+
+> **Note** — The project name **"LambChat"** and its logo may not be changed or removed.
 
 ---
 
 <div align="center">
 
-<sub><strong>LambChat</strong> is built for people who want AI agents that can actually do the work.</sub>
+<h3>🐑 LambChat</h3>
+
+<p><em>Built for people who want AI agents that can actually do the work.</em></p>
 
 <br>
 
-<strong>Created by <a href="https://github.com/Yanyutin753">Clivia</a></strong>
+<table>
+  <tr>
+    <td align="center">
+      <a href="https://github.com/Yanyutin753/LambChat">
+        <img src="https://img.shields.io/badge/GitHub-181717?style=for-the-badge&logo=github&logoColor=white" alt="GitHub"><br>
+        <sub>Repository</sub>
+      </a>
+    </td>
+    <td align="center">
+      <a href="mailto:3254822118@qq.com">
+        <img src="https://img.shields.io/badge/Email-D14836?style=for-the-badge&logo=gmail&logoColor=white" alt="Email"><br>
+        <sub>Contact</sub>
+      </a>
+    </td>
+    <td align="center">
+      <a href="https://yanyutin753.github.io/LambChat/en/">
+        <img src="https://img.shields.io/badge/Docs-0080FF?style=for-the-badge&logo=gitbook&logoColor=white" alt="Docs"><br>
+        <sub>Documentation</sub>
+      </a>
+    </td>
+    <td align="center">
+      <a href="README_CN.md">
+        <img src="https://img.shields.io/badge/中文-README-ED1C24?style=for-the-badge&logo=readme&logoColor=white" alt="中文 README"><br>
+        <sub>中文 README</sub>
+      </a>
+    </td>
+  </tr>
+</table>
 
 <br>
-
-<a href="https://github.com/Yanyutin753">GitHub</a> · <a href="mailto:3254822118@qq.com">Email</a> · <a href="README_CN.md">中文 README</a>
-
-<br><br>
 
 <img src=".github/images/wechat-qr.webp" width="160" alt="WeChat QR Code">
 
 <br>
 
-<sub>WeChat for deployment help, product feedback, and collaboration</sub>
+<sub>💬 WeChat for deployment help, product feedback, and collaboration</sub>
+
+<br>
+
+<sub>Powered by <a href="https://linux.do/">LINUX DO</a> — A New Ideal Community</sub>
 
 </div>
-
-<sub><a href="https://linux.do/">LINUX DO - A New Ideal Community</a></sub>

--- a/README_CN.md
+++ b/README_CN.md
@@ -326,6 +326,8 @@ pnpm run docs:build
 
 ## Star History
 
+<div align="center">
+
 <a href="https://star-history.com/#Yanyutin753/LambChat&Date">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Yanyutin753/LambChat&type=Date&theme=dark" />
@@ -334,30 +336,73 @@ pnpm run docs:build
  </picture>
 </a>
 
+</div>
+
+## 贡献者
+
+<div align="center">
+
+<a href="https://github.com/Yanyutin753/LambChat/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=Yanyutin753/LambChat" alt="Contributors">
+</a>
+
+</div>
+
 ## 许可证
 
-[MIT](LICENSE) — 项目名称 "LambChat" 及其标志不得被更改或移除。
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](LICENSE)
+
+> **注意** — 项目名称 **"LambChat"** 及其标志不得被更改或移除。
 
 ---
 
 <div align="center">
 
-<sub><strong>LambChat</strong> 想做的，不只是能聊天的 AI，而是真正能把事情做完的 Agent。</sub>
+<h3>🐑 LambChat</h3>
+
+<p><em>想做的，不只是能聊天的 AI，而是真正能把事情做完的 Agent。</em></p>
 
 <br>
 
-<strong>Created by <a href="https://github.com/Yanyutin753">Clivia</a></strong>
+<table>
+  <tr>
+    <td align="center">
+      <a href="https://github.com/Yanyutin753/LambChat">
+        <img src="https://img.shields.io/badge/GitHub-181717?style=for-the-badge&logo=github&logoColor=white" alt="GitHub"><br>
+        <sub>代码仓库</sub>
+      </a>
+    </td>
+    <td align="center">
+      <a href="mailto:3254822118@qq.com">
+        <img src="https://img.shields.io/badge/邮箱-D14836?style=for-the-badge&logo=gmail&logoColor=white" alt="Email"><br>
+        <sub>联系作者</sub>
+      </a>
+    </td>
+    <td align="center">
+      <a href="https://yanyutin753.github.io/LambChat/zh/">
+        <img src="https://img.shields.io/badge/文档-0080FF?style=for-the-badge&logo=gitbook&logoColor=white" alt="Docs"><br>
+        <sub>使用文档</sub>
+      </a>
+    </td>
+    <td align="center">
+      <a href="README.md">
+        <img src="https://img.shields.io/badge/English-README-ED1C24?style=for-the-badge&logo=readme&logoColor=white" alt="English README"><br>
+        <sub>English README</sub>
+      </a>
+    </td>
+  </tr>
+</table>
 
 <br>
-
-<a href="https://github.com/Yanyutin753">GitHub</a> · <a href="mailto:3254822118@qq.com">邮箱</a> · <a href="README.md">English README</a>
-
-<br><br>
 
 <img src=".github/images/wechat-qr.webp" width="160" alt="WeChat QR Code">
 
 <br>
 
-<sub>欢迎交流部署、产品想法和合作，添加时备注 <strong>LambChat</strong></sub>
+<sub>💬 欢迎交流部署、产品想法和合作，添加时备注 <strong>LambChat</strong></sub>
+
+<br>
+
+<sub>Powered by <a href="https://linux.do/">LINUX DO</a> — 新的理想型社区</sub>
 
 </div>


### PR DESCRIPTION
## 改动内容

对 README.md 和 README_CN.md 的末尾部分进行了美化，提升视觉体验。

### 具体改动

| 区域 | 改动 |
|---|---|
| **Star History** | 居中展示，增加 `<div align="center">` 包裹 |
| **Contributors** 🆕 | 新增贡献者头像墙，使用 [contrib.rocks](https://contrib.rocks) 自动生成，点击跳转 GitHub 贡献者页面 |
| **License** | 改用 `for-the-badge` 样式徽章 + 引用块展示注意事项 |
| **Footer** | 重新设计：标题 + 斜体简介 + 链接卡片表格（GitHub/Email/Docs/中文README）+ 微信二维码 + LINUX DO |
| **作者署名** | 去掉单独的作者署名，改用贡献者头像墙统一展示 |

### 效果预览

- 中英文 README 同步更新
- 所有 badge 使用 shields.io `for-the-badge` 风格，视觉统一
- 贡献者头像墙自动拉取，无需手动维护

---

> 📝 仅修改文档，不涉及任何代码逻辑变更。