### PR TITLE
fix: 定时任务单次执行超时默认值提升至 30 分钟

### DIFF
--- a/src/infra/scheduler/runner.py
+++ b/src/infra/scheduler/runner.py
@@ -40,7 +40,7 @@ from src.kernel.schemas.user import TokenPayload
 logger = get_logger(__name__)
 
 _POLL_INTERVAL = 2  # seconds between status checks when waiting for completion
-_DEFAULT_TIMEOUT = 600  # 10 minutes
+_DEFAULT_TIMEOUT = 1800  # 30 minutes
 _ASSISTANT_EVENT_TYPES = {
     "message",
     "assistant:message",

--- a/src/infra/tool/scheduled_task/create.py
+++ b/src/infra/tool/scheduled_task/create.py
@@ -146,9 +146,9 @@ async def scheduled_task_create(
     ] = None,
     timeout_seconds: Annotated[
         int,
-        "Maximum execution time in seconds. Range: 10-3600. Default: 600s (10 min). "
+        "Maximum execution time in seconds. Range: 10-3600. Default: 1800s (30 min). "
         "Do not set this too short; omit it unless the user explicitly asks for a shorter timeout.",
-    ] = 600,
+    ] = 1800,
     run_on_start: Annotated[
         bool,
         "Whether to run the task immediately after creation",

--- a/src/infra/tool/scheduled_task/delete.py
+++ b/src/infra/tool/scheduled_task/delete.py
@@ -30,8 +30,8 @@ async def scheduled_task_delete(
     task_id: Annotated[str, "ID of the task to delete"],
     runtime: Annotated[ToolRuntime, InjectedToolArg] = None,  # type: ignore[assignment]
 ) -> str:
-    """Delete a scheduled task. This is a soft delete — the task is marked as deleted
-    and will no longer appear in listings or fire."""
+    """Delete a scheduled task. This is a hard delete — the task document is physically
+    removed from the database and will no longer appear in listings or fire."""
     user_id = get_user_id_from_runtime(runtime)
     if not user_id:
         return _json({"error": "No user context available"})

--- a/src/kernel/schemas/scheduled_task.py
+++ b/src/kernel/schemas/scheduled_task.py
@@ -100,7 +100,7 @@ class ScheduledTaskCreate(BaseModel):
     enabled: bool = Field(True)
     run_on_start: bool = Field(False)
     max_retries: int = Field(0, ge=0, le=10)
-    timeout_seconds: int = Field(600, ge=10, le=3600)
+    timeout_seconds: int = Field(1800, ge=10, le=3600)
     source_session_id: Optional[str] = Field(
         None, description="Conversation session where the task was created"
     )
@@ -146,7 +146,7 @@ class ScheduledTask(BaseModel):
     enabled: bool = True
     run_on_start: bool = False
     max_retries: int = 0
-    timeout_seconds: int = 600
+    timeout_seconds: int = 1800
     owner_id: str = Field(..., description="Creator user_id")
     source_session_id: Optional[str] = None
     source_run_id: Optional[str] = None

--- a/tests/infra/tool/test_scheduled_task_tool.py
+++ b/tests/infra/tool/test_scheduled_task_tool.py
@@ -151,13 +151,13 @@ def test_create_tool_has_trigger_params() -> None:
     assert "team_query" in fields
 
 
-def test_create_tool_timeout_prompt_prefers_600s_default() -> None:
+def test_create_tool_timeout_prompt_prefers_1800s_default() -> None:
     fields = _tool_fields(scheduled_task_tool.scheduled_task_create)
     timeout_field = fields["timeout_seconds"]
 
-    assert timeout_field.default == 600
+    assert timeout_field.default == 1800
     assert timeout_field.description is not None
-    assert "Default: 600s" in timeout_field.description
+    assert "Default: 1800s" in timeout_field.description
     assert "Do not set this too short" in timeout_field.description
 
 


### PR DESCRIPTION
## 改动概要

### 1. 单次执行超时默认值 600s → 1800s（30 分钟）

将定时任务单次执行的超时默认从 10 分钟提升至 30 分钟，避免稍复杂的任务被过早判定为超时并取消执行。

涉及改动：
- `src/infra/scheduler/runner.py`：`_DEFAULT_TIMEOUT` 兜底常量
- `src/infra/tool/scheduled_task/create.py`：`scheduled_task_create` 工具参数默认值与文档
- `src/kernel/schemas/scheduled_task.py`：`ScheduledTaskCreate` 与持久化模型 `ScheduledTask` 的默认值
- `tests/infra/tool/test_scheduled_task_tool.py`：同步更新针对 600s 默认值的断言

补充说明：
- 超时上限仍为 3600s，30 分钟处于合法范围内
- 仅影响**新创建任务**的默认值；已持久化为 600s 的旧任务不受影响
- 相关测试已全部通过（76 passed）

### 2. 修正 `scheduled_task_delete` 文档

其 docstring 原描述为 soft delete，但实际实现（`ScheduledTaskStorage.delete_task` 为物理删除）不一致。已更正为与实现一致的描述。
