### PR TITLE
fix(chat): 修复长文本编辑开头/中间内容时输入框滚动跳转到末尾的问题

### DIFF
--- a/frontend/src/components/chat/__tests__/chatInputViewport.test.ts
+++ b/frontend/src/components/chat/__tests__/chatInputViewport.test.ts
@@ -4,16 +4,33 @@ import {
 } from "../chatInputViewport.ts";
 
 test("resizeTextareaForContent keeps the newest typed content visible", () => {
+  // 追加输入场景：光标在末尾，视口原本就在底部
   const textarea = {
     style: { height: "" },
     scrollHeight: 420,
-    scrollTop: 0,
+    scrollTop: 200,
+    clientHeight: 220, // 200 + 220 = 420 ≥ 419 → 已在底部
   };
 
   resizeTextareaForContent(textarea, 250);
 
   expect(textarea.style.height).toBe("250px");
   expect(textarea.scrollTop).toBe(420);
+});
+
+test("resizeTextareaForContent preserves scroll position when editing mid-text", () => {
+  // 编辑中间内容场景：光标在文本中间，视口不在底部
+  const textarea = {
+    style: { height: "" },
+    scrollHeight: 420,
+    scrollTop: 50,
+    clientHeight: 220, // 50 + 220 = 270 < 419 → 未在底部
+  };
+
+  resizeTextareaForContent(textarea, 250);
+
+  expect(textarea.style.height).toBe("250px");
+  expect(textarea.scrollTop).toBe(50);
 });
 
 test("getTextareaMaxHeightPx uses a comfortable fraction of small mobile viewports", () => {

--- a/frontend/src/components/chat/chatInputViewport.ts
+++ b/frontend/src/components/chat/chatInputViewport.ts
@@ -12,15 +12,21 @@ interface TextareaLike {
   };
   scrollHeight: number;
   scrollTop: number;
+  clientHeight: number;
 }
 
 export function resizeTextareaForContent(
   textarea: TextareaLike,
   maxHeightPx = DEFAULT_TEXTAREA_MAX_HEIGHT_PX,
 ): void {
+  const prevScrollTop = textarea.scrollTop;
+  const wasAtBottom =
+    prevScrollTop + textarea.clientHeight >= textarea.scrollHeight - 1;
   textarea.style.height = "auto";
   textarea.style.height = `${Math.min(textarea.scrollHeight, maxHeightPx)}px`;
-  textarea.scrollTop = textarea.scrollHeight;
+  // 仅在原本就在底部（追加输入场景）时才滚到底，让最新内容可见；
+  // 编辑中间内容时保持原滚动位置，避免视口被强制拉到末尾导致光标“看起来跳转”。
+  textarea.scrollTop = wasAtBottom ? textarea.scrollHeight : prevScrollTop;
 }
 
 export function getTextareaMaxHeightPx({


### PR DESCRIPTION
## 问题

在输入框中输入较长文本时，想修改前面的内容，输入框显示会跳转到末尾（输入本身能正常进行）。

## 根因

`resizeTextareaForContent` 每次内容变化都无条件执行 `scrollTop = scrollHeight`：

```js
textarea.style.height = "auto";
textarea.style.height = `${Math.min(textarea.scrollHeight, maxHeightPx)}px`;
textarea.scrollTop = textarea.scrollHeight;  // ← 无条件滚到底
```

当文本超过 maxHeight（150px）出现内部滚动时，编辑**开头/中间**内容 → `input` 变化 → 触发 resize → `scrollTop = scrollHeight` 把视口强制拉到末尾。光标实际仍在原位（所以输入正常），但视口被拉到底，用户看到末尾内容，表现为「光标跳到末尾」。

`scrollTop = scrollHeight` 本是为「追加输入时让最新内容可见」写的，但没区分「追加」与「编辑开头/中间」两种场景。

## 修复

改为仅在原本就在底部（追加输入场景）时才滚到底；编辑开头/中间内容时保持原滚动位置：

```js
const prevScrollTop = textarea.scrollTop;
const wasAtBottom =
  prevScrollTop + textarea.clientHeight >= textarea.scrollHeight - 1;
textarea.style.height = "auto";
textarea.style.height = `${Math.min(textarea.scrollHeight, maxHeightPx)}px`;
textarea.scrollTop = wasAtBottom ? textarea.scrollHeight : prevScrollTop;
```

- 追加输入（光标在末尾）→ 仍滚到底，最新内容可见（**保留原行为**）
- 编辑开头/中间（光标不在末尾）→ 保持原滚动位置，由浏览器原生维持光标可见

## 改动文件

- `frontend/src/components/chat/chatInputViewport.ts`：`resizeTextareaForContent` 改为条件滚底；`TextareaLike` 补 `clientHeight`
- `frontend/src/components/chat/__tests__/chatInputViewport.test.ts`：新增「编辑中间内容保持滚动位置」用例；现有用例 mock 补 `clientHeight`

## 验证

- **vitest**：4 个 viewport 测试全过（含新增用例 + 现有「追加输入滚到底」用例）
- **ESLint**：无错误
- **真实浏览器验证**（Chrome + 真实 ChatInput 组件）：输入 60 行长文本，光标置于第 31 行（中部），在中间键入字符 → 视口 `scrollTop` 保持 736（中部），不再跳到末尾（maxScroll 1323）
- **实机操作**：人工输入长文本（大于 60 行）后，编辑开头/中间内容时显示不再直接跳到末尾

改动隔离在纯函数 `resizeTextareaForContent` + 其测试，`useTextareaResize.ts` 与 `ChatInput.tsx` 未改动。
