### PR TITLE
fix(project-preview): 修复侧边栏模式下项目预览高度被截断

### DIFF
--- a/frontend/src/components/documents/previews/ProjectPreview.tsx
+++ b/frontend/src/components/documents/previews/ProjectPreview.tsx
@@ -292,7 +292,7 @@ export default function ProjectPreview({
       {/* 预览区域 */}
       <div
         className={clsx(
-          "flex-1 min-h-0 h-auto",
+          "flex-1 min-h-0 h-full",
           isFullscreen && "h-[calc(100dvh-120px)]",
         )}
       >


### PR DESCRIPTION
## 问题

项目预览（ProjectPreview）在侧边栏（非全屏）模式下高度被严重截断，Sandpack iframe 高度塌缩，无法完整预览项目。

## 根因

`ProjectPreview.tsx` 预览区域容器使用 `h-auto`（高度由内容决定）。但父级链路 `tool-console-body__content` 用的是 `min-h-full`，Sandpack 的 iframe 在 `h-auto` 容器里没有明确高度，会塌缩成默认极小高度。

只有全屏模式（`isFullscreen`）通过 `h-[calc(100dvh-120px)]` 给了明确高度能正常显示，侧边栏模式被遗漏。

虽然内部 `SandpackLayout` / `SandpackPreview` 都加了 `!h-full`，但外层包裹 div 是 `h-auto`，导致 `!h-full` 计算出的父级高度为 0，iframe 仍塌缩。

## 修复

将预览区域容器从 `h-auto` 改为 `h-full`：

```diff
- "flex-1 min-h-0 h-auto",
+ "flex-1 min-h-0 h-full",
  isFullscreen && "h-[calc(100dvh-120px)]",
```

- `flex-1 min-h-0` 保持不变，配合父级 `flex flex-col` 正确参与弹性布局
- `h-full` 让预览区域填满父级（根 div `h-full`）的剩余空间
- 全屏模式的 `h-[calc(100dvh-120px)]` 行为不受影响
- StackBlitz（Vue 项目）分支也受益

## 影响范围

- 仅改动 1 行，风险极低
- `ProjectPreviewCompact`（消息内嵌预览）使用固定高度，不受影响
- 全屏模式行为不变