### PR TITLE
fix(session): unblock session deletion stuck behind stale running traces

### DIFF
--- a/src/api/routes/session.py
+++ b/src/api/routes/session.py
@@ -230,7 +230,16 @@ async def delete_session(
 
     verify_session_ownership(session, user)
 
-    success = await manager.delete_session(session_id)
+    try:
+        success = await manager.delete_session(session_id)
+    except SessionError as exc:
+        logger.error("Delete session %s failed: %s", session_id, exc)
+        status_code = (
+            status.HTTP_409_CONFLICT
+            if str(exc) == "session_delete_in_progress"
+            else status.HTTP_500_INTERNAL_SERVER_ERROR
+        )
+        raise HTTPException(status_code=status_code, detail=str(exc)) from exc
     if not success:
         raise HTTPException(status_code=500, detail="删除失败")
 

--- a/src/infra/session/manager.py
+++ b/src/infra/session/manager.py
@@ -383,6 +383,7 @@ class SessionManager:
             raise SessionError("session_delete_in_progress")
         delete_operation_id = delete_operation["id"]
         try:
+            await self.trace_storage.expire_stale_running_traces(session_id)
             await self.clear_session_messages(session_id)
             if await self.trace_storage.has_session_trace_documents(session_id):
                 raise SessionError("session_delete_has_trace_survivors")

--- a/src/infra/session/session_attachment_operations.py
+++ b/src/infra/session/session_attachment_operations.py
@@ -1,11 +1,16 @@
 """Session-anchor operations for attachment cleanup and trace writer fencing."""
 
 import uuid
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from bson import ObjectId
 
 from src.infra.utils.datetime import utc_now
+
+# A delete fence held longer than this TTL belongs to a delete that died
+# mid-flight (process killed before its cancel path ran) and is safe to reclaim.
+SESSION_DELETE_FENCE_TTL = timedelta(minutes=10)
 
 
 class SessionAttachmentOperationsMixin:
@@ -276,6 +281,47 @@ class SessionAttachmentOperationsMixin:
         field = "attachment_delete_operation"
         operation = {"id": uuid.uuid4().hex, "claimed_at": utc_now()}
 
+        async def _reclaim_stale(
+            identity: dict[str, Any], existing_operation: dict[str, Any]
+        ) -> dict[str, Any] | None:
+            # A fence whose claimant died mid-delete (no cancel ran) would block
+            # deletion forever; reclaim it once it is older than the TTL.
+            claimed_at = existing_operation.get("claimed_at")
+            if claimed_at is None:
+                return None
+            try:
+                from src.infra.utils.datetime import ensure_utc
+
+                claimed_at = ensure_utc(claimed_at)
+            except (TypeError, ValueError):
+                return None
+            if (
+                not isinstance(claimed_at, datetime)
+                or claimed_at > utc_now() - SESSION_DELETE_FENCE_TTL
+            ):
+                return None
+            result = await self.collection.find_one_and_update(
+                {
+                    **identity,
+                    f"{field}.id": existing_operation.get("id"),
+                    f"{field}.claimed_at": claimed_at,
+                },
+                [
+                    {
+                        "$set": {
+                            field: {**operation, "uploaded_by": "$user_id"},
+                            "updated_at": utc_now(),
+                        }
+                    }
+                ],
+                return_document=True,
+            )
+            if result:
+                claimed_operation = result.get(field)
+                if isinstance(claimed_operation, dict):
+                    return {**claimed_operation, "acquired": True}
+            return None
+
         async def _claim(identity: dict[str, Any]) -> dict[str, Any] | None:
             for writer_predicate in (0, {"$exists": False}):
                 result = await self.collection.find_one_and_update(
@@ -295,6 +341,9 @@ class SessionAttachmentOperationsMixin:
             result = await self.collection.find_one(identity, {field: 1})
             existing_operation = result.get(field) if result else None
             if isinstance(existing_operation, dict):
+                reclaimed = await _reclaim_stale(identity, existing_operation)
+                if reclaimed is not None:
+                    return reclaimed
                 return {**existing_operation, "acquired": False}
             return None
 

--- a/src/infra/session/trace_attachment_cleanup.py
+++ b/src/infra/session/trace_attachment_cleanup.py
@@ -1,15 +1,25 @@
 """Strict attachment-cleanup reads and CAS deletion for trace storage."""
 
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, List, Optional
 
+from src.infra.logging import get_logger
 from src.infra.session._trace_storage_support import (
     SESSION_EVENT_FILTER_LIST_LIMIT,
     _bounded_unique_strings,
     _event_seq,
 )
 from src.infra.session.trace_event_chunks import ATTACHMENT_CHUNK_WRITE_FIELD
+from src.infra.utils.datetime import utc_now
 
 ATTACHMENT_CLEAR_TERMINAL_STATUSES = ("completed", "error")
+
+# A running trace whose updated_at heartbeat is older than this TTL belongs to
+# a writer that is gone (crashed run / missed restart recovery); it can never
+# reach a terminal status on its own and would block session deletion forever.
+STALE_RUNNING_TRACE_TTL = timedelta(minutes=10)
+
+logger = get_logger("src.infra.session.trace_storage")
 
 
 class TraceAttachmentCleanupMixin:
@@ -331,6 +341,51 @@ class TraceAttachmentCleanupMixin:
             return "deleted"
         survivor = await collection.find_one({"_id": document_id}, {"_id": 1})
         return "survivor" if survivor else "deleted"
+
+    async def expire_stale_running_traces(
+        self,
+        session_id: str,
+        *,
+        now: Optional[Any] = None,
+        ttl: timedelta = STALE_RUNNING_TRACE_TTL,
+    ) -> int:
+        """Transition stale running traces to error so destructive cleanup can proceed.
+
+        Only touches traces whose updated_at heartbeat is older than ``ttl``;
+        ``updated_at`` is deliberately preserved because it is the CAS version
+        the attachment-clear snapshot and group deletes match against.
+        """
+        current = now if now is not None else utc_now()
+        stale_before = current - ttl
+        try:
+            result = await self.collection.update_many(
+                {
+                    "session_id": session_id,
+                    "status": "running",
+                    "updated_at": {"$lte": stale_before},
+                },
+                {
+                    "$set": {
+                        "status": "error",
+                        "completed_at": current,
+                        "metadata.error_code": "stale_run_recovery",
+                    }
+                },
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to expire stale running traces for session %s: %s",
+                session_id,
+                e,
+            )
+            return 0
+        if result.modified_count:
+            logger.info(
+                "Expired %d stale running trace(s) for session %s",
+                result.modified_count,
+                session_id,
+            )
+        return result.modified_count
 
     async def has_session_trace_documents(self, session_id: str) -> bool:
         """Return whether any parent or directly session-scoped chunk survives."""

--- a/tests/api/routes/test_session_delete_route.py
+++ b/tests/api/routes/test_session_delete_route.py
@@ -1,0 +1,171 @@
+"""DELETE /sessions/{session_id} 路由的 SessionError 映射测试。"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from src.kernel.exceptions import SessionError
+
+
+class _Logger:
+    def debug(self, *args, **kwargs):
+        return None
+
+    def info(self, *args, **kwargs):
+        return None
+
+    def warning(self, *args, **kwargs):
+        return None
+
+    def error(self, *args, **kwargs):
+        return None
+
+
+def _load_session_routes_module(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "src.api.deps",
+        SimpleNamespace(get_current_user_required=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "src.infra.logging",
+        SimpleNamespace(get_logger=lambda _name: _Logger()),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "src.infra.folder.storage",
+        SimpleNamespace(get_project_storage=lambda: SimpleNamespace()),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "src.infra.session.favorites",
+        SimpleNamespace(
+            is_session_favorite=lambda *_args, **_kwargs: False,
+            normalize_session_metadata=lambda metadata, *_args, **_kwargs: metadata or {},
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "src.infra.session.manager",
+        SimpleNamespace(SessionManager=object),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "src.infra.session.storage",
+        SimpleNamespace(SessionStorage=object),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "src.kernel.config",
+        SimpleNamespace(
+            settings=SimpleNamespace(LLM_MAX_RETRIES=3, LLM_RETRY_DELAY=1),
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "src.kernel.schemas.session",
+        SimpleNamespace(
+            Session=object,
+            SessionCreate=object,
+            SessionUpdate=object,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "src.kernel.schemas.user",
+        SimpleNamespace(TokenPayload=object),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "src.infra.session.dual_writer",
+        SimpleNamespace(get_dual_writer=lambda: None, DualEventWriter=object),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "src.infra.session.trace_storage",
+        SimpleNamespace(get_trace_storage=lambda: None),
+    )
+    history_path = Path(__file__).parents[3] / "src/infra/session/history_compaction.py"
+    history_spec = importlib.util.spec_from_file_location(
+        "session_history_compaction_under_test",
+        history_path,
+    )
+    assert history_spec is not None
+    history_module = importlib.util.module_from_spec(history_spec)
+    assert history_spec.loader is not None
+    history_spec.loader.exec_module(history_module)
+    monkeypatch.setitem(
+        sys.modules,
+        "src.infra.session.history_compaction",
+        history_module,
+    )
+
+    path = Path(__file__).parents[3] / "src/api/routes/session.py"
+    spec = importlib.util.spec_from_file_location("session_routes_under_test", path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class _ManagerRaisingOnDelete:
+    def __init__(self, error: Exception) -> None:
+        self._error = error
+
+    async def get_session(self, session_id: str):
+        return SimpleNamespace(user_id="user-1", session_id=session_id, metadata={})
+
+    async def delete_session(self, _session_id: str) -> bool:
+        raise self._error
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error_code", "expected_status"),
+    [
+        ("session_delete_in_progress", 409),
+        ("session_delete_has_trace_survivors", 500),
+        ("session_delete_fence_unavailable", 500),
+    ],
+)
+async def test_delete_session_maps_session_error_to_status_code(
+    monkeypatch: pytest.MonkeyPatch, error_code: str, expected_status: int
+) -> None:
+    session_routes = _load_session_routes_module(monkeypatch)
+    manager = _ManagerRaisingOnDelete(SessionError(error_code))
+    monkeypatch.setattr(session_routes, "SessionManager", lambda: manager)
+    user = SimpleNamespace(sub="user-1", role="user")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await session_routes.delete_session("session-1", user=user)
+
+    assert exc_info.value.status_code == expected_status
+    assert exc_info.value.detail == error_code
+
+
+@pytest.mark.asyncio
+async def test_delete_session_returns_deleted_on_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session_routes = _load_session_routes_module(monkeypatch)
+
+    class _Manager:
+        async def get_session(self, session_id: str):
+            return SimpleNamespace(user_id="user-1", session_id=session_id, metadata={})
+
+        async def delete_session(self, _session_id: str) -> bool:
+            return True
+
+    manager = _Manager()
+    monkeypatch.setattr(session_routes, "SessionManager", lambda: manager)
+    user = SimpleNamespace(sub="user-1", role="user")
+
+    result = await session_routes.delete_session("session-1", user=user)
+
+    assert result == {"status": "deleted"}

--- a/tests/infra/session/test_attachment_cleanup.py
+++ b/tests/infra/session/test_attachment_cleanup.py
@@ -202,6 +202,15 @@ class _FilterAwareCollection:
                 )
         return SimpleNamespace(matched_count=0, modified_count=0)
 
+    async def update_many(self, query: dict[str, Any], update: dict, **_kwargs):
+        modified_count = 0
+        for document in self.documents:
+            if _matches(document, query):
+                before = deepcopy(document)
+                _apply_update(document, update)
+                modified_count += int(document != before)
+        return SimpleNamespace(matched_count=modified_count, modified_count=modified_count)
+
     async def insert_one(self, document: dict[str, Any]):
         self.documents.append(deepcopy(document))
         return SimpleNamespace(inserted_id=document.get("_id", "inserted"))
@@ -314,6 +323,9 @@ class _TraceStorage:
         self.deleted_session_ids.append(self.snapshot_session_id)
         self.events = []
         return "deleted"
+
+    async def expire_stale_running_traces(self, _session_id: str, **_kwargs) -> int:
+        return 0
 
     async def has_session_trace_documents(self, _session_id: str) -> bool:
         return bool(self.events)
@@ -1612,6 +1624,8 @@ async def test_delete_session_refuses_to_remove_anchor_while_running_trace_survi
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     cutoff = datetime(2026, 8, 11, 12, 0, tzinfo=timezone.utc)
+    # Pin "now" so the running trace stays fresh relative to the stale-TTL.
+    monkeypatch.setattr("src.infra.session.trace_attachment_cleanup.utc_now", lambda: cutoff)
     trace_storage, parents, _chunks = _trace_storage_with_documents(
         [
             {
@@ -1863,3 +1877,183 @@ async def test_concurrent_delete_request_cannot_cancel_the_owner_fence(
     allow_owner_to_finish.set()
     assert await owner is True
     assert storage.cancel_calls == []
+
+
+@pytest.mark.asyncio
+async def test_expire_stale_running_traces_transitions_only_stale_runs() -> None:
+    cutoff = datetime(2026, 8, 11, 12, 0, tzinfo=timezone.utc)
+    trace_storage, parents, _chunks = _trace_storage_with_documents(
+        [
+            {
+                "_id": "parent-stale",
+                "session_id": "session-1",
+                "trace_id": "trace-stale",
+                "status": "running",
+                "updated_at": cutoff - timedelta(minutes=30),
+                "events": [],
+            },
+            {
+                "_id": "parent-fresh",
+                "session_id": "session-1",
+                "trace_id": "trace-fresh",
+                "status": "running",
+                "updated_at": cutoff - timedelta(minutes=1),
+                "events": [],
+            },
+            {
+                "_id": "parent-terminal",
+                "session_id": "session-1",
+                "trace_id": "trace-terminal",
+                "status": "completed",
+                "updated_at": cutoff - timedelta(hours=2),
+                "events": [],
+            },
+            {
+                "_id": "parent-other-session",
+                "session_id": "session-2",
+                "trace_id": "trace-other",
+                "status": "running",
+                "updated_at": cutoff - timedelta(hours=3),
+                "events": [],
+            },
+        ],
+        [],
+    )
+
+    expired = await trace_storage.expire_stale_running_traces("session-1", now=cutoff)
+
+    assert expired == 1
+    stale = next(d for d in parents.documents if d["_id"] == "parent-stale")
+    assert stale["status"] == "error"
+    assert stale["completed_at"] == cutoff
+    assert stale["metadata"]["error_code"] == "stale_run_recovery"
+    # updated_at is the CAS version used by the clear/delete snapshot; keep it.
+    assert stale["updated_at"] == cutoff - timedelta(minutes=30)
+    fresh = next(d for d in parents.documents if d["_id"] == "parent-fresh")
+    assert fresh["status"] == "running"
+    terminal = next(d for d in parents.documents if d["_id"] == "parent-terminal")
+    assert terminal["status"] == "completed"
+    other = next(d for d in parents.documents if d["_id"] == "parent-other-session")
+    assert other["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_delete_session_expires_stale_running_trace_instead_of_refusing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cutoff = datetime(2026, 8, 11, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr("src.infra.session.trace_attachment_cleanup.utc_now", lambda: cutoff)
+    trace_storage, parents, _chunks = _trace_storage_with_documents(
+        [
+            {
+                "_id": "parent-running",
+                "session_id": "session-1",
+                "trace_id": "trace-running",
+                "status": "running",
+                "updated_at": cutoff - timedelta(minutes=30),
+                "events": [],
+            }
+        ],
+        [],
+    )
+    deleted_sessions: list[str] = []
+
+    class _Storage(_ExactSessionOperationStorage):
+        async def delete(self, session_id: str) -> bool:
+            deleted_sessions.append(session_id)
+            return True
+
+    class _RevealedStorage:
+        async def delete_by_session(self, _session_id: str) -> int:
+            return 0
+
+    manager = SessionManager()
+    manager._trace_storage = trace_storage
+    manager._file_record_storage = _FileRecordStorage()
+    manager.storage = _Storage(cutoff)
+    monkeypatch.setattr(
+        "src.infra.revealed_file.storage.get_revealed_file_storage",
+        lambda: _RevealedStorage(),
+    )
+
+    assert await manager.delete_session("session-1") is True
+
+    assert deleted_sessions == ["session-1"]
+    assert parents.ids() == set()
+
+
+@pytest.mark.asyncio
+async def test_stale_delete_fence_is_reclaimed_by_new_delete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = datetime(2026, 8, 11, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr("src.infra.session.session_attachment_operations.utc_now", lambda: now)
+
+    async def _skip_indexes(_storage: SessionStorage) -> None:
+        return None
+
+    monkeypatch.setattr(SessionStorage, "ensure_indexes_if_needed", _skip_indexes)
+    collection = _FilterAwareCollection(
+        [
+            {
+                "_id": "session-doc",
+                "session_id": "session-1",
+                "user_id": "owner-a",
+                "active_trace_writers": 0,
+                "attachment_delete_operation": {
+                    "id": "old-fence",
+                    "claimed_at": now - timedelta(minutes=11),
+                },
+            }
+        ]
+    )
+    storage = SessionStorage()
+    storage._collection = collection
+
+    claim = await storage.claim_attachment_delete_operation("session-1")
+
+    assert claim is not None
+    assert claim["acquired"] is True
+    assert claim["id"] != "old-fence"
+
+    doc = collection.documents[0]
+    assert doc["attachment_delete_operation"]["id"] == claim["id"]
+    assert await storage.delete_claimed_session("session-1", claim["id"]) is True
+
+
+@pytest.mark.asyncio
+async def test_fresh_delete_fence_still_blocks_new_delete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = datetime(2026, 8, 11, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr("src.infra.session.session_attachment_operations.utc_now", lambda: now)
+
+    async def _skip_indexes(_storage: SessionStorage) -> None:
+        return None
+
+    monkeypatch.setattr(SessionStorage, "ensure_indexes_if_needed", _skip_indexes)
+    collection = _FilterAwareCollection(
+        [
+            {
+                "_id": "session-doc",
+                "session_id": "session-1",
+                "user_id": "owner-a",
+                "active_trace_writers": 0,
+                "attachment_delete_operation": {
+                    "id": "active-fence",
+                    "claimed_at": now - timedelta(seconds=30),
+                },
+            }
+        ]
+    )
+    storage = SessionStorage()
+    storage._collection = collection
+
+    claim = await storage.claim_attachment_delete_operation("session-1")
+
+    assert claim == {
+        "id": "active-fence",
+        "claimed_at": now - timedelta(seconds=30),
+        "acquired": False,
+    }
+    assert collection.documents[0]["attachment_delete_operation"]["id"] == "active-fence"


### PR DESCRIPTION
## 问题

生产环境（lambchat.com）部分会话"删除会话失败"，且每次重试都失败、永不自愈。排查服务器 Mongo 发现 **67 个会话**的 trace 永远停在 `status: "running"`（最老的可追溯到 3 月），删除链路因此被永久卡死。

## 根因

`SessionManager.delete_session` 的清理快照只纳入终态（`completed`/`error`）trace；随后 `has_session_trace_documents` 只要发现该 session 还有任何 trace/chunk 文档就抛 `session_delete_has_trace_survivors` 并终止。run 中途死掉（进程被杀、重启恢复未覆盖）的 trace 永远到不了终态，于是对应会话**每次删除都失败**。此外 delete fence 无过期机制，删除中途进程被杀会留下永久 fence，导致 `session_delete_in_progress` 同样永久卡死。

## 修复

1. **过期 stale running trace**（`trace_attachment_cleanup.py`）：新增 `expire_stale_running_traces`，将 `updated_at` 心跳超过 10 分钟（`STALE_RUNNING_TRACE_TTL`）的 running trace 置为 `error`（`metadata.error_code="stale_run_recovery"`）。刻意**不改动 `updated_at`**——它是清理快照与 CAS 删除匹配的版本号。`delete_session` 在清理消息前调用。
2. **delete fence 过期回收**（`session_attachment_operations.py`）：`claim_attachment_delete_operation` 对 `claimed_at` 超过 10 分钟（`SESSION_DELETE_FENCE_TTL`）的旧 fence 原子回收，避免进程被杀后 `session_delete_in_progress` 永久阻塞。
3. **路由错误映射**（`api/routes/session.py`）：`DELETE /sessions/{id}` 捕获 `SessionError`：`session_delete_in_progress` → 409，其余 → 500，detail 为错误码并记录日志，替代原先未处理的 500。

安全边界保持不变：fence 只在 `active_trace_writers == 0` 时才能领取，真正在写的 run 依然会阻止删除；新写入依然被 fence 拒绝。

## 测试（TDD）

- `test_expire_stale_running_traces_transitions_only_stale_runs`：只过期 stale 的 running trace，fresh running / 终态 / 其他 session 不受影响，且保留 `updated_at`
- `test_delete_session_expires_stale_running_trace_instead_of_refusing`：含 stale running trace 的会话可成功删除
- `test_stale_delete_fence_is_reclaimed_by_new_delete` / `test_fresh_delete_fence_still_blocks_new_delete`：旧 fence 回收、新 fence 不受影响
- 路由参数化测试：三种 `SessionError` 的状态码映射与成功路径
- 既有"新鲜 running trace 拒绝删除"语义测试保留（固定时钟后仍通过）

验证：`uv run pytest`（2706 passed）、`make lint`、`make typecheck`、`ruff format` 全部通过。
