### PR TITLE
fix(chat): 粘贴长文本时保留输入框已有文字

### DIFF
--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -193,10 +193,10 @@ export const ChatInput = memo(function ChatInput({
   });
 
   const handleLongTextPaste = useCallback(
-    (text: string) => {
+    (text: string, preserveText?: string) => {
       // Expanded composer keeps long prompts editable as plain text.
       if (composerExpanded) return false;
-      return convertTextToAttachment(text);
+      return convertTextToAttachment(text, preserveText);
     },
     [composerExpanded, convertTextToAttachment],
   );

--- a/frontend/src/hooks/useLongTextConversion.ts
+++ b/frontend/src/hooks/useLongTextConversion.ts
@@ -48,7 +48,7 @@ export function useLongTextConversion({
   }, [t]);
 
   const convertTextToAttachment = useCallback(
-    (text: string) => {
+    (text: string, preserveText?: string) => {
       if (!shouldConvertLongText(text)) return false;
       if (!validateCount(1)) return false;
       if (convertingRef.current) return false;
@@ -57,8 +57,9 @@ export function useLongTextConversion({
       const file = createLongTextFile(text, buildLongTextFileName());
       uploadFiles([file], "document", buildLongTextClientMeta(text));
       setAllowOversizedText(false);
-      // Keep composer empty; long text lives only on the attachment card.
-      setInput("");
+      // Long text lives only on the attachment card; preserve any text the
+      // user had already typed outside the pasted segment.
+      setInput(preserveText ?? "");
       scheduleTextareaResize?.();
       showConvertedToast();
 

--- a/frontend/src/hooks/usePasteHandler.tsx
+++ b/frontend/src/hooks/usePasteHandler.tsx
@@ -14,7 +14,7 @@ export interface UsePasteHandlerOptions {
   validateCount: (count: number) => boolean;
   scheduleTextareaResize: () => void;
   /** Convert oversized pasted text into a long-text attachment. */
-  onLongTextPaste?: (text: string) => boolean;
+  onLongTextPaste?: (text: string, preserveText?: string) => boolean;
 }
 
 export function usePasteHandler({
@@ -67,7 +67,12 @@ export function usePasteHandler({
         const markdownText = turndown.turndown(tempDiv);
 
         if (markdownText.length > PASTE_TEXT_THRESHOLD) {
-          if (onLongTextPaste?.(markdownText)) return;
+          const textarea = textareaRef.current;
+          const before = textarea
+            ? input.substring(0, textarea.selectionStart)
+            : input;
+          const after = textarea ? input.substring(textarea.selectionEnd) : "";
+          if (onLongTextPaste?.(markdownText, before + after)) return;
         }
 
         insertText(markdownText);
@@ -77,11 +82,16 @@ export function usePasteHandler({
       const plainText = clipboardData.getData("text/plain");
       if (plainText && plainText.length > PASTE_TEXT_THRESHOLD) {
         e.preventDefault();
-        if (onLongTextPaste?.(plainText)) return;
+        const textarea = textareaRef.current;
+        const before = textarea
+          ? input.substring(0, textarea.selectionStart)
+          : input;
+        const after = textarea ? input.substring(textarea.selectionEnd) : "";
+        if (onLongTextPaste?.(plainText, before + after)) return;
         insertText(plainText);
       }
     },
-    [uploadFiles, validateCount, onLongTextPaste, insertText],
+    [uploadFiles, validateCount, onLongTextPaste, insertText, input, textareaRef],
   );
 
   return { handlePaste };


### PR DESCRIPTION
## 修复内容

修复 #191

### 问题

当用户在输入框中已经输入了文字（如「请帮我总结以下内容：」），然后粘贴一段超过 3000 字符的长文本时，长文本会被自动转为附件上传（✅），但 `convertTextToAttachment` 中的 `setInput("")` 会**把输入框中已有的文字也全部清空**（❌）。

### 根因

`useLongTextConversion.ts` 的 `convertTextToAttachment` 在转换后无条件执行 `setInput("")`。在 paste 路径中，传给它的 `text` 参数只包含被粘贴的内容，不包含输入框中原有的文字。

### 修复方案

将光标前后的已有文字（`before` + `after`）通过 `onLongTextPaste` → `convertTextToAttachment` 传递，转换后用 `setInput(preserveText)` 保留已有文字，只清空被粘贴的超长文本。

### 改动文件

| 文件 | 改动 |
|------|------|
| `useLongTextConversion.ts` | `convertTextToAttachment` 新增 `preserveText?` 参数 |
| `usePasteHandler.tsx` | paste 时计算光标前后的已有文字并传入 |
| `ChatInput.tsx` | `handleLongTextPaste` 透传 `preserveText` |

### 验证

- ✅ `tsc --noEmit` 类型检查通过
- ✅ `eslint` 零 error（不引入新 warning）