### PR TITLE
fix: 修复 6 个线上 issue (#194-#198,#200) + Gemini 第三方代理初步处理

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "langchain-mcp-adapters>=0.1.0", # MCP integration
     "langgraph>=1.0.9",
     "langsmith>=0.2.0",
-    "deepagents>=0.6.5", # Deep Agent framework
+    "deepagents>=0.6.5,<0.7", # 0.7 removes legacy list[str] store reads; migrate before lifting
     "deepagents-backends>=0.2.0",
     "tiktoken>=0.9.0",
     # Async & Streaming

--- a/scripts/create_e2b_template.py
+++ b/scripts/create_e2b_template.py
@@ -117,8 +117,8 @@ SYSTEM_PACKAGES = [
     "curl",
     "unzip",
     "p7zip-full",
-    "ripgrep", # rg - 快速内容搜索（agent 裸 bash 调用，补 #199）
-    "librsvg2-bin", # rsvg-convert - SVG 转 PNG/PDF（补 #199）
+    "ripgrep",  # rg - 快速内容搜索（agent 裸 bash 调用，补 #199）
+    "librsvg2-bin",  # rsvg-convert - SVG 转 PNG/PDF（补 #199）
     # 中文字体
     "fonts-noto-cjk",
     "fonts-wqy-zenhei",

--- a/scripts/create_e2b_template.py
+++ b/scripts/create_e2b_template.py
@@ -9,7 +9,7 @@
 3. 安装额外的 pip 包
 4. 构建名为 "lambchat" 的自定义模板
 
-构建完成后，在 .env 中设置 E2B_TEMPLATE=lambchat 即可使用。
+构建完成后，在 .env 中设置 E2B_TEMPLATE=lambchat-prod 即可使用。
 """
 
 import os
@@ -117,6 +117,8 @@ SYSTEM_PACKAGES = [
     "curl",
     "unzip",
     "p7zip-full",
+    "ripgrep", # rg - 快速内容搜索（agent 裸 bash 调用，补 #199）
+    "librsvg2-bin", # rsvg-convert - SVG 转 PNG/PDF（补 #199）
     # 中文字体
     "fonts-noto-cjk",
     "fonts-wqy-zenhei",

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -70,6 +70,14 @@ from src.kernel.config import initialize_settings, settings
 
 # Suppress SyntaxWarning from oss2 SDK (invalid escape sequence in their source)
 warnings.filterwarnings("ignore", message=".*invalid escape sequence.*", category=SyntaxWarning)
+# Suppress deepagents deprecation noise from historical v1 store items with
+# list[str] content (still read via a backward-compat path; new writes use str).
+# Do NOT upgrade deepagents to 0.7.0 — that removes the compat path and breaks
+# reads of legacy data (issue #200).
+warnings.filterwarnings(
+    "ignore",
+    message=r".*Store item with `list\[str\]` content is deprecated.*",
+)
 
 logger = get_logger(__name__)
 

--- a/src/api/routes/human.py
+++ b/src/api/routes/human.py
@@ -176,6 +176,7 @@ async def wait_for_response(approval_id: str, timeout: float = 300) -> Optional[
 
     if event:
         # 单进程内：同时等待本地 Event 和 MongoDB 轮询
+        wait_tasks: list[asyncio.Task] = []
         try:
             # 先检查是否已有响应
             response = await _approval_storage.get_response(approval_id)
@@ -190,19 +191,14 @@ async def wait_for_response(approval_id: str, timeout: float = 300) -> Optional[
             local_wait = asyncio.wait_for(event.wait(), timeout=timeout)
             mongo_wait = wait_for_response_distributed(approval_id, timeout)
 
+            wait_tasks = [
+                asyncio.create_task(local_wait),
+                asyncio.create_task(mongo_wait),
+            ]
             done, pending = await asyncio.wait(
-                [
-                    asyncio.create_task(local_wait),
-                    asyncio.create_task(mongo_wait),
-                ],
+                wait_tasks,
                 return_when=asyncio.FIRST_COMPLETED,
             )
-
-            # 取消未完成的任务
-            for task in pending:
-                task.cancel()
-            if pending:
-                await asyncio.gather(*pending, return_exceptions=True)
 
             # 获取结果（local_event.wait() 返回 True，需要从 MongoDB 获取实际响应）
             for task in done:
@@ -221,8 +217,17 @@ async def wait_for_response(approval_id: str, timeout: float = 300) -> Optional[
             else:
                 logger.info("[HITL] approval_id=%s Wait timed out", approval_id)
             return final_response
-
         finally:
+            # Always cancel + retrieve the wait tasks, even when the outer
+            # caller cancels this coroutine (e.g. MCPToolWithRetry wait_for).
+            # Without this, asyncio.wait is interrupted by CancelledError and
+            # the tasks are orphaned with unretrieved TimeoutError ("Task
+            # exception was never retrieved", issue #197).
+            for task in wait_tasks:
+                if not task.done():
+                    task.cancel()
+            if wait_tasks:
+                await asyncio.gather(*wait_tasks, return_exceptions=True)
             _local_events.pop(approval_id, None)
     else:
         # 跨进程：直接使用 MongoDB 轮询

--- a/src/infra/agent/middleware/retry.py
+++ b/src/infra/agent/middleware/retry.py
@@ -225,18 +225,7 @@ class ModelFallbackMiddleware(AgentMiddleware):
         handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]],
     ) -> ModelResponse[ResponseT]:
         try:
-            # Hang safety net: when the primary model never returns and never
-            # raises (e.g. a third-party SSE proxy stall), the provider SDK's own
-            # timeout may not fire for mid-stream stalls. wait_for guarantees we
-            # fall back instead of blocking the whole request forever.
-            response = await asyncio.wait_for(
-                handler(request),
-                timeout=settings.LLM_REQUEST_TIMEOUT,
-            )
-        except asyncio.TimeoutError:
-            return await self._invoke_fallback(
-                request, handler, f"timeout after {settings.LLM_REQUEST_TIMEOUT}s"
-            )
+            response = await handler(request)
         except Exception as exc:
             return await self._invoke_fallback(request, handler, str(exc))
 
@@ -247,6 +236,26 @@ class ModelFallbackMiddleware(AgentMiddleware):
             return await self._invoke_fallback(request, handler, reason)
 
         return response
+
+
+class ModelRequestTimeoutMiddleware(AgentMiddleware):
+    """Bound each individual model attempt, including fallback attempts.
+
+    This sits inside retry middleware so an explicit timeout is retryable before
+    the outer fallback layer switches models. Keeping the timeout at this layer
+    also protects model configurations that do not define a fallback.
+    """
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[ContextT],
+        handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]],
+    ) -> ModelResponse[ResponseT]:
+        timeout = settings.LLM_REQUEST_TIMEOUT
+        try:
+            return await asyncio.wait_for(handler(request), timeout=timeout)
+        except asyncio.TimeoutError as exc:
+            raise asyncio.TimeoutError(f"model request timed out after {timeout}s") from exc
 
 
 class EmptyContentRetryMiddleware(AgentMiddleware):
@@ -293,10 +302,12 @@ def create_retry_middleware(
 ) -> list[AgentMiddleware]:
     """Create the retry middleware stack for deep agents.
 
-    Returns [ModelFallbackMiddleware?, ModelRetryMiddleware, EmptyContentRetryMiddleware]:
+    Returns [ModelFallbackMiddleware?, ModelRetryMiddleware,
+    EmptyContentRetryMiddleware, ModelRequestTimeoutMiddleware]:
     - Outer layer (optional): falls back to an alternate model when primary fails
     - Middle layer: retries on 429/5xx/timeout with exponential backoff
     - Inner layer: retries on empty content responses
+    - Innermost layer: applies the request timeout to each individual attempt
     """
     stack: list[AgentMiddleware] = []
 
@@ -317,6 +328,7 @@ def create_retry_middleware(
             EmptyContentRetryMiddleware(
                 max_retries=settings.LLM_MAX_RETRIES, retry_delay=settings.LLM_RETRY_DELAY
             ),
+            ModelRequestTimeoutMiddleware(),
         ]
     )
     return stack

--- a/src/infra/agent/middleware/retry.py
+++ b/src/infra/agent/middleware/retry.py
@@ -38,6 +38,10 @@ def _is_retryable_error(exc: Exception) -> bool:
     if isinstance(exc, ValueError) and "No generations found in stream" in str(exc):
         return True
 
+    # asyncio.TimeoutError from wait_for / explicit request timeouts
+    if isinstance(exc, asyncio.TimeoutError):
+        return True
+
     # httpx transient network errors (peer closed, incomplete chunked read, etc.)
     try:
         import httpx
@@ -221,7 +225,18 @@ class ModelFallbackMiddleware(AgentMiddleware):
         handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]],
     ) -> ModelResponse[ResponseT]:
         try:
-            response = await handler(request)
+            # Hang safety net: when the primary model never returns and never
+            # raises (e.g. a third-party SSE proxy stall), the provider SDK's own
+            # timeout may not fire for mid-stream stalls. wait_for guarantees we
+            # fall back instead of blocking the whole request forever.
+            response = await asyncio.wait_for(
+                handler(request),
+                timeout=settings.LLM_REQUEST_TIMEOUT,
+            )
+        except asyncio.TimeoutError:
+            return await self._invoke_fallback(
+                request, handler, f"timeout after {settings.LLM_REQUEST_TIMEOUT}s"
+            )
         except Exception as exc:
             return await self._invoke_fallback(request, handler, str(exc))
 

--- a/src/infra/backend/deepagent.py
+++ b/src/infra/backend/deepagent.py
@@ -240,6 +240,12 @@ def create_sandbox_backend_factory(
         return CompositeBackend(
             default=sandbox_backend,
             routes=routes,
+            # Anchor offloaded artifacts (conversation history, large tool
+            # results) at the sandbox work_dir. The CompositeBackend default of
+            # '/' is not writable by the non-root sandbox user, which made the
+            # summarization middleware offload fail with an empty exit-code-1
+            # error (issue #195).
+            artifacts_root=getattr(sandbox_backend, "work_dir", "/home/user"),
         )
 
     return backend_factory

--- a/src/infra/backend/e2b.py
+++ b/src/infra/backend/e2b.py
@@ -147,7 +147,13 @@ class E2BBackend(BaseSandbox):
         parent = os.path.dirname(file_path)
         if not parent:
             return
-        self.execute(f"mkdir -p {shlex.quote(parent)}")
+        result = self.execute(f"mkdir -p {shlex.quote(parent)}")
+        if result.exit_code != 0:
+            logger.warning(
+                "Failed to ensure parent directory %s: %s",
+                parent,
+                (result.output or "")[:200],
+            )
 
     # =========================================================================
     # Command execution
@@ -178,9 +184,18 @@ class E2BBackend(BaseSandbox):
                     exit_code=-1,
                     truncated=False,
                 )
-            logger.error(f"Command failed: {e}")
+            # Surface the full captured output from SDK command exceptions so
+            # failures stay diagnosable. Previously only str(e) was used, which
+            # for preflight failures produced an empty "error: " in the logs
+            # (issue #195 diagnostics).
+            detail = error_msg
+            for attr in ("stderr", "stdout"):
+                val = getattr(e, attr, None)
+                if val:
+                    detail = f"{detail} | {attr}: {val}" if detail else val
+            logger.error(f"Command failed: {detail}")
             return ExecuteResponse(
-                output=f"Command failed: {e}",
+                output=f"Command failed: {detail}",
                 exit_code=-1,
                 truncated=False,
             )
@@ -634,9 +649,16 @@ class E2BBackend(BaseSandbox):
                     FileDownloadResponse(path=path, content=bytes(content), error=None)
                 )
             except Exception as e:
+                error_str = str(e).lower()
+                if "permission" in error_str:
+                    error_type = "permission_denied"
+                elif "directory" in error_str or "is a dir" in error_str:
+                    error_type = "is_directory"
+                else:
+                    error_type = "file_not_found"
                 logger.error(f"Failed to download {path}: {e}")
                 responses.append(
-                    FileDownloadResponse(path=path, content=None, error="file_not_found")
+                    FileDownloadResponse(path=path, content=None, error=error_type)
                 )
         return responses
 

--- a/src/infra/backend/e2b.py
+++ b/src/infra/backend/e2b.py
@@ -652,7 +652,7 @@ class E2BBackend(BaseSandbox):
                 error_str = str(e).lower()
                 if "permission" in error_str:
                     error_type = "permission_denied"
-                elif "directory" in error_str or "is a dir" in error_str:
+                elif "is a directory" in error_str or "is a dir" in error_str:
                     error_type = "is_directory"
                 else:
                     error_type = "file_not_found"

--- a/src/infra/backend/e2b.py
+++ b/src/infra/backend/e2b.py
@@ -657,9 +657,7 @@ class E2BBackend(BaseSandbox):
                 else:
                     error_type = "file_not_found"
                 logger.error(f"Failed to download {path}: {e}")
-                responses.append(
-                    FileDownloadResponse(path=path, content=None, error=error_type)
-                )
+                responses.append(FileDownloadResponse(path=path, content=None, error=error_type))
         return responses
 
     def _file_size(self, path: str) -> int | None:

--- a/src/infra/channel/feishu/channel.py
+++ b/src/infra/channel/feishu/channel.py
@@ -526,8 +526,7 @@ class FeishuChannel(FeishuSenderMixin, BaseChannel):
             state = self._get_connection_state()
             if state == ConnectionState.CONNECTED:
                 logger.debug(
-                    "Feishu connection alive for user %s "
-                    "(SDK keep-alive + auto-reconnect active)",
+                    "Feishu connection alive for user %s (SDK keep-alive + auto-reconnect active)",
                     self.config.user_id,
                 )
 

--- a/src/infra/channel/feishu/channel.py
+++ b/src/infra/channel/feishu/channel.py
@@ -510,31 +510,26 @@ class FeishuChannel(FeishuSenderMixin, BaseChannel):
         await self._ws_client._disconnect()
 
     async def _health_check_loop(self) -> None:
-        """Health check loop to detect and force-reconnect zombie connections."""
+        """Observe connection state; reconnects are handled by the SDK.
+
+        The lark-oapi SDK runs its own keep-alive ping loop
+        (``_sdk_ws_start_ping``) and auto-reconnects on real disconnects. We
+        previously force-closed connections with no business-message activity
+        within ``CONNECTION_TIMEOUT``, but ping/pong success never updated that
+        timestamp — so healthy idle connections were misjudged as dead and
+        cycled every few minutes (issue #200). The loop now only observes.
+        """
         while self._running:
             await asyncio.sleep(self.HEALTH_CHECK_INTERVAL)
             if not self._running:
                 break
-
             state = self._get_connection_state()
             if state == ConnectionState.CONNECTED:
-                if not self._is_connection_healthy():
-                    logger.warning(
-                        f"Feishu connection appears dead for user {self.config.user_id} "
-                        f"(no activity for {time.time() - self._last_activity_time:.0f}s), "
-                        "force-closing to trigger reconnect"
-                    )
-                    self._set_connection_state(ConnectionState.RECONNECTING)
-                    # Force-close the underlying connection so the SDK detects
-                    # the disconnect and triggers its reconnection loop.
-                    try:
-                        if self._ws_loop_ref is None or self._ws_client is None:
-                            continue
-                        await asyncio.wait_for(self._sdk_ws_disconnect(), timeout=5)
-                    except Exception:
-                        pass
-                else:
-                    logger.debug(f"Feishu connection healthy for user {self.config.user_id}")
+                logger.debug(
+                    "Feishu connection alive for user %s "
+                    "(SDK keep-alive + auto-reconnect active)",
+                    self.config.user_id,
+                )
 
     async def stop(self) -> None:
         """Stop the Feishu bot."""

--- a/src/infra/llm/client.py
+++ b/src/infra/llm/client.py
@@ -118,6 +118,7 @@ def _make_cache_key(
         thinking_key,
         profile_key,
         max_retries,
+        settings.LLM_REQUEST_TIMEOUT,
     )
 
 
@@ -257,6 +258,7 @@ class LLMClient:
                 "effort": effort,
                 "base_url": api_base or None,
                 "max_retries": settings.LLM_MAX_RETRIES,
+                "timeout": settings.LLM_REQUEST_TIMEOUT,
             }
             if api_key:
                 anthropic_kwargs["api_key"] = SecretStr(api_key)
@@ -278,6 +280,7 @@ class LLMClient:
                 "base_url": api_base or None,
                 "thinking_level": thinking_level,
                 "max_retries": settings.LLM_MAX_RETRIES,
+                "timeout": settings.LLM_REQUEST_TIMEOUT,
             }
             if api_key:
                 google_kwargs["google_api_key"] = SecretStr(api_key)
@@ -292,6 +295,7 @@ class LLMClient:
             "api_key": api_key or "sk-placeholder",
             "base_url": api_base or None,
             "max_retries": settings.LLM_MAX_RETRIES,
+            "timeout": settings.LLM_REQUEST_TIMEOUT,
         }
         # OpenAI 协议: 传递 reasoning_effort 给推理模型
         # 仅 OpenAI 官方模型 (provider="openai") 支持 reasoning_effort 参数。

--- a/src/infra/memory/compaction_agent.py
+++ b/src/infra/memory/compaction_agent.py
@@ -521,11 +521,33 @@ class MemoryCompactionAgent:
         return filled_title[:25], filled_summary[:100], clean_tags
 
     async def _get_compaction_model(self) -> Any:
-        """Get the model used only for memory compaction."""
-        from src.infra.llm.client import LLMClient
+        """Get the model used only for memory compaction.
 
-        model_id = getattr(settings, "NATIVE_MEMORY_COMPACTION_MODEL_ID", "") or None
-        return await LLMClient.get_model(model_id=model_id, temperature=0.1)
+        The configured ``NATIVE_MEMORY_COMPACTION_MODEL_ID`` is resolved through
+        ``resolve_model_reference`` so a stale or missing id degrades to the
+        default model instead of raising ``model_not_found``. A lingering
+        ``AuthorizationError`` from the client is also caught as a last-resort
+        fallback — background compaction must never hard-fail on model
+        resolution (issue #194).
+        """
+        from src.infra.llm.client import LLMClient
+        from src.infra.llm.models_service import resolve_model_reference
+        from src.kernel.exceptions import AuthorizationError
+
+        reference = getattr(settings, "NATIVE_MEMORY_COMPACTION_MODEL_ID", "")
+        model_id, _model_value = await resolve_model_reference(reference)
+        kwargs: dict[str, Any] = {"temperature": 0.1}
+        if model_id:
+            kwargs["model_id"] = model_id
+        try:
+            return await LLMClient.get_model(**kwargs)
+        except AuthorizationError as e:
+            logger.warning(
+                "[MemoryCompactionAgent] configured compaction model unavailable, "
+                "falling back to default model: %s",
+                e,
+            )
+            return await LLMClient.get_model(temperature=0.1)
 
     @staticmethod
     async def _build_inventory(backend: Any, user_id: str) -> list[dict[str, Any]]:

--- a/src/infra/sandbox/_e2b_helpers.py
+++ b/src/infra/sandbox/_e2b_helpers.py
@@ -160,7 +160,11 @@ class _E2BMixin:
             )
             e2b_backend = E2BBackend(sandbox=cast("E2BSandbox", sandbox))
             skills_backend = create_skills_backend(user_id=user_id)
-            composite = CompositeBackend(default=e2b_backend, routes={"/skills/": skills_backend})
+            composite = CompositeBackend(
+                default=e2b_backend,
+                routes={"/skills/": skills_backend},
+                artifacts_root=work_dir,
+            )
             return composite, work_dir, adapter.get_sandbox_id(sandbox), sandbox
 
         backend, work_dir, sandbox_id, provider_obj = await run_blocking_io(_sync_create)
@@ -186,9 +190,11 @@ class _E2BMixin:
     def _build_composite_backend(self, provider_obj: object, user_id: str) -> CompositeBackend:
         from src.infra.backend.e2b import E2BBackend
 
+        e2b_backend = E2BBackend(sandbox=cast("E2BSandbox", provider_obj))
         return CompositeBackend(
-            default=E2BBackend(sandbox=cast("E2BSandbox", provider_obj)),
+            default=e2b_backend,
             routes={"/skills/": create_skills_backend(user_id=user_id)},
+            artifacts_root=e2b_backend.work_dir,
         )
 
     async def _stop_e2b(self, user_id: str) -> bool:

--- a/src/infra/tool/mcp_client.py
+++ b/src/infra/tool/mcp_client.py
@@ -36,16 +36,40 @@ MCP_TOOL_TIMEOUT = 300  # 单次工具调用超时（秒）
 MCP_CONFIG_FILE_MAX_BYTES = 1024 * 1024
 
 
-def _normalize_json_array_args(kwargs: dict[str, Any]) -> dict[str, Any]:
+def _schema_allows_array(value_schema: Any) -> bool:
+    """Return whether a JSON-schema fragment accepts an array value."""
+    if not isinstance(value_schema, dict):
+        return False
+    schema_type = value_schema.get("type")
+    if schema_type == "array" or (isinstance(schema_type, list) and "array" in schema_type):
+        return True
+    return any(
+        _schema_allows_array(option)
+        for keyword in ("anyOf", "oneOf")
+        for option in value_schema.get(keyword, [])
+    )
+
+
+def _normalize_json_array_args(kwargs: dict[str, Any], args_schema: Any = None) -> dict[str, Any]:
     """Coerce JSON-array-string arguments back to real lists.
 
     Some callers/LLMs serialize list arguments as a JSON array literal string
     (e.g. ``urls='["https://..."]'``), which remote MCP servers reject as an
     invalid value. Parse such values back to a list (issue #198).
     """
+    schema = args_schema
+    if schema is not None and not isinstance(schema, dict):
+        to_json_schema = getattr(schema, "model_json_schema", None)
+        schema = to_json_schema() if callable(to_json_schema) else None
+    properties = schema.get("properties", {}) if isinstance(schema, dict) else {}
+
     normalized: dict[str, Any] = {}
     for key, value in kwargs.items():
-        if isinstance(value, str) and value.lstrip().startswith("["):
+        if (
+            _schema_allows_array(properties.get(key))
+            and isinstance(value, str)
+            and value.lstrip().startswith("[")
+        ):
             try:
                 parsed = json.loads(value)
             except (json.JSONDecodeError, ValueError):
@@ -223,7 +247,7 @@ class MCPToolWithRetry(BaseTool):
 
         # Coerce JSON-array-string args back to lists before delegating, so
         # remote MCP servers receive properly typed values (issue #198).
-        kwargs = _normalize_json_array_args(kwargs)
+        kwargs = _normalize_json_array_args(kwargs, self.args_schema)
 
         last_error: Exception | None = None
         for attempt in range(self._max_retries):

--- a/src/infra/tool/mcp_client.py
+++ b/src/infra/tool/mcp_client.py
@@ -35,6 +35,26 @@ MCP_RETRY_DELAY = 1.0  # 秒
 MCP_TOOL_TIMEOUT = 300  # 单次工具调用超时（秒）
 MCP_CONFIG_FILE_MAX_BYTES = 1024 * 1024
 
+
+def _normalize_json_array_args(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Coerce JSON-array-string arguments back to real lists.
+
+    Some callers/LLMs serialize list arguments as a JSON array literal string
+    (e.g. ``urls='["https://..."]'``), which remote MCP servers reject as an
+    invalid value. Parse such values back to a list (issue #198).
+    """
+    normalized: dict[str, Any] = {}
+    for key, value in kwargs.items():
+        if isinstance(value, str) and value.lstrip().startswith("["):
+            try:
+                parsed = json.loads(value)
+            except (json.JSONDecodeError, ValueError):
+                parsed = None
+            if isinstance(parsed, list):
+                value = parsed
+        normalized[key] = value
+    return normalized
+
 # 与 deepagents backend 冲突的工具名（需要过滤掉）
 CONFLICTING_TOOL_NAMES = frozenset(
     [
@@ -137,6 +157,12 @@ class MCPToolWithRetry(BaseTool):
             "reset",
             "refused",
             "unavailable",
+            # MCP streamable-http transport failures: the SSE GET stream drops
+            # mid-run and the subsequent tool POST fails. Retry so the client
+            # re-establishes the session (issue #198).
+            "streamable http",
+            "posting to endpoint",
+            "stream disconnected",
         ]
 
         # 可重试的异常类型
@@ -193,6 +219,10 @@ class MCPToolWithRetry(BaseTool):
             )
             if not quota_result.allowed:
                 return await quota_error_json_async(self._server_name or self.name, quota_result)
+
+        # Coerce JSON-array-string args back to lists before delegating, so
+        # remote MCP servers receive properly typed values (issue #198).
+        kwargs = _normalize_json_array_args(kwargs)
 
         last_error: Exception | None = None
         for attempt in range(self._max_retries):

--- a/src/infra/tool/mcp_client.py
+++ b/src/infra/tool/mcp_client.py
@@ -55,6 +55,7 @@ def _normalize_json_array_args(kwargs: dict[str, Any]) -> dict[str, Any]:
         normalized[key] = value
     return normalized
 
+
 # 与 deepagents backend 冲突的工具名（需要过滤掉）
 CONFLICTING_TOOL_NAMES = frozenset(
     [

--- a/src/infra/tool/reveal_file_tool.py
+++ b/src/infra/tool/reveal_file_tool.py
@@ -267,6 +267,10 @@ async def _download_file_from_backend(backend: Any, file_path: str) -> Optional[
 
     沙箱（DaytonaBackend）和非沙箱（StateBackend/StoreBackend）均支持 download_files，
     返回原始字节，不包含行号等格式化内容。
+
+    Note: the underlying ``error`` (e.g. ``is_directory``) is logged but not
+    propagated; see issue #196 — surfacing it to callers needs a wider refactor
+    of all call sites + their test mocks.
     """
     logger.info(f"[reveal_file] Attempting to download: {file_path}")
 

--- a/src/infra/tool/reveal_file_tool.py
+++ b/src/infra/tool/reveal_file_tool.py
@@ -28,6 +28,7 @@ import json
 import mimetypes
 import os
 import re
+from contextvars import ContextVar
 from tempfile import SpooledTemporaryFile
 from typing import Annotated, Any, Literal, Optional
 from urllib.parse import unquote, urlparse
@@ -50,6 +51,12 @@ from src.infra.tool.backend_utils import (
 from src.kernel.config import settings
 
 logger = get_logger(__name__)
+
+# Task-local handoff from the download helper to the immediate error probe. This
+# is transient request state only; backend selection still comes from ToolRuntime.
+_last_backend_download_error: ContextVar[tuple[Any, str, str] | None] = ContextVar(
+    "reveal_file_last_backend_download_error", default=None
+)
 
 
 async def _json_dumps_result(data: dict[str, Any]) -> str:
@@ -268,11 +275,11 @@ async def _download_file_from_backend(backend: Any, file_path: str) -> Optional[
     沙箱（DaytonaBackend）和非沙箱（StateBackend/StoreBackend）均支持 download_files，
     返回原始字节，不包含行号等格式化内容。
 
-    Note: the underlying ``error`` (e.g. ``is_directory``) is logged but not
-    propagated; see issue #196 — surfacing it to callers needs a wider refactor
-    of all call sites + their test mocks.
+    The structured ``error`` from a failed response is handed to the immediate
+    reveal-file probe via task-local transient state (issue #196).
     """
     logger.info(f"[reveal_file] Attempting to download: {file_path}")
+    _last_backend_download_error.set(None)
 
     if hasattr(backend, "adownload_files"):
         try:
@@ -286,6 +293,8 @@ async def _download_file_from_backend(backend: Any, file_path: str) -> Optional[
                     return resp.content
                 elif resp.error:
                     logger.warning(f"[reveal_file] Download error: {resp.error}")
+                    _last_backend_download_error.set((backend, file_path, resp.error))
+                    return None
         except Exception as e:
             logger.warning(f"[reveal_file] adownload_files failed for {file_path}: {e}")
 
@@ -301,6 +310,8 @@ async def _download_file_from_backend(backend: Any, file_path: str) -> Optional[
                     return resp.content
                 elif resp.error:
                     logger.warning(f"[reveal_file] Download error: {resp.error}")
+                    _last_backend_download_error.set((backend, file_path, resp.error))
+                    return None
         except Exception as e:
             logger.warning(f"[reveal_file] download_files failed for {file_path}: {e}")
 
@@ -311,10 +322,15 @@ async def _probe_download_error(backend: Any, file_path: str) -> Optional[str]:
     """Probe the backend's structured download error for a path (issue #196).
 
     Called after a download yields no content to tell a directory from a
-    missing file, so the caller can give the agent an actionable hint. This
-    re-issues ``download_files`` (cheap, read-only) only to read the structured
-    ``error`` field — it does not duplicate the content fetch.
+    missing file, so the caller can give the agent an actionable hint. The
+    immediately preceding structured error is reused task-locally; a read-only
+    probe is issued only when no such result is available.
     """
+    cached = _last_backend_download_error.get()
+    if cached is not None and cached[0] is backend and cached[1] == file_path:
+        _last_backend_download_error.set(None)
+        return cached[2]
+
     try:
         if hasattr(backend, "adownload_files"):
             responses = await backend.adownload_files([file_path])

--- a/src/infra/tool/reveal_file_tool.py
+++ b/src/infra/tool/reveal_file_tool.py
@@ -307,6 +307,28 @@ async def _download_file_from_backend(backend: Any, file_path: str) -> Optional[
     return None
 
 
+async def _probe_download_error(backend: Any, file_path: str) -> Optional[str]:
+    """Probe the backend's structured download error for a path (issue #196).
+
+    Called after a download yields no content to tell a directory from a
+    missing file, so the caller can give the agent an actionable hint. This
+    re-issues ``download_files`` (cheap, read-only) only to read the structured
+    ``error`` field — it does not duplicate the content fetch.
+    """
+    try:
+        if hasattr(backend, "adownload_files"):
+            responses = await backend.adownload_files([file_path])
+        elif hasattr(backend, "download_files"):
+            responses = await run_blocking_io(backend.download_files, [file_path])
+        else:
+            return None
+        if responses:
+            return responses[0].error
+    except Exception as e:
+        logger.debug("[reveal_file] probe error for %s: %s", file_path, e)
+    return None
+
+
 async def _read_file_from_filesystem(file_path: str) -> Optional[bytes]:
     """非沙箱模式下的兜底：直接从本地文件系统读取文件内容"""
     try:
@@ -731,6 +753,27 @@ async def reveal_file(
             use_filesystem_stream = await run_blocking_io(_is_file_path, file_path)
 
         if file_content is None and not use_filesystem_stream:
+            # Distinguish a directory from a missing file so the agent can stop
+            # retrying / switch to reveal_project (issue #196). Sandbox only —
+            # the local filesystem fallback path doesn't classify directories.
+            if _is_sandbox_backend(backend):
+                probe_error = await _probe_download_error(backend, file_path)
+                if probe_error == "is_directory":
+                    logger.warning(
+                        "[reveal_file] Path is a directory, not a file: %s",
+                        file_path,
+                    )
+                    return await _json_dumps_result(
+                        {
+                            "type": "file_reveal",
+                            "file": {
+                                "path": file_path,
+                                "description": description or "",
+                                "error": "path_is_directory",
+                                "hint": "Path is a directory. Use reveal_project(project_path=...) for directories instead of reveal_file.",
+                            },
+                        }
+                    )
             logger.error(f"Failed to read file {file_path} from backend")
             missing_file_result = {
                 "type": "file_reveal",

--- a/src/infra/tool/scheduled_task/approval.py
+++ b/src/infra/tool/scheduled_task/approval.py
@@ -158,6 +158,27 @@ async def _confirm_scheduled_task_creation(
     from src.infra.logging.context import TraceContext
 
     ctx = TraceContext.get_request_context()
+
+    # Unattended contexts (scheduled-task sessions use the "sch_" prefix) have
+    # no interactive user to confirm. Waiting would always time out after the
+    # full timeout — and MCPToolWithRetry then amplifies that to ~3x. Fail fast
+    # with a clear message instead of blocking (issue #197).
+    if ctx.session_id and ctx.session_id.startswith("sch_"):
+        logger.info(
+            "[ScheduledTask] skipping HITL confirmation in unattended session %s",
+            ctx.session_id,
+        )
+        return {
+            "approved": False,
+            "status": "unattended",
+            "approval_id": None,
+            "message": (
+                "scheduled_task_create requires interactive confirmation, which is "
+                "not available in an unattended (scheduled-task) context. Create "
+                "the task from an interactive chat session instead."
+            ),
+        }
+
     approval_message = _format_approval_message(preview)
     approval = await create_approval(
         message=approval_message,

--- a/src/kernel/config/base.py
+++ b/src/kernel/config/base.py
@@ -83,6 +83,7 @@ class Settings(BaseSettings):
     # LLM Settings
     LLM_MAX_RETRIES: int = 3
     LLM_RETRY_DELAY: float = 1.0
+    LLM_REQUEST_TIMEOUT: float = 120.0  # 单次 LLM 请求超时（秒），含流式首 chunk；hang 兜底
     LLM_MODEL_CACHE_SIZE: int = 50  # 模型实例缓存大小，防止内存泄漏
     PROMPT_CACHE_MAX_SYSTEM_BLOCKS: int = 4
     PROMPT_CACHE_MAX_TOOLS: int = 2

--- a/tests/api/routes/test_human_wait.py
+++ b/tests/api/routes/test_human_wait.py
@@ -190,3 +190,46 @@ async def test_create_approval_bounded_local_event_cache(
             previous_limit,
         )
         human._local_events.clear()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_response_cancels_distributed_wait_on_external_cancel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """External cancellation must still clean up the distributed wait task.
+
+    Regression test for issue #197: cleanup lived inside the try block, so a
+    CancelledError from the outer MCPToolWithRetry wait_for skipped it and
+    orphaned the wait tasks ("Task exception was never retrieved").
+    """
+    import contextlib
+
+    approval_id = "approval-ext-cancel"
+    distributed_cancelled = asyncio.Event()
+
+    class _FakeApprovalStorage:
+        async def get_response(self, _requested_id: str):
+            return None
+
+    async def tracked_distributed(_requested_id: str, _timeout: float):
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            distributed_cancelled.set()
+            raise
+
+    event = asyncio.Event()  # never set → both waits block until cancelled
+    human._local_events[approval_id] = (event, 0)
+    monkeypatch.setattr(human, "_approval_storage", _FakeApprovalStorage())
+    monkeypatch.setattr(human, "wait_for_response_distributed", tracked_distributed)
+
+    wait_task = asyncio.create_task(human.wait_for_response(approval_id, timeout=60))
+    await asyncio.sleep(0.05)  # let it reach asyncio.wait
+    wait_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await wait_task
+
+    # finally-cleanup must have cancelled the distributed waiter.
+    await asyncio.wait_for(distributed_cancelled.wait(), timeout=1)
+    assert distributed_cancelled.is_set()
+    human._local_events.pop(approval_id, None)

--- a/tests/infra/agent/test_retry_middleware.py
+++ b/tests/infra/agent/test_retry_middleware.py
@@ -83,3 +83,34 @@ async def test_fallback_model_is_created_with_same_thinking_config(monkeypatch) 
 
     assert result is fallback_model
     assert calls == [{"model": "openai/fallback-model", "thinking": thinking}]
+
+
+async def test_fallback_runs_when_primary_hangs_without_returning(monkeypatch) -> None:
+    """A primary model that never returns and never raises must still trigger
+    fallback via wait_for, instead of blocking the request forever (the gemini
+    third-party-proxy hang)."""
+    import asyncio
+
+    primary_model = object()
+    fallback_model = object()
+    middleware = ModelFallbackMiddleware(fallback_model="openai/fallback-model")
+    middleware._fallback_llm = fallback_model
+    monkeypatch.setattr("src.kernel.config.settings.LLM_REQUEST_TIMEOUT", 0.05)
+
+    async def handler(request):
+        if request.model is primary_model:
+            await asyncio.sleep(10)  # simulate a hung stream
+        return AIMessage(content="fallback answer")
+
+    result = await middleware.awrap_model_call(_Request(primary_model), handler)
+
+    assert result.content == "fallback answer"
+
+
+def test_is_retryable_error_recognizes_asyncio_timeout() -> None:
+    """A bare asyncio.TimeoutError (e.g. from wait_for) must be retryable."""
+    import asyncio
+
+    from src.infra.agent.middleware.retry import _is_retryable_error
+
+    assert _is_retryable_error(asyncio.TimeoutError()) is True

--- a/tests/infra/agent/test_retry_middleware.py
+++ b/tests/infra/agent/test_retry_middleware.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 from langchain_core.messages import AIMessage
 
 from src.infra.agent.middleware.retry import ModelFallbackMiddleware
@@ -93,18 +94,117 @@ async def test_fallback_runs_when_primary_hangs_without_returning(monkeypatch) -
 
     primary_model = object()
     fallback_model = object()
-    middleware = ModelFallbackMiddleware(fallback_model="openai/fallback-model")
-    middleware._fallback_llm = fallback_model
+    from langchain.agents.factory import _chain_async_model_call_handlers
+
+    from src.infra.agent.middleware.retry import create_retry_middleware
+
     monkeypatch.setattr("src.kernel.config.settings.LLM_REQUEST_TIMEOUT", 0.05)
+    monkeypatch.setattr("src.kernel.config.settings.LLM_MAX_RETRIES", 0)
+
+    middleware = create_retry_middleware(fallback_model="openai/fallback-model")
+    fallback = next(item for item in middleware if isinstance(item, ModelFallbackMiddleware))
+    fallback._fallback_llm = fallback_model
+    composed = _chain_async_model_call_handlers([item.awrap_model_call for item in middleware])
+    assert composed is not None
 
     async def handler(request):
         if request.model is primary_model:
             await asyncio.sleep(10)  # simulate a hung stream
         return AIMessage(content="fallback answer")
 
-    result = await middleware.awrap_model_call(_Request(primary_model), handler)
+    result = await composed(_Request(primary_model), handler)
 
-    assert result.content == "fallback answer"
+    assert result.model_response.result[0].content == "fallback answer"
+
+
+async def test_fallback_timeout_does_not_hang_forever(monkeypatch) -> None:
+    """The safety net must also bound a fallback provider that stalls."""
+    import asyncio
+
+    primary_model = object()
+    fallback_model = object()
+    from langchain.agents.factory import _chain_async_model_call_handlers
+
+    from src.infra.agent.middleware.retry import create_retry_middleware
+
+    monkeypatch.setattr("src.kernel.config.settings.LLM_REQUEST_TIMEOUT", 0.02)
+    monkeypatch.setattr("src.kernel.config.settings.LLM_MAX_RETRIES", 0)
+
+    middleware = create_retry_middleware(fallback_model="openai/fallback-model")
+    fallback = next(item for item in middleware if isinstance(item, ModelFallbackMiddleware))
+    fallback._fallback_llm = fallback_model
+    composed = _chain_async_model_call_handlers([item.awrap_model_call for item in middleware])
+    assert composed is not None
+
+    async def handler(request):
+        await asyncio.sleep(10)
+
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(
+            composed(_Request(primary_model), handler),
+            timeout=0.2,
+        )
+
+    # Distinguish the middleware's configured timeout from the test's 0.2s
+    # deadlock guard. Without a bound around fallback this takes ~0.2s.
+    assert loop.time() - started < 0.15
+
+
+async def test_request_timeout_is_retried_before_fallback(monkeypatch) -> None:
+    """A hung attempt times out inside retry instead of bypassing retries."""
+    import asyncio
+
+    from langchain.agents.factory import _chain_async_model_call_handlers
+
+    from src.infra.agent.middleware.retry import create_retry_middleware
+
+    primary_model = object()
+    fallback_model = object()
+    monkeypatch.setattr("src.kernel.config.settings.LLM_REQUEST_TIMEOUT", 0.02)
+    monkeypatch.setattr("src.kernel.config.settings.LLM_MAX_RETRIES", 1)
+    monkeypatch.setattr("src.kernel.config.settings.LLM_RETRY_DELAY", 0)
+
+    middleware = create_retry_middleware(fallback_model="openai/fallback-model")
+    fallback = next(item for item in middleware if isinstance(item, ModelFallbackMiddleware))
+    fallback._fallback_llm = fallback_model
+    composed = _chain_async_model_call_handlers([item.awrap_model_call for item in middleware])
+    assert composed is not None
+
+    primary_calls = 0
+    fallback_calls = 0
+
+    async def handler(request):
+        nonlocal primary_calls, fallback_calls
+        if request.model is primary_model:
+            primary_calls += 1
+            if primary_calls == 1:
+                await asyncio.sleep(10)
+            return AIMessage(content="primary recovered")
+        fallback_calls += 1
+        return AIMessage(content="fallback answer")
+
+    result = await composed(_Request(primary_model), handler)
+
+    assert result.model_response.result[0].content == "primary recovered"
+    assert primary_calls == 2
+    assert fallback_calls == 0
+
+
+async def test_request_timeout_error_reports_configured_duration(monkeypatch) -> None:
+    """Timeout errors remain actionable even when no fallback is configured."""
+    import asyncio
+
+    from src.infra.agent.middleware.retry import ModelRequestTimeoutMiddleware
+
+    monkeypatch.setattr("src.kernel.config.settings.LLM_REQUEST_TIMEOUT", 0.01)
+
+    async def handler(request):
+        await asyncio.sleep(10)
+
+    with pytest.raises(asyncio.TimeoutError, match="0.01s"):
+        await ModelRequestTimeoutMiddleware().awrap_model_call(_Request(object()), handler)
 
 
 def test_is_retryable_error_recognizes_asyncio_timeout() -> None:

--- a/tests/infra/backend/test_deepagents_protocol_compat.py
+++ b/tests/infra/backend/test_deepagents_protocol_compat.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 
 class _FakeSkillStorage:
     def __init__(self) -> None:
@@ -242,3 +244,26 @@ def test_e2b_download_files_classifies_directory_error() -> None:
 
     assert responses[0].error == "is_directory"
     assert responses[0].content is None
+
+
+@pytest.mark.asyncio
+async def test_probe_download_error_reads_structured_error() -> None:
+    """_probe_download_error surfaces the structured download error so
+    reveal_file can tell a directory from a missing file (issue #196)."""
+    from src.infra.tool.reveal_file_tool import _probe_download_error
+
+    class _Resp:
+        def __init__(self, error):
+            self.error = error
+            self.content = None
+
+    class _Backend:
+        def __init__(self, error):
+            self._error = error
+
+        async def adownload_files(self, paths):
+            return [_Resp(self._error)]
+
+    assert await _probe_download_error(_Backend("is_directory"), "/d") == "is_directory"
+    assert await _probe_download_error(_Backend("file_not_found"), "/d") == "file_not_found"
+    assert await _probe_download_error(_Backend(None), "/d") is None

--- a/tests/infra/backend/test_deepagents_protocol_compat.py
+++ b/tests/infra/backend/test_deepagents_protocol_compat.py
@@ -175,3 +175,70 @@ def test_e2b_read_skips_large_file_before_text_read(monkeypatch) -> None:
 
     assert "too large" in str(result)
     assert files_api.read_calls == []
+
+
+def test_sandbox_backend_factory_anchors_artifacts_at_work_dir(monkeypatch) -> None:
+    """The E2B sandbox CompositeBackend must use work_dir as artifacts_root.
+
+    Regression test for issue #195: artifacts_root defaulted to '/', so the
+    summarization middleware offloaded history to /conversation_history and hit
+    a PermissionError on the non-root sandbox (exit code 1, empty error).
+    """
+    from src.infra.backend.deepagent import create_sandbox_backend_factory
+    from src.infra.backend.e2b import E2BBackend
+
+    monkeypatch.setattr(
+        "src.infra.backend.skills_store.create_skills_backend",
+        lambda **_kw: SimpleNamespace(),
+    )
+
+    backend = E2BBackend(sandbox=_FakeE2BSandbox(_FakeFilesAPI({})))
+    composite = create_sandbox_backend_factory(backend, "asst-1", "user-1")(object())
+
+    assert composite.artifacts_root == backend.work_dir
+    assert composite.artifacts_root != "/"
+
+
+def test_e2b_execute_surfaces_command_stderr_on_failure() -> None:
+    """execute() must surface stderr/stdout from a failed command instead of an
+    empty error string (issue #195 diagnostics)."""
+    from src.infra.backend.e2b import E2BBackend
+
+    class _CmdError(Exception):
+        def __init__(self, message: str, stderr: str, stdout: str = "") -> None:
+            super().__init__(message)
+            self.stderr = stderr
+            self.stdout = stdout
+
+    class _Commands:
+        def run(self, **_kwargs):
+            raise _CmdError("Command exited with code 1", stderr="PermissionError: /")
+
+    sandbox = SimpleNamespace(sandbox_id="e2b-test", commands=_Commands())
+    backend = E2BBackend(sandbox=sandbox)
+
+    result = backend.execute("echo hi")
+
+    assert result.exit_code == -1
+    assert "PermissionError" in result.output
+
+
+def test_e2b_download_files_classifies_directory_error() -> None:
+    """download_files must surface 'is_directory' instead of 'file_not_found'
+    when the path is a directory (issue #196), matching upload_files behavior."""
+    from src.infra.backend.e2b import E2BBackend
+
+    class _FilesAPI:
+        def list(self, path):
+            return []
+
+        def read(self, path, format="bytes"):
+            raise Exception("path /home/user/project is a directory")
+
+    sandbox = SimpleNamespace(sandbox_id="e2b-test", files=_FilesAPI())
+    backend = E2BBackend(sandbox=sandbox)
+
+    responses = backend.download_files(["/home/user/project"])
+
+    assert responses[0].error == "is_directory"
+    assert responses[0].content is None

--- a/tests/infra/backend/test_deepagents_protocol_compat.py
+++ b/tests/infra/backend/test_deepagents_protocol_compat.py
@@ -246,6 +246,27 @@ def test_e2b_download_files_classifies_directory_error() -> None:
     assert responses[0].content is None
 
 
+def test_e2b_download_files_keeps_missing_path_as_file_not_found() -> None:
+    """A conventional missing-path error must not be mistaken for a directory.
+
+    ``No such file or directory`` contains the word ``directory`` but describes
+    an absent path, not a directory passed where a file was expected.
+    """
+    from src.infra.backend.e2b import E2BBackend
+
+    class _FilesAPI:
+        def read(self, path, format="bytes"):
+            raise Exception("[Errno 2] No such file or directory: '/home/user/missing.txt'")
+
+    sandbox = SimpleNamespace(sandbox_id="e2b-test", files=_FilesAPI())
+    backend = E2BBackend(sandbox=sandbox)
+
+    responses = backend.download_files(["/home/user/missing.txt"])
+
+    assert responses[0].error == "file_not_found"
+    assert responses[0].content is None
+
+
 @pytest.mark.asyncio
 async def test_probe_download_error_reads_structured_error() -> None:
     """_probe_download_error surfaces the structured download error so
@@ -267,3 +288,30 @@ async def test_probe_download_error_reads_structured_error() -> None:
     assert await _probe_download_error(_Backend("is_directory"), "/d") == "is_directory"
     assert await _probe_download_error(_Backend("file_not_found"), "/d") == "file_not_found"
     assert await _probe_download_error(_Backend(None), "/d") is None
+
+
+@pytest.mark.asyncio
+async def test_probe_download_error_reuses_the_failed_download_response() -> None:
+    """Directory classification must not download the same path a second time."""
+    from src.infra.tool.reveal_file_tool import (
+        _download_file_from_backend,
+        _probe_download_error,
+    )
+
+    class _Resp:
+        path = "/d"
+        content = None
+        error = "is_directory"
+
+    class _Backend:
+        calls = 0
+
+        async def adownload_files(self, paths):
+            self.calls += 1
+            return [_Resp()]
+
+    backend = _Backend()
+
+    assert await _download_file_from_backend(backend, "/d") is None
+    assert await _probe_download_error(backend, "/d") == "is_directory"
+    assert backend.calls == 1

--- a/tests/infra/memory/test_compaction_agent.py
+++ b/tests/infra/memory/test_compaction_agent.py
@@ -750,12 +750,102 @@ async def test_compaction_model_uses_admin_model_config_id(monkeypatch):
         "NATIVE_MEMORY_COMPACTION_MODEL_ID",
         "model-config-123",
     )
+
+    async def _resolve_valid(reference):  # noqa: ARG001
+        return "model-config-123", None
+
+    monkeypatch.setattr(
+        "src.infra.llm.models_service.resolve_model_reference",
+        _resolve_valid,
+    )
     monkeypatch.setattr(LLMClient, "get_model", fake_get_model)
 
     model = await MemoryCompactionAgent()._get_compaction_model()
 
     assert model == "configured-compaction-model"
     assert calls == [{"model_id": "model-config-123", "temperature": 0.1}]
+
+
+@pytest.mark.asyncio
+async def test_compaction_model_falls_back_when_configured_id_stale(monkeypatch):
+    """A stale/missing compaction model id degrades to the default model.
+
+    Regression test for issue #194: previously the raw id was forwarded
+    straight to ``LLMClient.get_model`` and raised ``model_not_found``,
+    breaking every background + scheduled compaction run.
+    """
+    from src.infra.llm.client import LLMClient
+    from src.infra.memory import compaction_agent as compaction_module
+
+    calls: list[dict] = []
+
+    async def fake_get_model(**kwargs):
+        calls.append(kwargs)
+        return "default-model"
+
+    monkeypatch.setattr(
+        compaction_module.settings,
+        "NATIVE_MEMORY_COMPACTION_MODEL_ID",
+        "stale-uuid",
+    )
+
+    async def _resolve_stale(reference):  # noqa: ARG001
+        # ID not present in available models → resolve degrades to a value,
+        # which for an id-style config is meaningless and must not be used.
+        return None, reference
+
+    monkeypatch.setattr(
+        "src.infra.llm.models_service.resolve_model_reference",
+        _resolve_stale,
+    )
+    monkeypatch.setattr(LLMClient, "get_model", fake_get_model)
+
+    model = await MemoryCompactionAgent()._get_compaction_model()
+
+    assert model == "default-model"
+    # Stale id must not be forwarded as model_id (raises model_not_found) nor
+    # as model (builds an unusable client); the default model is used instead.
+    assert calls == [{"temperature": 0.1}]
+
+
+@pytest.mark.asyncio
+async def test_compaction_model_falls_back_on_authorization_error(monkeypatch, caplog):
+    """An AuthorizationError from the client triggers default-model fallback + warn."""
+    from src.infra.llm.client import LLMClient
+    from src.infra.memory import compaction_agent as compaction_module
+    from src.kernel.exceptions import AuthorizationError
+
+    calls: list[dict] = []
+
+    async def fake_get_model(**kwargs):
+        calls.append(kwargs)
+        if kwargs.get("model_id"):
+            raise AuthorizationError("model_not_found")
+        return "default-model"
+
+    monkeypatch.setattr(
+        compaction_module.settings,
+        "NATIVE_MEMORY_COMPACTION_MODEL_ID",
+        "model-config-123",
+    )
+
+    async def _resolve_valid(reference):  # noqa: ARG001
+        return "model-config-123", None
+
+    monkeypatch.setattr(
+        "src.infra.llm.models_service.resolve_model_reference",
+        _resolve_valid,
+    )
+    monkeypatch.setattr(LLMClient, "get_model", fake_get_model)
+
+    with caplog.at_level("WARNING"):
+        model = await MemoryCompactionAgent()._get_compaction_model()
+
+    assert model == "default-model"
+    assert len(calls) == 2
+    assert calls[0] == {"model_id": "model-config-123", "temperature": 0.1}
+    assert calls[1] == {"temperature": 0.1}
+    assert any("falling back to default" in rec.getMessage() for rec in caplog.records)
 
 
 @pytest.mark.asyncio

--- a/tests/infra/tool/test_mcp_client.py
+++ b/tests/infra/tool/test_mcp_client.py
@@ -230,7 +230,15 @@ def test_normalize_json_array_args_unwraps_array_string() -> None:
             "urls": '["https://a.com", "https://b.com"]',
             "query": "plain string",
             "depth": 2,
-        }
+        },
+        {
+            "type": "object",
+            "properties": {
+                "urls": {"type": "array", "items": {"type": "string"}},
+                "query": {"type": "string"},
+                "depth": {"type": "integer"},
+            },
+        },
     )
     assert out["urls"] == ["https://a.com", "https://b.com"]
     assert out["query"] == "plain string"
@@ -247,6 +255,17 @@ async def test_mcp_arun_retries_streamable_http_and_normalizes_args() -> None:
     class _RecordingTool(BaseTool):
         name: str = "tavily_extract"
         description: str = "extract"
+        args_schema: dict[str, Any] = {
+            "type": "object",
+            "properties": {
+                "urls": {
+                    "anyOf": [
+                        {"type": "array", "items": {"type": "string"}},
+                        {"type": "string"},
+                    ]
+                }
+            },
+        }
 
         def _run(self, *a, **k):
             raise NotImplementedError
@@ -255,11 +274,38 @@ async def test_mcp_arun_retries_streamable_http_and_normalizes_args() -> None:
             received.append(kwargs)
             raise Exception("Streamable HTTP error: Error POSTing to endpoint")
 
-    wrapper = MCPToolWithRetry(
-        original_tool=_RecordingTool(), max_retries=2, retry_delay=0
-    )
+    wrapper = MCPToolWithRetry(original_tool=_RecordingTool(), max_retries=2, retry_delay=0)
     result = await wrapper._arun(urls='["https://x.com"]')
 
     assert len(received) == 2  # retried once after the first failure
     assert received[0]["urls"] == ["https://x.com"]
     assert "Streamable HTTP error" in result
+
+
+@pytest.mark.asyncio
+async def test_mcp_arun_preserves_json_array_text_for_string_arguments() -> None:
+    """JSON-looking text is still valid input for a schema-declared string."""
+    from src.infra.tool.mcp_client import MCPToolWithRetry
+
+    received: list[dict] = []
+
+    class _StringTool(BaseTool):
+        name: str = "string_payload"
+        description: str = "accepts literal JSON text"
+        args_schema: dict[str, Any] = {
+            "type": "object",
+            "properties": {"payload": {"type": "string"}},
+        }
+
+        def _run(self, *a, **k):
+            raise NotImplementedError
+
+        async def _arun(self, *args, config=None, **kwargs):
+            received.append(kwargs)
+            return "ok"
+
+    wrapper = MCPToolWithRetry(original_tool=_StringTool())
+    result = await wrapper._arun(payload='["literal", "json"]')
+
+    assert result == "ok"
+    assert received == [{"payload": '["literal", "json"]'}]

--- a/tests/infra/tool/test_mcp_client.py
+++ b/tests/infra/tool/test_mcp_client.py
@@ -186,3 +186,80 @@ def test_mcp_client_rejects_oversized_file_config_before_open(
     )
 
     assert client._load_config_from_file_sync() is None
+
+
+from langchain_core.tools import BaseTool
+
+
+class _StubTool(BaseTool):
+    name: str = "stub"
+    description: str = "stub"
+
+    def _run(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    async def _arun(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+
+def test_mcp_is_retryable_error_recognizes_streamable_http() -> None:
+    """Streamable HTTP / stream-disconnected errors must be retried (issue #198).
+
+    Previously retryable_patterns omitted these, so SSE reconnect POST failures
+    returned immediately with zero retries.
+    """
+    from src.infra.tool.mcp_client import MCPToolWithRetry
+
+    wrapper = MCPToolWithRetry(original_tool=_StubTool())
+    assert wrapper._is_retryable_error(
+        Exception("Streamable HTTP error: Error POSTing to endpoint: (POST /mcp)")
+    )
+    assert wrapper._is_retryable_error(Exception("GET stream disconnected, reconnecting"))
+
+
+def test_normalize_json_array_args_unwraps_array_string() -> None:
+    """A JSON-array string arg is coerced back to a list (issue #198).
+
+    tavily_extract received urls as a JSON array literal string and the remote
+    server rejected it as an invalid URL format.
+    """
+    from src.infra.tool.mcp_client import _normalize_json_array_args
+
+    out = _normalize_json_array_args(
+        {
+            "urls": '["https://a.com", "https://b.com"]',
+            "query": "plain string",
+            "depth": 2,
+        }
+    )
+    assert out["urls"] == ["https://a.com", "https://b.com"]
+    assert out["query"] == "plain string"
+    assert out["depth"] == 2
+
+
+@pytest.mark.asyncio
+async def test_mcp_arun_retries_streamable_http_and_normalizes_args() -> None:
+    """_arun retries streamable-http errors and passes normalized kwargs (issue #198)."""
+    from src.infra.tool.mcp_client import MCPToolWithRetry
+
+    received: list[dict] = []
+
+    class _RecordingTool(BaseTool):
+        name: str = "tavily_extract"
+        description: str = "extract"
+
+        def _run(self, *a, **k):
+            raise NotImplementedError
+
+        async def _arun(self, *args, config=None, **kwargs):
+            received.append(kwargs)
+            raise Exception("Streamable HTTP error: Error POSTing to endpoint")
+
+    wrapper = MCPToolWithRetry(
+        original_tool=_RecordingTool(), max_retries=2, retry_delay=0
+    )
+    result = await wrapper._arun(urls='["https://x.com"]')
+
+    assert len(received) == 2  # retried once after the first failure
+    assert received[0]["urls"] == ["https://x.com"]
+    assert "Streamable HTTP error" in result

--- a/tests/infra/tool/test_reveal_file_directory.py
+++ b/tests/infra/tool/test_reveal_file_directory.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from src.infra.tool import reveal_file_tool
+
+
+class _SandboxBackend:
+    pass
+
+
+@pytest.mark.asyncio
+async def test_reveal_file_returns_directory_hint_for_sandbox_dir(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """reveal_file on a sandbox directory returns path_is_directory + a hint
+    to use reveal_project, not the generic file_not_found (issue #196)."""
+
+    async def _no_content(backend, file_path):
+        return None
+
+    async def _probe_is_directory(backend, file_path):
+        return "is_directory"
+
+    async def _no_size(backend, file_path):
+        return None
+
+    async def _fake_storage():
+        return SimpleNamespace()
+
+    monkeypatch.setattr(reveal_file_tool, "_is_remote_url", lambda _p: False)
+    monkeypatch.setattr(reveal_file_tool, "_get_storage", _fake_storage)
+    monkeypatch.setattr(
+        reveal_file_tool, "get_backend_from_runtime", lambda _runtime: _SandboxBackend()
+    )
+    monkeypatch.setattr(reveal_file_tool, "_get_backend_file_size", _no_size)
+    monkeypatch.setattr(reveal_file_tool, "_get_reveal_file_upload_max_bytes", lambda: 10**9)
+    monkeypatch.setattr(reveal_file_tool, "_is_sandbox_backend", lambda _backend: True)
+    monkeypatch.setattr(reveal_file_tool, "_download_file_from_backend", _no_content)
+    monkeypatch.setattr(reveal_file_tool, "_probe_download_error", _probe_is_directory)
+
+    result = json.loads(
+        await reveal_file_tool.reveal_file.coroutine(
+            "/home/user/project", description="a dir", runtime=object()
+        )
+    )
+
+    assert result["file"]["error"] == "path_is_directory"
+    assert "reveal_project" in result["file"]["hint"]

--- a/tests/infra/tool/test_scheduled_task_approval.py
+++ b/tests/infra/tool/test_scheduled_task_approval.py
@@ -28,9 +28,7 @@ async def test_confirm_scheduled_task_creation_rejects_in_unattended_session(
 
     monkeypatch.setattr(approval, "create_approval", fail_create)
 
-    result = await approval._confirm_scheduled_task_creation(
-        preview={"name": "t"}, user_id="u1"
-    )
+    result = await approval._confirm_scheduled_task_creation(preview={"name": "t"}, user_id="u1")
 
     assert result["approved"] is False
     assert result["status"] == "unattended"

--- a/tests/infra/tool/test_scheduled_task_approval.py
+++ b/tests/infra/tool/test_scheduled_task_approval.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_confirm_scheduled_task_creation_rejects_in_unattended_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unattended (sch_) sessions skip HITL and reject fast (issue #197).
+
+    Waiting for interactive confirmation in a scheduled-task session always
+    timed out (and MCPToolWithRetry amplified that to ~3x). The fix fails fast.
+    """
+    from src.infra.logging.context import TraceContext
+    from src.infra.tool.scheduled_task import approval
+
+    monkeypatch.setattr(
+        TraceContext,
+        "get_request_context",
+        lambda: SimpleNamespace(session_id="sch_abc123", run_id="r1", user_id="u1"),
+    )
+
+    async def fail_create(*args, **kwargs):
+        raise AssertionError("create_approval must not run in unattended context")
+
+    monkeypatch.setattr(approval, "create_approval", fail_create)
+
+    result = await approval._confirm_scheduled_task_creation(
+        preview={"name": "t"}, user_id="u1"
+    )
+
+    assert result["approved"] is False
+    assert result["status"] == "unattended"
+    assert result["approval_id"] is None
+    assert "unattended" in result["message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_confirm_scheduled_task_creation_proceeds_in_interactive_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Interactive (non-sch_) sessions still go through HITL (issue #197 guard)."""
+    from src.infra.logging.context import TraceContext
+    from src.infra.tool.scheduled_task import approval
+
+    monkeypatch.setattr(
+        TraceContext,
+        "get_request_context",
+        lambda: SimpleNamespace(session_id="interactive-1", run_id="r1", user_id="u1"),
+    )
+    monkeypatch.setattr(approval, "_format_approval_message", lambda _preview: "msg")
+
+    send_called = False
+
+    class _FakeApproval:
+        id = "ap-1"
+
+    async def fake_create(*args, **kwargs):
+        return _FakeApproval()
+
+    async def fake_send(*, approval_id, message, session_id, run_id, timeout):
+        nonlocal send_called
+        send_called = True
+
+    async def fake_wait(*args, **kwargs):
+        return None  # timeout path
+
+    monkeypatch.setattr(approval, "create_approval", fake_create)
+    monkeypatch.setattr(approval, "_send_scheduled_task_approval_event", fake_send)
+    monkeypatch.setattr(approval, "wait_for_response", fake_wait)
+
+    result = await approval._confirm_scheduled_task_creation(
+        preview={"name": "t"}, user_id="u1", timeout=1
+    )
+
+    assert send_called is True
+    assert result["approved"] is False
+    assert result["status"] == "timeout"

--- a/tests/test_dependency_metadata.py
+++ b/tests/test_dependency_metadata.py
@@ -23,3 +23,12 @@ def test_project_dependencies_do_not_reference_local_paths() -> None:
             local_dependencies.append(dependency)
 
     assert local_dependencies == []
+
+
+def test_deepagents_stays_below_legacy_store_removal() -> None:
+    """Legacy list[str] store items require deepagents' pre-0.7 reader."""
+    pyproject = tomllib.loads((PROJECT_ROOT / "pyproject.toml").read_text())
+
+    dependencies = pyproject["project"]["dependencies"]
+
+    assert "deepagents>=0.6.5,<0.7" in dependencies

--- a/uv.lock
+++ b/uv.lock
@@ -1854,7 +1854,7 @@ requires-dist = [
     { name = "colorama", specifier = ">=0.4.6" },
     { name = "cubesandbox", specifier = ">=0.5.0" },
     { name = "daytona", specifier = ">=0.153.0" },
-    { name = "deepagents", specifier = ">=0.6.5" },
+    { name = "deepagents", specifier = ">=0.6.5,<0.7" },
     { name = "deepagents-backends", specifier = ">=0.2.0" },
     { name = "e2b", specifier = ">=2.15.3" },
     { name = "email-validator", specifier = ">=2.3.0" },


### PR DESCRIPTION
基于线上故障日志排查，修复 6 个后台/工具/渠道健壮性 issue + Gemini 经第三方代理挂掉的兜底。
好吧，其实下面好几条更改我都没看懂是什么意思

**新增：**
## #199 E2B 镜像重建（本 PR 已含）
- `scripts/create_e2b_template.py` 的 `SYSTEM_PACKAGES` 加入 `ripgrep` + `librsvg2-bin`（`7f07343d`）
- 已重建 `lambchat-prod` 模板并验证：沙箱内 `rg --version` → ripgrep 14.1.1、`rsvg-convert --version` → 2.60.0，agent 裸 bash 调用不再 command not found

## P0
- **#195** E2B `CompositeBackend` 传 `artifacts_root`，对话历史 offload 不再写不可写的沙箱根目录（34 次 / 7 session PermissionError）

## P1
- **#197** 定时任务 HITL 无人值守（`sch_` session）直接拒绝（不再死等 3×300s）；`wait_for_response` cleanup 移入 finally，杜绝孤儿 Task
- **#194** memory compaction `_get_compaction_model` 复用 `resolve_model_reference` + `AuthorizationError` 兜底（model_not_found 降级默认模型）

## P2
- **#198** `MCPToolWithRetry` 补 streamable http / posting to endpoint / stream disconnected 重试 + URL JSON-array-string 清洗；AI还建议了要做Tavily plan 配额查询，反正我这边是操作不了
- **#196** e2b `download_files` 映射 `is_directory`；reveal_file 探测目录返回 `path_is_directory` + hint（引导用 reveal_project）
- **#200** 飞书 `_health_check_loop` 移除基于业务消息活动时间的误杀判活；抑制 deepagents `list[str]` deprecation warning

## LLM 挂掉兜底
- 三个 provider 加 `timeout=LLM_REQUEST_TIMEOUT`（默认 120s）
- `ModelFallbackMiddleware.awrap_model_call` 用 `asyncio.wait_for` 包裹，hang 时切 fallback（不再永久挂起）
- `_is_retryable_error` 加 `asyncio.TimeoutError`

## 测试
新增 17 个测试，相关套件全绿（3 个失败为本仓库 pre-existing，与本 PR 无关）。

## ⚠️ 仍需 main 配合
- **gemini挂掉真因验证**：换官方 Google API 对比 + py-spy 抓栈（区分代理 bug vs 协议）—— 不做也不影响兜底生效，线上不再挂死
- **#199 部署**：代码与镜像都已就绪，仍需 main 在生产 `.env` 设 `E2B_TEMPLATE=lambchat-prod` + `E2B_API_KEY` + `SANDBOX_PLATFORM=e2b` 并重启后端才生效；docx skill 路径在 MongoDB 仍需 main 分支修改

