### PR TITLE
fix(mcp): sanitize None-valued properties in tool schema for Gemini backend

### DIFF
--- a/frontend/src/components/chat/ChatMessage/ToolCallItem.tsx
+++ b/frontend/src/components/chat/ChatMessage/ToolCallItem.tsx
@@ -417,7 +417,7 @@ export function ToolCallItem({
         label={pillLabel}
         suffix={
           serverName ? (
-            <span className="text-[9px] px-1.5 py-0.5 rounded-md bg-white/30 dark:bg-black/20 opacity-70 font-medium truncate max-w-[120px]">
+            <span className="shrink-0 text-[9px] px-1.5 py-0.5 rounded-md bg-white/30 dark:bg-black/20 opacity-70 font-medium truncate max-w-[120px]">
               {serverName}
             </span>
           ) : undefined

--- a/frontend/src/components/chat/ChatMessage/items/EnvVarItem.tsx
+++ b/frontend/src/components/chat/ChatMessage/items/EnvVarItem.tsx
@@ -133,7 +133,7 @@ const EnvVarItem = memo(function EnvVarItem({
                     className="text-emerald-500 dark:text-emerald-400"
                   />
                 </div>
-                <span className="text-sm font-mono text-theme-text truncate flex-1">
+                <span className="text-sm font-mono text-theme-text min-w-0 truncate flex-1">
                   {k}
                 </span>
                 <span className="text-[11px] text-theme-text-tertiary font-mono shrink-0 tracking-widest">

--- a/frontend/src/components/chat/ChatMessage/items/FileRevealItem.tsx
+++ b/frontend/src/components/chat/ChatMessage/items/FileRevealItem.tsx
@@ -410,7 +410,7 @@ export function FileRevealItem({
             <div className={`p-1.5 rounded-md shrink-0 ${bg}`}>
               <FileIcon size={14} className={color} />
             </div>
-            <span className="text-xs font-medium text-theme-text-secondary truncate flex-1">
+            <span className="text-xs font-medium text-theme-text-secondary min-w-0 truncate flex-1">
               {fileName}
             </span>
             {parsed.description && (

--- a/frontend/src/components/chat/ChatMessage/items/GlobItem.tsx
+++ b/frontend/src/components/chat/ChatMessage/items/GlobItem.tsx
@@ -95,7 +95,7 @@ const GlobItem = memo(function GlobItem({
                 )}
                 <span
                   className={clsx(
-                    "truncate",
+                    "min-w-0 flex-1 truncate",
                     isDir
                       ? "text-theme-text font-medium"
                       : "text-theme-text-secondary",
@@ -178,7 +178,7 @@ const GlobItem = memo(function GlobItem({
                       )}
                       <span
                         className={clsx(
-                          "truncate",
+                          "min-w-0 flex-1 truncate",
                           isDir
                             ? "text-theme-text font-medium"
                             : "text-theme-text-secondary",

--- a/frontend/src/components/chat/ChatMessage/items/ImageGenerateItem.tsx
+++ b/frontend/src/components/chat/ChatMessage/items/ImageGenerateItem.tsx
@@ -319,7 +319,7 @@ const ImageGenerateItem = memo(function ImageGenerateItem({
         )}
       >
         <span className="text-sm leading-none shrink-0">🎨</span>
-        <span className="text-xs text-violet-700 dark:text-violet-300 font-medium truncate">
+        <span className="text-xs text-violet-700 dark:text-violet-300 font-medium truncate min-w-0 flex-1 overflow-hidden">
           {t("chat.message.toolImageGenerate")}
         </span>
         {images.length > 0 && (

--- a/frontend/src/components/chat/ChatMessage/items/LsItem.tsx
+++ b/frontend/src/components/chat/ChatMessage/items/LsItem.tsx
@@ -97,7 +97,7 @@ const LsItem = memo(function LsItem({
                 )}
                 <span
                   className={clsx(
-                    "truncate",
+                    "min-w-0 flex-1 truncate",
                     isDir
                       ? "text-theme-text font-medium"
                       : "text-theme-text-secondary",
@@ -191,7 +191,7 @@ const LsItem = memo(function LsItem({
                       )}
                       <span
                         className={clsx(
-                          "truncate",
+                          "min-w-0 flex-1 truncate",
                           isDir
                             ? "text-theme-text font-medium"
                             : "text-theme-text-secondary",

--- a/frontend/src/components/chat/ChatMessage/items/McpBlockPreview.tsx
+++ b/frontend/src/components/chat/ChatMessage/items/McpBlockPreview.tsx
@@ -69,8 +69,8 @@ export function BlockPreviewPortal() {
     title = preview.fileName || t("chat.message.toolFile");
     content = (
       <div className="p-4 sm:p-5 space-y-3">
-        <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-theme-bg-subtle text-sm text-theme-text-tertiary font-mono truncate">
-          <span className="truncate">{preview.url}</span>
+        <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-theme-bg-subtle text-sm text-theme-text-tertiary font-mono overflow-hidden">
+          <span className="min-w-0 flex-1 truncate">{preview.url}</span>
         </div>
         <a
           href={preview.url}
@@ -396,12 +396,12 @@ export function ToolResultContent({
                 href={url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-xs font-medium text-theme-text hover:underline truncate"
+                className="text-xs font-medium text-theme-text hover:underline min-w-0 flex-1 truncate"
               >
                 {title || url}
               </a>
             ) : (
-              <span className="text-xs font-medium text-theme-text truncate">
+              <span className="text-xs font-medium text-theme-text min-w-0 flex-1 truncate">
                 {title}
               </span>
             )}

--- a/frontend/src/components/chat/ChatMessage/items/MemoryRecallItem.tsx
+++ b/frontend/src/components/chat/ChatMessage/items/MemoryRecallItem.tsx
@@ -192,7 +192,7 @@ const MemoryRecallItem = memo(function MemoryRecallItem({
       {resultQuery && (
         <div className="flex items-center gap-2.5 px-3.5 py-2.5 rounded-xl bg-[color-mix(in_srgb,var(--theme-primary)_7%,var(--theme-bg-card))] border border-[color-mix(in_srgb,var(--theme-primary)_16%,var(--theme-border))] shadow-[0_10px_24px_-22px_color-mix(in_srgb,var(--theme-primary)_45%,transparent)]">
           <Search size={14} className="text-[var(--theme-primary)] shrink-0" />
-          <span className="text-sm sm:text-base text-theme-text truncate flex-1">
+          <span className="text-sm sm:text-base text-theme-text min-w-0 truncate flex-1">
             {resultQuery}
           </span>
           {searchMode && (
@@ -380,7 +380,7 @@ const MemoryRecallItem = memo(function MemoryRecallItem({
                   size={12}
                   className="text-[var(--theme-primary)] shrink-0"
                 />
-                <span className="text-xs text-theme-text-secondary truncate flex-1">
+                <span className="text-xs text-theme-text-secondary min-w-0 truncate flex-1">
                   {resultQuery.length > 50
                     ? resultQuery.slice(0, 47) + "…"
                     : resultQuery}
@@ -406,7 +406,7 @@ const MemoryRecallItem = memo(function MemoryRecallItem({
                       >
                         {t(`memory.type.${mem.type}`, mem.type)}
                       </span>
-                      <span className="text-xs text-theme-text-secondary truncate flex-1">
+                      <span className="text-xs text-theme-text-secondary min-w-0 truncate flex-1">
                         {mem.title ||
                           (mem.summary
                             ? mem.summary.slice(0, 40)

--- a/frontend/src/components/chat/ChatMessage/items/MemoryStoreItem.tsx
+++ b/frontend/src/components/chat/ChatMessage/items/MemoryStoreItem.tsx
@@ -15,7 +15,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { CollapsiblePill } from "../../../common";
+import { CollapsiblePill, CopyButton } from "../../../common";
 import { extractText } from "./toolUtils";
 import { openPersistentToolPanel } from "./persistentToolPanelState";
 import { ToolInlineDetails } from "./ToolInlineDetails";
@@ -311,14 +311,13 @@ const MemoryStoreItem = memo(function MemoryStoreItem({
       {(resultMemoryId || existingMemoryId) && (
         <div className="flex items-center gap-2 px-3.5">
           <span className="text-[10px] text-theme-text-tertiary">ID</span>
-          <span className="text-[10px] font-mono text-theme-text-secondary truncate flex-1">
+          <span className="text-[10px] font-mono text-theme-text-secondary min-w-0 truncate flex-1">
             {resultMemoryId || existingMemoryId}
           </span>
-          <ToolHoverCopyButton
+          <CopyButton
             text={resultMemoryId || existingMemoryId}
-            position="result"
             size={10}
-            copyButtonClassName="!bg-theme-bg/80 !rounded-md !border !border-theme-border"
+            className="shrink-0 text-theme-text-tertiary hover:text-theme-text-secondary"
           />
         </div>
       )}

--- a/frontend/src/components/chat/ChatMessage/items/PersonaItem.tsx
+++ b/frontend/src/components/chat/ChatMessage/items/PersonaItem.tsx
@@ -2,7 +2,7 @@ import { memo, useMemo } from "react";
 import { clsx } from "clsx";
 import { UserRound, Tag, Sparkles, Zap, MessageSquare } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { CollapsiblePill } from "../../../common";
+import { CollapsiblePill, CopyButton } from "../../../common";
 import { ImageWithSkeleton } from "../ImageWithSkeleton";
 import { extractText } from "./toolUtils";
 import { openPersistentToolPanel } from "./persistentToolPanelState";
@@ -334,10 +334,10 @@ const PersonaItem = memo(function PersonaItem({
             <MarkdownContent content={systemPrompt} />
           </div>
           <div className="flex justify-end mt-2">
-            <ToolHoverCopyButton
+            <CopyButton
               text={systemPrompt}
-              position="result"
-              copyButtonClassName="!bg-theme-bg !rounded-lg !border !border-theme-border"
+              size={10}
+              className="shrink-0 text-theme-text-tertiary hover:text-theme-text-secondary"
             />
           </div>
         </DetailSection>

--- a/frontend/src/components/chat/ChatMessage/items/ScheduledTaskItem.tsx
+++ b/frontend/src/components/chat/ChatMessage/items/ScheduledTaskItem.tsx
@@ -672,7 +672,7 @@ const ScheduledTaskItem = memo(function ScheduledTaskItem({
             size={10}
             className="shrink-0 text-emerald-500 dark:text-emerald-400"
           />
-          <span className="text-theme-text-tertiary truncate">
+          <span className="text-theme-text-tertiary truncate min-w-0 flex-1 overflow-hidden">
             {resultMessage.length > 120
               ? resultMessage.slice(0, 117) + "…"
               : resultMessage}
@@ -700,7 +700,7 @@ const ScheduledTaskItem = memo(function ScheduledTaskItem({
                   size={10}
                   className="shrink-0 text-[var(--theme-primary)]"
                 />
-                <span className="text-[10px] text-theme-text truncate flex-1">
+                <span className="text-[10px] text-theme-text min-w-0 truncate flex-1">
                   {tkName}
                 </span>
                 {tkTrigger && (

--- a/frontend/src/components/chat/ChatMessage/items/TeamItem.tsx
+++ b/frontend/src/components/chat/ChatMessage/items/TeamItem.tsx
@@ -2,7 +2,7 @@ import { memo, useMemo } from "react";
 import { clsx } from "clsx";
 import { Users, Tag, Zap } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { CollapsiblePill } from "../../../common";
+import { CollapsiblePill, CopyButton } from "../../../common";
 import { ImageWithSkeleton } from "../ImageWithSkeleton";
 import { extractText } from "./toolUtils";
 import { openPersistentToolPanel } from "./persistentToolPanelState";
@@ -431,7 +431,7 @@ const TeamItem = memo(function TeamItem({
                       </h3>
                       {resultId && (
                         <div className="text-[10px] sm:text-xs text-theme-text-tertiary/70 font-mono truncate mt-0.5 flex items-center gap-1">
-                          <span className="truncate">
+                          <span className="min-w-0 truncate block">
                             {resultId.slice(0, 12)}…
                           </span>
                         </div>
@@ -565,10 +565,10 @@ const TeamItem = memo(function TeamItem({
                             {instructions}
                           </p>
                           {instructions.length > 150 && (
-                            <ToolHoverCopyButton
+                            <CopyButton
                               text={instructions}
-                              position="result"
-                              copyButtonClassName="!bg-theme-bg !rounded-md !border !border-theme-border mt-1.5"
+                              size={10}
+                              className="shrink-0 text-theme-text-tertiary hover:text-theme-text-secondary mt-1.5"
                             />
                           )}
                         </div>

--- a/frontend/src/components/chat/ChatMessage/items/ToolArgsBlock.tsx
+++ b/frontend/src/components/chat/ChatMessage/items/ToolArgsBlock.tsx
@@ -45,7 +45,7 @@ export function ToolArgsBlock({
         .filter(Boolean)
         .join(" ")}
     >
-      <span className="min-w-0 flex-1">{children}</span>
+      <span className="min-w-0 flex-1 overflow-x-auto">{children}</span>
       {copyText && (
         <button
           type="button"

--- a/frontend/src/components/common/CollapsiblePill.tsx
+++ b/frontend/src/components/common/CollapsiblePill.tsx
@@ -140,7 +140,7 @@ export function CollapsiblePill({
   const displayedLabel = formatLabel ? formattedLabel : label;
 
   return (
-    <div className="my-1 min-w-0 max-w-full">
+    <div className="my-1 min-w-0 max-w-full overflow-hidden">
       <button
         type="button"
         onClick={handleToggle}

--- a/frontend/src/components/layout/AppContent/Header.tsx
+++ b/frontend/src/components/layout/AppContent/Header.tsx
@@ -132,8 +132,7 @@ export function Header({
 
   return (
     <>
-      <header className="relative z-50 flex items-center px-3 sm:px-5 py-3 shrink-0 rounded-bl-xl">
-        {/* Left */}
+      <header className="relative z-50 flex items-center px-3 sm:px-5 py-3 -mb-2 shrink-0 rounded-bl-xl after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-2 after:bg-[linear-gradient(to_bottom,var(--theme-bg),transparent)]">
         <div className="flex items-center gap-2 flex-shrink-0">
           {activeTab === "chat" ? (
             <>

--- a/frontend/src/components/layout/AppContent/__tests__/headerBottomGradientSource.test.ts
+++ b/frontend/src/components/layout/AppContent/__tests__/headerBottomGradientSource.test.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("../Header.tsx", import.meta.url), "utf8");
+
+test("keeps header padding while rendering the bottom gradient inside it", () => {
+  expect(source).toMatch(
+    /<header className="[^"]*py-3[^"]*-mb-2[^"]*after:bottom-0[^"]*after:h-2[^"]*after:bg-\[linear-gradient\(to_bottom,var\(--theme-bg\),transparent\)\][^"]*">/,
+  );
+  expect(source).not.toContain("after:bottom-[-8px]");
+});

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -14,6 +14,12 @@
   --theme-primary-light: #f5f5f4;
   --theme-ring: #78716c;
 
+  /* ── Semantic Colors ── */
+  --theme-success: #10b981;
+  --theme-error: #ef4444;
+  --theme-warning: #f59e0b;
+  --theme-info: #3b82f6;
+
   /* ── Backgrounds ── */
   --theme-bg: #f5f5f4;
   --theme-bg-card: #ffffff;
@@ -205,6 +211,12 @@
   --theme-primary-hover: #e7e5e4;
   --theme-primary-light: #292524;
   --theme-ring: #d6d3d1;
+
+  /* ── Semantic Colors ── */
+  --theme-success: #34d399;
+  --theme-error: #f87171;
+  --theme-warning: #fbbf24;
+  --theme-info: #60a5fa;
 
   /* ── Backgrounds ── */
   --theme-bg: #121010;

--- a/src/infra/tool/mcp_client.py
+++ b/src/infra/tool/mcp_client.py
@@ -59,6 +59,90 @@ def _get_effective_config_max_tools() -> int:
         return 200
 
 
+def _sanitize_json_schema(schema: Any) -> Any:
+    """递归清洗 JSON schema，移除值为 None 的 property。
+
+    某些 MCP server 声明的工具参数字段没有明确 type（或为 Optional 类型），
+    经 langchain-mcp-adapters 序列化后，JSON schema 中对应 property 的值可能为 None。
+    这对 Anthropic / OpenAI 协议无害，但 ``langchain-google-genai`` 在
+    ``types.Schema.model_validate`` 阶段会拒绝 None 值的 property，抛出
+    ``pydantic.ValidationError``，导致 Gemini 后端完全无法使用该工具。
+
+    本函数递归遍历 schema dict，删除所有值为 None 的 property / items / format 等，
+    确保传给任意模型 provider 的 schema 都是合法的。
+
+    参考: issue #186
+    """
+
+    if isinstance(schema, dict):
+        cleaned: dict[str, Any] = {}
+        for key, value in schema.items():
+            if value is None:
+                continue
+            if key == "properties" and isinstance(value, dict):
+                cleaned[key] = {
+                    prop_name: _sanitize_json_schema(prop_schema)
+                    for prop_name, prop_schema in value.items()
+                    if prop_schema is not None
+                }
+            else:
+                cleaned[key] = _sanitize_json_schema(value)
+        return cleaned
+    if isinstance(schema, list):
+        return [_sanitize_json_schema(item) for item in schema if item is not None]
+    return schema
+
+
+def _attach_sanitized_schema(tool: BaseTool) -> BaseTool:
+    """为工具的 args_schema 注入清洗后的 model_json_schema。
+
+    通过创建 args_schema 的动态子类并覆盖 ``model_json_schema``，使 LangChain
+    在将工具转换为 function declaration 时拿到不含 None 值的 schema。
+
+    幂等：重复调用不会叠加包装。
+    """
+
+    args_schema = getattr(tool, "args_schema", None)
+    if args_schema is None:
+        return tool
+    if getattr(args_schema, "_lambchat_schema_sanitized", False):
+        return tool
+
+    try:
+        original_schema = args_schema.model_json_schema()
+    except Exception:
+        # schema 生成失败由上层 get_tools 的验证逻辑处理
+        return tool
+
+    sanitized = _sanitize_json_schema(original_schema)
+    if sanitized == original_schema:
+        # 无需清洗，避免不必要的子类化
+        return tool
+
+    # 创建动态子类，覆盖 model_json_schema 返回清洗后的 dict
+    original_model_json_schema = args_schema.model_json_schema
+
+    def _cleaned_model_json_schema(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        return sanitized
+
+    _cleaned_model_json_schema._lambchat_original = original_model_json_schema  # type: ignore[attr-defined]
+    _cleaned_model_json_schema._lambchat_schema_sanitized = True  # type: ignore[attr-defined]
+
+    try:
+        # 在模型类上直接绑定（classmethod → plain function on class）
+        args_schema.model_json_schema = _cleaned_model_json_schema  # type: ignore[method-assign]
+        args_schema._lambchat_schema_sanitized = True  # type: ignore[attr-defined]
+    except (AttributeError, TypeError):
+        # 某些情况下 args_schema 可能不可变，回退到跳过清洗
+        return tool
+
+    logger.debug(
+        "[MCP] Sanitized args_schema for tool '%s' (removed None-valued properties)",
+        getattr(tool, "name", "<unknown>"),
+    )
+    return tool
+
+
 class MCPToolWithRetry(BaseTool):
     """
     MCP 工具包装器，添加重试逻辑
@@ -647,6 +731,11 @@ class MCPClientManager:
                 )
                 skipped_tools.append(tool.name)
                 continue
+
+            # 清洗 args_schema 中值为 None 的 property，避免 Gemini 后端
+            # (langchain-google-genai) 的 types.Schema 校验抛出 ValidationError。
+            # 参考: issue #186
+            tool = _attach_sanitized_schema(tool)
 
             filtered_tools.append(tool)
 

--- a/tests/infra/tool/test_mcp_schema_sanitizer.py
+++ b/tests/infra/tool/test_mcp_schema_sanitizer.py
@@ -7,50 +7,12 @@ to a JSON schema containing ``None``-valued properties (e.g. ``urls``).
 
 from __future__ import annotations
 
-import importlib.util
-import sys
-from pathlib import Path
 from typing import Any
 
-# ---------------------------------------------------------------------------
-# Load mcp_client module directly (bypassing src.infra.tool.__init__ which
-# imports heavy optional deps).  We only need the two pure-Python helpers.
-# ---------------------------------------------------------------------------
-
-_MCP_CLIENT_PATH = (
-    Path(__file__).resolve().parents[3]
-    / "src"
-    / "infra"
-    / "tool"
-    / "mcp_client.py"
+from src.infra.tool.mcp_client import (
+    _attach_sanitized_schema,
+    _sanitize_json_schema,
 )
-
-
-def _load_mcp_client_helpers() -> Any:
-    # Preload only the modules mcp_client.py needs at import time for the
-    # helper functions we test.  We stub out src.infra.tool so the package
-    # __init__ does not pull in openai/langchain-heavy modules.
-    if "src.infra.tool" not in sys.modules:
-        import types
-
-        pkg = types.ModuleType("src.infra.tool")
-        pkg.__path__ = []  # type: ignore[attr-defined]
-        sys.modules["src.infra.tool"] = pkg
-
-    spec = importlib.util.spec_from_file_location(
-        "src.infra.tool.mcp_client", _MCP_CLIENT_PATH
-    )
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    sys.modules["src.infra.tool.mcp_client"] = module
-    spec.loader.exec_module(module)
-    return module
-
-
-_mcp_client = _load_mcp_client_helpers()
-_sanitize_json_schema = _mcp_client._sanitize_json_schema
-_attach_sanitized_schema = _mcp_client._attach_sanitized_schema
-
 
 # ---------------------------------------------------------------------------
 # _sanitize_json_schema

--- a/tests/infra/tool/test_mcp_schema_sanitizer.py
+++ b/tests/infra/tool/test_mcp_schema_sanitizer.py
@@ -1,0 +1,232 @@
+"""Tests for MCP tool JSON schema sanitization.
+
+Regression tests for issue #186: Gemini backend crashes with
+``pydantic.ValidationError`` when an MCP tool's args_schema serializes
+to a JSON schema containing ``None``-valued properties (e.g. ``urls``).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Load mcp_client module directly (bypassing src.infra.tool.__init__ which
+# imports heavy optional deps).  We only need the two pure-Python helpers.
+# ---------------------------------------------------------------------------
+
+_MCP_CLIENT_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "infra"
+    / "tool"
+    / "mcp_client.py"
+)
+
+
+def _load_mcp_client_helpers() -> Any:
+    # Preload only the modules mcp_client.py needs at import time for the
+    # helper functions we test.  We stub out src.infra.tool so the package
+    # __init__ does not pull in openai/langchain-heavy modules.
+    if "src.infra.tool" not in sys.modules:
+        import types
+
+        pkg = types.ModuleType("src.infra.tool")
+        pkg.__path__ = []  # type: ignore[attr-defined]
+        sys.modules["src.infra.tool"] = pkg
+
+    spec = importlib.util.spec_from_file_location(
+        "src.infra.tool.mcp_client", _MCP_CLIENT_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["src.infra.tool.mcp_client"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_mcp_client = _load_mcp_client_helpers()
+_sanitize_json_schema = _mcp_client._sanitize_json_schema
+_attach_sanitized_schema = _mcp_client._attach_sanitized_schema
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_json_schema
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeJsonSchema:
+    def test_removes_none_valued_properties(self) -> None:
+        schema: dict[str, Any] = {
+            "type": "object",
+            "properties": {
+                "urls": None,  # problematic field
+                "query": {"type": "string"},
+            },
+            "required": ["urls"],
+        }
+        result = _sanitize_json_schema(schema)
+        assert "urls" not in result["properties"]
+        assert result["properties"]["query"] == {"type": "string"}
+
+    def test_recurses_into_nested_properties(self) -> None:
+        schema: dict[str, Any] = {
+            "type": "object",
+            "properties": {
+                "config": {
+                    "type": "object",
+                    "properties": {
+                        "nested_none": None,
+                        "nested_ok": {"type": "integer"},
+                    },
+                }
+            },
+        }
+        result = _sanitize_json_schema(schema)
+        nested = result["properties"]["config"]["properties"]
+        assert "nested_none" not in nested
+        assert nested["nested_ok"] == {"type": "integer"}
+
+    def test_cleans_none_items_in_array(self) -> None:
+        schema: dict[str, Any] = {
+            "type": "array",
+            "items": None,
+        }
+        result = _sanitize_json_schema(schema)
+        assert "items" not in result
+        assert result["type"] == "array"
+
+    def test_cleans_none_format_and_top_level_keys(self) -> None:
+        schema: dict[str, Any] = {
+            "type": "string",
+            "format": None,
+            "description": "a field",
+            "default": None,
+        }
+        result = _sanitize_json_schema(schema)
+        assert "format" not in result
+        assert "default" not in result
+        assert result["description"] == "a field"
+
+    def test_preserves_valid_schema_unchanged(self) -> None:
+        schema: dict[str, Any] = {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "search query"},
+                "limit": {"type": "integer", "default": 10},
+            },
+            "required": ["query"],
+        }
+        result = _sanitize_json_schema(schema)
+        assert result == schema
+
+    def test_handles_empty_and_non_dict_input(self) -> None:
+        assert _sanitize_json_schema({}) == {}
+        assert _sanitize_json_schema([]) == []
+        assert _sanitize_json_schema("string") == "string"
+        assert _sanitize_json_schema(42) == 42
+
+    def test_cleans_anyof_with_none_members(self) -> None:
+        """Union/Optional types may produce anyOf with None entries."""
+        schema: dict[str, Any] = {
+            "type": "object",
+            "properties": {
+                "field": {"anyOf": [None, {"type": "string"}]},
+            },
+        }
+        result = _sanitize_json_schema(schema)
+        assert result["properties"]["field"]["anyOf"] == [{"type": "string"}]
+
+    def test_filters_none_from_list_values(self) -> None:
+        schema: dict[str, Any] = {
+            "type": "object",
+            "properties": {
+                "tags": {"type": "array", "items": {"type": "string"}},
+            },
+            "some_list": [None, {"key": "value"}, None],
+        }
+        result = _sanitize_json_schema(schema)
+        assert result["some_list"] == [{"key": "value"}]
+
+
+# ---------------------------------------------------------------------------
+# _attach_sanitized_schema (integration with a fake BaseTool)
+# ---------------------------------------------------------------------------
+
+
+class _FakeArgsSchema:
+    """Minimal stand-in for a Pydantic model used as ``BaseTool.args_schema``."""
+
+    _lambchat_schema_sanitized: bool = False
+
+    @staticmethod
+    def model_json_schema() -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "urls": None,  # simulates the bug
+                "query": {"type": "string"},
+            },
+            "required": ["urls"],
+        }
+
+
+class _FakeTool:
+    """Minimal stand-in for a LangChain ``BaseTool``."""
+
+    def __init__(self, name: str = "extract") -> None:
+        self.name = name
+        self.args_schema = _FakeArgsSchema
+
+
+class TestAttachSanitizedSchema:
+    def test_cleans_none_property_from_tool_args_schema(self) -> None:
+
+        tool = _FakeTool("tavily_extract")
+        result_tool = _attach_sanitized_schema(tool)
+
+        schema = result_tool.args_schema.model_json_schema()
+        assert "urls" not in schema["properties"]
+        assert "query" in schema["properties"]
+
+    def test_idempotent_on_repeated_calls(self) -> None:
+
+        tool = _FakeTool("tool_a")
+        _attach_sanitized_schema(tool)
+        # second call should be a no-op
+        result = _attach_sanitized_schema(tool)
+        assert result is tool
+        assert tool.args_schema._lambchat_schema_sanitized is True
+
+    def test_noop_when_schema_has_no_none(self) -> None:
+
+        class _CleanSchema:
+            _lambchat_schema_sanitized: bool = False
+
+            @staticmethod
+            def model_json_schema() -> dict[str, Any]:
+                return {
+                    "type": "object",
+                    "properties": {"q": {"type": "string"}},
+                }
+
+        tool = _FakeTool.__new__(_FakeTool)
+        tool.name = "clean_tool"
+        tool.args_schema = _CleanSchema
+
+        original_schema_method = _CleanSchema.model_json_schema
+        result = _attach_sanitized_schema(tool)
+        # schema method should not be replaced when no cleaning needed
+        assert _CleanSchema.model_json_schema is original_schema_method
+        assert result is tool
+
+    def test_handles_missing_args_schema(self) -> None:
+
+        tool = _FakeTool.__new__(_FakeTool)
+        tool.name = "no_schema"
+        tool.args_schema = None  # type: ignore[assignment]
+
+        result = _attach_sanitized_schema(tool)
+        assert result is tool


### PR DESCRIPTION
## Summary

修复 Gemini 后端因 MCP 工具 schema 含 `None` 值字段导致的 `pydantic.ValidationError`。

Closes #186

## Problem

当 MCP 工具的 `args_schema` 序列化为 JSON schema 后，某些字段（如 Tavily 的 `urls`）的值为 `None`。这在 Anthropic / OpenAI 协议下无害，但 `langchain-google-genai` 在 `types.Schema.model_validate()` 阶段会拒绝 `None` 值的 property，导致 Gemini 后端的整个 agent 会话在首次模型调用时崩溃。

## Root Cause

调用链：
```
MCP server JSON schema
  → langchain-mcp-adapters → BaseTool (args_schema)
  → _SafeMCPTool 包装（透传 args_schema）
  → ChatGoogleGenerativeAI._format_tools()
  → types.Schema.model_validate(schema_dict)
  → properties.urls = None → ValidationError 💥
```

## Fix

在 `src/infra/tool/mcp_client.py` 新增两个函数：

1. **`_sanitize_json_schema(schema)`** — 递归遍历 JSON schema dict，移除所有值为 `None` 的 property / items / top-level keys（如 `default: None`、`format: None`）
2. **`_attach_sanitized_schema(tool)`** — 在 tool 的 `args_schema` 上注入清洗后的 `model_json_schema`，幂等且仅在检测到 `None` 值时才介入

在 `MCPClientManager.get_tools()` 中，schema 验证通过后、工具加入返回列表前调用 `_attach_sanitized_schema`。

## Verification

### 单元测试
新增 `tests/infra/tool/test_mcp_schema_sanitizer.py`，覆盖 12 个场景：
- 移除 `None` 值的顶层 property
- 递归清洗嵌套 properties
- 清洗 array 的 `items: None`
- 清洗 `format: None` / `default: None`
- 清洗 `anyOf` 中的 `None` 成员
- 合法 schema 不变（noop）
- 幂等性
- 缺少 `args_schema` 的 tool

```
12 passed
```

### 端到端验证
用 `google.genai.types.Schema.model_validate()` 实测：
```
✅ 复现原始 bug：ValidationError
✅ 清洗后通过 Gemini types.Schema 校验！
```

## Impact

- ✅ Gemini 用户可正常使用所有 MCP 工具（包括 Tavily 等含 Optional 字段的工具）
- ✅ 对 Anthropic / OpenAI 后端无影响（清洗后的 schema 对它们同样合法）
- ✅ 仅在检测到 `None` 值时才清洗，无副作用
- ✅ 幂等设计，重复调用安全