### PR TITLE
feat(file-panel): 全部文件面板支持文件夹下载 + 一键下载全部 (#201)

### DIFF
--- a/frontend/src/components/chat/ChatMessage/RevealArtifactsSummary.tsx
+++ b/frontend/src/components/chat/ChatMessage/RevealArtifactsSummary.tsx
@@ -82,6 +82,15 @@ function downloadFile(name: string, url?: string) {
   a.click();
 }
 
+function getDownloadFailureMessage(
+  baseMessage: string,
+  error: unknown,
+): string {
+  return error instanceof Error && error.message
+    ? `${baseMessage}: ${error.message}`
+    : baseMessage;
+}
+
 function getTreeDirSize(node: RevealArtifactTreeDir): number {
   return node.children.reduce((sum, child) => {
     if (child.kind === "file") {
@@ -259,8 +268,13 @@ function TreeDirRow({
                 await exportProjectZip({}, node.name, binaryFiles, {
                   failOnBinaryError: true,
                 });
-              } catch {
-                toast.error(t("chat.message.downloadFailed", "下载失败"));
+              } catch (error) {
+                toast.error(
+                  getDownloadFailureMessage(
+                    t("chat.message.downloadFailed", "下载失败"),
+                    error,
+                  ),
+                );
               } finally {
                 setIsDownloading(false);
               }
@@ -447,8 +461,13 @@ function DownloadAllButton({ artifacts }: { artifacts: RevealArtifact[] }) {
             binaryFiles,
             { failOnBinaryError: true },
           );
-        } catch {
-          toast.error(t("chat.message.downloadFailed", "下载失败"));
+        } catch (error) {
+          toast.error(
+            getDownloadFailureMessage(
+              t("chat.message.downloadFailed", "下载失败"),
+              error,
+            ),
+          );
         } finally {
           setIsDownloading(false);
         }

--- a/frontend/src/components/chat/ChatMessage/RevealArtifactsSummary.tsx
+++ b/frontend/src/components/chat/ChatMessage/RevealArtifactsSummary.tsx
@@ -1,6 +1,14 @@
 import { type ReactNode, useCallback, useMemo, useState } from "react";
-import { FolderTree, Code2, ChevronRight, Download, Copy, Loader2 } from "lucide-react";
+import {
+  FolderTree,
+  Code2,
+  ChevronRight,
+  Download,
+  Copy,
+  Loader2,
+} from "lucide-react";
 import clsx from "clsx";
+import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import type { MessagePart } from "../../../types";
 import { getFileTypeInfo, isImageFile } from "../../documents/utils";
@@ -9,6 +17,7 @@ import { openPersistentToolPanel } from "./items/persistentToolPanelState";
 import type { RevealPreviewOpenSource } from "./items/revealPreviewState";
 import type { RevealPreviewRequest } from "./items/revealPreviewData";
 import {
+  buildRevealArtifactBinaryFiles,
   buildRevealArtifactTree,
   collectRevealArtifacts,
   getRevealArtifactStats,
@@ -84,14 +93,11 @@ function getTreeDirSize(node: RevealArtifactTreeDir): number {
 
 function collectSubtreeFiles(
   node: RevealArtifactTreeDir,
-): { path: string; url?: string }[] {
-  const out: { path: string; url?: string }[] = [];
+): (RevealArtifact & { kind: "file" })[] {
+  const out: (RevealArtifact & { kind: "file" })[] = [];
   for (const child of node.children) {
     if (child.kind === "file") {
-      out.push({
-        path: child.artifact.path,
-        url: child.artifact.preview.signedUrl,
-      });
+      out.push(child.artifact);
     } else {
       out.push(...collectSubtreeFiles(child));
     }
@@ -202,59 +208,74 @@ function TreeDirRow({
   const [expanded, setExpanded] = useState(defaultExpanded ?? false);
   const [isDownloading, setIsDownloading] = useState(false);
   const dirSize = expanded ? getTreeDirSize(node) : 0;
+  const { binaryFiles, skippedCount } = useMemo(
+    () => buildRevealArtifactBinaryFiles(collectSubtreeFiles(node)),
+    [node],
+  );
+  const hasDownloadableFiles = Object.keys(binaryFiles).length > 0;
 
   return (
     <div>
-      <button
-        type="button"
-        onClick={() => setExpanded((v) => !v)}
-        className="flex items-center gap-3 w-full px-3 py-2.5 rounded-xl hover:bg-stone-50 dark:hover:bg-stone-800/60 transition-colors group"
-      >
-        <FolderIcon size={36} className="shrink-0" />
-        <div className="flex-1 min-w-0 text-left">
-          <div className="text-sm font-medium text-stone-800 dark:text-stone-200 truncate">
-            {node.name}
-          </div>
-          {expanded && dirSize > 0 && (
-            <div className="text-xs text-stone-400 dark:text-stone-500 mt-0.5">
-              {formatSize(dirSize)}
-            </div>
-          )}
-        </div>
-        <span
-          onClick={async (e) => {
-            e.stopPropagation();
-            if (isDownloading) return;
-            const collected = collectSubtreeFiles(node);
-            if (collected.length === 0) return;
-            const binaryFiles: Record<string, string> = {};
-            for (const f of collected) {
-              if (f.url) binaryFiles[f.path] = f.url;
-            }
-            try {
-              setIsDownloading(true);
-              await exportProjectZip({}, node.name, binaryFiles);
-            } finally {
-              setIsDownloading(false);
-            }
-          }}
-          title={t("project.exportZip")}
-          className="shrink-0 p-1.5 rounded-lg text-stone-400 hover:text-stone-600 dark:hover:text-stone-300 hover:bg-stone-100 dark:hover:bg-stone-700 opacity-0 group-hover:opacity-100 transition-all"
+      <div className="flex items-center gap-3 w-full px-3 py-2.5 rounded-xl hover:bg-stone-50 dark:hover:bg-stone-800/60 transition-colors group">
+        <button
+          type="button"
+          aria-expanded={expanded}
+          onClick={() => setExpanded((v) => !v)}
+          className="flex min-w-0 flex-1 items-center gap-3 text-left"
         >
-          {isDownloading ? (
-            <Loader2 size={18} className="animate-spin" />
-          ) : (
-            <Download size={18} />
-          )}
-        </span>
-        <ChevronRight
-          size={18}
-          className={clsx(
-            "shrink-0 text-stone-400 transition-transform duration-200",
-            expanded && "rotate-90",
-          )}
-        />
-      </button>
+          <FolderIcon size={36} className="shrink-0" />
+          <div className="flex-1 min-w-0">
+            <div className="text-sm font-medium text-stone-800 dark:text-stone-200 truncate">
+              {node.name}
+            </div>
+            {expanded && dirSize > 0 && (
+              <div className="text-xs text-stone-400 dark:text-stone-500 mt-0.5">
+                {formatSize(dirSize)}
+              </div>
+            )}
+          </div>
+          <ChevronRight
+            size={18}
+            className={clsx(
+              "shrink-0 text-stone-400 transition-transform duration-200",
+              expanded && "rotate-90",
+            )}
+          />
+        </button>
+        {hasDownloadableFiles && (
+          <button
+            type="button"
+            aria-label={`${t("project.exportZip")}: ${node.name}`}
+            aria-busy={isDownloading}
+            disabled={isDownloading}
+            onClick={async () => {
+              if (isDownloading) return;
+              if (skippedCount > 0) {
+                toast.error(t("chat.message.downloadFailed", "下载失败"));
+                return;
+              }
+              try {
+                setIsDownloading(true);
+                await exportProjectZip({}, node.name, binaryFiles, {
+                  failOnBinaryError: true,
+                });
+              } catch {
+                toast.error(t("chat.message.downloadFailed", "下载失败"));
+              } finally {
+                setIsDownloading(false);
+              }
+            }}
+            title={t("project.exportZip")}
+            className="shrink-0 rounded-lg p-1.5 text-stone-400 opacity-100 transition-all hover:bg-stone-100 hover:text-stone-600 disabled:pointer-events-none disabled:opacity-50 dark:hover:bg-stone-700 dark:hover:text-stone-300 sm:opacity-0 sm:group-hover:opacity-100 sm:focus-visible:opacity-100"
+          >
+            {isDownloading ? (
+              <Loader2 size={18} className="animate-spin" />
+            ) : (
+              <Download size={18} />
+            )}
+          </button>
+        )}
+      </div>
       {expanded && (
         <div className={clsx(depth === 0 ? "pl-2" : "pl-4")}>
           {node.children.map((child, i) =>
@@ -399,6 +420,54 @@ function getRevealArtifactImagePreviewItems(
   });
 }
 
+function DownloadAllButton({ artifacts }: { artifacts: RevealArtifact[] }) {
+  const { t } = useTranslation();
+  const [isDownloading, setIsDownloading] = useState(false);
+  const { binaryFiles, skippedCount } = useMemo(
+    () => buildRevealArtifactBinaryFiles(artifacts),
+    [artifacts],
+  );
+
+  if (Object.keys(binaryFiles).length === 0) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={async () => {
+        if (isDownloading) return;
+        if (skippedCount > 0) {
+          toast.error(t("chat.message.downloadFailed", "下载失败"));
+          return;
+        }
+        try {
+          setIsDownloading(true);
+          await exportProjectZip(
+            {},
+            t("chat.message.allFiles", "全部文件"),
+            binaryFiles,
+            { failOnBinaryError: true },
+          );
+        } catch {
+          toast.error(t("chat.message.downloadFailed", "下载失败"));
+        } finally {
+          setIsDownloading(false);
+        }
+      }}
+      disabled={isDownloading}
+      aria-busy={isDownloading}
+      className="flex items-center gap-1 rounded-md px-2 py-0.5 text-[11px] font-medium text-[var(--theme-text-secondary)] hover:bg-[var(--theme-bg-subtle)] transition-colors disabled:opacity-50"
+      title={t("chat.message.downloadAll", "下载全部")}
+    >
+      {isDownloading ? (
+        <Loader2 size={12} className="animate-spin" />
+      ) : (
+        <Download size={12} />
+      )}
+      {t("chat.message.downloadAll", "下载全部")}
+    </button>
+  );
+}
+
 /* ------------------------------------------------------------------ */
 /*  Main component                                                     */
 /* ------------------------------------------------------------------ */
@@ -422,7 +491,6 @@ export function RevealArtifactsSummary({
   const [activeImagePreviewId, setActiveImagePreviewId] = useState<
     string | null
   >(null);
-  const [isDownloadingAll, setIsDownloadingAll] = useState(false);
 
   const fileTree = useMemo(
     () =>
@@ -477,28 +545,6 @@ export function RevealArtifactsSummary({
     }
   }, [nextImageItem]);
 
-  const handleDownloadAll = async () => {
-    if (isDownloadingAll) return;
-    const fileArtifacts = artifacts.filter(
-      (a): a is RevealArtifact & { kind: "file" } => a.kind === "file",
-    );
-    if (fileArtifacts.length === 0) return;
-    const binaryFiles: Record<string, string> = {};
-    for (const a of fileArtifacts) {
-      if (a.preview.signedUrl) binaryFiles[a.path] = a.preview.signedUrl;
-    }
-    try {
-      setIsDownloadingAll(true);
-      await exportProjectZip(
-        {},
-        t("chat.message.allFiles", "全部文件"),
-        binaryFiles,
-      );
-    } finally {
-      setIsDownloadingAll(false);
-    }
-  };
-
   if (isStreaming || artifacts.length === 0) {
     return null;
   }
@@ -519,22 +565,7 @@ export function RevealArtifactsSummary({
                 {subtitle}
               </span>
               <div className="flex items-center gap-2">
-                {stats.fileCount > 0 && (
-                  <button
-                    type="button"
-                    onClick={handleDownloadAll}
-                    disabled={isDownloadingAll}
-                    className="flex items-center gap-1 rounded-md px-2 py-0.5 text-[11px] font-medium text-[var(--theme-text-secondary)] hover:bg-[var(--theme-bg-subtle)] transition-colors disabled:opacity-50"
-                    title={t("chat.message.downloadAll", "下载全部")}
-                  >
-                    {isDownloadingAll ? (
-                      <Loader2 size={12} className="animate-spin" />
-                    ) : (
-                      <Download size={12} />
-                    )}
-                    {t("chat.message.downloadAll", "下载全部")}
-                  </button>
-                )}
+                <DownloadAllButton artifacts={artifacts} />
                 <span className="shrink-0 rounded-md bg-[var(--theme-primary)]/10 px-2 py-0.5 text-[11px] font-bold tabular-nums text-[var(--theme-primary)]">
                   {stats.totalCount}
                 </span>

--- a/frontend/src/components/chat/ChatMessage/RevealArtifactsSummary.tsx
+++ b/frontend/src/components/chat/ChatMessage/RevealArtifactsSummary.tsx
@@ -217,7 +217,7 @@ function TreeDirRow({
   const [expanded, setExpanded] = useState(defaultExpanded ?? false);
   const [isDownloading, setIsDownloading] = useState(false);
   const dirSize = expanded ? getTreeDirSize(node) : 0;
-  const { binaryFiles, skippedCount } = useMemo(
+  const { binaryFiles, skippedCount, skippedPaths } = useMemo(
     () => buildRevealArtifactBinaryFiles(collectSubtreeFiles(node)),
     [node],
   );
@@ -260,7 +260,12 @@ function TreeDirRow({
             onClick={async () => {
               if (isDownloading) return;
               if (skippedCount > 0) {
-                toast.error(t("chat.message.downloadFailed", "下载失败"));
+                toast.error(
+                  `${t(
+                    "chat.message.downloadFailed",
+                    "下载失败",
+                  )}: ${skippedPaths.join(", ")}`,
+                );
                 return;
               }
               try {
@@ -437,7 +442,7 @@ function getRevealArtifactImagePreviewItems(
 function DownloadAllButton({ artifacts }: { artifacts: RevealArtifact[] }) {
   const { t } = useTranslation();
   const [isDownloading, setIsDownloading] = useState(false);
-  const { binaryFiles, skippedCount } = useMemo(
+  const { binaryFiles, skippedCount, skippedPaths } = useMemo(
     () => buildRevealArtifactBinaryFiles(artifacts),
     [artifacts],
   );
@@ -450,7 +455,12 @@ function DownloadAllButton({ artifacts }: { artifacts: RevealArtifact[] }) {
       onClick={async () => {
         if (isDownloading) return;
         if (skippedCount > 0) {
-          toast.error(t("chat.message.downloadFailed", "下载失败"));
+          toast.error(
+            `${t(
+              "chat.message.downloadFailed",
+              "下载失败",
+            )}: ${skippedPaths.join(", ")}`,
+          );
           return;
         }
         try {

--- a/frontend/src/components/chat/ChatMessage/RevealArtifactsSummary.tsx
+++ b/frontend/src/components/chat/ChatMessage/RevealArtifactsSummary.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useCallback, useMemo, useState } from "react";
-import { FolderTree, Code2, ChevronRight, Download, Copy } from "lucide-react";
+import { FolderTree, Code2, ChevronRight, Download, Copy, Loader2 } from "lucide-react";
 import clsx from "clsx";
 import { useTranslation } from "react-i18next";
 import type { MessagePart } from "../../../types";
@@ -18,6 +18,7 @@ import {
 } from "./revealArtifacts";
 import { ImageWithSkeleton } from "./ImageWithSkeleton";
 import { copyToClipboard } from "../../../utils/clipboard";
+import { exportProjectZip } from "../../../utils/exportProjectZip";
 
 function FolderIcon({
   size = 36,
@@ -79,6 +80,23 @@ function getTreeDirSize(node: RevealArtifactTreeDir): number {
     }
     return sum + getTreeDirSize(child);
   }, 0);
+}
+
+function collectSubtreeFiles(
+  node: RevealArtifactTreeDir,
+): { path: string; url?: string }[] {
+  const out: { path: string; url?: string }[] = [];
+  for (const child of node.children) {
+    if (child.kind === "file") {
+      out.push({
+        path: child.artifact.path,
+        url: child.artifact.preview.signedUrl,
+      });
+    } else {
+      out.push(...collectSubtreeFiles(child));
+    }
+  }
+  return out;
 }
 
 function getFileIcon(name: string) {
@@ -180,7 +198,9 @@ function TreeDirRow({
   ) => boolean;
   onOpenImagePreview?: (artifact: RevealArtifact & { kind: "file" }) => void;
 }) {
+  const { t } = useTranslation();
   const [expanded, setExpanded] = useState(defaultExpanded ?? false);
+  const [isDownloading, setIsDownloading] = useState(false);
   const dirSize = expanded ? getTreeDirSize(node) : 0;
 
   return (
@@ -188,7 +208,7 @@ function TreeDirRow({
       <button
         type="button"
         onClick={() => setExpanded((v) => !v)}
-        className="flex items-center gap-3 w-full px-3 py-2.5 rounded-xl hover:bg-stone-50 dark:hover:bg-stone-800/60 transition-colors"
+        className="flex items-center gap-3 w-full px-3 py-2.5 rounded-xl hover:bg-stone-50 dark:hover:bg-stone-800/60 transition-colors group"
       >
         <FolderIcon size={36} className="shrink-0" />
         <div className="flex-1 min-w-0 text-left">
@@ -201,6 +221,32 @@ function TreeDirRow({
             </div>
           )}
         </div>
+        <span
+          onClick={async (e) => {
+            e.stopPropagation();
+            if (isDownloading) return;
+            const collected = collectSubtreeFiles(node);
+            if (collected.length === 0) return;
+            const binaryFiles: Record<string, string> = {};
+            for (const f of collected) {
+              if (f.url) binaryFiles[f.path] = f.url;
+            }
+            try {
+              setIsDownloading(true);
+              await exportProjectZip({}, node.name, binaryFiles);
+            } finally {
+              setIsDownloading(false);
+            }
+          }}
+          title={t("project.exportZip")}
+          className="shrink-0 p-1.5 rounded-lg text-stone-400 hover:text-stone-600 dark:hover:text-stone-300 hover:bg-stone-100 dark:hover:bg-stone-700 opacity-0 group-hover:opacity-100 transition-all"
+        >
+          {isDownloading ? (
+            <Loader2 size={18} className="animate-spin" />
+          ) : (
+            <Download size={18} />
+          )}
+        </span>
         <ChevronRight
           size={18}
           className={clsx(
@@ -376,6 +422,7 @@ export function RevealArtifactsSummary({
   const [activeImagePreviewId, setActiveImagePreviewId] = useState<
     string | null
   >(null);
+  const [isDownloadingAll, setIsDownloadingAll] = useState(false);
 
   const fileTree = useMemo(
     () =>
@@ -430,6 +477,28 @@ export function RevealArtifactsSummary({
     }
   }, [nextImageItem]);
 
+  const handleDownloadAll = async () => {
+    if (isDownloadingAll) return;
+    const fileArtifacts = artifacts.filter(
+      (a): a is RevealArtifact & { kind: "file" } => a.kind === "file",
+    );
+    if (fileArtifacts.length === 0) return;
+    const binaryFiles: Record<string, string> = {};
+    for (const a of fileArtifacts) {
+      if (a.preview.signedUrl) binaryFiles[a.path] = a.preview.signedUrl;
+    }
+    try {
+      setIsDownloadingAll(true);
+      await exportProjectZip(
+        {},
+        t("chat.message.allFiles", "全部文件"),
+        binaryFiles,
+      );
+    } finally {
+      setIsDownloadingAll(false);
+    }
+  };
+
   if (isStreaming || artifacts.length === 0) {
     return null;
   }
@@ -449,9 +518,27 @@ export function RevealArtifactsSummary({
               <span className="text-[11px] font-medium text-[var(--theme-text-secondary)]">
                 {subtitle}
               </span>
-              <span className="shrink-0 rounded-md bg-[var(--theme-primary)]/10 px-2 py-0.5 text-[11px] font-bold tabular-nums text-[var(--theme-primary)]">
-                {stats.totalCount}
-              </span>
+              <div className="flex items-center gap-2">
+                {stats.fileCount > 0 && (
+                  <button
+                    type="button"
+                    onClick={handleDownloadAll}
+                    disabled={isDownloadingAll}
+                    className="flex items-center gap-1 rounded-md px-2 py-0.5 text-[11px] font-medium text-[var(--theme-text-secondary)] hover:bg-[var(--theme-bg-subtle)] transition-colors disabled:opacity-50"
+                    title={t("chat.message.downloadAll", "下载全部")}
+                  >
+                    {isDownloadingAll ? (
+                      <Loader2 size={12} className="animate-spin" />
+                    ) : (
+                      <Download size={12} />
+                    )}
+                    {t("chat.message.downloadAll", "下载全部")}
+                  </button>
+                )}
+                <span className="shrink-0 rounded-md bg-[var(--theme-primary)]/10 px-2 py-0.5 text-[11px] font-bold tabular-nums text-[var(--theme-primary)]">
+                  {stats.totalCount}
+                </span>
+              </div>
             </div>
           </div>
           <div className="flex-1 overflow-y-auto p-1.5">

--- a/frontend/src/components/chat/ChatMessage/__tests__/revealArtifacts.test.ts
+++ b/frontend/src/components/chat/ChatMessage/__tests__/revealArtifacts.test.ts
@@ -1,9 +1,73 @@
 import {
+  buildRevealArtifactBinaryFiles,
   buildRevealArtifactTree,
   collectRevealArtifacts,
   getRevealArtifactStats,
   type RevealArtifact,
 } from "../revealArtifacts.ts";
+
+test("builds safe unique ZIP paths and skips files without a signed URL", () => {
+  const artifacts: RevealArtifact[] = [
+    {
+      kind: "file",
+      id: "file:first-report",
+      name: "Report.pdf",
+      path: "https://files.example.test/first/report.pdf",
+      fileSize: 10,
+      preview: {
+        kind: "file",
+        previewKey: "first-report",
+        filePath: "https://files.example.test/first/report.pdf",
+        signedUrl: "/api/upload/file/first-report",
+      },
+    },
+    {
+      kind: "file",
+      id: "file:second-report",
+      name: "report.pdf",
+      path: "https://files.example.test/second/report.pdf",
+      fileSize: 20,
+      preview: {
+        kind: "file",
+        previewKey: "second-report",
+        filePath: "https://files.example.test/second/report.pdf",
+        signedUrl: "/api/upload/file/second-report",
+      },
+    },
+    {
+      kind: "file",
+      id: "file:windows-path",
+      name: "notes.txt",
+      path: "C:\\workspace\\notes.txt",
+      preview: {
+        kind: "file",
+        previewKey: "windows-path",
+        filePath: "C:\\workspace\\notes.txt",
+        signedUrl: "/api/upload/file/notes",
+      },
+    },
+    {
+      kind: "file",
+      id: "file:missing-url",
+      name: "missing.txt",
+      path: "/workspace/missing.txt",
+      preview: {
+        kind: "file",
+        previewKey: "missing-url",
+        filePath: "/workspace/missing.txt",
+      },
+    },
+  ];
+
+  expect(buildRevealArtifactBinaryFiles(artifacts)).toEqual({
+    binaryFiles: {
+      "Report.pdf": "/api/upload/file/first-report",
+      "report (2).pdf": "/api/upload/file/second-report",
+      "workspace/notes.txt": "/api/upload/file/notes",
+    },
+    skippedCount: 1,
+  });
+});
 
 test("collects successful file and project reveal artifacts from current message parts", () => {
   const artifacts = collectRevealArtifacts([

--- a/frontend/src/components/chat/ChatMessage/__tests__/revealArtifacts.test.ts
+++ b/frontend/src/components/chat/ChatMessage/__tests__/revealArtifacts.test.ts
@@ -66,6 +66,7 @@ test("builds safe unique ZIP paths and skips files without a signed URL", () => 
       "workspace/notes.txt": "/api/upload/file/notes",
     },
     skippedCount: 1,
+    skippedPaths: ["/workspace/missing.txt"],
   });
 });
 
@@ -103,6 +104,7 @@ test("sanitizes unsafe fallback names with the same ZIP path rules", () => {
       "file (2)": "/api/upload/file/unsafe-control",
     },
     skippedCount: 0,
+    skippedPaths: [],
   });
 });
 

--- a/frontend/src/components/chat/ChatMessage/__tests__/revealArtifacts.test.ts
+++ b/frontend/src/components/chat/ChatMessage/__tests__/revealArtifacts.test.ts
@@ -69,6 +69,43 @@ test("builds safe unique ZIP paths and skips files without a signed URL", () => 
   });
 });
 
+test("sanitizes unsafe fallback names with the same ZIP path rules", () => {
+  const artifacts: RevealArtifact[] = [
+    {
+      kind: "file",
+      id: "file:unsafe-dot-dot",
+      name: "..",
+      path: "https://files.example.test/no-safe-name",
+      preview: {
+        kind: "file",
+        previewKey: "unsafe-dot-dot",
+        filePath: "https://files.example.test/no-safe-name",
+        signedUrl: "/api/upload/file/unsafe-dot-dot",
+      },
+    },
+    {
+      kind: "file",
+      id: "file:unsafe-control",
+      name: "\0",
+      path: "https://files.example.test/control",
+      preview: {
+        kind: "file",
+        previewKey: "unsafe-control",
+        filePath: "https://files.example.test/control",
+        signedUrl: "/api/upload/file/unsafe-control",
+      },
+    },
+  ];
+
+  expect(buildRevealArtifactBinaryFiles(artifacts)).toEqual({
+    binaryFiles: {
+      file: "/api/upload/file/unsafe-dot-dot",
+      "file (2)": "/api/upload/file/unsafe-control",
+    },
+    skippedCount: 0,
+  });
+});
+
 test("collects successful file and project reveal artifacts from current message parts", () => {
   const artifacts = collectRevealArtifacts([
     {

--- a/frontend/src/components/chat/ChatMessage/__tests__/revealArtifactsDownload.test.tsx
+++ b/frontend/src/components/chat/ChatMessage/__tests__/revealArtifactsDownload.test.tsx
@@ -206,7 +206,9 @@ test("does not silently create a partial ZIP when one signed URL is missing", as
   fireEvent.click(screen.getByRole("button", { name: "Download all" }));
 
   await waitFor(() => {
-    expect(mocks.toastError).toHaveBeenCalledWith("Download failed");
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      "Download failed: /workspace/missing.txt",
+    );
   });
   expect(mocks.exportProjectZip).not.toHaveBeenCalled();
 });

--- a/frontend/src/components/chat/ChatMessage/__tests__/revealArtifactsDownload.test.tsx
+++ b/frontend/src/components/chat/ChatMessage/__tests__/revealArtifactsDownload.test.tsx
@@ -1,0 +1,210 @@
+/** @vitest-environment jsdom */
+
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, expect, test, vi } from "vitest";
+import type { MessagePart } from "../../../../types";
+
+const mocks = vi.hoisted(() => ({
+  exportProjectZip: vi.fn(),
+  openPersistentToolPanel: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock("../items/persistentToolPanelState", () => ({
+  openPersistentToolPanel: mocks.openPersistentToolPanel,
+}));
+vi.mock("../../../../utils/exportProjectZip", () => ({
+  exportProjectZip: mocks.exportProjectZip,
+}));
+vi.mock("react-hot-toast", () => ({
+  default: { error: mocks.toastError },
+}));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | Record<string, unknown>) => {
+      const translations: Record<string, string> = {
+        "chat.message.allFiles": "All files",
+        "chat.message.artifactsSubtitleFiles": "1 file",
+        "chat.message.copy": "Copy",
+        "chat.message.downloadAll": "Download all",
+        "chat.message.downloadFailed": "Download failed",
+        "chat.message.files": "Files",
+        "project.exportZip": "Export ZIP",
+        "project.preview": "Preview",
+      };
+      return (
+        translations[key] ?? (typeof fallback === "string" ? fallback : key)
+      );
+    },
+  }),
+}));
+vi.mock("../../../common", () => ({ ImageViewer: () => null }));
+vi.mock("../ImageWithSkeleton", () => ({
+  ImageWithSkeleton: ({ alt }: { alt: string }) => <span>{alt}</span>,
+}));
+
+import { RevealArtifactsSummary } from "../RevealArtifactsSummary";
+
+function filePart(input: {
+  id: string;
+  name: string;
+  path: string;
+  signedUrl?: string;
+}): MessagePart {
+  return {
+    type: "artifact",
+    success: true,
+    artifact: {
+      kind: "file",
+      id: input.id,
+      name: input.name,
+      path: input.path,
+      preview: {
+        kind: "file",
+        previewKey: input.id,
+        filePath: input.path,
+        signedUrl: input.signedUrl,
+      },
+    },
+  };
+}
+
+function openAllFilesPanel(parts: MessagePart[]): void {
+  render(<RevealArtifactsSummary parts={parts} />);
+  fireEvent.click(screen.getByText("All files").closest('[role="button"]')!);
+  const panel = mocks.openPersistentToolPanel.mock.calls.at(-1)?.[0] as
+    | { children: ReactNode }
+    | undefined;
+  if (!panel) throw new Error("All files panel did not open");
+  render(<>{panel.children}</>);
+}
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+test("download-all state lives in the mounted panel and blocks duplicate clicks", async () => {
+  let finishDownload: (() => void) | undefined;
+  mocks.exportProjectZip.mockImplementation(
+    () =>
+      new Promise<void>((resolve) => {
+        finishDownload = resolve;
+      }),
+  );
+  openAllFilesPanel([
+    filePart({
+      id: "file:report",
+      name: "report.pdf",
+      path: "/workspace/report.pdf",
+      signedUrl: "/api/upload/file/report",
+    }),
+  ]);
+
+  const downloadAll = screen.getByRole("button", { name: "Download all" });
+  fireEvent.click(downloadAll);
+
+  expect(mocks.exportProjectZip).toHaveBeenCalledTimes(1);
+  expect(downloadAll).toBeDisabled();
+  fireEvent.click(downloadAll);
+  expect(mocks.exportProjectZip).toHaveBeenCalledTimes(1);
+
+  await act(async () => finishDownload?.());
+  expect(downloadAll).toBeEnabled();
+});
+
+test("folder downloads are real buttons and do not toggle the folder", () => {
+  mocks.exportProjectZip.mockResolvedValue(undefined);
+  openAllFilesPanel([
+    filePart({
+      id: "file:report",
+      name: "report.pdf",
+      path: "/workspace/folder/report.pdf",
+      signedUrl: "/api/upload/file/report",
+    }),
+  ]);
+
+  fireEvent.click(screen.getByRole("button", { name: "workspace" }));
+  const folderDownload = screen.getByRole("button", {
+    name: "Export ZIP: folder",
+  });
+  expect(screen.queryByText("report.pdf")).not.toBeInTheDocument();
+
+  fireEvent.click(folderDownload);
+
+  expect(screen.queryByText("report.pdf")).not.toBeInTheDocument();
+  expect(mocks.exportProjectZip).toHaveBeenCalledTimes(1);
+});
+
+test("does not offer ZIP actions when revealed files have no signed URL", () => {
+  openAllFilesPanel([
+    filePart({
+      id: "file:missing",
+      name: "missing.txt",
+      path: "/workspace/folder/missing.txt",
+    }),
+  ]);
+
+  expect(
+    screen.queryByRole("button", { name: "Download all" }),
+  ).not.toBeInTheDocument();
+  fireEvent.click(screen.getByRole("button", { name: "workspace" }));
+  expect(
+    screen.queryByRole("button", { name: "Export ZIP: folder" }),
+  ).not.toBeInTheDocument();
+});
+
+test("reports ZIP download failures and restores the action", async () => {
+  mocks.exportProjectZip.mockRejectedValue(new Error("expired signed URL"));
+  openAllFilesPanel([
+    filePart({
+      id: "file:report",
+      name: "report.pdf",
+      path: "/workspace/report.pdf",
+      signedUrl: "/api/upload/file/report",
+    }),
+  ]);
+
+  const downloadAll = screen.getByRole("button", { name: "Download all" });
+  fireEvent.click(downloadAll);
+
+  await waitFor(() => {
+    expect(mocks.toastError).toHaveBeenCalledWith("Download failed");
+  });
+  expect(mocks.exportProjectZip).toHaveBeenCalledWith(
+    {},
+    "All files",
+    { "workspace/report.pdf": "/api/upload/file/report" },
+    { failOnBinaryError: true },
+  );
+  expect(downloadAll).toBeEnabled();
+});
+
+test("does not silently create a partial ZIP when one signed URL is missing", async () => {
+  openAllFilesPanel([
+    filePart({
+      id: "file:available",
+      name: "available.txt",
+      path: "/workspace/available.txt",
+      signedUrl: "/api/upload/file/available",
+    }),
+    filePart({
+      id: "file:missing",
+      name: "missing.txt",
+      path: "/workspace/missing.txt",
+    }),
+  ]);
+
+  fireEvent.click(screen.getByRole("button", { name: "Download all" }));
+
+  await waitFor(() => {
+    expect(mocks.toastError).toHaveBeenCalledWith("Download failed");
+  });
+  expect(mocks.exportProjectZip).not.toHaveBeenCalled();
+});

--- a/frontend/src/components/chat/ChatMessage/__tests__/revealArtifactsDownload.test.tsx
+++ b/frontend/src/components/chat/ChatMessage/__tests__/revealArtifactsDownload.test.tsx
@@ -175,7 +175,9 @@ test("reports ZIP download failures and restores the action", async () => {
   fireEvent.click(downloadAll);
 
   await waitFor(() => {
-    expect(mocks.toastError).toHaveBeenCalledWith("Download failed");
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      "Download failed: expired signed URL",
+    );
   });
   expect(mocks.exportProjectZip).toHaveBeenCalledWith(
     {},

--- a/frontend/src/components/chat/ChatMessage/revealArtifacts.ts
+++ b/frontend/src/components/chat/ChatMessage/revealArtifacts.ts
@@ -249,6 +249,74 @@ function normalizeArtifactPath(path: string): string {
     .replace(/^\/+|\/+$/g, "");
 }
 
+export interface RevealArtifactBinaryFiles {
+  binaryFiles: Record<string, string>;
+  skippedCount: number;
+}
+
+function normalizeZipEntryPath(path: string, fallbackName: string): string {
+  const rawPath = /^https?:\/\//i.test(path) ? fallbackName : path;
+  const segments = rawPath
+    .replace(/\\/g, "/")
+    .replace(/^[a-zA-Z]:\//, "")
+    .split("/");
+  const safeSegments: string[] = [];
+
+  for (const segment of segments) {
+    if (!segment || segment === ".") continue;
+    if (segment === "..") {
+      safeSegments.pop();
+      continue;
+    }
+    safeSegments.push(segment.replace(/\0/g, ""));
+  }
+
+  return safeSegments.filter(Boolean).join("/") || fallbackName || "file";
+}
+
+function makeUniqueZipEntryPath(path: string, usedPaths: Set<string>): string {
+  const slashIndex = path.lastIndexOf("/");
+  const directory = slashIndex >= 0 ? path.slice(0, slashIndex + 1) : "";
+  const fileName = slashIndex >= 0 ? path.slice(slashIndex + 1) : path;
+  const dotIndex = fileName.lastIndexOf(".");
+  const hasExtension = dotIndex > 0;
+  const stem = hasExtension ? fileName.slice(0, dotIndex) : fileName;
+  const extension = hasExtension ? fileName.slice(dotIndex) : "";
+  let candidate = path;
+  let suffix = 2;
+
+  while (usedPaths.has(candidate.toLocaleLowerCase())) {
+    candidate = `${directory}${stem} (${suffix})${extension}`;
+    suffix += 1;
+  }
+  usedPaths.add(candidate.toLocaleLowerCase());
+  return candidate;
+}
+
+export function buildRevealArtifactBinaryFiles(
+  artifacts: RevealArtifact[],
+): RevealArtifactBinaryFiles {
+  const binaryFiles: Record<string, string> = {};
+  const usedPaths = new Set<string>();
+  let skippedCount = 0;
+
+  for (const artifact of artifacts) {
+    if (artifact.kind !== "file") continue;
+    const url = artifact.preview.signedUrl;
+    if (!url) {
+      skippedCount += 1;
+      continue;
+    }
+    const path = makeUniqueZipEntryPath(
+      normalizeZipEntryPath(artifact.path, artifact.name),
+      usedPaths,
+    );
+    binaryFiles[path] = url;
+  }
+
+  return { binaryFiles, skippedCount };
+}
+
 function getRevealArtifactDedupeKey(artifact: RevealArtifact): string {
   if (artifact.kind === "file") {
     const normalizedPath = normalizeArtifactPath(artifact.path);

--- a/frontend/src/components/chat/ChatMessage/revealArtifacts.ts
+++ b/frontend/src/components/chat/ChatMessage/revealArtifacts.ts
@@ -252,6 +252,7 @@ function normalizeArtifactPath(path: string): string {
 export interface RevealArtifactBinaryFiles {
   binaryFiles: Record<string, string>;
   skippedCount: number;
+  skippedPaths: string[];
 }
 
 function normalizeZipEntryPath(path: string, fallbackName: string): string {
@@ -308,12 +309,14 @@ export function buildRevealArtifactBinaryFiles(
   const binaryFiles: Record<string, string> = {};
   const usedPaths = new Set<string>();
   let skippedCount = 0;
+  const skippedPaths: string[] = [];
 
   for (const artifact of artifacts) {
     if (artifact.kind !== "file") continue;
     const url = artifact.preview.signedUrl;
     if (!url) {
       skippedCount += 1;
+      skippedPaths.push(artifact.path || artifact.name);
       continue;
     }
     const path = makeUniqueZipEntryPath(
@@ -323,7 +326,7 @@ export function buildRevealArtifactBinaryFiles(
     binaryFiles[path] = url;
   }
 
-  return { binaryFiles, skippedCount };
+  return { binaryFiles, skippedCount, skippedPaths };
 }
 
 function getRevealArtifactDedupeKey(artifact: RevealArtifact): string {

--- a/frontend/src/components/chat/ChatMessage/revealArtifacts.ts
+++ b/frontend/src/components/chat/ChatMessage/revealArtifacts.ts
@@ -256,22 +256,31 @@ export interface RevealArtifactBinaryFiles {
 
 function normalizeZipEntryPath(path: string, fallbackName: string): string {
   const rawPath = /^https?:\/\//i.test(path) ? fallbackName : path;
-  const segments = rawPath
-    .replace(/\\/g, "/")
-    .replace(/^[a-zA-Z]:\//, "")
-    .split("/");
-  const safeSegments: string[] = [];
+  const sanitize = (candidate: string): string => {
+    const segments = candidate
+      .replace(/\\/g, "/")
+      .replace(/^[a-zA-Z]:\//, "")
+      .split("/");
+    const safeSegments: string[] = [];
 
-  for (const segment of segments) {
-    if (!segment || segment === ".") continue;
-    if (segment === "..") {
-      safeSegments.pop();
-      continue;
+    for (const segment of segments) {
+      if (!segment || segment === ".") continue;
+      if (segment === "..") {
+        safeSegments.pop();
+        continue;
+      }
+      const cleaned = Array.from(segment)
+        .filter((character) => {
+          const codePoint = character.codePointAt(0) ?? 0;
+          return codePoint >= 32 && codePoint !== 127;
+        })
+        .join("");
+      if (cleaned) safeSegments.push(cleaned);
     }
-    safeSegments.push(segment.replace(/\0/g, ""));
-  }
+    return safeSegments.join("/");
+  };
 
-  return safeSegments.filter(Boolean).join("/") || fallbackName || "file";
+  return sanitize(rawPath) || sanitize(fallbackName) || "file";
 }
 
 function makeUniqueZipEntryPath(path: string, usedPaths: Set<string>): string {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -590,6 +590,7 @@
     "mermaidDiagram": "Mermaid Diagram",
     "message": {
       "allFiles": "All files",
+      "downloadAll": "Download all",
       "args": "Args",
       "artifactsSubtitleFiles": "{{count}} files",
       "artifactsSubtitleMixed": "{{files}} files · {{projects}} projects",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -591,6 +591,7 @@
     "message": {
       "allFiles": "All files",
       "downloadAll": "Download all",
+      "downloadFailed": "Download failed",
       "args": "Args",
       "artifactsSubtitleFiles": "{{count}} files",
       "artifactsSubtitleMixed": "{{files}} files · {{projects}} projects",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -590,6 +590,7 @@
     "mermaidDiagram": "Mermaid 図",
     "message": {
       "allFiles": "すべてのファイル",
+      "downloadAll": "すべてダウンロード",
       "args": "引数",
       "artifactsSubtitleFiles": "{{count}} 件のファイル",
       "artifactsSubtitleMixed": "{{files}} 件のファイル · {{projects}} 件のプロジェクト",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -591,6 +591,7 @@
     "message": {
       "allFiles": "すべてのファイル",
       "downloadAll": "すべてダウンロード",
+      "downloadFailed": "ダウンロードに失敗しました",
       "args": "引数",
       "artifactsSubtitleFiles": "{{count}} 件のファイル",
       "artifactsSubtitleMixed": "{{files}} 件のファイル · {{projects}} 件のプロジェクト",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -590,6 +590,7 @@
     "mermaidDiagram": "Mermaid 다이어그램",
     "message": {
       "allFiles": "모든 파일",
+      "downloadAll": "전체 다운로드",
       "args": "인수",
       "artifactsSubtitleFiles": "파일 {{count}}개",
       "artifactsSubtitleMixed": "파일 {{files}}개 · 프로젝트 {{projects}}개",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -591,6 +591,7 @@
     "message": {
       "allFiles": "모든 파일",
       "downloadAll": "전체 다운로드",
+      "downloadFailed": "다운로드에 실패했습니다",
       "args": "인수",
       "artifactsSubtitleFiles": "파일 {{count}}개",
       "artifactsSubtitleMixed": "파일 {{files}}개 · 프로젝트 {{projects}}개",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -591,6 +591,7 @@
     "message": {
       "allFiles": "Все файлы",
       "downloadAll": "Скачать всё",
+      "downloadFailed": "Не удалось скачать",
       "args": "Аргументы",
       "artifactsSubtitleFiles": "{{count}} файлов",
       "artifactsSubtitleMixed": "{{files}} файлов · {{projects}} проектов",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -590,6 +590,7 @@
     "mermaidDiagram": "Диаграмма Mermaid",
     "message": {
       "allFiles": "Все файлы",
+      "downloadAll": "Скачать всё",
       "args": "Аргументы",
       "artifactsSubtitleFiles": "{{count}} файлов",
       "artifactsSubtitleMixed": "{{files}} файлов · {{projects}} проектов",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -590,6 +590,7 @@
     "mermaidDiagram": "Mermaid 图表",
     "message": {
       "allFiles": "全部文件",
+      "downloadAll": "下载全部",
       "args": "参数",
       "artifactsSubtitleFiles": "{{count}} 个文件",
       "artifactsSubtitleMixed": "{{files}} 个文件 · {{projects}} 个项目",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -591,6 +591,7 @@
     "message": {
       "allFiles": "全部文件",
       "downloadAll": "下载全部",
+      "downloadFailed": "下载失败",
       "args": "参数",
       "artifactsSubtitleFiles": "{{count}} 个文件",
       "artifactsSubtitleMixed": "{{files}} 个文件 · {{projects}} 个项目",

--- a/frontend/src/utils/__tests__/exportProjectZip.test.ts
+++ b/frontend/src/utils/__tests__/exportProjectZip.test.ts
@@ -59,3 +59,21 @@ test("default export keeps the existing best-effort binary contract", async () =
   expect(createObjectUrl).toHaveBeenCalledOnce();
   expect(revokeObjectUrl).toHaveBeenCalledWith("blob:best-effort");
 });
+
+test("preserves non-Latin letters in the downloaded ZIP name", async () => {
+  vi.stubGlobal("URL", {
+    ...URL,
+    createObjectURL: vi.fn(() => "blob:localized-name"),
+    revokeObjectURL: vi.fn(),
+  });
+  let downloadedName = "";
+  vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(function (
+    this: HTMLAnchorElement,
+  ) {
+    downloadedName = this.download;
+  });
+
+  await exportProjectZip({}, "すべてのファイル");
+
+  expect(downloadedName).toBe("すべてのファイル.zip");
+});

--- a/frontend/src/utils/__tests__/exportProjectZip.test.ts
+++ b/frontend/src/utils/__tests__/exportProjectZip.test.ts
@@ -1,0 +1,61 @@
+/** @vitest-environment jsdom */
+
+import { afterEach, expect, test, vi } from "vitest";
+import { exportProjectZip } from "../exportProjectZip";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+test("strict binary export rejects instead of downloading a partial ZIP", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: false,
+      arrayBuffer: vi.fn(),
+    }),
+  );
+  const createObjectUrl = vi.fn(() => "blob:partial");
+  vi.stubGlobal("URL", {
+    ...URL,
+    createObjectURL: createObjectUrl,
+    revokeObjectURL: vi.fn(),
+  });
+
+  await expect(
+    exportProjectZip(
+      {},
+      "files",
+      { "broken.pdf": "/api/upload/file/broken" },
+      { failOnBinaryError: true },
+    ),
+  ).rejects.toThrow("Failed to download 1 binary file: broken.pdf");
+  expect(createObjectUrl).not.toHaveBeenCalled();
+});
+
+test("default export keeps the existing best-effort binary contract", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: false,
+      arrayBuffer: vi.fn(),
+    }),
+  );
+  const createObjectUrl = vi.fn(() => "blob:best-effort");
+  const revokeObjectUrl = vi.fn();
+  vi.stubGlobal("URL", {
+    ...URL,
+    createObjectURL: createObjectUrl,
+    revokeObjectURL: revokeObjectUrl,
+  });
+  vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+  await expect(
+    exportProjectZip({ "readme.txt": "kept" }, "project", {
+      "broken.pdf": "/api/upload/file/broken",
+    }),
+  ).resolves.toBeUndefined();
+  expect(createObjectUrl).toHaveBeenCalledOnce();
+  expect(revokeObjectUrl).toHaveBeenCalledWith("blob:best-effort");
+});

--- a/frontend/src/utils/__tests__/exportProjectZip.test.ts
+++ b/frontend/src/utils/__tests__/exportProjectZip.test.ts
@@ -60,6 +60,32 @@ test("default export keeps the existing best-effort binary contract", async () =
   expect(revokeObjectUrl).toHaveBeenCalledWith("blob:best-effort");
 });
 
+test("default export does not silently apply strict resource limits", async () => {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    headers: { get: () => String(30 * 1024 * 1024) },
+    arrayBuffer: vi.fn().mockResolvedValue(new Uint8Array([1]).buffer),
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  vi.stubGlobal("URL", {
+    ...URL,
+    createObjectURL: vi.fn(() => "blob:legacy"),
+    revokeObjectURL: vi.fn(),
+  });
+  vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+  const binaryFiles = Object.fromEntries(
+    Array.from({ length: 51 }, (_, index) => [
+      `file-${index}.bin`,
+      `/api/upload/file/${index}`,
+    ]),
+  );
+
+  await expect(
+    exportProjectZip({}, "legacy", binaryFiles),
+  ).resolves.toBeUndefined();
+  expect(fetchMock).toHaveBeenCalledTimes(51);
+});
+
 test("preserves non-Latin letters in the downloaded ZIP name", async () => {
   vi.stubGlobal("URL", {
     ...URL,

--- a/frontend/src/utils/__tests__/exportProjectZip.test.ts
+++ b/frontend/src/utils/__tests__/exportProjectZip.test.ts
@@ -77,3 +77,109 @@ test("preserves non-Latin letters in the downloaded ZIP name", async () => {
 
   expect(downloadedName).toBe("すべてのファイル.zip");
 });
+
+test("normalizes and preserves combining marks in the downloaded ZIP name", async () => {
+  vi.stubGlobal("URL", {
+    ...URL,
+    createObjectURL: vi.fn(() => "blob:localized-name"),
+    revokeObjectURL: vi.fn(),
+  });
+  let downloadedName = "";
+  vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(function (
+    this: HTMLAnchorElement,
+  ) {
+    downloadedName = this.download;
+  });
+
+  await exportProjectZip({}, "Cafe\u0301 हिंदी");
+
+  expect(downloadedName).toBe("Café_हिंदी.zip");
+});
+
+test("rejects strict exports above the binary file limit before fetching", async () => {
+  const fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+  const binaryFiles = Object.fromEntries(
+    Array.from({ length: 3 }, (_, index) => [
+      `file-${index}.bin`,
+      `/api/upload/file/${index}`,
+    ]),
+  );
+
+  await expect(
+    exportProjectZip({}, "files", binaryFiles, {
+      failOnBinaryError: true,
+      maxBinaryFiles: 2,
+    }),
+  ).rejects.toThrow("Binary ZIP limit exceeded: at most 2 files");
+  expect(fetchMock).not.toHaveBeenCalled();
+});
+
+test("limits binary fetch concurrency", async () => {
+  let active = 0;
+  let maxActive = 0;
+  let started = 0;
+  const releases: Array<() => void> = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockImplementation(async () => {
+      active += 1;
+      started += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise<void>((resolve) => releases.push(resolve));
+      active -= 1;
+      return {
+        ok: true,
+        headers: { get: () => "1" },
+        arrayBuffer: vi.fn().mockResolvedValue(new Uint8Array([1]).buffer),
+      };
+    }),
+  );
+  vi.stubGlobal("URL", {
+    ...URL,
+    createObjectURL: vi.fn(() => "blob:limited"),
+    revokeObjectURL: vi.fn(),
+  });
+  vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+  const exportPromise = exportProjectZip(
+    {},
+    "files",
+    Object.fromEntries(
+      Array.from({ length: 5 }, (_, index) => [
+        `file-${index}.bin`,
+        `/api/upload/file/${index}`,
+      ]),
+    ),
+    { binaryConcurrency: 2 },
+  );
+  await vi.waitFor(() => expect(started).toBe(2));
+  releases.splice(0).forEach((release) => release());
+  await vi.waitFor(() => expect(started).toBe(4));
+  releases.splice(0).forEach((release) => release());
+  await vi.waitFor(() => expect(started).toBe(5));
+  releases.splice(0).forEach((release) => release());
+  await exportPromise;
+
+  expect(maxActive).toBe(2);
+});
+
+test("rejects a strict export when downloaded bytes exceed the limit", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      headers: { get: () => "4" },
+      arrayBuffer: vi.fn().mockResolvedValue(new Uint8Array(4).buffer),
+    }),
+  );
+
+  await expect(
+    exportProjectZip(
+      {},
+      "files",
+      { "large.bin": "/api/upload/file/large" },
+      { failOnBinaryError: true, maxBinaryBytes: 3 },
+    ),
+  ).rejects.toThrow("Failed to download 1 binary file: large.bin");
+});

--- a/frontend/src/utils/exportProjectZip.ts
+++ b/frontend/src/utils/exportProjectZip.ts
@@ -4,6 +4,68 @@ import { buildUploadProxyUrl } from "../services/api/config";
 export interface ExportProjectZipOptions {
   /** Reject before creating the ZIP if any binary URL cannot be downloaded. */
   failOnBinaryError?: boolean;
+  /** Resource guards for browser and mobile WebView ZIP generation. */
+  maxBinaryFiles?: number;
+  maxBinaryBytes?: number;
+  maxBinaryFileBytes?: number;
+  binaryConcurrency?: number;
+  binaryTimeoutMs?: number;
+}
+
+const DEFAULT_MAX_BINARY_FILES = 50;
+const DEFAULT_MAX_BINARY_BYTES = 100 * 1024 * 1024;
+const DEFAULT_MAX_BINARY_FILE_BYTES = 25 * 1024 * 1024;
+const DEFAULT_BINARY_CONCURRENCY = 3;
+const DEFAULT_BINARY_TIMEOUT_MS = 30_000;
+
+function positiveInteger(value: number | undefined, fallback: number): number {
+  return Number.isInteger(value) && value !== undefined && value > 0
+    ? value
+    : fallback;
+}
+
+async function readResponseWithinLimit(
+  response: Response,
+  maxBytes: number,
+): Promise<Uint8Array> {
+  const contentLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+    throw new Error("Binary file exceeds ZIP download limit");
+  }
+
+  if (!response.body) {
+    const buffer = new Uint8Array(await response.arrayBuffer());
+    if (buffer.byteLength > maxBytes) {
+      throw new Error("Binary file exceeds ZIP download limit");
+    }
+    return buffer;
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBytes) {
+        await reader.cancel();
+        throw new Error("Binary file exceeds ZIP download limit");
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const result = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return result;
 }
 
 export async function exportProjectZip(
@@ -24,26 +86,79 @@ export async function exportProjectZip(
 
   // 添加二进制文件（从 OSS URL 拉取）
   if (binaryFiles) {
-    const failedPaths = (
-      await Promise.all(
-        Object.entries(binaryFiles).map(async ([path, url]) => {
-          try {
-            const readUrl = buildUploadProxyUrl(url) || url;
-            const resp = await fetch(readUrl);
-            if (!resp.ok) return path;
-            const buffer = await resp.arrayBuffer();
-            const normalizedPath = path.startsWith("/") ? path.slice(1) : path;
-            if (normalizedPath) {
-              zip.file(normalizedPath, buffer);
-            }
-            return null;
-          } catch {
-            // 跳过下载失败的二进制文件
-            return path;
+    const maxFiles = positiveInteger(
+      options.maxBinaryFiles,
+      DEFAULT_MAX_BINARY_FILES,
+    );
+    const maxBytes = positiveInteger(
+      options.maxBinaryBytes,
+      DEFAULT_MAX_BINARY_BYTES,
+    );
+    const maxFileBytes = Math.min(
+      positiveInteger(
+        options.maxBinaryFileBytes,
+        DEFAULT_MAX_BINARY_FILE_BYTES,
+      ),
+      maxBytes,
+    );
+    const concurrency = Math.min(
+      positiveInteger(options.binaryConcurrency, DEFAULT_BINARY_CONCURRENCY),
+      8,
+    );
+    const timeoutMs = positiveInteger(
+      options.binaryTimeoutMs,
+      DEFAULT_BINARY_TIMEOUT_MS,
+    );
+    const allEntries = Object.entries(binaryFiles);
+    if (options.failOnBinaryError && allEntries.length > maxFiles) {
+      throw new Error(`Binary ZIP limit exceeded: at most ${maxFiles} files`);
+    }
+
+    const entries = allEntries.slice(0, maxFiles);
+    const failedPaths = allEntries.slice(maxFiles).map(([path]) => path);
+    let nextIndex = 0;
+    let downloadedBytes = 0;
+
+    const downloadWorker = async () => {
+      while (nextIndex < entries.length) {
+        const index = nextIndex;
+        nextIndex += 1;
+        const [path, sourceUrl] = entries[index];
+        const controller = new AbortController();
+        const timeoutId = window.setTimeout(
+          () => controller.abort(),
+          timeoutMs,
+        );
+        try {
+          const readUrl = buildUploadProxyUrl(sourceUrl) || sourceUrl;
+          const response = await fetch(readUrl, { signal: controller.signal });
+          if (!response.ok) throw new Error("Binary download failed");
+          const remainingBytes = Math.max(maxBytes - downloadedBytes, 0);
+          const buffer = await readResponseWithinLimit(
+            response,
+            Math.min(maxFileBytes, remainingBytes),
+          );
+          if (downloadedBytes + buffer.byteLength > maxBytes) {
+            throw new Error("Binary ZIP exceeds total download limit");
           }
-        }),
-      )
-    ).filter((path): path is string => path !== null);
+          downloadedBytes += buffer.byteLength;
+          const normalizedPath = path.startsWith("/") ? path.slice(1) : path;
+          if (normalizedPath) zip.file(normalizedPath, buffer);
+        } catch {
+          // Best-effort callers keep the previous behavior; strict callers reject below.
+          failedPaths.push(path);
+        } finally {
+          window.clearTimeout(timeoutId);
+        }
+      }
+    };
+
+    await Promise.all(
+      Array.from(
+        { length: Math.min(concurrency, entries.length) },
+        downloadWorker,
+      ),
+    );
 
     if (options.failOnBinaryError && failedPaths.length > 0) {
       const fileLabel = failedPaths.length === 1 ? "file" : "files";
@@ -59,7 +174,10 @@ export async function exportProjectZip(
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
-  a.download = `${projectName.replace(/[^\p{L}\p{N}_-]/gu, "_")}.zip`;
+  const safeProjectName =
+    projectName.normalize("NFC").replace(/[^\p{L}\p{M}\p{N}_-]/gu, "_") ||
+    "project";
+  a.download = `${safeProjectName}.zip`;
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);

--- a/frontend/src/utils/exportProjectZip.ts
+++ b/frontend/src/utils/exportProjectZip.ts
@@ -1,10 +1,16 @@
 import JSZip from "jszip";
 import { buildUploadProxyUrl } from "../services/api/config";
 
+export interface ExportProjectZipOptions {
+  /** Reject before creating the ZIP if any binary URL cannot be downloaded. */
+  failOnBinaryError?: boolean;
+}
+
 export async function exportProjectZip(
   files: Record<string, string>,
   projectName: string,
   binaryFiles?: Record<string, string>,
+  options: ExportProjectZipOptions = {},
 ): Promise<void> {
   const zip = new JSZip();
 
@@ -18,22 +24,35 @@ export async function exportProjectZip(
 
   // 添加二进制文件（从 OSS URL 拉取）
   if (binaryFiles) {
-    await Promise.all(
-      Object.entries(binaryFiles).map(async ([path, url]) => {
-        try {
-          const readUrl = buildUploadProxyUrl(url) || url;
-          const resp = await fetch(readUrl);
-          if (!resp.ok) return;
-          const buffer = await resp.arrayBuffer();
-          const normalizedPath = path.startsWith("/") ? path.slice(1) : path;
-          if (normalizedPath) {
-            zip.file(normalizedPath, buffer);
+    const failedPaths = (
+      await Promise.all(
+        Object.entries(binaryFiles).map(async ([path, url]) => {
+          try {
+            const readUrl = buildUploadProxyUrl(url) || url;
+            const resp = await fetch(readUrl);
+            if (!resp.ok) return path;
+            const buffer = await resp.arrayBuffer();
+            const normalizedPath = path.startsWith("/") ? path.slice(1) : path;
+            if (normalizedPath) {
+              zip.file(normalizedPath, buffer);
+            }
+            return null;
+          } catch {
+            // 跳过下载失败的二进制文件
+            return path;
           }
-        } catch {
-          // 跳过下载失败的二进制文件
-        }
-      }),
-    );
+        }),
+      )
+    ).filter((path): path is string => path !== null);
+
+    if (options.failOnBinaryError && failedPaths.length > 0) {
+      const fileLabel = failedPaths.length === 1 ? "file" : "files";
+      throw new Error(
+        `Failed to download ${
+          failedPaths.length
+        } binary ${fileLabel}: ${failedPaths.join(", ")}`,
+      );
+    }
   }
 
   const blob = await zip.generateAsync({ type: "blob" });

--- a/frontend/src/utils/exportProjectZip.ts
+++ b/frontend/src/utils/exportProjectZip.ts
@@ -59,10 +59,7 @@ export async function exportProjectZip(
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
-  a.download = `${projectName.replace(
-    /[^a-zA-Z0-9_\u4e00-\u9fa5-]/g,
-    "_",
-  )}.zip`;
+  a.download = `${projectName.replace(/[^\p{L}\p{N}_-]/gu, "_")}.zip`;
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);

--- a/frontend/src/utils/exportProjectZip.ts
+++ b/frontend/src/utils/exportProjectZip.ts
@@ -86,30 +86,35 @@ export async function exportProjectZip(
 
   // 添加二进制文件（从 OSS URL 拉取）
   if (binaryFiles) {
-    const maxFiles = positiveInteger(
-      options.maxBinaryFiles,
-      DEFAULT_MAX_BINARY_FILES,
-    );
-    const maxBytes = positiveInteger(
-      options.maxBinaryBytes,
-      DEFAULT_MAX_BINARY_BYTES,
-    );
+    const resourceGuardsEnabled =
+      options.failOnBinaryError === true ||
+      options.maxBinaryFiles !== undefined ||
+      options.maxBinaryBytes !== undefined ||
+      options.maxBinaryFileBytes !== undefined ||
+      options.binaryTimeoutMs !== undefined;
+    const allEntries = Object.entries(binaryFiles);
+    const maxFiles = resourceGuardsEnabled
+      ? positiveInteger(options.maxBinaryFiles, DEFAULT_MAX_BINARY_FILES)
+      : allEntries.length;
+    const maxBytes = resourceGuardsEnabled
+      ? positiveInteger(options.maxBinaryBytes, DEFAULT_MAX_BINARY_BYTES)
+      : Number.MAX_SAFE_INTEGER;
     const maxFileBytes = Math.min(
-      positiveInteger(
-        options.maxBinaryFileBytes,
-        DEFAULT_MAX_BINARY_FILE_BYTES,
-      ),
+      resourceGuardsEnabled
+        ? positiveInteger(
+            options.maxBinaryFileBytes,
+            DEFAULT_MAX_BINARY_FILE_BYTES,
+          )
+        : Number.MAX_SAFE_INTEGER,
       maxBytes,
     );
     const concurrency = Math.min(
       positiveInteger(options.binaryConcurrency, DEFAULT_BINARY_CONCURRENCY),
       8,
     );
-    const timeoutMs = positiveInteger(
-      options.binaryTimeoutMs,
-      DEFAULT_BINARY_TIMEOUT_MS,
-    );
-    const allEntries = Object.entries(binaryFiles);
+    const timeoutMs = resourceGuardsEnabled
+      ? positiveInteger(options.binaryTimeoutMs, DEFAULT_BINARY_TIMEOUT_MS)
+      : undefined;
     if (options.failOnBinaryError && allEntries.length > maxFiles) {
       throw new Error(`Binary ZIP limit exceeded: at most ${maxFiles} files`);
     }
@@ -125,10 +130,9 @@ export async function exportProjectZip(
         nextIndex += 1;
         const [path, sourceUrl] = entries[index];
         const controller = new AbortController();
-        const timeoutId = window.setTimeout(
-          () => controller.abort(),
-          timeoutMs,
-        );
+        const timeoutId = timeoutMs
+          ? window.setTimeout(() => controller.abort(), timeoutMs)
+          : undefined;
         try {
           const readUrl = buildUploadProxyUrl(sourceUrl) || sourceUrl;
           const response = await fetch(readUrl, { signal: controller.signal });
@@ -148,7 +152,7 @@ export async function exportProjectZip(
           // Best-effort callers keep the previous behavior; strict callers reject below.
           failedPaths.push(path);
         } finally {
-          window.clearTimeout(timeoutId);
+          if (timeoutId !== undefined) window.clearTimeout(timeoutId);
         }
       }
     };


### PR DESCRIPTION
「全部文件」面板此前只能逐个文件下载：文件夹行只有展开/收起箭头、面板顶部没有「下载全部」。

## 为什么单独开这个 PR（不和另一份合并）
本 PR 和 `feat/filetree-download-folder` 是**姊妹 PR**，都做"下载文件夹为 ZIP"，但改的是**不同的下载入口和组件**，互补、不重叠；但主要原因其实是我在写下载文件夹那一条的时候没有上git读完feature...

## 改动（对应 issue 两点需求）注：如果觉得前端方面不符合要求就再接着修

**1. 文件夹下载**
- `TreeDirRow`（文件夹行）hover 显示下载按钮，点击打包该文件夹下所有文件为 ZIP
- 新增 `collectSubtreeFiles`：递归收集子目录所有文件 artifact（path + signedUrl）

**2. 一键下载全部**
- 面板顶部（文件计数旁）加「下载全部」按钮，点击打包所有 `file` 类型 artifact（不含 project 类型）

## 技术实现
- 复用现有 `exportProjectZip`（JSZip），无新依赖；RevealArtifact 文件皆为 URL-based，走 `binaryFiles` 通道（fetch → arrayBuffer → zip）
- ZIP 内保持原始目录结构；文件名 = 文件夹名 / 「全部文件」
- **下载中 loading**：图标切换为 `Loader2` 旋转动画（`animate-spin`），完成后恢复 `Download`；`isDownloading` / `isDownloadingAll` 防重复点击
- i18n 新增 `chat.message.downloadAll`（en/zh/ja/ko/ru），文件夹下载复用 `project.exportZip`

## 范围
仅改 `RevealArtifactsSummary.tsx` + 5 个 locale 文件，不动其它组件。

## 验证
`tsc -b` 类型检查通过。
