### PR TITLE
fix(llm): 思考强度 off/none 显式传参 + 按模型家族最大兼容门控（默认 low）

### DIFF
--- a/frontend/src/components/profile/tabs/ProfilePreferencesTab.tsx
+++ b/frontend/src/components/profile/tabs/ProfilePreferencesTab.tsx
@@ -169,7 +169,7 @@ export function ProfilePreferencesTab() {
       ) {
         return stored;
       }
-      return "off";
+      return "low";
     });
 
   // Default model preference

--- a/src/agents/core/thinking.py
+++ b/src/agents/core/thinking.py
@@ -12,7 +12,11 @@ BUDGET_TOKENS_MAP: dict[str, int] = {
 
 
 def normalize_thinking_level(value: Any) -> str:
-    """Normalize legacy and current thinking option values."""
+    """Normalize legacy and current thinking option values.
+
+    Missing/invalid values normalize to "low" (the default intensity);
+    explicit off-aliases (false/none/disabled) normalize to "off".
+    """
     if isinstance(value, bool):
         return "medium" if value else "off"
 
@@ -25,19 +29,25 @@ def normalize_thinking_level(value: Any) -> str:
         if normalized in {"disabled", "disable", "false", "none"}:
             return "off"
 
-    return "off"
+    return "low"
 
 
-def build_thinking_config(agent_options: dict[str, Any] | None) -> dict[str, Any] | None:
+def build_thinking_config(agent_options: dict[str, Any] | None) -> dict[str, Any]:
     """Build provider thinking config from agent options.
 
+    Never returns None: an explicit "off" yields a disabled dict so the client
+    layer can still express "disable thinking" to providers that need it
+    explicitly (e.g. reasoning_effort="none"); omitting the option yields the
+    default "low" level.
+
     Returns a dict with:
-      - "level": normalized level string (for Google protocol)
-      - "budget_tokens": mapped token budget (for Anthropic protocol)
+      - "type": "enabled" | "disabled"
+      - "level": normalized level string (also used by Google protocol)
+      - "budget_tokens": mapped token budget (used by Anthropic manual thinking)
     """
     level = normalize_thinking_level((agent_options or {}).get("enable_thinking"))
     if level == "off":
-        return None
+        return {"type": "disabled", "level": "off", "budget_tokens": 0}
 
     return {
         "type": "enabled",

--- a/src/agents/fast_agent/graph.py
+++ b/src/agents/fast_agent/graph.py
@@ -62,7 +62,7 @@ class FastAgent(BaseGraphAgent):
     _options = {
         "enable_thinking": {
             "type": "string",
-            "default": "off",
+            "default": "low",
             "label": "Thinking",
             "label_key": "agentOptions.enableThinking.label",
             "description": "Control thinking intensity (supported models only)",

--- a/src/agents/search_agent/graph.py
+++ b/src/agents/search_agent/graph.py
@@ -68,7 +68,7 @@ class SearchAgent(BaseGraphAgent):
     _options = {
         "enable_thinking": {
             "type": "string",
-            "default": "off",
+            "default": "low",
             "label": "Thinking",
             "label_key": "agentOptions.enableThinking.label",
             "description": "Control thinking intensity (supported models only)",

--- a/src/agents/team_agent/graph.py
+++ b/src/agents/team_agent/graph.py
@@ -62,7 +62,7 @@ class TeamAgent(BaseGraphAgent):
     _options = {
         "enable_thinking": {
             "type": "string",
-            "default": "off",
+            "default": "low",
             "label": "Thinking",
             "label_key": "agentOptions.enableThinking.label",
             "description": "Control thinking intensity (supported models only)",

--- a/src/infra/goal.py
+++ b/src/infra/goal.py
@@ -147,7 +147,7 @@ def _create_rubric_middleware_with_retry(
       exponential back-off.
     - **400 (e.g. thinking + tool_choice)** → ``ModelRetryMiddleware`` skips
       (400 is not retryable), ``ModelFallbackMiddleware`` catches and replays
-      on the fallback model (without thinking).
+      on the fallback model (with the same thinking config).
 
     Non-retryable, non-fallback errors still surface as ``grader_error`` via
     the base class ``_handle_grader_exception``.

--- a/src/infra/llm/client.py
+++ b/src/infra/llm/client.py
@@ -6,6 +6,7 @@ LLM 客户端
 
 import asyncio
 import os
+import re
 from collections import OrderedDict
 from functools import lru_cache
 from typing import Any, Optional
@@ -133,6 +134,169 @@ def _langchain_profile(profile: Optional[dict]) -> Optional[dict]:
     }
 
 
+# ── Thinking-effort capability gating (issue #211) ──
+# Maximum-compatibility policy: every model family only receives thinking
+# parameters documented as supported by its provider; unverified combinations
+# are never sent (prefer a silent no-op over a provider 400).
+
+# OpenAI-protocol providers whose reasoning models accept reasoning_effort.
+# o1 系不发送：o1-preview/o1-mini 不支持该参数（发送即 400），o1 已退役。
+_REASONING_EFFORT_PREFIXES: dict[str, tuple[str, ...]] = {
+    "openai": ("gpt-5", "o3", "o4"),
+    "xai": ("grok-4",),
+}
+# gpt 版本解析：reasoning_effort="none" 自 gpt-5.1 起支持，用版本比较保持
+# 对未来 5.x 家族的前向兼容（避免硬编码枚举封顶）。
+_GPT_VERSION_RE = re.compile(r"(?:chatgpt-)?gpt-(\d+)(?:[.](\d{1,2})(?!\d))?")
+# zhipu hybrid-reasoning GLM families that accept the `thinking` request-body
+# field (via model_kwargs). GLM-4.x supports explicit "disabled"; GLM-5.x does
+# not (its thinking cannot be turned off). glm-4.7 未核实，不发送。
+_ZHIPU_THINKING_PREFIXES = (
+    "glm-4.5",
+    "glm-4-5",
+    "glm-4.6",
+    "glm-4-6",
+    "glm-5",
+)
+_ZHIPU_DISABLED_PREFIXES = ("glm-4.5", "glm-4-5", "glm-4.6", "glm-4-6")
+
+# 次版本限定为 1-2 位数字且后不跟数字：防止把官方 model ID 里的发布日期
+# 后缀（claude-opus-4-20250514 / grok-4-0709-beta）当成次版本吞掉——否则
+# (4, 20250514) 会被误判进 effort era。
+_CLAUDE_VERSION_RE = re.compile(r"claude-(?:[a-z]+-)*?(\d+)(?:[-.](\d{1,2})(?!\d))?")
+_GEMINI_VERSION_RE = re.compile(r"gemini-(\d+)(?:[-.](\d{1,2})(?!\d))?")
+_GROK_VERSION_RE = re.compile(r"grok-(\d+)(?:[-.](\d{1,2})(?!\d))?")
+
+_EFFORT_BY_LEVEL = {"low": "low", "medium": "medium", "high": "high", "max": "high"}
+
+
+def _version_tuple(match: "re.Match[str]") -> tuple[int, int]:
+    return int(match.group(1)), int(match.group(2) or 0)
+
+
+def _resolve_reasoning_effort(
+    provider: str,
+    model_name: str,
+    thinking: dict[str, Any],
+) -> Optional[str]:
+    """Map a thinking config to reasoning_effort for OpenAI-protocol providers.
+
+    Returns None when the provider/model family is not documented to accept
+    reasoning_effort. For "off", falls back to the model's lowest supported
+    effort value ("none" where the family supports it) so the disable intent
+    is still expressed instead of silently reverting to the model default.
+    """
+    prefixes = _REASONING_EFFORT_PREFIXES.get(provider)
+    if not prefixes:
+        return None
+    name = model_name.lower()
+    # 固定档/非推理变体（gpt-5.1-chat-latest、grok-4-fast-non-reasoning 等）：
+    # effort 不可配置，发送会 400
+    if name.endswith("-chat-latest") or name.endswith("-non-reasoning"):
+        return None
+    if not any(name.startswith(prefix) for prefix in prefixes):
+        return None
+
+    level = str(thinking.get("level") or "medium")
+    enabled = thinking.get("type") == "enabled"
+    if provider == "xai":
+        # grok has no "none" value; omitting the parameter would default to
+        # high, so an explicit off floors to the lowest supported effort.
+        if not enabled:
+            return "low"
+        if level == "max":
+            match = _GROK_VERSION_RE.search(name)
+            return "xhigh" if match and _version_tuple(match) >= (4, 6) else "high"
+        return _EFFORT_BY_LEVEL.get(level, "medium")
+
+    if enabled:
+        return _EFFORT_BY_LEVEL.get(level, "medium")
+    # off → 该模型最低支持档；-pro 变体不支持 minimal/none，统一落到 low
+    if "-pro" not in name:
+        match = _GPT_VERSION_RE.search(name)
+        if match and _version_tuple(match) >= (5, 1):
+            return "none"
+        if name.startswith("gpt-5"):
+            return "minimal"
+    return "low"
+
+
+def _resolve_zhipu_thinking_body(
+    provider: str,
+    model_name: str,
+    thinking: dict[str, Any],
+) -> Optional[dict[str, Any]]:
+    """Map a thinking config to zhipu's `thinking` request-body field."""
+    # 仅智谱官方端点已验证；第三方 GLM 托管（SiliconFlow/OpenRouter 等）不发送
+    if provider != "zhipu":
+        return None
+    name = model_name.lower()
+    if not any(name.startswith(prefix) for prefix in _ZHIPU_THINKING_PREFIXES):
+        return None
+    if thinking.get("type") == "enabled":
+        return {"thinking": {"type": "enabled"}}
+    if any(name.startswith(prefix) for prefix in _ZHIPU_DISABLED_PREFIXES):
+        return {"thinking": {"type": "disabled"}}
+    # GLM-5.x rejects thinking.type="disabled"; leave the model default alone.
+    return None
+
+
+def _resolve_anthropic_thinking(
+    model_name: str,
+    thinking: Optional[dict[str, Any]],
+) -> tuple[Optional[dict[str, Any]], Optional[str], Optional[float]]:
+    """Resolve (thinking_param, effort_param, temperature_override) for Claude.
+
+    Family eras: legacy (<= claude-3-5) and the 4.6 gap accept nothing;
+    manual era (3.7 ~ 4.5) uses thinking+budget_tokens with temperature=1;
+    effort era (4.7+/5) uses effort only — manual "enabled" is rejected there
+    (and triggers a client-side ValueError for claude-opus-5*).
+    """
+    if not thinking:
+        # 未配置思考的调用方（标题生成/推荐等）保持原行为，不注入任何参数
+        return None, None, None
+    match = _CLAUDE_VERSION_RE.search(model_name.lower())
+    if match is None:
+        return None, None, None
+    version = _version_tuple(match)
+
+    if version[0] >= 5 or version >= (4, 7):
+        level = str(thinking.get("level") or "low")
+        if thinking.get("type") != "enabled":
+            # Newest models always think and reject "disabled"; floor effort.
+            level = "low"
+        effort = _EFFORT_BY_LEVEL.get(level, "low")
+        # Newest models also reject non-default sampling parameters outright.
+        return None, effort, 1.0
+    if version == (4, 6):
+        # Manual thinking returns 400 and adaptive thinking is only accepted
+        # on 4.7+/Sonnet 5 — no verified combination, send nothing.
+        return None, None, None
+    if (3, 7) <= version <= (4, 5):
+        if thinking.get("type") != "enabled":
+            return None, None, None
+        manual: dict[str, Any] = {"type": "enabled"}
+        # Anthropic 对 enabled thinking 强制要求 budget_tokens（>=1024）
+        manual["budget_tokens"] = thinking.get("budget_tokens") or 1024
+        # Manual thinking is incompatible with any temperature other than 1.
+        return manual, None, 1.0
+    return None, None, None
+
+
+def _resolve_gemini_thinking_level(
+    model_name: str,
+    thinking: dict[str, Any],
+) -> Optional[str]:
+    """Map a thinking config to thinking_level for Gemini 2.5+ models."""
+    match = _GEMINI_VERSION_RE.search(model_name.lower())
+    if match is None or _version_tuple(match) < (2, 5):
+        return None
+    if thinking.get("type") != "enabled":
+        return None
+    level = str(thinking.get("level") or "medium")
+    return _EFFORT_BY_LEVEL.get(level, "medium")
+
+
 async def _lookup_stored_api_key(
     *,
     model_id: Optional[str],
@@ -231,22 +395,18 @@ class LLMClient:
         protocol = _resolve_protocol(provider)
 
         if protocol == "anthropic":
-            # 将 thinking config 转换为 Anthropic API 格式
-            anthropic_thinking = None
-            effort = None
-            if thinking and thinking.get("type") == "enabled":
-                budget_tokens = thinking.get("budget_tokens")
-                level = thinking.get("level", "medium")
-                # 新版模型 (Claude 4.7+) 使用 output_config.effort
-                # 旧版模型使用 budget_tokens
-                # 两者都传，由 API 选择
-                anthropic_thinking = {"type": "enabled"}
-                if budget_tokens:
-                    anthropic_thinking["budget_tokens"] = budget_tokens
-                effort = level
+            # 按 Claude 家族分代门控（issue #211）：manual 时代（3.7~4.5）传
+            # thinking+budget_tokens 并强制 temperature=1；4.7+/5 系只传 effort
+            # （对这些模型传 manual thinking 会被 API 拒绝，claude-opus-5* 更会
+            # 触发 langchain-anthropic 客户端 ValueError）；3-5 系与 4.6 不传。
+            anthropic_thinking, effort, temperature_override = _resolve_anthropic_thinking(
+                model_name, thinking
+            )
             anthropic_kwargs: dict[str, Any] = {
                 "model_name": model_name,
-                "temperature": temperature,
+                "temperature": (
+                    temperature_override if temperature_override is not None else temperature
+                ),
                 "max_tokens": max_tokens,  # type: ignore[arg-type]
                 "thinking": anthropic_thinking,
                 "effort": effort,
@@ -262,13 +422,10 @@ class LLMClient:
                 anthropic_kwargs["profile"] = profile
             return ChatAnthropic(**anthropic_kwargs, **kwargs)
         if protocol == "google":
-            if thinking and thinking.get("type") == "enabled":
-                thinking_level = thinking.get("level", "medium")
-                # Google only accepts minimal/low/medium/high — map "max" to "high"
-                if thinking_level == "max":
-                    thinking_level = "high"
-            else:
-                thinking_level = None
+            # 仅 Gemini 2.5+ 思考系接受 thinking_level；老模型与关闭档一律不传。
+            # （langchain-google-genai 文档注明 2.5 系惯用 thinking_budget、3 系用
+            # thinking_level；沿用本分支原有的 thinking_level 行为，非本次回归项。）
+            thinking_level = _resolve_gemini_thinking_level(model_name, thinking or {})
             google_kwargs: dict[str, Any] = {
                 "model": model_name,
                 "temperature": temperature,
@@ -298,27 +455,30 @@ class LLMClient:
             "first_event_timeout": settings.LLM_REQUEST_TIMEOUT,
             "non_streaming_timeout": settings.LLM_REQUEST_TIMEOUT,
         }
-        # OpenAI 协议: 传递 reasoning_effort 给推理模型
-        # 仅 OpenAI 官方模型 (provider="openai") 支持 reasoning_effort 参数。
-        # 其他 OpenAI 兼容提供商 (DeepSeek、Qwen 等) 有各自的推理机制，
-        # 发送 reasoning_effort 会触发不兼容的"思考模式"导致 API 报错。
-        if thinking and thinking.get("type") == "enabled":
-            if provider == "openai":
-                level = thinking.get("level", "medium")
-                openai_effort_map = {
-                    "low": "low",
-                    "medium": "medium",
-                    "high": "high",
-                    "max": "high",
-                }
-                openai_kwargs["reasoning_effort"] = openai_effort_map.get(level, "medium")
-            else:
+        # OpenAI 协议：按 provider/模型家族门控思考参数（issue #211）
+        # - openai/xai 推理模型收到 reasoning_effort（off 映射到该模型最低
+        #   支持档，支持 none 的家族为 "none"）
+        # - zhipu GLM-4.5+/GLM-5 收到 `thinking` 请求体字段（经 model_kwargs）
+        # - 其他 OpenAI 兼容提供商 (DeepSeek、Qwen 等) 有各自的推理机制，
+        #   发送 reasoning_effort 会触发不兼容的"思考模式"导致 API 报错
+        reasoning_effort: Optional[str] = None
+        zhipu_thinking_body: Optional[dict[str, Any]] = None
+        if thinking:
+            reasoning_effort = _resolve_reasoning_effort(provider, model_name, thinking)
+            zhipu_thinking_body = _resolve_zhipu_thinking_body(provider, model_name, thinking)
+            if reasoning_effort is None and zhipu_thinking_body is None:
                 logger.debug(
-                    "Thinking requested but reasoning_effort not supported "
+                    "Thinking requested but no thinking parameter is supported "
                     "for provider '%s' (model: %s); skipped.",
                     provider,
                     model_name,
                 )
+        if reasoning_effort is not None:
+            openai_kwargs["reasoning_effort"] = reasoning_effort
+        if zhipu_thinking_body:
+            model_kwargs = dict(kwargs.pop("model_kwargs", {}) or {})
+            model_kwargs.update(zhipu_thinking_body)
+            openai_kwargs["model_kwargs"] = model_kwargs
         if profile:
             openai_kwargs["profile"] = profile
         return ChatOpenAI(**openai_kwargs, **kwargs)

--- a/tests/agents/core/test_thinking.py
+++ b/tests/agents/core/test_thinking.py
@@ -1,10 +1,20 @@
-from src.agents.core.thinking import build_thinking_config
+from src.agents.core.thinking import build_thinking_config, normalize_thinking_level
 
 
-def test_build_thinking_config_returns_none_when_disabled() -> None:
-    assert build_thinking_config({"enable_thinking": False}) is None
-    assert build_thinking_config({"enable_thinking": "off"}) is None
-    assert build_thinking_config({}) is None
+def test_build_thinking_config_returns_disabled_dict_when_off() -> None:
+    disabled = {"type": "disabled", "level": "off", "budget_tokens": 0}
+    assert build_thinking_config({"enable_thinking": False}) == disabled
+    assert build_thinking_config({"enable_thinking": "off"}) == disabled
+    assert build_thinking_config({"enable_thinking": "none"}) == disabled
+    assert build_thinking_config({"enable_thinking": "disabled"}) == disabled
+
+
+def test_build_thinking_config_defaults_to_low_when_missing() -> None:
+    low = {"type": "enabled", "level": "low", "budget_tokens": 1024}
+    assert build_thinking_config({}) == low
+    assert build_thinking_config(None) == low
+    assert build_thinking_config({"enable_thinking": None}) == low
+    assert build_thinking_config({"enable_thinking": "bogus-value"}) == low
 
 
 def test_build_thinking_config_maps_legacy_boolean_to_medium() -> None:
@@ -36,3 +46,15 @@ def test_build_thinking_config_maps_supported_levels() -> None:
         "level": "max",
         "budget_tokens": 65536,
     }
+
+
+def test_normalize_thinking_level_defaults_to_low() -> None:
+    assert normalize_thinking_level(None) == "low"
+    assert normalize_thinking_level("unknown") == "low"
+
+
+def test_normalize_thinking_level_keeps_explicit_off() -> None:
+    assert normalize_thinking_level("off") == "off"
+    assert normalize_thinking_level(False) == "off"
+    assert normalize_thinking_level("none") == "off"
+    assert normalize_thinking_level("disabled") == "off"

--- a/tests/infra/llm/test_thinking_gating.py
+++ b/tests/infra/llm/test_thinking_gating.py
@@ -1,0 +1,310 @@
+"""Capability-gated thinking parameter construction for the three protocol branches.
+
+Covers the maximum-compatibility policy from issue #211: every model family
+only receives thinking parameters documented as supported; unverified
+combinations are never sent (prefer a silent no-op over a provider 400).
+"""
+
+from src.infra.llm.client import LLMClient
+
+_BUDGETS = {"low": 1024, "medium": 8192, "high": 32768, "max": 65536}
+ENABLED = lambda level: {"type": "enabled", "level": level, "budget_tokens": _BUDGETS[level]}  # noqa: E731
+OFF = {"type": "disabled", "level": "off", "budget_tokens": 0}
+
+
+def _openai_model(provider: str, model_name: str, thinking: dict | None):
+    return LLMClient._create_model(
+        provider,
+        model_name,
+        temperature=0.7,
+        api_key="sk-test",
+        thinking=thinking,
+    )
+
+
+def _anthropic_model(model_name: str, thinking: dict | None, temperature: float = 0.7):
+    return LLMClient._create_model(
+        "anthropic",
+        model_name,
+        temperature=temperature,
+        api_key="sk-test",
+        thinking=thinking,
+    )
+
+
+def _google_model(model_name: str, thinking: dict | None):
+    return LLMClient._create_model(
+        "google",
+        model_name,
+        temperature=0.7,
+        api_key="sk-test",
+        thinking=thinking,
+    )
+
+
+# ── OpenAI provider ──────────────────────────────────────────────────────
+
+
+def test_openai_reasoning_models_receive_effort_per_level() -> None:
+    for level, expected in [("low", "low"), ("medium", "medium"), ("high", "high"), ("max", "high")]:
+        model = _openai_model("openai", "gpt-5.5", ENABLED(level))
+        assert model.reasoning_effort == expected
+
+
+def test_openai_off_maps_to_none_when_supported() -> None:
+    for model_name in ("gpt-5.1", "gpt-5.5", "gpt-5.5-chat"):
+        model = _openai_model("openai", model_name, OFF)
+        assert model.reasoning_effort == "none", model_name
+
+
+def test_openai_off_maps_to_minimal_on_gpt5_family_without_none() -> None:
+    for model_name in ("gpt-5", "gpt-5-mini", "gpt-5-nano"):
+        model = _openai_model("openai", model_name, OFF)
+        assert model.reasoning_effort == "minimal", model_name
+
+
+def test_openai_off_maps_to_low_on_o_series() -> None:
+    for model_name in ("o3", "o3-mini", "o4-mini"):
+        model = _openai_model("openai", model_name, OFF)
+        assert model.reasoning_effort == "low", model_name
+
+
+def test_openai_non_reasoning_models_never_receive_effort() -> None:
+    for model_name in ("gpt-4o", "gpt-4o-mini", "gpt-4.1"):
+        for thinking in (ENABLED("high"), OFF):
+            model = _openai_model("openai", model_name, thinking)
+            assert model.reasoning_effort is None, model_name
+
+
+def test_openai_chat_latest_variants_receive_no_effort() -> None:
+    for thinking in (ENABLED("low"), OFF):
+        model = _openai_model("openai", "gpt-5.1-chat-latest", thinking)
+        assert model.reasoning_effort is None
+
+
+# ── xAI provider (grok) ──────────────────────────────────────────────────
+
+
+def test_xai_grok46_receives_effort_per_level() -> None:
+    for level, expected in [("low", "low"), ("medium", "medium"), ("high", "high")]:
+        model = _openai_model("xai", "grok-4.6", ENABLED(level))
+        assert model.reasoning_effort == expected
+    model = _openai_model("xai", "grok-4.6", ENABLED("max"))
+    assert model.reasoning_effort == "xhigh"
+
+
+def test_xai_grok45_has_no_xhigh() -> None:
+    model = _openai_model("xai", "grok-4.5", ENABLED("max"))
+    assert model.reasoning_effort == "high"
+
+
+def test_xai_off_maps_to_lowest_supported() -> None:
+    for model_name in ("grok-4.5", "grok-4.6", "grok-4-fast"):
+        model = _openai_model("xai", model_name, OFF)
+        assert model.reasoning_effort == "low", model_name
+
+
+def test_xai_older_grok_models_receive_nothing() -> None:
+    for thinking in (ENABLED("high"), OFF):
+        model = _openai_model("xai", "grok-3-mini", thinking)
+        assert model.reasoning_effort is None
+
+
+def test_xai_dated_alias_is_not_misread_as_47() -> None:
+    # 回归：grok-4-0709-beta 的日期后缀曾被吞成次版本号 (4,709)，max 档误发 xhigh
+    model = _openai_model("xai", "grok-4-0709-beta", ENABLED("max"))
+    assert model.reasoning_effort == "high"
+
+
+def test_xai_non_reasoning_variant_excluded() -> None:
+    for thinking in (ENABLED("low"), OFF):
+        model = _openai_model("xai", "grok-4-fast-non-reasoning", thinking)
+        assert model.reasoning_effort is None
+
+
+def test_openai_o1_family_not_supported() -> None:
+    # o1-preview/o1-mini 不支持 reasoning_effort（发送即 400），o1 已退役 → 整族不发送
+    for model_name in ("o1", "o1-mini", "o1-preview"):
+        for thinking in (ENABLED("low"), OFF):
+            model = _openai_model("openai", model_name, thinking)
+            assert model.reasoning_effort is None, model_name
+
+
+def test_openai_pro_variants_off_floor_to_low() -> None:
+    # gpt-5-pro 仅支持 low/medium/high，不支持 minimal/none
+    for model_name in ("gpt-5-pro", "gpt-5.1-pro"):
+        model = _openai_model("openai", model_name, OFF)
+        assert model.reasoning_effort == "low", model_name
+
+
+# ── zhipu provider (GLM) ─────────────────────────────────────────────────
+
+
+def test_zhipu_glm4_receives_thinking_body() -> None:
+    model = _openai_model("zhipu", "glm-4.6", ENABLED("low"))
+    assert model.model_kwargs["thinking"] == {"type": "enabled"}
+    model = _openai_model("zhipu", "glm-4.5-air", ENABLED("high"))
+    assert model.model_kwargs["thinking"] == {"type": "enabled"}
+
+
+def test_zhipu_glm4_off_disables_thinking() -> None:
+    model = _openai_model("zhipu", "glm-4.6", OFF)
+    assert model.model_kwargs["thinking"] == {"type": "disabled"}
+
+
+def test_zhipu_glm5_cannot_disable() -> None:
+    model = _openai_model("zhipu", "glm-5.3", OFF)
+    assert "thinking" not in model.model_kwargs
+    model = _openai_model("zhipu", "glm-5.3", ENABLED("medium"))
+    assert model.model_kwargs["thinking"] == {"type": "enabled"}
+
+
+def test_zhipu_legacy_models_receive_nothing() -> None:
+    for thinking in (ENABLED("low"), OFF):
+        model = _openai_model("zhipu", "chatglm-3-turbo", thinking)
+        assert "thinking" not in model.model_kwargs
+        assert model.reasoning_effort is None
+
+
+def test_zhipu_unverified_families_receive_nothing() -> None:
+    # glm-4.7 未在官方矩阵核实 → 不发送
+    for thinking in (ENABLED("low"), OFF):
+        model = _openai_model("zhipu", "glm-4.7", thinking)
+        assert "thinking" not in model.model_kwargs
+
+
+def test_zhipu_body_not_sent_to_other_providers_hosting_glm() -> None:
+    # 第三方 GLM 托管（SiliconFlow/OpenRouter 等）只按模型名匹配时不得收到智谱字段
+    for provider in ("openai", "deepseek", "siliconflow"):
+        model = _openai_model(provider, "glm-4.6", ENABLED("low"))
+        assert "thinking" not in model.model_kwargs, provider
+
+
+def test_zhipu_does_not_receive_openai_cache_extensions() -> None:
+    model = _openai_model("zhipu", "glm-4.6", ENABLED("low"))
+    assert "prompt_cache_key" not in model.model_kwargs
+    assert "prompt_cache_retention" not in model.model_kwargs
+
+
+# ── other OpenAI-compatible providers keep current behaviour ────────────
+
+
+def test_other_openai_protocol_providers_receive_no_thinking_params() -> None:
+    for provider, model_name in (("deepseek", "deepseek-chat"), ("qwen", "qwen-max")):
+        for thinking in (ENABLED("medium"), OFF):
+            model = _openai_model(provider, model_name, thinking)
+            assert model.reasoning_effort is None
+            assert "thinking" not in model.model_kwargs
+
+
+# ── Anthropic protocol branch ────────────────────────────────────────────
+
+
+def test_claude_3_5_receives_no_thinking_params() -> None:
+    for thinking in (ENABLED("high"), OFF):
+        model = _anthropic_model("claude-3-5-sonnet-latest", thinking)
+        assert model.thinking is None
+        assert model.reasoning_effort is None
+
+
+def test_claude_manual_era_receives_thinking_and_budget() -> None:
+    for model_name in ("claude-opus-4-1-20250805", "claude-sonnet-4-5", "claude-3-7-sonnet-latest"):
+        model = _anthropic_model(model_name, ENABLED("medium"))
+        assert model.thinking == {"type": "enabled", "budget_tokens": 8192}, model_name
+        assert model.reasoning_effort is None
+        # manual thinking rejects any temperature other than 1
+        assert model.temperature == 1.0, model_name
+
+
+def test_claude_manual_era_off_sends_nothing_and_keeps_temperature() -> None:
+    model = _anthropic_model("claude-opus-4-1-20250805", OFF)
+    assert model.thinking is None
+    assert model.reasoning_effort is None
+    assert model.temperature == 0.7
+
+
+def test_claude_dated_ids_resolve_to_manual_era() -> None:
+    # 回归：日期后缀（20250514）曾被正则吞成次版本号，导致 Claude 4 被误判
+    # 进 effort era（发 output_config.effort 而不发 manual thinking）
+    for model_name in ("claude-opus-4-20250514", "claude-sonnet-4-20250514", "claude-opus-4-0-20250514"):
+        model = _anthropic_model(model_name, ENABLED("medium"))
+        assert model.thinking == {"type": "enabled", "budget_tokens": 8192}, model_name
+        assert model.reasoning_effort is None, model_name
+        off = _anthropic_model(model_name, OFF)
+        assert off.thinking is None
+        assert off.reasoning_effort is None
+        assert off.temperature == 0.7
+
+
+def test_claude_4_6_gap_sends_nothing() -> None:
+    for thinking in (ENABLED("medium"), OFF):
+        model = _anthropic_model("claude-opus-4-6", thinking)
+        assert model.thinking is None
+        assert model.reasoning_effort is None
+
+
+def test_claude_effort_era_receives_effort_only() -> None:
+    for model_name in ("claude-opus-5", "claude-sonnet-5", "claude-opus-4-7"):
+        model = _anthropic_model(model_name, ENABLED("low"))
+        assert model.thinking is None, model_name
+        assert model.reasoning_effort == "low", model_name
+        # newest models also reject non-default sampling parameters
+        assert model.temperature == 1.0, model_name
+
+
+def test_claude_effort_era_max_maps_to_high() -> None:
+    model = _anthropic_model("claude-opus-5", ENABLED("max"))
+    assert model.reasoning_effort == "high"
+
+
+def test_claude_effort_era_off_floors_to_low() -> None:
+    model = _anthropic_model("claude-opus-5", OFF)
+    assert model.thinking is None
+    assert model.reasoning_effort == "low"
+
+
+def test_anthropic_without_thinking_config_keeps_current_behaviour() -> None:
+    # 未配置思考的调用方（标题生成/推荐等）不应被注入任何参数
+    model = _anthropic_model("claude-opus-5", None)
+    assert model.thinking is None
+    assert model.reasoning_effort is None
+    assert model.temperature == 0.7
+
+
+def test_anthropic_protocol_third_party_models_receive_nothing() -> None:
+    for model_name in ("kimi-k2-instruct", "minimax-m2", "glm-4.7"):
+        for thinking in (ENABLED("high"), OFF):
+            model = _anthropic_model(model_name, thinking)
+            assert model.thinking is None, model_name
+            assert model.reasoning_effort is None, model_name
+
+
+# ── Google protocol branch ───────────────────────────────────────────────
+
+
+def test_gemini_2_5_receives_thinking_level_per_level() -> None:
+    for level, expected in [("low", "low"), ("medium", "medium"), ("high", "high"), ("max", "high")]:
+        model = _google_model("gemini-2.5-flash", ENABLED(level))
+        assert model.reasoning_effort == expected
+
+
+def test_gemini_off_omits_thinking_level() -> None:
+    model = _google_model("gemini-2.5-flash", OFF)
+    assert model.reasoning_effort is None
+
+
+def test_gemini_newer_families_supported() -> None:
+    model = _google_model("gemini-3-pro-preview", ENABLED("low"))
+    assert model.reasoning_effort == "low"
+
+
+def test_gemini_old_models_receive_nothing() -> None:
+    for model_name in ("gemini-2.0-flash", "gemini-1.5-pro", "gemma-3-27b-it", "gemini-flash-latest"):
+        for thinking in (ENABLED("high"), OFF):
+            model = _google_model(model_name, thinking)
+            assert model.reasoning_effort is None, model_name
+
+
+def test_gemini_2_5_lite_variant_supported() -> None:
+    model = _google_model("gemini-2.5-flash-lite", ENABLED("low"))
+    assert model.reasoning_effort == "low"


### PR DESCRIPTION
修复 #211。
按之前沟通的结论实现：最大兼容原则（每个模型只发送其官方文档确认支持的参数，未验证的组合一律不发送），未上线的 Claude / Gemini 系一并支持。

## 一、要解决的问题

### 问题 1：用户选了「关闭思考」，实际关不掉（issue 主诉）

现在的参数链路是：前端选择思考强度 → `agent_options.enable_thinking` →
`build_thinking_config()` 生成配置 → `client.py` 按协议分支发参数。

当强度为 `off` 时，`build_thinking_config()` 返回 `None`，导致 `client.py`
**一个参数都不发**，模型于是使用自己出厂默认的思考行为。对 OpenAI 的推理模型来说，
省略 `reasoning_effort` 意味着用默认档——gpt-5 / gpt-5.5 默认 `medium`（等于开思考），
所以用户选「关闭」实际上关不掉。（gpt-5.1 是例外：它的默认值本身就是 `none`，不受影响。）

### 问题 2：GLM 和 Grok 的思考开关完全是摆设

`client.py` 的 OpenAI 分支里，只有 `provider == "openai"` 才会发送
`reasoning_effort`。智谱（zhipu）和 xAI 虽然走的是 OpenAI 兼容协议，但 provider
名称不是 `"openai"`，于是在任何思考档位下都被直接跳过，只打一条 debug 日志。

结果是：GLM-4.6 默认混合思考（模型自动判断是否思考，等于开着），用户关不掉；
grok-4.5 / grok-4.6 默认 `high` 档，用户降不下来。和问题 1 是同一个用户可见症状
（选了没效果），但机制不同，所以一并修。

### 问题 3：开启思考时，对不支持的模型会直接报错

现在的代码在发送思考参数前**没有任何模型能力判断**，以下组合会失败：

- claude-3-5 系：不支持 thinking 参数 → 服务端 400；
- claude-3-7 ~ 4.5：开 thinking 时 API 强制要求 temperature 必须是 1，
  而 LambChat 默认 temperature=0.7 → 400；
- claude-4.6 及以后：manual thinking 已被 API 拒绝；
- claude-opus-5*：更严重，langchain-anthropic 会在**客户端本地直接抛 ValueError**
  （因为我们对所有开启思考的请求同时发送 thinking 和 effort 两个参数）——这是一个
  独立于本 issue 的现存 bug，本 PR 顺带修复；
- gpt-4o / gpt-4.1 等非推理模型：收到 `reasoning_effort` → 400；
- gemini 1.5 / 2.0 等老模型：收到 `thinking_level` → 报错。

默认值改成 `low` 之后，这些组合会出现在默认路径上，所以门控是本次修复的主体。

### 问题 4：默认值

三个 agent 的 `enable_thinking` 默认值目前是 `off`，issue 要求改为 `low`。

## 二、修复思路

总原则（最大兼容）：

1. 用户的思考意图**显式**传给模型，不再靠省略参数隐式表达；
2. 每个模型家族只发送其**官方文档确认支持**的参数和取值；
3. 没有文档依据的组合**一律不发送**——宁可某个档位无效（no-op），也不能让请求报 400；
4. 用户要的档位在目标模型上不存在时（比如某模型没有「关闭」），落到该模型
   **最接近的最低支持档**，并在代码注释里写明原因。

## 三、逐家说明

### GPT（openai）

只有推理模型才发 `reasoning_effort`：gpt-5 全系和 o3 / o4-mini；
gpt-4o、gpt-4.1 等非推理模型完全不带这个参数。

`off` 的映射分三种情况：

- gpt-5.1 及以后（5.5 等）：发 `none`，这是真正的关闭值（OpenAI 从 gpt-5.1 开始支持）；
  判断用版本比较而非硬编码模型名单，未来 5.x 新家族自动适用；
- gpt-5 初代（含 mini / nano）：没有 `none`，最低是 `minimal`，落到 `minimal`；
- o3 / o4-mini：最低档是 `low`，落到 `low`。

两个特殊变体：`-pro` 型号（如 gpt-5-pro、gpt-5.1-pro）官方不支持 minimal / none，
`off` 统一落到 `low`；`-chat-latest` 型号是固定思考档的变体，什么档位都不发。

### Grok（xai）

grok-4 系支持 `reasoning_effort`（low / medium / high，4.6 起增加 xhigh），
**没有关闭值，且思维链常开**。

`off` 映射为 `low` 而不是省略——因为省略参数时模型默认 `high`，比用户想要的更「爱思考」，
发 `low` 才是更接近用户意图的最低档。`max` 档映射 `xhigh`，但只对 grok-4.6 及以后
（4.5 没有 xhigh，发过去会 400，落到 `high`）。

边界防护：`grok-4-0709-beta` 这类带日期后缀的真实模型 ID 不会被误判成
「grok 4.709 版」（否则会错误地拿到 xhigh）；`grok-4-fast-non-reasoning`
非推理变体整体不发。

### GLM（智谱）

智谱的 OpenAI 兼容接口用请求体里的 `thinking: {"type": "enabled"/"disabled"}`
字段控制思考，和 OpenAI 的 `reasoning_effort` 是两套东西，所以按 provider 单独构造。

- GLM-4.5 / 4.6：二值控制。`off` → `disabled`（真正的关闭），其余档位 → `enabled`
  （这两代没有更深的中途档，开思考后深度由模型自判）；
- GLM-5.x：官方已不支持 `disabled`（思维无法关闭），`off` 时不发送任何参数，
  其余档位发 `enabled`；
- 只对 provider 为 `zhipu`（智谱官方端点）生效。第三方托管的 GLM（比如 SiliconFlow、
  OpenRouter 上配的 glm 模型）不发这个字段——那些端点是否接受智谱私有字段没有验证过；
- glm-4.7 暂不发送（官方文档未核实，见「保守处理」）。

### Claude（anthropic）

Claude 各代对思考参数的支持差异很大，按模型名解析版本后分四档处理：

- **claude-3-5 及更早**：不支持思考参数，什么都不发；
- **claude-3-7 ~ 4.5（manual thinking 时代）**：发 `thinking={"type":"enabled",
  "budget_tokens":N}`（N 按档位映射 1024~65536），**同时把 temperature 强制为 1**
  ——这是 API 的硬性要求，不改必 400。`off` 时不发思考参数（对这几代，不发就等于关闭，
  这个行为原本就正确，保持不变），temperature 也不动；
- **claude-4.6**：manual thinking 被 API 拒绝、新的 adaptive 形态又只被 4.7+ 接受，
  没有已验证的安全组合，保守起见什么都不发（见「保守处理」）；
- **claude-4.7+ / 5 系（effort 时代）**：只传 `effort`，**绝不传 manual thinking**——
  这同时消除了开头提到的 claude-opus-5* 客户端 ValueError。这几代模型思维链无法关闭
  （官方拒绝 disabled），`off` 落到 `effort=low`。另外这批最新的模型对非默认采样参数
  本身就会报错，所以只要走到这一档就把 temperature 置为 1。

非 claude 命名但走 Anthropic 协议的模型（kimi、zai 的 GLM、minimax 等）不匹配任何
claude 版本号，一律不发送——各家的思考机制不同且未验证。

**一个刻意保留的行为**：完全没配置思考的调用方（标题生成、推荐、上下文压缩等内部
LLM 调用）保持原样，一个参数都不注入，不受本次门控影响。

### Gemini（google）

2.5 及以上的思考系模型发 `thinking_level`（low / medium / high，`max` 沿用原有的
降级到 `high`）；`off` 时不发（等于关闭，原行为正确）；1.5 / 2.0 等老模型和
无法识别版本的名字（如 `gemini-flash-latest`）不发。

## 四、默认值 off → low

- 三个 agent 的 `graph.py` 与前端 `ProfilePreferencesTab` 的兜底值同步改为 `low`。
  必须前后端一起改：前端是从后端下发的 options `default` 构建请求值的，只改后端
  会出现「设置页显示 Off、实际生效 low」的错位；
- **存量用户不受影响**：曾经显式选过 `off` 的用户，选择同时存在 localStorage 和
  服务端 metadata 里，优先级高于一切默认值；
- 受影响的路径（`enable_thinking` 缺失的调用）：API 直调、飞书渠道、会话恢复、
  定时任务——这些会话从「不思考」变为「low 思考」。

## 五、保守处理（有文档依据后可放开）

| 项 | 当前处理 | 原因 |
|---|---|---|
| claude-4.6 | 不发送任何思考参数 | manual 被 400、adaptive 仅 4.7+ 接受，无安全组合 |
| GLM-4.7 | 不发送 | 官方文档未核实 |
| gemini 2.5 的参数形态 | 沿用原有 `thinking_level` | langchain 文档提到 2.5 惯用 thinking_budget，未改行为只加注释 |

## 六、测试与验证

- 重写 `tests/agents/core/test_thinking.py`：disabled dict、默认 low、
  显式 off 与缺失配置的语义区分；
- 新增 `tests/infra/llm/test_thinking_gating.py`（43 个用例）：覆盖上述全部
  家族 × 档位组合，以及边界回归——带日期后缀的官方模型 ID、`-pro` / `-chat-latest` /
  `-non-reasoning` 变体、第三方托管的 GLM、未配置思考的调用方零注入、
  claude-opus-5 不再收到 manual thinking；
- `build_thinking_config()` 的所有消费方（retry / rubric 中间件、fallback 链）
  已逐一核实为精确判断 `type == "enabled"`，disabled dict 不会误触发任何路径；
- ruff / mypy 通过；基于最新 main（7ced0768），已适配 #7cadb4c6 引入的适配器层重构。
