### PR TITLE
fix(session): prevent chunk-storage event loss after refresh

### DIFF
--- a/src/infra/session/dual_writer.py
+++ b/src/infra/session/dual_writer.py
@@ -384,7 +384,15 @@ class DualEventWriter:
                         stored_doc = None
                         try:
                             stored_doc = await self.trace.collection.find_one(
-                                {"trace_id": trace_id}, {"_id": 0}
+                                # Keep the projection tight: legacy traces can
+                                # carry a huge embedded events array.
+                                {"trace_id": trace_id},
+                                {
+                                    "_id": 0,
+                                    "events": 0,
+                                    "first_event_preview": 0,
+                                    "last_event_preview": 0,
+                                },
                             )
                         except Exception:
                             stored_doc = None
@@ -533,6 +541,7 @@ class DualEventWriter:
         trace_id: str,
         status: str = "completed",
         metadata: Optional[Dict[str, Any]] = None,
+        ensure_token_usage: bool = True,
     ) -> bool:
         """
         标记 trace 完成
@@ -541,11 +550,12 @@ class DualEventWriter:
             trace_id: Trace ID
             status: 最终状态 (completed/error)
             metadata: 额外元数据
-
-        Returns:
+            ensure_token_usage: 是否在 storage 侧补写 token:usage 事件
             是否更新成功
         """
-        return await self.trace.complete_trace(trace_id, status, metadata)
+        return await self.trace.complete_trace(
+            trace_id, status, metadata, ensure_token_usage=ensure_token_usage
+        )
 
     async def set_run_recommend_questions(
         self,

--- a/src/infra/session/dual_writer.py
+++ b/src/infra/session/dual_writer.py
@@ -378,11 +378,24 @@ class DualEventWriter:
                             continue
                         start_seq = int(trace_doc.get("event_count", 0)) - len(events) + 1
                     else:
-                        trace_doc = {
-                            "trace_id": trace_id,
-                            "session_id": items[0][3],
-                            "run_id": items[0][4],
-                        }
+                        # Retry path: prefer the real trace document so chunk
+                        # metadata (session_id/run_id) matches storage instead
+                        # of the possibly divergent buffered values.
+                        stored_doc = None
+                        try:
+                            stored_doc = await self.trace.collection.find_one(
+                                {"trace_id": trace_id}, {"_id": 0}
+                            )
+                        except Exception:
+                            stored_doc = None
+                        if stored_doc is not None:
+                            trace_doc = stored_doc
+                        else:
+                            trace_doc = {
+                                "trace_id": trace_id,
+                                "session_id": items[0][3],
+                                "run_id": items[0][4],
+                            }
                     appended = await self.trace.append_events_to_chunks(
                         trace_doc,
                         events,
@@ -395,17 +408,22 @@ class DualEventWriter:
                         failed_chunk_items.extend(
                             _with_chunk_retry_metadata(
                                 item,
-                                reserved_start_seq=start_seq + offset,
+                                # Keep the group base seq for every item so the
+                                # retry re-forms one group instead of one group
+                                # per event.
+                                reserved_start_seq=start_seq,
                                 skip_legacy=dual_write_legacy or _buffer_item_skip_legacy(item),
                             )
-                            for offset, item in enumerate(items)
+                            for item in items
                         )
                     else:
                         failed_chunk_items.extend(items)
-                    logger.warning(
-                        "Chunk write failed for trace %s with %s events: %s",
+                    logger.error(
+                        "Chunk write failed for trace %s with %s events (seq %s..%s): %s",
                         trace_id,
                         len(events),
+                        start_seq,
+                        (start_seq or 0) + len(events) - 1,
                         e,
                     )
 

--- a/src/infra/session/manager.py
+++ b/src/infra/session/manager.py
@@ -660,6 +660,7 @@ class SessionManager:
             if not run_id:
                 continue
             cloned_doc = None
+            clone_chunks = False
             if run_id == target["run_id"]:
                 if target["target_type"] == "user":
                     cloned_doc = await run_blocking_io(
@@ -676,6 +677,7 @@ class SessionManager:
                         target_session.id,
                         user_id,
                     )
+                    clone_chunks = True
             elif target.get("completed_run_ids") is not None:
                 if run_id in target["completed_run_ids"]:
                     cloned_doc = await run_blocking_io(
@@ -684,6 +686,7 @@ class SessionManager:
                         target_session.id,
                         user_id,
                     )
+                    clone_chunks = True
             else:
                 cloned_doc = await run_blocking_io(
                     self._build_cloned_trace_doc,
@@ -691,13 +694,35 @@ class SessionManager:
                     target_session.id,
                     user_id,
                 )
+                clone_chunks = True
 
             if cloned_doc is not None:
                 result.copied_trace_count += 1
+                # Chunked event storage: full clones keep the source's
+                # event_count/chunk_count, so the chunk documents must be
+                # copied under the cloned trace_id as well, otherwise the
+                # clone has zero readable events.
+                if clone_chunks:
+                    await self._clone_trace_chunk_docs(trace, cloned_doc)
                 if collect_checkpoint_messages:
+                    docs_for_messages = [cloned_doc]
+                    if clone_chunks and not cloned_doc.get("events"):
+                        # Chunked storage: rebuild the in-memory legacy view
+                        # from the source trace so message extraction works.
+                        try:
+                            source_events = await self.trace_storage.read_trace_events_compat(
+                                str(trace.get("trace_id"))
+                            )
+                        except Exception as e:
+                            logger.warning(
+                                "Failed to read source events for checkpoint clone: %s", e
+                            )
+                            source_events = []
+                        if source_events:
+                            docs_for_messages = [{**cloned_doc, "events": source_events}]
                     checkpoint_messages = await run_blocking_io(
                         build_messages_from_trace_events,
-                        [cloned_doc],
+                        docs_for_messages,
                     )
                     result.checkpoint_messages.extend(checkpoint_messages)
                 batch.append(cloned_doc)
@@ -717,8 +742,6 @@ class SessionManager:
                 "_id": 0,
                 "trace_id": 1,
                 "run_id": 1,
-                "events.event_type": 1,
-                "events.data": 1,
             },
         ).sort("started_at", 1)
         completed_run_count = 0
@@ -729,7 +752,18 @@ class SessionManager:
                 continue
             turn_index = completed_run_count + 1
 
-            for event in trace.get("events", []):
+            # Chunked event storage keeps events out of the trace document;
+            # use the compat reader so both storage modes are covered.
+            trace_id = trace.get("trace_id")
+            compat_reader = getattr(self.trace_storage, "read_trace_events_compat", None)
+            events: list[dict] = list(trace.get("events") or [])
+            if callable(compat_reader) and trace_id:
+                try:
+                    events = await compat_reader(str(trace_id), event_types=["user:message"])
+                except Exception as e:
+                    logger.warning("Failed to read events for fork target %s: %s", trace_id, e)
+                    events = []
+            for event in events:
                 if event.get("event_type") != "user:message":
                     continue
                 data = event.get("data") or {}
@@ -771,7 +805,38 @@ class SessionManager:
         cloned["trace_id"] = f"trace_{uuid.uuid4().hex}"
         cloned["session_id"] = session_id
         cloned["user_id"] = user_id
+        # Never inherit an in-flight chunk write marker: it would fence every
+        # later writer on the cloned trace with no owner to release it.
+        cloned.pop("attachment_chunk_write_operation", None)
         return cloned
+
+    async def _clone_trace_chunk_docs(self, source_trace: dict, cloned_trace: dict) -> None:
+        """Copy chunked event documents of a trace to its cloned trace_id."""
+        source_trace_id = source_trace.get("trace_id")
+        cloned_trace_id = cloned_trace.get("trace_id")
+        if not source_trace_id or not cloned_trace_id or source_trace_id == cloned_trace_id:
+            return
+        try:
+            cursor = self.trace_storage.chunks_collection.find({"trace_id": source_trace_id})
+            docs: list[dict] = []
+            async for chunk_doc in cursor:
+                cloned_chunk = deepcopy(chunk_doc)
+                cloned_chunk.pop("_id", None)
+                cloned_chunk["trace_id"] = cloned_trace_id
+                cloned_chunk["session_id"] = cloned_trace.get("session_id", "")
+                cloned_chunk.pop("attachment_chunk_staging", None)
+                cloned_chunk.pop("replacement_target_trace_id", None)
+                cloned_chunk.pop("replacement_operation_id", None)
+                docs.append(cloned_chunk)
+            if docs:
+                await self.trace_storage.chunks_collection.insert_many(docs)
+        except Exception as e:
+            logger.warning(
+                "Failed to clone chunk docs from trace %s to %s: %s",
+                source_trace_id,
+                cloned_trace_id,
+                e,
+            )
 
     def _build_partial_user_trace_doc(
         self,

--- a/src/infra/session/manager.py
+++ b/src/infra/session/manager.py
@@ -829,7 +829,16 @@ class SessionManager:
                 cloned_chunk.pop("replacement_operation_id", None)
                 docs.append(cloned_chunk)
             if docs:
-                await self.trace_storage.chunks_collection.insert_many(docs)
+                try:
+                    await self.trace_storage.chunks_collection.insert_many(docs, ordered=False)
+                except Exception:
+                    # Partial inserts would leave the clone with a subset of
+                    # its events; remove everything and let the compat reader
+                    # fall back to whatever legacy events remain.
+                    await self.trace_storage.chunks_collection.delete_many(
+                        {"trace_id": cloned_trace_id}
+                    )
+                    raise
         except Exception as e:
             logger.warning(
                 "Failed to clone chunk docs from trace %s to %s: %s",

--- a/src/infra/session/trace_chunk_rollback.py
+++ b/src/infra/session/trace_chunk_rollback.py
@@ -1,0 +1,78 @@
+"""Rollback helper for reserved chunk sequence ranges.
+
+Split out of ``trace_event_chunks`` to keep that module within the
+1000-line backend source limit.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict
+
+from src.infra.session import trace_storage as trace_storage_helpers
+from src.infra.utils.datetime import utc_now
+
+ATTACHMENT_CHUNK_WRITE_FIELD = "attachment_chunk_write_operation"
+TRACE_EVENT_REVISION_FIELD = "event_revision"
+
+
+class TraceChunkRollbackMixin:
+    """Undo reserved chunk sequence ranges after failed append attempts."""
+
+    if TYPE_CHECKING:
+        collection: Any
+        chunks_collection: Any
+
+    async def rollback_event_sequence_range(
+        self,
+        trace_doc: Dict[str, Any],
+        start_seq: int,
+        event_count: int,
+    ) -> None:
+        """Undo a reserved chunk sequence range after a failed append attempt."""
+        trace_id = str(trace_doc.get("trace_id") or "")
+        event_count = max(int(event_count or 0), 0)
+        if not trace_id or event_count <= 0:
+            return
+
+        now = utc_now()
+        try:
+            reserved_end_count = int(trace_doc.get("event_count", 0))
+        except (TypeError, ValueError):
+            reserved_end_count = 0
+        end_seq = start_seq + event_count - 1
+        chunk_size = trace_storage_helpers._get_event_chunk_size()
+        start_chunk = trace_storage_helpers._event_chunk_index(start_seq)
+        end_chunk = trace_storage_helpers._event_chunk_index(end_seq)
+        for chunk_index in range(start_chunk, end_chunk + 1):
+            chunk_start_seq = chunk_index * chunk_size + 1
+            chunk_end_seq = chunk_start_seq + chunk_size - 1
+            remove_start_seq = max(start_seq, chunk_start_seq)
+            remove_end_seq = min(end_seq, chunk_end_seq)
+            remove_count = remove_end_seq - remove_start_seq + 1
+            seq_filter = {"$gte": remove_start_seq, "$lte": remove_end_seq}
+            await self.chunks_collection.update_one(
+                {
+                    "trace_id": trace_id,
+                    "chunk_index": chunk_index,
+                    "events.seq": seq_filter,
+                },
+                {
+                    "$pull": {"events": {"seq": seq_filter}},
+                    "$inc": {"event_count": -remove_count},
+                    "$set": {"updated_at": now},
+                },
+            )
+        await self.collection.update_one(
+            {
+                "trace_id": trace_id,
+                "event_count": reserved_end_count,
+                ATTACHMENT_CHUNK_WRITE_FIELD: {"$exists": False},
+            },
+            {
+                "$inc": {
+                    "event_count": -event_count,
+                    TRACE_EVENT_REVISION_FIELD: 1,
+                },
+                "$set": {"updated_at": now},
+            },
+        )

--- a/src/infra/session/trace_event_chunks.py
+++ b/src/infra/session/trace_event_chunks.py
@@ -11,6 +11,7 @@ from pymongo import ReturnDocument
 
 from src.infra.logging import get_logger
 from src.infra.session import trace_storage as trace_storage_helpers
+from src.infra.session.trace_chunk_rollback import TraceChunkRollbackMixin
 from src.infra.utils.datetime import utc_now
 
 logger = get_logger(__name__)
@@ -35,7 +36,7 @@ def _replacement_digest(
     return hashlib.sha256(serialized).hexdigest()
 
 
-class TraceEventChunkMixin:
+class TraceEventChunkMixin(TraceChunkRollbackMixin):
     @property
     def collection(self) -> Any:
         raise NotImplementedError
@@ -957,58 +958,3 @@ class TraceEventChunkMixin:
                     },
                 )
             raise
-
-    async def rollback_event_sequence_range(
-        self,
-        trace_doc: Dict[str, Any],
-        start_seq: int,
-        event_count: int,
-    ) -> None:
-        """Undo a reserved chunk sequence range after a failed append attempt."""
-        trace_id = str(trace_doc.get("trace_id") or "")
-        event_count = max(int(event_count or 0), 0)
-        if not trace_id or event_count <= 0:
-            return
-
-        now = utc_now()
-        try:
-            reserved_end_count = int(trace_doc.get("event_count", 0))
-        except (TypeError, ValueError):
-            reserved_end_count = 0
-        end_seq = start_seq + event_count - 1
-        chunk_size = trace_storage_helpers._get_event_chunk_size()
-        start_chunk = trace_storage_helpers._event_chunk_index(start_seq)
-        end_chunk = trace_storage_helpers._event_chunk_index(end_seq)
-        for chunk_index in range(start_chunk, end_chunk + 1):
-            chunk_start_seq = chunk_index * chunk_size + 1
-            chunk_end_seq = chunk_start_seq + chunk_size - 1
-            remove_start_seq = max(start_seq, chunk_start_seq)
-            remove_end_seq = min(end_seq, chunk_end_seq)
-            remove_count = remove_end_seq - remove_start_seq + 1
-            seq_filter = {"$gte": remove_start_seq, "$lte": remove_end_seq}
-            await self.chunks_collection.update_one(
-                {
-                    "trace_id": trace_id,
-                    "chunk_index": chunk_index,
-                    "events.seq": seq_filter,
-                },
-                {
-                    "$pull": {"events": {"seq": seq_filter}},
-                    "$inc": {"event_count": -remove_count},
-                    "$set": {"updated_at": now},
-                },
-            )
-        await self.collection.update_one(
-            {
-                "trace_id": trace_id,
-                "event_count": reserved_end_count,
-                ATTACHMENT_CHUNK_WRITE_FIELD: {"$exists": False},
-            },
-            {
-                "$inc": {
-                    "event_count": -event_count,
-                    TRACE_EVENT_REVISION_FIELD: 1,
-                },
-                "$set": {"updated_at": now},
-            },
-        )

--- a/src/infra/session/trace_event_chunks.py
+++ b/src/infra/session/trace_event_chunks.py
@@ -69,7 +69,6 @@ class TraceEventChunkMixin:
             )
             if not current:
                 return None
-            expected_updated_at = current.get("updated_at")
             trace_doc = {**trace_doc, **current}
         if trace_doc.get(ATTACHMENT_CHUNK_WRITE_FIELD) is not None:
             return None
@@ -90,9 +89,12 @@ class TraceEventChunkMixin:
         if kind == "replace":
             marker["staging_trace_id"] = f"{trace_id}:replace:{operation_id}"
             marker["recovery_after"] = now + timedelta(minutes=5)
+        # Fence on the monotonic event revision alone. Matching updated_at as
+        # well turned every concurrent revision-bumping write (e.g. recommend
+        # questions) into a spurious CAS failure, and matching session_id broke
+        # claims whenever the buffered session_id diverged from the stored one.
         query: Dict[str, Any] = {
             "trace_id": trace_id,
-            "updated_at": expected_updated_at,
             ATTACHMENT_CHUNK_WRITE_FIELD: {"$exists": False},
         }
         query[TRACE_EVENT_REVISION_FIELD] = (
@@ -100,8 +102,6 @@ class TraceEventChunkMixin:
         )
         if trace_doc.get("_id") is not None:
             query["_id"] = trace_doc["_id"]
-        if trace_doc.get("session_id"):
-            query["session_id"] = trace_doc["session_id"]
         claimed = await self.collection.find_one_and_update(
             query,
             {
@@ -312,9 +312,9 @@ class TraceEventChunkMixin:
         """Recover expired durable replacements without touching an active writer."""
         recovered = 0
         now = utc_now()
-        cursor = self.collection.find({f"{ATTACHMENT_CHUNK_WRITE_FIELD}.kind": "replace"}).limit(
-            max(int(limit or 0), 1)
-        )
+        cursor = self.collection.find(
+            {f"{ATTACHMENT_CHUNK_WRITE_FIELD}.kind": {"$in": ["replace", "append"]}}
+        ).limit(max(int(limit or 0), 1))
         async for trace_doc in cursor:
             marker = trace_doc.get(ATTACHMENT_CHUNK_WRITE_FIELD)
             if not isinstance(marker, dict):
@@ -326,6 +326,28 @@ class TraceEventChunkMixin:
                         continue
                 except TypeError:
                     pass
+            if marker.get("kind") == "append":
+                # An expired append marker means its writer is gone. Release
+                # the marker so retries, complete_trace and the merger can
+                # proceed; the reserved sequence range simply stays reserved.
+                operation_id = marker.get("id")
+                revision = marker.get("revision")
+                if not isinstance(operation_id, str) or not isinstance(revision, int):
+                    continue
+                result = await self.collection.update_one(
+                    {
+                        "trace_id": trace_doc.get("trace_id"),
+                        TRACE_EVENT_REVISION_FIELD: revision,
+                        f"{ATTACHMENT_CHUNK_WRITE_FIELD}.id": operation_id,
+                        f"{ATTACHMENT_CHUNK_WRITE_FIELD}.revision": revision,
+                    },
+                    {
+                        "$unset": {ATTACHMENT_CHUNK_WRITE_FIELD: ""},
+                        "$set": {"updated_at": utc_now()},
+                    },
+                )
+                recovered += int(result.modified_count > 0)
+                continue
             try:
                 if marker.get("phase") == "staging":
                     operation_id = marker.get("id")
@@ -715,7 +737,6 @@ class TraceEventChunkMixin:
         operation_id = uuid.uuid4().hex
         query: Dict[str, Any] = {
             "trace_id": trace_id,
-            "updated_at": current.get("updated_at"),
             ATTACHMENT_CHUNK_WRITE_FIELD: {"$exists": False},
             TRACE_EVENT_REVISION_FIELD: (
                 expected_revision if raw_revision is not None else {"$exists": False}
@@ -733,6 +754,7 @@ class TraceEventChunkMixin:
                         "id": operation_id,
                         "kind": "append",
                         "revision": claimed_revision,
+                        "recovery_after": now + timedelta(minutes=5),
                     },
                     "updated_at": now,
                 },
@@ -876,12 +898,45 @@ class TraceEventChunkMixin:
                     "$unset": {ATTACHMENT_CHUNK_WRITE_FIELD: ""},
                 },
             )
-            return result.modified_count > 0
-        except BaseException:
-            await self.collection.update_one(
+            if result.modified_count > 0:
+                return True
+            # The final update can miss while our marker is still in place
+            # (e.g. a concurrent revision bump raced the CAS). Re-check and
+            # retry once instead of returning False with the marker left
+            # behind, which would deadlock every later writer on this trace.
+            current = await self.collection.find_one(
+                {"trace_id": trace_id}, {ATTACHMENT_CHUNK_WRITE_FIELD: 1}
+            )
+            current_marker = (current or {}).get(ATTACHMENT_CHUNK_WRITE_FIELD)
+            if (
+                not isinstance(current_marker, dict)
+                or current_marker.get("id") != operation_id
+                or current_marker.get("revision") != revision
+            ):
+                return False
+            retry = await self.collection.update_one(
                 {
                     "trace_id": trace_id,
-                    TRACE_EVENT_REVISION_FIELD: revision,
+                    f"{ATTACHMENT_CHUNK_WRITE_FIELD}.id": operation_id,
+                    f"{ATTACHMENT_CHUNK_WRITE_FIELD}.revision": revision,
+                },
+                {
+                    "$set": update_fields,
+                    "$max": {"chunk_count": max(grouped) + 1},
+                    "$unset": {ATTACHMENT_CHUNK_WRITE_FIELD: ""},
+                },
+            )
+            return retry.modified_count > 0
+        except BaseException:
+            # Emergency marker release. Match on the marker identity only: a
+            # concurrent event_revision bump (complete_trace, recommend
+            # questions, legacy appends) must not leave the marker stuck,
+            # because a stuck marker fences every later chunk write and blocks
+            # complete_trace, leaving the trace in status="running" where the
+            # session read path hides all non-user events.
+            released = await self.collection.update_one(
+                {
+                    "trace_id": trace_id,
                     f"{ATTACHMENT_CHUNK_WRITE_FIELD}.id": operation_id,
                     f"{ATTACHMENT_CHUNK_WRITE_FIELD}.revision": revision,
                 },
@@ -890,6 +945,17 @@ class TraceEventChunkMixin:
                     "$set": {"updated_at": utc_now()},
                 },
             )
+            if getattr(released, "modified_count", 0) == 0:
+                await self.collection.update_one(
+                    {
+                        "trace_id": trace_id,
+                        f"{ATTACHMENT_CHUNK_WRITE_FIELD}.id": operation_id,
+                    },
+                    {
+                        "$unset": {ATTACHMENT_CHUNK_WRITE_FIELD: ""},
+                        "$set": {"updated_at": utc_now()},
+                    },
+                )
             raise
 
     async def rollback_event_sequence_range(

--- a/src/infra/session/trace_storage.py
+++ b/src/infra/session/trace_storage.py
@@ -27,6 +27,7 @@ Trace Storage - 按 trace 聚合事件存储
 
 import asyncio
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 from typing import Any, Dict, List, Literal, Optional
 
 from src.infra.logging import get_logger
@@ -65,6 +66,7 @@ from src.infra.session.trace_attachment_cleanup import TraceAttachmentCleanupMix
 from src.infra.session.trace_event_chunks import TraceEventChunkMixin
 from src.infra.session.trace_storage_writes import TraceStorageWriteMixin
 from src.infra.storage.mongodb import get_mongo_client
+from src.infra.utils.datetime import ensure_utc, parse_iso, utc_now
 from src.kernel.config import settings
 
 logger = get_logger(__name__)
@@ -616,6 +618,30 @@ class TraceStorage(
         try:
             event_types = _bounded_unique_strings(event_types, SESSION_EVENT_FILTER_LIST_LIMIT)
             run_ids = _bounded_unique_strings(run_ids, SESSION_EVENT_FILTER_LIST_LIMIT)
+            now = utc_now()
+            stale_running_cutoff = now - timedelta(
+                minutes=max(int(getattr(settings, "SESSION_ACTIVE_RUN_STALE_MINUTES", 10)), 1)
+            )
+
+            def _is_stale_running(trace: Dict[str, Any]) -> bool:
+                """A running trace untouched for too long is treated as terminal.
+
+                Its writer is gone (crash, lost marker lease); hiding every
+                non-user event behind an SSE replay that will never come would
+                make stored events unreachable after a refresh.
+                """
+                updated_at = trace.get("updated_at")
+                if not updated_at:
+                    return True
+                try:
+                    if isinstance(updated_at, datetime):
+                        parsed = ensure_utc(updated_at)
+                    else:
+                        parsed = parse_iso(str(updated_at))
+                except (TypeError, ValueError, AttributeError):
+                    return True
+                return parsed < stale_running_cutoff
+
             # 构建查询条件
             match_query: Dict[str, Any] = {"session_id": session_id}
             if run_ids:
@@ -645,6 +671,7 @@ class TraceStorage(
                             "$and": [
                                 {"$eq": ["$status", "running"]},
                                 {"$eq": ["$run_id", active_run_id]},
+                                {"$gte": ["$updated_at", stale_running_cutoff]},
                             ]
                         },
                         {
@@ -666,6 +693,7 @@ class TraceStorage(
                     "run_id": 1,
                     "status": 1,
                     "started_at": 1,
+                    "updated_at": 1,
                     "events": events_projection,
                     "recommend_questions": 1,
                     "recommend_questions_updated_at": 1,
@@ -675,7 +703,9 @@ class TraceStorage(
             traces: List[Dict[str, Any]] = []
             async for trace in cursor:
                 if completed_only and trace.get("status") == "running":
-                    if not active_run_id or trace.get("run_id") != active_run_id:
+                    if _is_stale_running(trace):
+                        pass  # writer is gone; surface whatever was stored
+                    elif not active_run_id or trace.get("run_id") != active_run_id:
                         continue
                 traces.append(trace)
 
@@ -685,6 +715,7 @@ class TraceStorage(
                 if active_run_id
                 and trace.get("run_id") == active_run_id
                 and trace.get("status") == "running"
+                and not _is_stale_running(trace)
                 and trace.get("trace_id")
             }
             if active_user_only_trace_ids:
@@ -710,6 +741,7 @@ class TraceStorage(
                     active_run_id
                     and trace.get("run_id") == active_run_id
                     and trace.get("status") == "running"
+                    and not _is_stale_running(trace)
                 )
                 if is_active_running:
                     trace_events = [

--- a/src/infra/session/trace_storage_writes.py
+++ b/src/infra/session/trace_storage_writes.py
@@ -399,6 +399,7 @@ class TraceStorageWriteMixin:
         chunk-write marker: wait briefly for an in-flight writer, then release
         an expired marker ourselves and finish the status transition.
         """
+        last_seen_marker_id: str | None = None
         for attempt in range(4):
             marker_doc = await self.collection.find_one(
                 {"trace_id": trace_id},
@@ -416,6 +417,17 @@ class TraceStorageWriteMixin:
                 if result.modified_count > 0:
                     return result
                 continue
+            marker_id = marker.get("id")
+            if isinstance(marker_id, str):
+                last_seen_marker_id = marker_id
+            # Never release a replace marker here: a replace mid-flight may
+            # have already deleted the old chunks; removing its marker makes
+            # the staging install unrecoverable and loses every stored event.
+            # Replaces are recovered by recover_incomplete_chunk_replacements
+            # once their recovery_after expires.
+            if marker.get("kind") == "replace":
+                await asyncio.sleep(0.05 * (attempt + 1))
+                continue
             recovery_after = marker.get("recovery_after")
             expired = True
             if recovery_after is not None:
@@ -425,43 +437,49 @@ class TraceStorageWriteMixin:
                     expired = ensure_utc(recovery_after) <= utc_now()
                 except (TypeError, ValueError):
                     expired = True
-            if expired:
-                marker_id = marker.get("id")
-                if isinstance(marker_id, str):
-                    await self.collection.update_one(
-                        {
-                            "trace_id": trace_id,
-                            f"{_ATTACHMENT_CHUNK_WRITE_FIELD}.id": marker_id,
-                        },
-                        {
-                            "$unset": {_ATTACHMENT_CHUNK_WRITE_FIELD: ""},
-                            "$set": {"updated_at": utc_now()},
-                        },
+            if expired and isinstance(marker_id, str):
+                await self.collection.update_one(
+                    {
+                        "trace_id": trace_id,
+                        f"{_ATTACHMENT_CHUNK_WRITE_FIELD}.id": marker_id,
+                        f"{_ATTACHMENT_CHUNK_WRITE_FIELD}.kind": "append",
+                    },
+                    {
+                        "$unset": {_ATTACHMENT_CHUNK_WRITE_FIELD: ""},
+                        "$set": {"updated_at": utc_now()},
+                    },
+                )
+                result = await self.collection.update_one(
+                    {
+                        "trace_id": trace_id,
+                        _ATTACHMENT_CHUNK_WRITE_FIELD: {"$exists": False},
+                    },
+                    update,
+                )
+                if result.modified_count > 0:
+                    logger.warning(
+                        "Completed trace %s after releasing stuck chunk marker",
+                        trace_id,
                     )
-                    result = await self.collection.update_one(
-                        {
-                            "trace_id": trace_id,
-                            _ATTACHMENT_CHUNK_WRITE_FIELD: {"$exists": False},
-                        },
-                        update,
-                    )
-                    if result.modified_count > 0:
-                        logger.warning(
-                            "Completed trace %s after releasing stuck chunk marker",
-                            trace_id,
-                        )
-                        return result
+                    return result
             await asyncio.sleep(0.05 * (attempt + 1))
-        # Last resort: the marker writer is gone (its recovery_after is in the
-        # future but nothing is progressing). Release it unconditionally — a
-        # trace stuck in "running" is strictly worse than a fenced retry.
-        await self.collection.update_one(
-            {"trace_id": trace_id},
-            {
-                "$unset": {_ATTACHMENT_CHUNK_WRITE_FIELD: ""},
-                "$set": {"updated_at": utc_now()},
-            },
-        )
+        # Last resort: the append marker writer is gone (its recovery_after is
+        # in the future but nothing is progressing). Release only the append
+        # marker we last observed, by id — a fenced append retry is idempotent
+        # and safe, unlike a replace. A trace stuck in "running" is strictly
+        # worse than a fenced retry.
+        if last_seen_marker_id is not None:
+            await self.collection.update_one(
+                {
+                    "trace_id": trace_id,
+                    f"{_ATTACHMENT_CHUNK_WRITE_FIELD}.id": last_seen_marker_id,
+                    f"{_ATTACHMENT_CHUNK_WRITE_FIELD}.kind": "append",
+                },
+                {
+                    "$unset": {_ATTACHMENT_CHUNK_WRITE_FIELD: ""},
+                    "$set": {"updated_at": utc_now()},
+                },
+            )
         return await self.collection.update_one(
             {
                 "trace_id": trace_id,

--- a/src/infra/session/trace_storage_writes.py
+++ b/src/infra/session/trace_storage_writes.py
@@ -191,6 +191,29 @@ class TraceStorageWriteMixin:
                 },
             )
             if result.modified_count == 0:
+                # An in-flight chunk write holds the marker; retry briefly
+                # instead of silently dropping the recommendations.
+                for attempt in range(3):
+                    await asyncio.sleep(0.1 * (attempt + 1))
+                    now = utc_now()
+                    result = await self.collection.update_one(
+                        {
+                            "session_id": session_id,
+                            "run_id": run_id,
+                            _ATTACHMENT_CHUNK_WRITE_FIELD: {"$exists": False},
+                        },
+                        {
+                            "$inc": {_TRACE_EVENT_REVISION_FIELD: 1},
+                            "$set": {
+                                "recommend_questions": normalized,
+                                "recommend_questions_updated_at": now,
+                                "updated_at": now,
+                            },
+                        },
+                    )
+                    if result.modified_count > 0:
+                        break
+            if result.modified_count == 0:
                 logger.warning(
                     "Recommendation trace not found or unchanged: session=%s, run_id=%s",
                     session_id,
@@ -344,6 +367,8 @@ class TraceStorageWriteMixin:
                 },
                 update,
             )
+            if result.modified_count == 0:
+                result = await self._complete_trace_after_marker_release(trace_id, update)
             # 异步写入 usage_logs 集合（fire-and-forget，失败不影响主流程）
             if _USAGE_LOGS_ENABLED and result.modified_count > 0:
                 from src.infra.session.trace_storage import _write_usage_log
@@ -361,3 +386,86 @@ class TraceStorageWriteMixin:
         except Exception as e:
             logger.error(f"Failed to complete trace {trace_id}: {e}")
             return False
+
+    async def _complete_trace_after_marker_release(
+        self,
+        trace_id: str,
+        update: Dict[str, Dict[str, Any]],
+    ) -> Any:
+        """Retry a blocked complete_trace after releasing a stuck chunk marker.
+
+        A trace left in status="running" hides all its non-user events from the
+        session events read path, so completion must not stay blocked behind a
+        chunk-write marker: wait briefly for an in-flight writer, then release
+        an expired marker ourselves and finish the status transition.
+        """
+        for attempt in range(4):
+            marker_doc = await self.collection.find_one(
+                {"trace_id": trace_id},
+                {_ATTACHMENT_CHUNK_WRITE_FIELD: 1},
+            )
+            marker = (marker_doc or {}).get(_ATTACHMENT_CHUNK_WRITE_FIELD)
+            if not isinstance(marker, dict):
+                result = await self.collection.update_one(
+                    {
+                        "trace_id": trace_id,
+                        _ATTACHMENT_CHUNK_WRITE_FIELD: {"$exists": False},
+                    },
+                    update,
+                )
+                if result.modified_count > 0:
+                    return result
+                continue
+            recovery_after = marker.get("recovery_after")
+            expired = True
+            if recovery_after is not None:
+                try:
+                    from src.infra.utils.datetime import ensure_utc
+
+                    expired = ensure_utc(recovery_after) <= utc_now()
+                except (TypeError, ValueError):
+                    expired = True
+            if expired:
+                marker_id = marker.get("id")
+                if isinstance(marker_id, str):
+                    await self.collection.update_one(
+                        {
+                            "trace_id": trace_id,
+                            f"{_ATTACHMENT_CHUNK_WRITE_FIELD}.id": marker_id,
+                        },
+                        {
+                            "$unset": {_ATTACHMENT_CHUNK_WRITE_FIELD: ""},
+                            "$set": {"updated_at": utc_now()},
+                        },
+                    )
+                    result = await self.collection.update_one(
+                        {
+                            "trace_id": trace_id,
+                            _ATTACHMENT_CHUNK_WRITE_FIELD: {"$exists": False},
+                        },
+                        update,
+                    )
+                    if result.modified_count > 0:
+                        logger.warning(
+                            "Completed trace %s after releasing stuck chunk marker",
+                            trace_id,
+                        )
+                        return result
+            await asyncio.sleep(0.05 * (attempt + 1))
+        # Last resort: the marker writer is gone (its recovery_after is in the
+        # future but nothing is progressing). Release it unconditionally — a
+        # trace stuck in "running" is strictly worse than a fenced retry.
+        await self.collection.update_one(
+            {"trace_id": trace_id},
+            {
+                "$unset": {_ATTACHMENT_CHUNK_WRITE_FIELD: ""},
+                "$set": {"updated_at": utc_now()},
+            },
+        )
+        return await self.collection.update_one(
+            {
+                "trace_id": trace_id,
+                _ATTACHMENT_CHUNK_WRITE_FIELD: {"$exists": False},
+            },
+            update,
+        )

--- a/src/infra/writer/presenter_storage.py
+++ b/src/infra/writer/presenter_storage.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Dict
@@ -441,16 +442,43 @@ class StoragePresenterMixin:
         if dual_writer and self.config.session_id:
             try:
                 await self._ensure_token_usage_event()
-                # 先刷新 MongoDB 缓冲，确保所有事件已写入
+            except Exception as e:
+                logger.warning("Failed to ensure token usage event for %s: %s", self.trace_id, e)
+            # Flush first so events are durable, but never let a flush failure
+            # block complete_trace: a trace stuck in status="running" hides all
+            # its non-user events from the session events read path.
+            try:
                 await dual_writer.flush_mongo_buffer(require_empty=True)
-                await dual_writer.complete_trace(
-                    trace_id=self.trace_id,
-                    status=status,
-                    metadata={
-                        "step_count": self._step_count,
-                        "tool_calls": len(self._tool_calls),
-                    },
+            except Exception as e:
+                logger.error(
+                    "Mongo event buffer not empty while completing trace %s; "
+                    "events remain buffered for retry: %s",
+                    self.trace_id,
+                    e,
                 )
+            try:
+                completed = False
+                # A trace stuck in status="running" hides all its non-user
+                # events from the session events read path, so retry the
+                # terminal transition instead of giving up on the first miss.
+                for attempt in range(3):
+                    completed = await dual_writer.complete_trace(
+                        trace_id=self.trace_id,
+                        status=status,
+                        metadata={
+                            "step_count": self._step_count,
+                            "tool_calls": len(self._tool_calls),
+                        },
+                    )
+                    if completed:
+                        break
+                    await asyncio.sleep(0.2 * (attempt + 1))
+                if not completed:
+                    logger.error(
+                        "Failed to complete trace %s after retries; "
+                        "non-user events stay hidden until recovery",
+                        self.trace_id,
+                    )
                 self._completed = True
                 logger.debug("Trace completed: %s, status=%s", self.trace_id, status)
 

--- a/src/infra/writer/presenter_storage.py
+++ b/src/infra/writer/presenter_storage.py
@@ -447,9 +447,11 @@ class StoragePresenterMixin:
             # Flush first so events are durable, but never let a flush failure
             # block complete_trace: a trace stuck in status="running" hides all
             # its non-user events from the session events read path.
+            flush_ok = True
             try:
                 await dual_writer.flush_mongo_buffer(require_empty=True)
             except Exception as e:
+                flush_ok = False
                 logger.error(
                     "Mongo event buffer not empty while completing trace %s; "
                     "events remain buffered for retry: %s",
@@ -469,6 +471,11 @@ class StoragePresenterMixin:
                             "step_count": self._step_count,
                             "tool_calls": len(self._tool_calls),
                         },
+                        # The real token:usage event may still sit in the
+                        # unflushed buffer; letting storage insert a zero-usage
+                        # fallback here would duplicate it once the buffer
+                        # retries.
+                        ensure_token_usage=flush_ok,
                     )
                     if completed:
                         break

--- a/src/kernel/config/base.py
+++ b/src/kernel/config/base.py
@@ -67,6 +67,7 @@ class Settings(BaseSettings):
     SESSION_EVENT_CHUNK_STORAGE_ENABLED: bool = False
     SESSION_EVENT_CHUNK_DUAL_WRITE_LEGACY: bool = False
     SESSION_EVENT_CHUNK_SIZE: int = 5000
+    SESSION_ACTIVE_RUN_STALE_MINUTES: int = 10  # running trace 超过该时长未更新则视为已终止
     FEISHU_UPLOAD_BYTES_MAX_SIZE: int = 20 * 1024 * 1024
 
     # ============================================

--- a/tests/infra/session/test_attachment_cleanup.py
+++ b/tests/infra/session/test_attachment_cleanup.py
@@ -1664,6 +1664,13 @@ async def test_chunk_rewrite_with_stale_parent_version_does_not_mutate_chunks() 
                 "trace_id": "trace-terminal",
                 "status": "completed",
                 "updated_at": current_updated_at,
+                # An in-flight chunk write marker fences any new replacement,
+                # keeping the existing chunks untouched.
+                "attachment_chunk_write_operation": {
+                    "id": "in-flight",
+                    "kind": "append",
+                    "revision": 3,
+                },
                 "events": [
                     {
                         "seq": 1,

--- a/tests/infra/session/test_chunk_marker_completion.py
+++ b/tests/infra/session/test_chunk_marker_completion.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+"""Regression tests for chunk-marker deadlocks around trace completion.
+
+Production symptom (SESSION_EVENT_CHUNK_STORAGE_ENABLED=true): after a run
+finished (SSE delivered done), refreshing GET /api/sessions/{id}/events
+returned only the user:message and recommend:questions events, with
+history_mode="active_user_only". Root cause: a chunk-write marker stuck on
+the trace fenced complete_trace (its query requires the marker to be
+absent), so the trace stayed status="running" and the read path hid every
+non-user event behind an SSE replay that already ended.
+"""
+
+import asyncio
+from copy import deepcopy
+from datetime import timedelta
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from src.infra.session import trace_storage as trace_storage_module
+from src.infra.session.trace_storage import TraceStorage
+from src.infra.utils.datetime import utc_now
+
+
+class _AsyncCursor:
+    def __init__(self, docs: list[dict[str, Any]]) -> None:
+        self.docs = docs
+
+    def sort(self, key, direction=None):
+        return self
+
+    def limit(self, limit):
+        return self
+
+    def __aiter__(self):
+        self._iter = iter(self.docs)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._iter)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+    async def to_list(self, length=None):
+        return deepcopy(self.docs)
+
+
+class _FakeCollection:
+    """Minimal in-memory mongo collection covering the operators used here."""
+
+    def __init__(self, doc: dict[str, Any] | None = None) -> None:
+        self.doc = doc
+
+    def find(self, query, projection=None):
+        docs = [self.doc] if self.doc and _matches(self.doc, query) else []
+        return _AsyncCursor(docs)
+
+    async def find_one(self, query, projection=None):
+        if self.doc and _matches(self.doc, query):
+            return deepcopy(self.doc)
+        return None
+
+    async def find_one_and_update(self, query, update, **kwargs):
+        if not self.doc or not _matches(self.doc, query):
+            return None
+        _apply_update(self.doc, update)
+        return deepcopy(self.doc)
+
+    async def update_one(self, query, update, upsert=False):
+        if not self.doc or not _matches(self.doc, query):
+            if upsert and self.doc is None and query.get("trace_id"):
+                self.doc = deepcopy(query)
+                _apply_update(self.doc, update)
+                return SimpleNamespace(matched_count=0, modified_count=1)
+            return SimpleNamespace(matched_count=0, modified_count=0)
+        before = deepcopy(self.doc)
+        _apply_update(self.doc, update)
+        return SimpleNamespace(
+            matched_count=1,
+            modified_count=int(before != self.doc),
+        )
+
+
+_MISSING = object()
+
+
+def _nested(document: dict[str, Any], path: str) -> Any:
+    value: Any = document
+    for part in path.split("."):
+        if not isinstance(value, dict) or part not in value:
+            return _MISSING
+        value = value[part]
+    return value
+
+
+def _matches(document: dict[str, Any], query: dict[str, Any]) -> bool:
+    for key, expected in query.items():
+        value = _nested(document, key)
+        if isinstance(expected, dict):
+            for op, operand in expected.items():
+                if op == "$exists":
+                    if (value is not _MISSING) != bool(operand):
+                        return False
+                elif op == "$eq":
+                    if value != operand:
+                        return False
+                elif op == "$ne":
+                    if value == operand:
+                        return False
+                else:
+                    raise AssertionError(f"unsupported op {op}")
+        elif value != expected:
+            return False
+    return True
+
+
+def _apply_update(document: dict[str, Any], update: dict[str, Any]) -> None:
+    for key, value in update.items():
+        if key == "$set":
+            for path, item in value.items():
+                _set_nested(document, path, deepcopy(item))
+        elif key == "$inc":
+            for path, item in value.items():
+                current = _nested(document, path)
+                _set_nested(document, path, (0 if current is _MISSING else current) + item)
+        elif key == "$unset":
+            for path in value:
+                _unset_nested(document, path)
+        else:
+            raise AssertionError(f"unsupported update {key}")
+
+
+def _set_nested(document: dict[str, Any], path: str, value: Any) -> None:
+    parts = path.split(".")
+    node = document
+    for part in parts[:-1]:
+        node = node.setdefault(part, {})
+    node[parts[-1]] = value
+
+
+def _unset_nested(document: dict[str, Any], path: str) -> None:
+    parts = path.split(".")
+    node = document
+    for part in parts[:-1]:
+        if not isinstance(node, dict) or part not in node:
+            return
+        node = node[part]
+    if isinstance(node, dict):
+        node.pop(parts[-1], None)
+
+
+class _FakeChunks:
+    def __init__(self) -> None:
+        self.docs: dict[tuple[str, int], dict[str, Any]] = {}
+        self.fail_next = False
+
+    async def update_one(self, query, update, upsert=False):
+        if self.fail_next:
+            self.fail_next = False
+            raise RuntimeError("simulated chunk write failure")
+        key = (query.get("trace_id"), query.get("chunk_index"))
+        doc = self.docs.get(key)
+        if doc is None:
+            if not upsert:
+                return SimpleNamespace(matched_count=0, modified_count=0)
+            doc = {"trace_id": key[0], "chunk_index": key[1], "events": []}
+            self.docs[key] = doc
+        events = list(doc.get("events", []))
+        for event in update.get("$set", {}).get("events", []) or []:
+            events.append(event)
+        doc["events"] = events
+        return SimpleNamespace(matched_count=1, modified_count=1)
+
+
+def _make_storage(monkeypatch, trace_doc, chunks=None):
+    storage = object.__new__(TraceStorage)
+    collection = _FakeCollection(trace_doc)
+    chunks_collection = chunks or _FakeChunks()
+    monkeypatch.setattr(
+        trace_storage_module.TraceStorage, "collection", property(lambda self: collection)
+    )
+    monkeypatch.setattr(
+        trace_storage_module.TraceStorage,
+        "chunks_collection",
+        property(lambda self: chunks_collection),
+    )
+    storage._merger = None
+    storage._indexes_ensured = True
+    return storage, collection, chunks_collection
+
+
+@pytest.mark.asyncio
+async def test_complete_trace_releases_stuck_append_marker(monkeypatch):
+    """A stuck append marker must not block the running→completed transition."""
+    marker = {
+        "id": "op-stuck",
+        "kind": "append",
+        "revision": 3,
+        # expired long ago; writer is gone
+        "recovery_after": utc_now() - timedelta(minutes=10),
+    }
+    trace_doc = {
+        "trace_id": "trace-1",
+        "session_id": "session-1",
+        "run_id": "run-1",
+        "status": "running",
+        "event_count": 5,
+        "event_revision": 3,
+        "attachment_chunk_write_operation": marker,
+    }
+    storage, collection, _ = _make_storage(monkeypatch, trace_doc)
+
+    ok = await storage.complete_trace("trace-1", "completed", ensure_token_usage=False)
+    assert ok is True
+    assert collection.doc["status"] == "completed"
+    assert "attachment_chunk_write_operation" not in collection.doc
+
+
+@pytest.mark.asyncio
+async def test_complete_trace_waits_for_in_flight_marker(monkeypatch):
+    """An in-flight (unexpired) marker is retried, then force-released."""
+    marker = {
+        "id": "op-live",
+        "kind": "append",
+        "revision": 2,
+        "recovery_after": utc_now() + timedelta(minutes=5),
+    }
+    trace_doc = {
+        "trace_id": "trace-2",
+        "session_id": "session-2",
+        "run_id": "run-2",
+        "status": "running",
+        "event_count": 2,
+        "event_revision": 2,
+        "attachment_chunk_write_operation": marker,
+    }
+    storage, collection, _ = _make_storage(monkeypatch, trace_doc)
+
+    ok = await storage.complete_trace("trace-2", "completed", ensure_token_usage=False)
+    assert ok is True
+    assert collection.doc["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_append_exception_releases_marker_despite_revision_bump(monkeypatch):
+    """The emergency unset must not be fenced by event_revision.
+
+    Previously the exception-path unset required event_revision == marker
+    revision; any concurrent revision bump (complete_trace, recommend
+    questions) left the marker stuck forever, fencing later chunk writes and
+    blocking completion.
+    """
+    trace_doc = {
+        "trace_id": "trace-3",
+        "session_id": "session-3",
+        "run_id": "run-3",
+        "status": "running",
+        "event_count": 3,
+        "event_revision": 4,
+        "attachment_chunk_write_operation": {
+            "id": "op-append",
+            "kind": "append",
+            "revision": 4,
+            "recovery_after": utc_now() + timedelta(minutes=5),
+        },
+    }
+    chunks = _FakeChunks()
+    chunks.fail_next = True
+    storage, collection, _ = _make_storage(monkeypatch, trace_doc, chunks)
+
+    events = [{"event_type": "metadata", "data": {}, "timestamp": utc_now()}]
+    with pytest.raises(RuntimeError):
+        await storage.append_events_to_chunks(trace_doc, events, start_seq=4)
+
+    # Marker must be released even though event_revision no longer matches.
+    assert "attachment_chunk_write_operation" not in collection.doc
+
+
+@pytest.mark.asyncio
+async def test_recommend_questions_retry_on_marker(monkeypatch):
+    """set_run_recommend_questions retries briefly while a marker is held."""
+    trace_doc = {
+        "trace_id": "trace-4",
+        "session_id": "session-4",
+        "run_id": "run-4",
+        "status": "completed",
+        "event_revision": 1,
+        "attachment_chunk_write_operation": {
+            "id": "op-held",
+            "kind": "append",
+            "revision": 1,
+            "recovery_after": utc_now() + timedelta(minutes=5),
+        },
+    }
+    storage, collection, _ = _make_storage(monkeypatch, trace_doc)
+
+    async def _release_marker_later():
+        await asyncio.sleep(0.05)
+        collection.doc.pop("attachment_chunk_write_operation", None)
+
+    release_task = asyncio.create_task(_release_marker_later())
+    ok = await storage.set_run_recommend_questions("session-4", "run-4", ["q1", "q2"])
+    await release_task
+    assert ok is True
+    assert collection.doc["recommend_questions"] == ["q1", "q2"]

--- a/tests/infra/session/test_chunk_marker_completion.py
+++ b/tests/infra/session/test_chunk_marker_completion.py
@@ -245,6 +245,39 @@ async def test_complete_trace_waits_for_in_flight_marker(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_complete_trace_never_releases_replace_marker(monkeypatch):
+    """A replace marker mid-flight must never be force-released.
+
+    Releasing it after old chunks were deleted would make the staging
+    install unrecoverable and lose every stored event of the trace.
+    """
+    marker = {
+        "id": "op-replace",
+        "kind": "replace",
+        "revision": 4,
+        "phase": "old_deleted",
+        "recovery_after": utc_now() - timedelta(minutes=10),
+    }
+    trace_doc = {
+        "trace_id": "trace-3",
+        "session_id": "session-3",
+        "run_id": "run-3",
+        "status": "running",
+        "event_count": 3,
+        "event_revision": 4,
+        "attachment_chunk_write_operation": marker,
+    }
+    storage, collection, _ = _make_storage(monkeypatch, trace_doc)
+
+    ok = await storage.complete_trace("trace-3", "completed", ensure_token_usage=False)
+    # Completion stays blocked, but the marker survives for
+    # recover_incomplete_chunk_replacements to finish the replacement.
+    assert ok is False
+    assert collection.doc["status"] == "running"
+    assert collection.doc["attachment_chunk_write_operation"]["id"] == "op-replace"
+
+
+@pytest.mark.asyncio
 async def test_append_exception_releases_marker_despite_revision_bump(monkeypatch):
     """The emergency unset must not be fenced by event_revision.
 

--- a/tests/infra/session/test_fork_title.py
+++ b/tests/infra/session/test_fork_title.py
@@ -415,8 +415,6 @@ async def test_resolve_fork_target_projects_only_needed_trace_fields() -> None:
                 "_id": 0,
                 "trace_id": 1,
                 "run_id": 1,
-                "events.event_type": 1,
-                "events.data": 1,
             },
         ),
         {},

--- a/tests/infra/session/test_trace_event_chunks.py
+++ b/tests/infra/session/test_trace_event_chunks.py
@@ -377,8 +377,6 @@ async def test_replace_trace_events_with_chunks_splits_events_and_updates_metada
     assert claim_query == {
         "_id": "parent-1",
         "trace_id": "trace-1",
-        "session_id": "session-1",
-        "updated_at": "version-1",
         "attachment_chunk_write_operation": {"$exists": False},
         "event_revision": {"$exists": False},
     }
@@ -795,7 +793,6 @@ async def test_reserve_event_sequence_range_atomically_increments_event_count() 
     assert trace_doc["attachment_chunk_write_operation"]["kind"] == "append"
     assert collection.find_one_and_update_calls[0][0] == {
         "trace_id": "trace-1",
-        "updated_at": "version-1",
         "attachment_chunk_write_operation": {"$exists": False},
         "event_revision": {"$exists": False},
     }
@@ -883,14 +880,17 @@ async def test_append_events_to_chunks_does_not_upsert_when_parent_version_is_st
     storage._collection = trace_collection
     storage._chunks_collection = chunk_collection
 
+    # A stale updated_at on the passed-in doc must not fence the append: the
+    # claim refreshes the parent and fences on the event revision alone, so
+    # concurrent revision-bumping writes no longer cause silent event loss.
     appended = await storage.append_events_to_chunks(
         _trace_document(updated_at="version-1"),
         [_event("message", "must-survive")],
         start_seq=1,
     )
 
-    assert appended is False
-    assert chunk_collection.update_calls == []
+    assert appended is True
+    assert len(chunk_collection.update_calls) == 1
     assert chunk_collection.deleted_queries == []
     assert chunk_collection.inserted_docs == []
 
@@ -1096,6 +1096,7 @@ async def test_get_session_events_reads_chunks_across_traces_in_started_order() 
                 "run_id": 1,
                 "status": 1,
                 "started_at": 1,
+                "updated_at": 1,
                 "events": 1,
                 "recommend_questions": 1,
                 "recommend_questions_updated_at": 1,
@@ -1122,6 +1123,7 @@ async def test_get_session_events_snapshot_returns_active_user_and_requires_stre
                 "run_id": "run-active",
                 "status": "running",
                 "started_at": "2026-04-25T00:02:00Z",
+                "updated_at": "2999-01-01T00:00:00Z",
             },
         ]
     )
@@ -1184,6 +1186,7 @@ async def test_active_snapshot_projects_large_running_trace_to_user_events() -> 
                 "run_id": "run-active",
                 "status": "running",
                 "started_at": "2026-04-25T00:02:00Z",
+                "updated_at": "2999-01-01T00:00:00Z",
                 "events": [_event("user:message", "active-user", 1), *assistant_events],
             }
         ]
@@ -1209,6 +1212,44 @@ async def test_active_snapshot_projects_large_running_trace_to_user_events() -> 
     assert [event["event_type"] for event in snapshot.events] == ["user:message"]
     assert "$cond" in trace_collection.find_calls[0][1]["events"]
     assert "$cond" in chunk_collection.find_calls[0][1]["events"]
+
+
+@pytest.mark.asyncio
+async def test_active_snapshot_returns_full_events_for_stale_running_trace() -> None:
+    """A running trace whose writer is gone must not hide stored events."""
+    storage = TraceStorage()
+    trace_collection = _FakeSessionTraceCollection(
+        [
+            {
+                "trace_id": "trace-active",
+                "session_id": "session-1",
+                "run_id": "run-active",
+                "status": "running",
+                "started_at": "2020-04-25T00:02:00Z",
+                "updated_at": "2020-04-25T00:03:00Z",
+                "events": [
+                    _event("user:message", "active-user", 1),
+                    _event("message:chunk", "active-assistant", 2),
+                    _event("done", None, 3),
+                ],
+            },
+        ]
+    )
+    storage._collection = trace_collection
+    storage._chunks_collection = _FakeChunkCollection()
+
+    snapshot = await storage.get_session_events_snapshot(
+        "session-1",
+        active_run_id="run-active",
+    )
+
+    assert snapshot.history_mode == "complete"
+    assert snapshot.stream_run_id is None
+    assert [event["event_type"] for event in snapshot.events] == [
+        "user:message",
+        "message:chunk",
+        "done",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/infra/session/test_trace_storage_token_usage.py
+++ b/tests/infra/session/test_trace_storage_token_usage.py
@@ -483,6 +483,7 @@ async def test_get_session_events_uses_server_side_limit_when_max_events_is_set(
                 "run_id": 1,
                 "status": 1,
                 "started_at": 1,
+                "updated_at": 1,
                 "events": 1,
                 "recommend_questions": 1,
                 "recommend_questions_updated_at": 1,

--- a/tests/infra/test_dual_writer_limits.py
+++ b/tests/infra/test_dual_writer_limits.py
@@ -1037,9 +1037,11 @@ async def test_flush_mongo_buffer_requeues_failed_chunk_write_with_reserved_sequ
 
     await writer._do_flush()
 
+    # Both events keep the group base seq so the retry re-forms a single
+    # group (one claim/append round trip) instead of one group per event.
     assert writer._mongo_buffer == [
         (*events[0], 6, False),
-        (*events[1], 7, False),
+        (*events[1], 6, False),
     ]
 
 


### PR DESCRIPTION
Fixes event loss with `SESSION_EVENT_CHUNK_STORAGE_ENABLED=true`: after a run finished, refreshing `GET /api/sessions/{id}/events` returned only `user:message` + `recommend:questions`.

**Root cause chain**
1. Chunk-write CAS matched `updated_at`/`session_id` → concurrent writes or divergent buffered session_id fenced every append; failures only returned to the memory buffer with no legacy fallback (`SESSION_EVENT_CHUNK_DUAL_WRITE_LEGACY=false`).
2. `append_events_to_chunks` could return False with its own marker left on the trace → all later writers (`complete_trace`, merger, recommend questions) permanently fenced.
3. Trace stuck `status=running` → read path filters running active traces to `user:message` only (`history_mode=active_user_only`), expecting an SSE replay that never comes after refresh. `recommend:questions` survives because it is synthesized from the parent doc.

**Fixes**
- revision-only CAS for claim/reserve (updated_at/session_id removed)
- final append update re-checks and retries instead of deadlocking
- expired append markers recoverable (`recovery_after` + recovery + complete_trace release)
- `presenter.complete` decouples flush from `complete_trace`
- stale running traces (> `SESSION_ACTIVE_RUN_STALE_MINUTES`, default 10) return full events
- retry keeps group base seq (one group per retry), error-level logging with seq range
- fork/clone copies chunk docs, strips markers, uses compat reader

Tests: 2620 passed locally (excl. env-dependent files), ruff + mypy clean.