### PR TITLE
fix(tool-panel): 修复项目预览高度链断裂导致 iframe 高度塌缩

### DIFF
--- a/frontend/src/components/chat/ChatMessage/items/ToolResultPanel.tsx
+++ b/frontend/src/components/chat/ChatMessage/items/ToolResultPanel.tsx
@@ -605,7 +605,7 @@ export function ToolResultPanel({
         aria-busy={!contentReady}
       >
         <div
-          className={`tool-console-body__content min-h-full transition-opacity duration-150 ${
+          className={`tool-console-body__content min-h-full h-full transition-opacity duration-150 ${
             contentReady ? "opacity-100" : "opacity-0"
           }`}
           aria-hidden={!contentReady}


### PR DESCRIPTION
## 问题

接续 #172。上一轮修复了 `ProjectPreview.tsx` 内部的 `h-auto → h-full`，但用户反馈仍未解决。完整追踪 DOM 高度链后，发现真正的断裂点在 `ProjectPreview` 上方 3 层。

## 根因（完整高度链分析）

```
document.body
  └─ overlay (fixed inset-0)                          ✅ 有高度(=视口)
      └─ tool-console-panel (h-full flex flex-col)     ✅ h-full 生效
          └─ tool-console-body (flex-1 min-h-0)         ✅ flex子项,高度确定
              └─ body__content (min-h-full)             🔴 断裂!
                  └─ ProjectPreview根 (h-full)          🔴 h-full 失效
                      └─ 预览区域 (flex-1 h-full)        🔴 失效
                          └─ SandpackProvider (!h-full)  🔴 失效
                              └─ SandpackLayout (!h-full) 🔴 失效
                                  └─ iframe              🔴 高度塌缩
```

**断裂点**：`ToolResultPanel.tsx:608` 的 `body__content` 使用 `min-h-full`（`min-height: 100%`）。

CSS 规则：子元素的 `height: 100%` 只有在父元素有**明确的 `height` 值**（非 `auto`）时才能解析。`min-height` 不满足该条件。

- `tool-console-body`（`flex-1 min-h-0 overflow-auto`）高度是确定的 ✅
- 但子级 `body__content` 用 `min-h-full`，实际 `height: auto`（由内容撑开）🔴
- 导致 ProjectPreview 根 div 的 `h-full` 无法解析，退化回 `auto` 🔴
- 一路向下，Sandpack 的所有 `!h-full` 全部失效，iframe 高度塌缩 🔴

## 修复

给 `body__content` 补充 `h-full`：

```diff
- className={`tool-console-body__content min-h-full transition-opacity ...`}
+ className={`tool-console-body__content min-h-full h-full transition-opacity ...`}
```

- `h-full`：让高度从 `tool-console-body`（高度确定）传递下来，贯通整条链
- 保留 `min-h-full`：对其他场景无副作用（min-height:100% + height:100% 不冲突）
- 父级 `tool-console-body` 有 `overflow-auto`，内容超高仍可滚动

## 影响范围

- 仅改动 1 行（加一个 class），风险极低
- `ToolResultPanel` 是通用组件，也被 McpBlockPreview / DocumentPreview 使用：
  - 这些场景的内容容器原本就是 `min-h-full`（内容撑开），加 `h-full` 后容器至少占满 body 高度，不会破坏现有滚动行为（`overflow-auto` 仍在父级）
  - 全屏模式（`isFullscreen`）的 `h-[calc(100dvh-120px)]` 行为不变

## 与 #172 的关系

#172 修的 `ProjectPreview.tsx` 内部 `h-auto → h-full` 是对的，但不够——断裂点在它上方。两个 PR 叠加后，整条高度链才完整贯通。