### PR TITLE
feat: 生图 HTTP 超时与连接池参数全部可配置

### DIFF
--- a/src/infra/tool/image_generation_tool.py
+++ b/src/infra/tool/image_generation_tool.py
@@ -69,21 +69,32 @@ def _get_image_api_client() -> httpx.AsyncClient:
     global _image_api_client
     if _image_api_client is None or getattr(_image_api_client, "is_closed", False):
         read_timeout = float(getattr(settings, "IMAGE_GENERATION_TIMEOUT", 120) or 120)
+        connect_t = float(getattr(settings, "IMAGE_API_CONNECT_TIMEOUT", 10.0) or 10.0)
+        write_t = float(getattr(settings, "IMAGE_API_WRITE_TIMEOUT", 30.0) or 30.0)
+        pool_t = float(getattr(settings, "IMAGE_API_POOL_TIMEOUT", 5.0) or 5.0)
+        max_conn = int(getattr(settings, "IMAGE_API_MAX_CONNECTIONS", 20) or 20)
+        max_keepalive = int(getattr(settings, "IMAGE_API_MAX_KEEPALIVE_CONNECTIONS", 5) or 5)
         _image_api_client = httpx.AsyncClient(
-            timeout=httpx.Timeout(connect=10.0, read=read_timeout, write=30.0, pool=5.0),
-            limits=httpx.Limits(max_connections=20, max_keepalive_connections=5),
+            timeout=httpx.Timeout(connect=connect_t, read=read_timeout, write=write_t, pool=pool_t),
+            limits=httpx.Limits(max_connections=max_conn, max_keepalive_connections=max_keepalive),
         )
     return _image_api_client
 
 
 def _get_download_client() -> httpx.AsyncClient:
-    """参考图下载复用 client（follow_redirects，读超时 60s）。"""
+    """参考图下载复用 client（follow_redirects）。"""
     global _download_client
     if _download_client is None or getattr(_download_client, "is_closed", False):
+        connect_t = float(getattr(settings, "IMAGE_API_CONNECT_TIMEOUT", 10.0) or 10.0)
+        read_t = float(getattr(settings, "IMAGE_DOWNLOAD_TIMEOUT", 60.0) or 60.0)
+        write_t = float(getattr(settings, "IMAGE_DOWNLOAD_WRITE_TIMEOUT", 30.0) or 30.0)
+        pool_t = float(getattr(settings, "IMAGE_API_POOL_TIMEOUT", 5.0) or 5.0)
+        max_conn = int(getattr(settings, "IMAGE_API_MAX_CONNECTIONS", 20) or 20)
+        max_keepalive = int(getattr(settings, "IMAGE_API_MAX_KEEPALIVE_CONNECTIONS", 5) or 5)
         _download_client = httpx.AsyncClient(
             follow_redirects=True,
-            timeout=httpx.Timeout(connect=10.0, read=60.0, write=30.0, pool=5.0),
-            limits=httpx.Limits(max_connections=20, max_keepalive_connections=5),
+            timeout=httpx.Timeout(connect=connect_t, read=read_t, write=write_t, pool=pool_t),
+            limits=httpx.Limits(max_connections=max_conn, max_keepalive_connections=max_keepalive),
         )
     return _download_client
 

--- a/src/kernel/config/base.py
+++ b/src/kernel/config/base.py
@@ -386,7 +386,16 @@ class Settings(BaseSettings):
     IMAGE_GENERATION_API_KEY: str = ""
     IMAGE_GENERATION_BASE_URL: str = "https://api.openai.com/v1"
     IMAGE_GENERATION_MODEL: str = "gpt-image-2"
-    IMAGE_GENERATION_TIMEOUT: int = 120
+    IMAGE_GENERATION_TIMEOUT: int = 120  # 生图 API read timeout（两次数据读取间最大空闲间隔）
+    # 生图 HTTP 超时细粒度控制（秒）。带宽差时可调大 write/download 相关值。
+    IMAGE_API_CONNECT_TIMEOUT: float = 10.0  # TCP 连接建立超时
+    IMAGE_API_WRITE_TIMEOUT: float = 30.0  # 发送请求体超时（含上传参考图）
+    IMAGE_API_POOL_TIMEOUT: float = 5.0  # 从连接池获取连接的等待超时
+    IMAGE_DOWNLOAD_TIMEOUT: float = 60.0  # 下载参考图 read timeout
+    IMAGE_DOWNLOAD_WRITE_TIMEOUT: float = 30.0  # 下载参考图 write timeout
+    # 连接池大小
+    IMAGE_API_MAX_CONNECTIONS: int = 20
+    IMAGE_API_MAX_KEEPALIVE_CONNECTIONS: int = 5
 
     _jwt_secret_key_generated: bool = PrivateAttr(False)
     _mcp_encryption_salt_generated: bool = PrivateAttr(False)


### PR DESCRIPTION
## 背景

#185 把生图超时做了分离（connect/read/write/pool），但 connect/write/pool 和连接池大小都是硬编码的。带宽差的环境无法调整。

## 改动

把所有超时和连接池参数从 `settings` 读取，可通过环境变量覆盖：

| 环境变量 | 默认值 | 说明 |
|---|---|---|
| `IMAGE_API_CONNECT_TIMEOUT` | 10.0 | TCP 连接建立超时 |
| `IMAGE_API_WRITE_TIMEOUT` | 30.0 | 发送请求体超时（含上传参考图） |
| `IMAGE_API_POOL_TIMEOUT` | 5.0 | 从连接池获取连接的等待超时 |
| `IMAGE_DOWNLOAD_TIMEOUT` | 60.0 | 下载参考图 read timeout |
| `IMAGE_DOWNLOAD_WRITE_TIMEOUT` | 30.0 | 下载参考图 write timeout |
| `IMAGE_API_MAX_CONNECTIONS` | 20 | 连接池最大连接数 |
| `IMAGE_API_MAX_KEEPALIVE_CONNECTIONS` | 5 | keepalive 连接数 |

所有默认值与 #185 合入的硬编码值一致，**完全向后兼容**。

### 带宽差时的推荐配置示例

```env
IMAGE_API_WRITE_TIMEOUT=120
IMAGE_DOWNLOAD_TIMEOUT=180
IMAGE_DOWNLOAD_WRITE_TIMEOUT=120
```

## 改动文件

- `src/kernel/config/base.py` — 新增 7 个配置项
- `src/infra/tool/image_generation_tool.py` — `_get_image_api_client` / `_get_download_client` 从 settings 读取参数