### PR TITLE
fix(db): 修复收藏夹/反馈并发重复创建，减少冗余数据库读取

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -427,6 +427,12 @@ def _startup_index_initializers():
         await MCPStorage().ensure_indexes()
         logger.info("MCPStorage indexes initialized")
 
+    async def _init_feedback_storage() -> None:
+        from src.infra.feedback.storage import FeedbackStorage
+
+        await FeedbackStorage().create_indexes()
+        logger.info("FeedbackStorage indexes initialized")
+
     return [
         ("agent_config_storage", _init_agent_config_storage),
         ("model_storage", _init_model_storage),
@@ -444,6 +450,7 @@ def _startup_index_initializers():
         ("persona_preset_storage", _init_persona_preset_storage),
         ("role_storage", _init_role_storage),
         ("mcp_storage", _init_mcp_storage),
+        ("feedback_storage", _init_feedback_storage),
     ]
 
 

--- a/src/infra/agent/model_storage.py
+++ b/src/infra/agent/model_storage.py
@@ -324,8 +324,9 @@ class ModelStorage:
         Returns:
             是否存在
         """
-        doc = await self._get_collection().find_one({"value": value})
-        return doc is not None
+        # P2-12: 仅判存在性，count_documents + limit 避免读取整文档（含加密 api_key）
+        count = await self._get_collection().count_documents({"value": value}, limit=1)
+        return count > 0
 
     @staticmethod
     def _upsert_identity_filter(model: ModelConfig) -> dict[str, Any]:

--- a/src/infra/feedback/storage.py
+++ b/src/infra/feedback/storage.py
@@ -78,12 +78,9 @@ class FeedbackStorage:
         Raises:
             ValueError: 如果用户已对该 run 提交过反馈
         """
-        # 检查是否已存在
-        existing = await self.get_user_feedback_for_run(
-            user_id, feedback_data.session_id, feedback_data.run_id
-        )
-        if existing:
-            raise ValueError("您已经对该对话提交过反馈")
+        # 并发安全（P2-10）：依赖 user_run_unique 唯一索引，不再"先检查后插入"。
+        # 直接 insert，冲突即重复，捕获 DuplicateKeyError → ValueError（保持调用方契约）。
+        from pymongo.errors import DuplicateKeyError
 
         now = utc_now()
         feedback_dict: dict[str, Any] = {
@@ -99,7 +96,11 @@ class FeedbackStorage:
             feedback_dict["attachments"] = [
                 a.model_dump(by_alias=True) for a in feedback_data.attachments
             ]
-        result = await self.collection.insert_one(feedback_dict)
+        try:
+            result = await self.collection.insert_one(feedback_dict)
+        except DuplicateKeyError:
+            # 唯一索引 user_run_unique 冲突 = 该 (user_id, session_id, run_id) 已有反馈
+            raise ValueError("您已经对该对话提交过反馈")
         feedback_dict["id"] = str(result.inserted_id)
         return Feedback.model_validate(feedback_dict)
 

--- a/src/infra/folder/storage.py
+++ b/src/infra/folder/storage.py
@@ -4,9 +4,12 @@ from typing import Optional
 
 from bson import ObjectId
 
+from src.infra.logging import get_logger
 from src.infra.utils.datetime import utc_now
 from src.kernel.config import settings
 from src.kernel.schemas.project import Project, ProjectCreate, ProjectUpdate
+
+logger = get_logger(__name__)
 
 PROJECT_LIST_LIMIT = 100
 DEFAULT_PROJECT_ICON = "💬"
@@ -36,14 +39,33 @@ class ProjectStorage:
         return self._collection
 
     async def ensure_indexes(self) -> None:
-        """Create indexes for the projects collection."""
-        from src.infra.logging import get_logger
+        """创建索引（含 P2-10 partial 唯一索引，消除 check-then-insert 竞态）。
 
-        logger = get_logger(__name__)
+        - project_user_type_idx：通用 (user_id, type) 查询索引
+        - project_user_favorites_uniq：每用户最多一个 favorites（partial 唯一）
+        - project_user_name_type_channel_uniq：自动创建的 channel 项目每用户每 name 唯一（partial 唯一）
+
+        并发安全依赖 partial 唯一索引；ensure_favorites_project /
+        get_or_create_by_name 捕获 DuplicateKeyError 回查已存在文档。
+        """
         try:
             await self.collection.create_index(
                 [("user_id", 1), ("type", 1)],
                 name="project_user_type_idx",
+                background=True,
+            )
+            await self.collection.create_index(
+                [("user_id", 1), ("type", 1)],
+                name="project_user_favorites_uniq",
+                unique=True,
+                partialFilterExpression={"type": "favorites"},
+                background=True,
+            )
+            await self.collection.create_index(
+                [("user_id", 1), ("name", 1), ("type", 1)],
+                name="project_user_name_type_channel_uniq",
+                unique=True,
+                partialFilterExpression={"type": "channel"},
                 background=True,
             )
             logger.info("Project storage indexes ensured")
@@ -159,6 +181,8 @@ class ProjectStorage:
         Returns the favorites project.
         """
         # Check if favorites project already exists
+        from pymongo.errors import DuplicateKeyError
+
         existing = await self.get_by_type(user_id, "favorites")
         if existing:
             return existing
@@ -174,11 +198,16 @@ class ProjectStorage:
             "created_at": now,
             "updated_at": now,
         }
-
-        result = await self.collection.insert_one(project_dict)
-        project_dict["id"] = str(result.inserted_id)
-
-        return Project(**project_dict)
+        try:
+            result = await self.collection.insert_one(project_dict)
+            project_dict["id"] = str(result.inserted_id)
+            return Project(**project_dict)
+        except DuplicateKeyError:
+            # 并发：另一请求已建 favorites，回查返回已存在（幂等）
+            existing = await self.get_by_type(user_id, "favorites")
+            if existing:
+                return existing
+            raise
 
     async def get_or_create_by_name(
         self, user_id: str, name: str, project_type: str = "channel", icon: str = "💬"
@@ -186,10 +215,13 @@ class ProjectStorage:
         """Get or create a project by name for a user.
 
         Used by channels (e.g. Feishu) to auto-create a project for organizing conversations.
+        并发安全：依赖 project_user_name_type_channel_uniq partial 唯一索引（type=channel）；
+        insert 冲突时回查已存在文档。其它 type 无唯一索引保护。
         """
-        project_dict = await self.collection.find_one(
-            {"user_id": user_id, "name": name, "type": project_type}
-        )
+        from pymongo.errors import DuplicateKeyError
+
+        query = {"user_id": user_id, "name": name, "type": project_type}
+        project_dict = await self.collection.find_one(query)
         if project_dict:
             project_dict["id"] = str(project_dict.pop("_id"))
             return Project(**project_dict)
@@ -204,9 +236,17 @@ class ProjectStorage:
             "created_at": now,
             "updated_at": now,
         }
-        result = await self.collection.insert_one(project_dict)
-        project_dict["id"] = str(result.inserted_id)
-        return Project(**project_dict)
+        try:
+            result = await self.collection.insert_one(project_dict)
+            project_dict["id"] = str(result.inserted_id)
+            return Project(**project_dict)
+        except DuplicateKeyError:
+            # 并发：另一请求已建同 (user,name,type)，回查返回已存在（幂等）
+            project_dict = await self.collection.find_one(query)
+            if project_dict:
+                project_dict["id"] = str(project_dict.pop("_id"))
+                return Project(**project_dict)
+            raise
 
 
 # Singleton instance

--- a/src/infra/storage/mongodb.py
+++ b/src/infra/storage/mongodb.py
@@ -138,8 +138,9 @@ class MongoDBStorage(StorageBase):
 
     async def exists(self, key: str) -> bool:
         """检查键是否存在"""
-        result = await self.collection.find_one({"_id": key})
-        return result is not None
+        # P2-12: 仅判存在性，count_documents + limit 避免读取整文档字段
+        count = await self.collection.count_documents({"_id": key}, limit=1)
+        return count > 0
 
     async def keys(self, pattern: str) -> list[str]:
         """获取匹配的键列表，默认限制数量避免误扫全库。"""

--- a/tests/infra/agent/test_model_storage.py
+++ b/tests/infra/agent/test_model_storage.py
@@ -353,3 +353,33 @@ async def test_upsert_by_value_does_not_overwrite_different_provider() -> None:
     ]
     assert collection.updated_queries == []
     assert collection.inserted_docs[0]["provider"] == "azure"
+
+
+class _ExistsCollection:
+    """Fake collection recording count_documents calls (for exists checks)."""
+
+    def __init__(self, count: int) -> None:
+        self.count = count
+        self.count_calls: list[tuple[dict[str, Any], dict[str, Any]]] = []
+
+    async def count_documents(self, query: dict[str, Any], **kwargs):
+        self.count_calls.append((query, kwargs))
+        return self.count
+
+
+@pytest.mark.asyncio
+async def test_exists_uses_count_documents_with_limit_and_avoids_loading_doc() -> None:
+    storage = ModelStorage()
+
+    # 存在：count=1 → True，用 count_documents(limit=1)，不读取整文档（含加密 api_key）
+    present = _ExistsCollection(count=1)
+    storage._collection = present
+    assert await storage.exists("openai/gpt-4.1") is True
+    query, kwargs = present.count_calls[0]
+    assert query == {"value": "openai/gpt-4.1"}
+    assert kwargs.get("limit") == 1
+
+    # 不存在：count=0 → False
+    absent = _ExistsCollection(count=0)
+    storage._collection = absent
+    assert await storage.exists("missing/model") is False

--- a/tests/infra/test_feedback_storage_create.py
+++ b/tests/infra/test_feedback_storage_create.py
@@ -1,0 +1,84 @@
+"""Tests for FeedbackStorage P2-10 race fix (insert + DuplicateKeyError, no precheck find)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pymongo.errors import DuplicateKeyError
+
+from src.infra.feedback.storage import FeedbackStorage
+from src.kernel.schemas.feedback import FeedbackCreate
+
+
+class _FakeFeedbackCollection:
+    """Records insert_one / create_index; insert_one may raise DuplicateKeyError."""
+
+    def __init__(self, *, insert_raises=None):
+        self.insert_raises = insert_raises
+        self.insert_calls: list[dict[str, Any]] = []
+        self.create_index_calls: list[tuple[list, dict[str, Any]]] = []
+
+    async def insert_one(self, doc: dict[str, Any]):
+        self.insert_calls.append(dict(doc))
+        if self.insert_raises:
+            raise self.insert_raises
+
+        class _Result:
+            inserted_id = "fb-1"
+
+        return _Result()
+
+    async def create_index(self, keys, **kwargs):
+        self.create_index_calls.append((keys, kwargs))
+
+
+def _feedback_create() -> FeedbackCreate:
+    return FeedbackCreate(session_id="sess-1", run_id="run-1", rating="up", comment="good")
+
+
+@pytest.mark.asyncio
+async def test_create_returns_feedback_on_success() -> None:
+    storage = FeedbackStorage()
+    collection = _FakeFeedbackCollection()
+    storage._collection = collection
+
+    feedback = await storage.create(_feedback_create(), "user-1", "alice")
+
+    assert feedback.id == "fb-1"
+    assert feedback.user_id == "user-1"
+    assert feedback.username == "alice"
+    assert feedback.session_id == "sess-1"
+    assert feedback.run_id == "run-1"
+    assert feedback.rating == "up"
+    assert len(collection.insert_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_create_raises_value_error_on_duplicate() -> None:
+    """重复：insert 抛 DuplicateKeyError → ValueError（保持路由层 except ValueError 契约）。"""
+    storage = FeedbackStorage()
+    collection = _FakeFeedbackCollection(insert_raises=DuplicateKeyError("duplicate"))
+    storage._collection = collection
+
+    with pytest.raises(ValueError, match="您已经对该对话提交过反馈"):
+        await storage.create(_feedback_create(), "user-1", "alice")
+
+
+@pytest.mark.asyncio
+async def test_create_indexes_builds_unique_index() -> None:
+    """create() 的并发保护依赖 user_run_unique 唯一索引（启动初始化负责创建）。"""
+    storage = FeedbackStorage()
+    collection = _FakeFeedbackCollection()
+    storage._collection = collection
+
+    await storage.create_indexes()
+
+    unique_indexes = [
+        (keys, kwargs) for keys, kwargs in collection.create_index_calls if kwargs.get("unique")
+    ]
+    assert any(
+        keys == [("user_id", 1), ("session_id", 1), ("run_id", 1)]
+        and kwargs.get("name") == "user_run_unique"
+        for keys, kwargs in unique_indexes
+    )

--- a/tests/infra/test_mongodb_storage.py
+++ b/tests/infra/test_mongodb_storage.py
@@ -92,6 +92,36 @@ async def test_mongodb_storage_keys_uses_projection_anchored_regex_and_limit() -
     assert collection.last_cursor.limit_value == 1000
 
 
+class _CountDocumentsCollection:
+    """Fake collection recording count_documents calls (for exists checks)."""
+
+    def __init__(self, count: int) -> None:
+        self.count = count
+        self.count_calls: list[tuple[dict, dict]] = []
+
+    async def count_documents(self, query: dict, **kwargs):
+        self.count_calls.append((query, kwargs))
+        return self.count
+
+
+@pytest.mark.asyncio
+async def test_mongodb_storage_exists_uses_count_documents_with_limit() -> None:
+    storage = MongoDBStorage(collection_name="storage")
+
+    # 存在：count=1 → True，用 count_documents(limit=1) 不读取整文档
+    present = _CountDocumentsCollection(count=1)
+    storage._collection = present
+    assert await storage.exists("some-key") is True
+    query, kwargs = present.count_calls[0]
+    assert query == {"_id": "some-key"}
+    assert kwargs.get("limit") == 1
+
+    # 不存在：count=0 → False
+    absent = _CountDocumentsCollection(count=0)
+    storage._collection = absent
+    assert await storage.exists("missing-key") is False
+
+
 @pytest.mark.asyncio
 async def test_approval_storage_list_pending_applies_default_limit() -> None:
     storage = ApprovalStorage()

--- a/tests/infra/test_project_storage_race.py
+++ b/tests/infra/test_project_storage_race.py
@@ -1,0 +1,145 @@
+"""Tests for ProjectStorage P2-10 race fix (unique partial indexes + DuplicateKeyError)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pymongo.errors import DuplicateKeyError
+
+from src.infra.folder.storage import ProjectStorage
+from src.infra.utils.datetime import utc_now
+
+
+class _FakeProjectCollection:
+    """Records find_one / insert_one / create_index; insert_one may raise DuplicateKeyError."""
+
+    def __init__(self, *, find_one_seq=None, insert_raises=None):
+        self._find_one_seq = list(find_one_seq or [])
+        self._find_one_idx = 0
+        self.insert_raises = insert_raises
+        self.insert_calls: list[dict[str, Any]] = []
+        self.create_index_calls: list[tuple[list, dict[str, Any]]] = []
+
+    async def find_one(self, query: dict[str, Any]) -> dict[str, Any] | None:
+        if self._find_one_idx < len(self._find_one_seq):
+            doc = self._find_one_seq[self._find_one_idx]
+            self._find_one_idx += 1
+            return dict(doc) if doc else None
+        return None
+
+    async def insert_one(self, doc: dict[str, Any]):
+        self.insert_calls.append(dict(doc))
+        if self.insert_raises:
+            raise self.insert_raises
+
+        class _Result:
+            inserted_id = "new-id"
+
+        return _Result()
+
+    async def create_index(self, keys, **kwargs):
+        self.create_index_calls.append((keys, kwargs))
+
+
+def _fav_doc() -> dict[str, Any]:
+    return {
+        "_id": "fav-1",
+        "name": "Favorites",
+        "type": "favorites",
+        "icon": "Star",
+        "sort_order": 0,
+        "user_id": "user-1",
+        "created_at": utc_now(),
+        "updated_at": utc_now(),
+    }
+
+
+def _channel_doc(doc_id: str = "ch-1", name: str = "feishu-channel") -> dict[str, Any]:
+    return {
+        "_id": doc_id,
+        "name": name,
+        "type": "channel",
+        "icon": "💬",
+        "sort_order": 100,
+        "user_id": "user-1",
+        "created_at": utc_now(),
+        "updated_at": utc_now(),
+    }
+
+
+@pytest.mark.asyncio
+async def test_ensure_indexes_creates_partial_unique_indexes() -> None:
+    storage = ProjectStorage()
+    collection = _FakeProjectCollection()
+    storage._collection = collection
+
+    await storage.ensure_indexes()
+
+    by_name = {kwargs["name"]: kwargs for _keys, kwargs in collection.create_index_calls}
+    assert "project_user_type_idx" in by_name  # 通用查询索引保留
+    # P2-10 ①：favorites partial 唯一
+    fav = by_name["project_user_favorites_uniq"]
+    assert fav["unique"] is True
+    assert fav["partialFilterExpression"] == {"type": "favorites"}
+    # P2-10 ②：channel partial 唯一
+    ch = by_name["project_user_name_type_channel_uniq"]
+    assert ch["unique"] is True
+    assert ch["partialFilterExpression"] == {"type": "channel"}
+
+
+@pytest.mark.asyncio
+async def test_ensure_favorites_returns_existing_on_duplicate() -> None:
+    """并发：首次无 → insert 抛 DuplicateKeyError → 回查返回已存在（幂等）。"""
+    storage = ProjectStorage()
+    collection = _FakeProjectCollection(
+        find_one_seq=[None, _fav_doc()],
+        insert_raises=DuplicateKeyError("duplicate"),
+    )
+    storage._collection = collection
+
+    project = await storage.ensure_favorites_project("user-1")
+
+    assert project.id == "fav-1"
+    assert len(collection.insert_calls) == 1  # 未重试裸 insert
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_by_name_returns_existing_on_duplicate() -> None:
+    """并发：首次无 → insert 抛 DuplicateKeyError → 回查返回已存在（幂等）。"""
+    storage = ProjectStorage()
+    collection = _FakeProjectCollection(
+        find_one_seq=[None, _channel_doc()],
+        insert_raises=DuplicateKeyError("duplicate"),
+    )
+    storage._collection = collection
+
+    project = await storage.get_or_create_by_name("user-1", "feishu-channel")
+
+    assert project.id == "ch-1"
+    assert project.name == "feishu-channel"
+    assert len(collection.insert_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_by_name_inserts_when_absent() -> None:
+    storage = ProjectStorage()
+    collection = _FakeProjectCollection(find_one_seq=[None])  # 无 → insert 成功
+    storage._collection = collection
+
+    project = await storage.get_or_create_by_name("user-1", "new-channel")
+
+    assert project.name == "new-channel"
+    assert len(collection.insert_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_by_name_returns_existing_without_insert() -> None:
+    storage = ProjectStorage()
+    collection = _FakeProjectCollection(find_one_seq=[_channel_doc(name="existing")])
+    storage._collection = collection
+
+    project = await storage.get_or_create_by_name("user-1", "existing")
+
+    assert project.id == "ch-1"
+    assert collection.insert_calls == []  # 命中已有，未 insert


### PR DESCRIPTION
## 概述

**背景**:LambChat 现支持单会话分享(一条链接分享一个会话,full 全量 / partial 按 run 选取),但用户只能**逐个会话**分享,无法一次分享整个项目、或项目内若干会话的集合。

**本 PR** 扩展出**项目维度分享**——一条链接分享整个项目,复刻与单会话一致的两种粒度:

| 粒度 | 行为 | 项目后续增删会话 | 项目被删除后 |
|------|------|----------------|-------------|
| **full**(实时) | 分享项目当前全部会话,访问时实时计算成员 | 自动反映到分享 | 分享失效(联动删除) |
| **partial**(快照) | 创建时打一份快照 | 与原项目解耦、不随之变化 | 分享仍可访问 |

**向后兼容**:现有单会话分享完全不受影响——`share_scope` 默认 `session`,老链接 / 老前端 / 老 API 行为不变,老文档零迁移。

## 后端

**Schema**
- 新增 `ShareScope` 枚举(`session` / `project`)、`ProjectSnapshot`
- `ShareCreate.session_id` 改为可选(项目分享不绑定单个会话)
- 新增 `SharedProjectContentResponse` 等响应模型

**存储层**(复用 `shared_sessions` 集合,零新集合)
- 新增字段:`share_scope` / `project_id` / `session_ids` / `project_snapshot`
- 新增方法:`list_by_project` / `delete_by_project`
- `project_id` 稀疏索引(只索引项目分享文档,不影响单会话分享)

**API**
- `POST /api/share` 扩展支持 `share_scope=project`
- `GET /api/share/public/{share_id}` 统一公开读,按 scope 分流返回 manifest
- `GET /api/share/public/{share_id}/sessions/{session_id}` 子会话事件按需加载(项目分享下会话内容懒加载,避免一次返回全量)
- `GET /api/share/project/{project_id}` 列项目的分享

**安全**
- `partial` 创建时校验项目属主 + `session_ids` 归属(防越权把他人会话纳入快照)
- manifest / 子会话响应裁剪安全字段,不泄露 `user_id` 等内部信息

**清理联动**
- 项目删除时:删除 `full` 分享(实时引用随之失效)、保留 `partial` 快照(快照自洽,仍可访问)

**修复**
- session 批量查询对缺少 `session_id` 字段的会话回退 `_id` 查询,避免 manifest 漏取成员
- `list_ids_by_project` 排序保证分页稳定

## 前端

- 新增 `SharedProjectPage`(项目封面 + 会话列表 + 加载更多分页)、`ShareProjectDialog`、`SharedEntry`
- `share.ts` 扩展 `listByProject` / `getSessionContentInProject`
- 路由按 `share_scope` 分流渲染(单会话 vs 项目)

## SEO

- 新增 `build_shared_project_seo`
- `/shared/{id}` SSR 按 scope 分流

## 工程杂项

- `vitest@4.1.9` patch:worker 启动超时 60s/90s → 600s/900s,规避慢机 / WSL 超时
- eslint `no-unused-vars` 增强(忽略 `_` 前缀变量与解构剩余 siblings)

## 兼容性

- `share_scope` 默认 `session`,**老文档零迁移**
- `session_id` 改可选,老调用方行为不变
- 公开读返回 union(新老字段并集),老前端忽略新字段即可

## 测试

- 后端:`test_project_share_routes.py`、`test_seo.py`、`test_batch_lookup_limits.py`
- 前端:`shareProjectDialogState.test.ts`、`sharedProjectPageState.test.ts`