### PR TITLE
fix(SummaryItem): add missing text-xs and font-medium classes

### DIFF
--- a/frontend/src/components/chat/ChatMessage/SummaryItem.tsx
+++ b/frontend/src/components/chat/ChatMessage/SummaryItem.tsx
@@ -45,7 +45,7 @@ export function SummaryItem({
       icon={<FileText size={12} className="shrink-0 opacity-50" />}
       label={t("chat.message.summary")}
       suffix={
-        <span className="font-mono min-w-0 truncate overflow-hidden leading-none">
+        <span className="text-xs font-mono font-medium min-w-0 truncate overflow-hidden leading-none">
           {t("chat.message.summaryDescription")}
         </span>
       }


### PR DESCRIPTION
## Summary

Fixed the `main` branch Lint CI failure (Frontend Tests).

**Root cause:** The `SummaryItem` component's `suffix` span was missing `text-xs` and `font-medium` Tailwind classes, which are expected by `summaryItemSource.test.ts`.

**Fix:** Added `text-xs font-medium` to the suffix span className in `frontend/src/components/chat/ChatMessage/SummaryItem.tsx`.

---

*Generated by AI agent.*