### PR TITLE
feat(filetree): 支持在分享对话链接中，下载子文件夹为 ZIP

### DIFF
--- a/frontend/src/components/chat/ChatMessage/items/FileTreeView.tsx
+++ b/frontend/src/components/chat/ChatMessage/items/FileTreeView.tsx
@@ -132,6 +132,27 @@ function downloadFile(
   URL.revokeObjectURL(href);
 }
 
+function collectSubtreeFiles(
+  node: TreeNode,
+  files: Record<string, string>,
+): { textFiles: Record<string, string>; binFiles: Record<string, string> } {
+  const textFiles: Record<string, string> = {};
+  const binFiles: Record<string, string> = {};
+  const walk = (n: TreeNode) => {
+    if (!n.isDir) {
+      if (n.isBinary && n.url) {
+        binFiles[n.path] = n.url;
+      } else if (files[n.path] != null) {
+        textFiles[n.path] = files[n.path];
+      }
+      return;
+    }
+    n.children.forEach(walk);
+  };
+  walk(node);
+  return { textFiles, binFiles };
+}
+
 function FileTreeNode({
   node,
   files,
@@ -148,16 +169,23 @@ function FileTreeNode({
   onFileClick?: (node: TreeNode) => void;
 }) {
   const { t } = useTranslation();
+  const [isDownloading, setIsDownloading] = useState(false);
+  const { textFiles, binFiles } = useMemo(
+    () => collectSubtreeFiles(node, files),
+    [node, files],
+  );
   if (node.isDir) {
     const expanded = expandedDirs.has(node.path);
     const dirSize = expanded
       ? node.children.reduce((sum, c) => sum + (c.size || 0), 0)
       : 0;
+    const hasFiles =
+      Object.keys(textFiles).length + Object.keys(binFiles).length > 0;
     return (
       <div>
         <button
           onClick={() => toggleDir(node.path)}
-          className="flex items-center gap-3 w-full px-3 py-2.5 rounded-xl hover:bg-theme-bg-subtle transition-colors"
+          className="flex items-center gap-3 w-full px-3 py-2.5 rounded-xl hover:bg-theme-bg-subtle transition-colors group"
         >
           <FolderIcon size={36} className="shrink-0" />
           <div className="flex-1 min-w-0 text-left">
@@ -170,6 +198,27 @@ function FileTreeNode({
               </div>
             )}
           </div>
+          {hasFiles && (
+            <span
+              onClick={async (e) => {
+                e.stopPropagation();
+                if (isDownloading) return;
+                try {
+                  setIsDownloading(true);
+                  await exportProjectZip(textFiles, node.name, binFiles);
+                } finally {
+                  setIsDownloading(false);
+                }
+              }}
+              title={t("project.downloadFolder")}
+              className={clsx(
+                "shrink-0 p-1.5 rounded-lg text-theme-text-tertiary hover:text-theme-text-secondary hover:bg-theme-bg-subtle opacity-0 group-hover:opacity-100 transition-all",
+                isDownloading && "opacity-50 pointer-events-none",
+              )}
+            >
+              <Download size={18} />
+            </span>
+          )}
           <ChevronRight
             size={18}
             className={clsx(

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1917,6 +1917,7 @@
     "exitFullscreen": "Exit fullscreen",
     "expand": "Expand",
     "exportZip": "Export ZIP",
+    "downloadFolder": "Download folder as ZIP",
     "fileCount": "{{count}} files",
     "fullscreen": "Fullscreen",
     "fullscreenHint": "Press Esc to exit fullscreen",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1917,6 +1917,7 @@
     "exitFullscreen": "全画面を終了",
     "expand": "展開",
     "exportZip": "ZIPエクスポート",
+    "downloadFolder": "フォルダを ZIP でダウンロード",
     "fileCount": "{{count}}ファイル",
     "fullscreen": "全画面",
     "fullscreenHint": "Esc を押して全画面を終了",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1917,6 +1917,7 @@
     "exitFullscreen": "전체 화면 종료",
     "expand": "펼치기",
     "exportZip": "ZIP 내보내기",
+    "downloadFolder": "폴더를 ZIP으로 다운로드",
     "fileCount": "{{count}}개 파일",
     "fullscreen": "전체 화면",
     "fullscreenHint": "Esc를 눌러 전체 화면 종료",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1917,6 +1917,7 @@
     "exitFullscreen": "Выйти из полноэкранного режима",
     "expand": "Развернуть",
     "exportZip": "Экспорт ZIP",
+    "downloadFolder": "Скачать папку как ZIP",
     "fileCount": "{{count}} файлов",
     "fullscreen": "Полный экран",
     "fullscreenHint": "Нажмите Esc для выхода из полноэкранного режима",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -1917,6 +1917,7 @@
     "exitFullscreen": "退出全屏",
     "expand": "展开",
     "exportZip": "导出 ZIP",
+    "downloadFolder": "下载此文件夹为 ZIP",
     "fileCount": "{{count}} 个文件",
     "fullscreen": "全屏",
     "fullscreenHint": "按 Esc 退出全屏",


### PR DESCRIPTION
文件树预览（FileTreeView）此前只能下载整个项目或单个文件，不能单独下载某个
子文件夹。在目录节点加 hover 下载按钮，收集该子目录所有后代文件（文本从 files
prop、二进制从 node.url）后复用 exportProjectZip 打包为 zip。

- 新增纯函数 collectSubtreeFiles（DFS，免透传 binaryFiles prop）
- 目录行加 group + Download span（复用文件行样式，isDownloading 防重复点击）
- zip 内保持原路径、用目录名命名；空目录不渲染按钮（防御）
- i18n 新增 project.downloadFolder（en/zh/ja/ko/ru）
- 仅改 FileTreeView.tsx + 5 locale，零新依赖，不动其它组件
- 分享页与主聊天共用 FileTreeView，自动两边生效