### PR TITLE
fix(steer): 刷新后插话可见 + 送达时轮次分割（对齐 Codex）

### DIFF
--- a/frontend/src/hooks/useAgent.ts
+++ b/frontend/src/hooks/useAgent.ts
@@ -188,6 +188,7 @@ export function useAgent(options?: UseAgentOptions): UseAgentReturn {
       streamVersionRef,
       setSessionId,
       setMessages,
+      messagesRef,
       setConnectionStatus: (status) =>
         setConnectionStatus(status as ConnectionStatus),
       setIsInitializingSandbox,

--- a/frontend/src/hooks/useAgent/__tests__/steerTurnSplit.test.ts
+++ b/frontend/src/hooks/useAgent/__tests__/steerTurnSplit.test.ts
@@ -1,0 +1,97 @@
+import type { Message } from "../../../types/message";
+import { splitAssistantTurnOnSteerDelivery } from "../steerTurnSplit";
+
+function msg(partial: Partial<Message> & Pick<Message, "id" | "role">): Message {
+  return { content: "", timestamp: new Date(), ...partial } as Message;
+}
+
+describe("splitAssistantTurnOnSteerDelivery", () => {
+  const base: Message[] = [
+    msg({ id: "run1:user", role: "user", content: "开始任务" }),
+    msg({
+      id: "run1:assistant",
+      role: "assistant",
+      content: "第一轮回复",
+      isStreaming: true,
+      parts: [],
+    }),
+    msg({
+      id: "steer-1",
+      role: "user",
+      content: "中途插话",
+      metadata: { steered: true, queued: true },
+    }),
+  ];
+
+  test("送达时封存旧助手轮次，插话后开新轮次接收后续事件", () => {
+    const result = splitAssistantTurnOnSteerDelivery(base, "中途插话", "run1:assistant");
+
+    expect(result.map((m) => m.id)).toEqual([
+      "run1:user",
+      "run1:assistant#t1",
+      "steer-1",
+      "run1:assistant",
+    ]);
+    const oldTurn = result[1];
+    expect(oldTurn.isStreaming).toBe(false);
+    const newTurn = result[3];
+    expect(newTurn.role).toBe("assistant");
+    expect(newTurn.isStreaming).toBe(true);
+    expect(newTurn.parts).toEqual([]);
+  });
+
+  test("非插话的 user:message 不触发分割", () => {
+    const noSteer: Message[] = [
+      msg({ id: "run1:user", role: "user", content: "开始任务" }),
+      msg({ id: "run1:assistant", role: "assistant", isStreaming: true }),
+    ];
+    expect(splitAssistantTurnOnSteerDelivery(noSteer, "普通消息", "run1:assistant")).toBe(
+      noSteer,
+    );
+  });
+
+  test("无匹配排队插话（内容不同）不分割", () => {
+    expect(splitAssistantTurnOnSteerDelivery(base, "别的内容", "run1:assistant")).toBe(base);
+  });
+
+  test("多次送达递增轮次后缀", () => {
+    const once = splitAssistantTurnOnSteerDelivery(base, "中途插话", "run1:assistant");
+    const withSecondSteer = [
+      ...once.slice(0, 3),
+      msg({
+        id: "run1:assistant",
+        role: "assistant",
+        isStreaming: true,
+        parts: [],
+      }),
+      msg({
+        id: "steer-2",
+        role: "user",
+        content: "第二次插话",
+        metadata: { steered: true, queued: true },
+      }),
+    ];
+    const twice = splitAssistantTurnOnSteerDelivery(
+      withSecondSteer,
+      "第二次插话",
+      "run1:assistant",
+    );
+    expect(twice.map((m) => m.id)).toContain("run1:assistant#t2");
+    expect(twice.map((m) => m.id)).toContain("run1:assistant");
+  });
+
+  test("找不到流式助手消息时安全返回原数组", () => {
+    const noAssistant: Message[] = [
+      msg({ id: "u", role: "user", content: "x" }),
+      msg({
+        id: "steer-1",
+        role: "user",
+        content: "中途插话",
+        metadata: { queued: true },
+      }),
+    ];
+    expect(
+      splitAssistantTurnOnSteerDelivery(noAssistant, "中途插话", "missing"),
+    ).toBe(noAssistant);
+  });
+});

--- a/frontend/src/hooks/useAgent/eventHandlers.ts
+++ b/frontend/src/hooks/useAgent/eventHandlers.ts
@@ -22,6 +22,10 @@ import type {
   UseAgentOptions,
 } from "./types";
 import { clearAllLoadingStates } from "./messageParts";
+import {
+  hasQueuedSteerMessage,
+  splitAssistantTurnOnSteerDelivery,
+} from "./steerTurnSplit";
 import { convertAttachments, processMessageEvent } from "./eventProcessor";
 import { dispatchToolMutationRefresh } from "../../components/chat/ChatMessage/items/toolMutationEvents";
 
@@ -37,6 +41,7 @@ export interface EventHandlerContext {
   streamVersionRef: React.MutableRefObject<number>;
   setSessionId: (id: string) => void;
   setMessages: React.Dispatch<React.SetStateAction<Message[]>>;
+  messagesRef?: React.MutableRefObject<Message[]>;
   setConnectionStatus: (status: string) => void;
   setIsInitializingSandbox: (loading: boolean) => void;
   setSandboxError: (error: string | null) => void;
@@ -206,6 +211,18 @@ export function handleStreamEvent(
     }
 
     case "user:message": {
+      // 插话送达：先做轮次分割（封存当前助手轮次，插话后开新轮次），
+      // 再走标准 user:message 原地更新（清除排队态）
+      const steerContent =
+        typeof data.content === "string" ? data.content.trim() : "";
+      if (
+        steerContent &&
+        hasQueuedSteerMessage(ctx.messagesRef?.current ?? [], steerContent)
+      ) {
+        ctx.setMessages((prev) =>
+          splitAssistantTurnOnSteerDelivery(prev, steerContent, messageId),
+        );
+      }
       handleUserMessage(data, messageId, eventTimestamp, ctx);
       return;
     }

--- a/frontend/src/hooks/useAgent/steerTurnSplit.ts
+++ b/frontend/src/hooks/useAgent/steerTurnSplit.ts
@@ -1,0 +1,73 @@
+import type { Message } from "../../types/message";
+import { clearAllLoadingStates } from "./messageParts";
+
+/**
+ * 插话送达时的"轮次分割"（对齐 Codex 的逐 item 渲染语义）。
+ *
+ * 实时视图中一个 run 的所有模型输出流进同一个助手消息（run 级
+ * messageId）。插话送达（user:message 事件匹配到排队气泡）时：
+ * 1. 封存当前流式助手消息（重命名 id、清加载态）；
+ * 2. 在插话气泡之后插入新的助手占位（沿用原 messageId 接收后续事件）。
+ *
+ * 最终顺序：[助手轮1] [插话气泡] [助手轮2（继续流式）] —— 与刷新后
+ * 历史加载器的轮次交错顺序一致。非插话的 user:message 不受影响。
+ */
+export function hasQueuedSteerMessage(
+  messages: Message[],
+  steerContent: string,
+): boolean {
+  return messages.some(
+    (m) =>
+      m.role === "user" &&
+      m.metadata?.queued === true &&
+      m.content === steerContent,
+  );
+}
+
+export function splitAssistantTurnOnSteerDelivery(
+  messages: Message[],
+  steerContent: string,
+  assistantId: string,
+): Message[] {
+  if (!hasQueuedSteerMessage(messages, steerContent)) return messages;
+
+  const assistantIndex = messages.findIndex(
+    (m) => m.id === assistantId && m.role === "assistant",
+  );
+  if (assistantIndex === -1) return messages;
+
+  // 已分割过的轮次用 #tN 后缀，递增避免冲突
+  const turnNumbers = messages
+    .map((m) => m.id.match(/^.*#t(\d+)$/)?.[1])
+    .filter((n): n is string => n != null)
+    .map(Number);
+  const nextTurn = (turnNumbers.length ? Math.max(...turnNumbers) : 0) + 1;
+
+  const sealed: Message = {
+    ...messages[assistantIndex],
+    id: `${assistantId}#t${nextTurn}`,
+    isStreaming: false,
+    parts: clearAllLoadingStates(messages[assistantIndex].parts || []),
+  };
+
+  // 插话气泡（排队中、内容匹配）之后插入新助手轮次
+  const steerIndex = messages.findIndex(
+    (m) =>
+      m.role === "user" &&
+      m.metadata?.queued === true &&
+      m.content === steerContent,
+  );  // split 前已确认存在
+  const freshTurn: Message = {
+    id: assistantId,
+    role: "assistant",
+    content: "",
+    timestamp: new Date(),
+    parts: [],
+    isStreaming: true,
+  };
+
+  const next = [...messages];
+  next[assistantIndex] = sealed;
+  next.splice(steerIndex + 1, 0, freshTurn);
+  return next;
+}

--- a/src/agents/fast_agent/nodes.py
+++ b/src/agents/fast_agent/nodes.py
@@ -265,7 +265,7 @@ async def fast_agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict
     user_middleware = create_retry_middleware(
         fallback_model=fallback_model_value, thinking=thinking_config
     )
-    user_middleware.insert(0, SteerMiddleware(session_id=str(session_id)))
+    user_middleware.insert(0, SteerMiddleware(session_id=str(session_id), presenter=presenter))
     user_middleware.append(ToolResultBinaryMiddleware(base_url=subagent_base_url))
     user_middleware.append(ArtifactDeliveryMiddleware())
     if image_url_to_base64:

--- a/src/agents/search_agent/nodes.py
+++ b/src/agents/search_agent/nodes.py
@@ -268,7 +268,9 @@ async def agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict[str,
     user_middleware = create_retry_middleware(
         fallback_model=fallback_model_value, thinking=thinking_config
     )
-    user_middleware.insert(0, SteerMiddleware(session_id=str(state.get("session_id") or "")))
+    user_middleware.insert(
+        0, SteerMiddleware(session_id=str(state.get("session_id") or ""), presenter=presenter)
+    )
     user_middleware.append(ToolResultBinaryMiddleware(base_url=search_base_url))
     user_middleware.append(ArtifactDeliveryMiddleware(workspace_path=sandbox_work_dir))
     if image_url_to_base64:

--- a/src/agents/team_agent/nodes.py
+++ b/src/agents/team_agent/nodes.py
@@ -736,7 +736,9 @@ async def team_router_node(state: Dict[str, Any], config: RunnableConfig) -> Dic
     user_middleware = create_retry_middleware(
         fallback_model=fallback_model_value, thinking=thinking_config
     )
-    user_middleware.insert(0, SteerMiddleware(session_id=str(state.get("session_id") or "")))
+    user_middleware.insert(
+        0, SteerMiddleware(session_id=str(state.get("session_id") or ""), presenter=presenter)
+    )
     user_middleware.append(ToolResultBinaryMiddleware(base_url=subagent_base_url))
     user_middleware.append(ArtifactDeliveryMiddleware(workspace_path=sandbox_work_dir))
     if image_url_to_base64:

--- a/src/infra/agent/middleware/steer.py
+++ b/src/infra/agent/middleware/steer.py
@@ -29,18 +29,30 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-async def _persist_delivered_user_messages(session_id: str, texts: list[str]) -> None:
+async def _persist_delivered_user_messages(
+    session_id: str, texts: list[str], presenter: Any = None
+) -> None:
     """把已注入的插话消息写入 user:message 事件（尽力而为）。
 
-    事件经 dual_writer 双写 Redis + MongoDB：SSE 实时下发（前端按标准
-    user:message 渲染）且刷新/重载后历史可见。失败只记日志，不影响注入。
+    优先复用当前 run 的 ``presenter.emit_user_message``：事件自动归属
+    该 run 的 trace，MongoDB 历史（completed_only 聚合）刷新后可见。
+    无 presenter 时回退 dual_writer 直写（仅 Redis SSE，不进历史，
+    仅作实时展示兜底）。失败只记日志，不影响注入。
     """
     import uuid
 
-    from src.infra.session.dual_writer import get_dual_writer
-    from src.infra.utils.datetime import utc_now_iso
-
     try:
+        if presenter is not None:
+            for text in texts:
+                await presenter.emit_user_message(
+                    text,
+                    message_id=f"steer-{uuid.uuid4().hex[:12]}",
+                )
+            return
+
+        from src.infra.session.dual_writer import get_dual_writer
+        from src.infra.utils.datetime import utc_now_iso
+
         writer = get_dual_writer()
         for text in texts:
             await writer.write_event(
@@ -63,9 +75,10 @@ async def _persist_delivered_user_messages(session_id: str, texts: list[str]) ->
 class SteerMiddleware(AgentMiddleware):
     """把会话插话队列中的用户消息注入下一次模型调用。"""
 
-    def __init__(self, *, session_id: str) -> None:
+    def __init__(self, *, session_id: str, presenter: Any = None) -> None:
         super().__init__()
         self._session_id = session_id
+        self._presenter = presenter
 
     async def awrap_model_call(
         self,
@@ -95,7 +108,9 @@ class SteerMiddleware(AgentMiddleware):
         # 注入成功：写 user:message 事件（SSE + 历史持久化），
         # 再把插话消息写入图状态，checkpoint 持久化
         if self._session_id:
-            await _persist_delivered_user_messages(self._session_id, pending)
+            await _persist_delivered_user_messages(
+                self._session_id, pending, presenter=self._presenter
+            )
 
         from langchain.agents.middleware.types import ExtendedModelResponse
         from langgraph.types import Command as LangCommand

--- a/tests/agents/core/test_node_utils_fallback.py
+++ b/tests/agents/core/test_node_utils_fallback.py
@@ -61,9 +61,7 @@ async def test_resolve_fallback_model_global_default(
 
         storage.get = AsyncMock(side_effect=get)
 
-    with patch(
-        "src.infra.agent.model_storage.get_model_storage", return_value=storage
-    ):
+    with patch("src.infra.agent.model_storage.get_model_storage", return_value=storage):
         result = await resolve_fallback_model(
             "m1" if db_model else None,
             db_model.value if db_model else "primary-model",

--- a/tests/api/routes/test_chat_steer.py
+++ b/tests/api/routes/test_chat_steer.py
@@ -42,9 +42,7 @@ async def test_steer_enqueues_message_for_running_session(monkeypatch) -> None:
 
     from src.infra.task.steer import get_steer_queue
 
-    result = await steer_running_agent(
-        "session-1", SteerRequest(message="中途插话"), user=_user()
-    )
+    result = await steer_running_agent("session-1", SteerRequest(message="中途插话"), user=_user())
 
     assert result["status"] == "queued"
     assert await get_steer_queue().drain("session-1") == ["中途插话"]
@@ -57,15 +55,11 @@ async def test_steer_rejects_when_task_not_running(monkeypatch) -> None:
     )
     monkeypatch.setattr(
         "src.api.routes.chat.get_task_manager",
-        lambda: SimpleNamespace(
-            get_status=AsyncMock(return_value=TaskStatus.WAITING_HUMAN)
-        ),
+        lambda: SimpleNamespace(get_status=AsyncMock(return_value=TaskStatus.WAITING_HUMAN)),
     )
 
     with pytest.raises(HTTPException) as exc_info:
-        await steer_running_agent(
-            "session-1", SteerRequest(message="hi"), user=_user()
-        )
+        await steer_running_agent("session-1", SteerRequest(message="hi"), user=_user())
     assert exc_info.value.status_code == 409
 
 
@@ -76,9 +70,7 @@ async def test_steer_rejects_missing_session(monkeypatch) -> None:
     )
 
     with pytest.raises(HTTPException) as exc_info:
-        await steer_running_agent(
-            "session-1", SteerRequest(message="hi"), user=_user()
-        )
+        await steer_running_agent("session-1", SteerRequest(message="hi"), user=_user())
     assert exc_info.value.status_code == 404
 
 
@@ -89,9 +81,7 @@ async def test_steer_rejects_other_users_session(monkeypatch) -> None:
     )
 
     with pytest.raises(HTTPException) as exc_info:
-        await steer_running_agent(
-            "session-1", SteerRequest(message="hi"), user=_user("user-1")
-        )
+        await steer_running_agent("session-1", SteerRequest(message="hi"), user=_user("user-1"))
     assert exc_info.value.status_code == 403
 
 

--- a/tests/infra/agent/test_steer_middleware.py
+++ b/tests/infra/agent/test_steer_middleware.py
@@ -125,11 +125,35 @@ async def test_failed_model_call_requeues_messages() -> None:
     assert await get_steer_queue().drain("session-fail") == ["重要插话"]
 
 
-async def test_successful_injection_persists_user_message_events(monkeypatch) -> None:
-    """注入成功后写 user:message 事件（SSE 实时 + 历史持久化）。"""
+async def test_successful_injection_persists_via_presenter(monkeypatch) -> None:
+    """注入成功后经 presenter.emit_user_message 持久化（归属当前 run 的 trace，刷新后历史可见）。"""
     from src.infra.task.steer import get_steer_queue
 
     await get_steer_queue().enqueue("session-p", "要持久化的插话")
+
+    emitted: list[dict] = []
+
+    class _FakePresenter:
+        async def emit_user_message(self, content, message_id=None, **kwargs):
+            emitted.append({"content": content, "message_id": message_id})
+
+    middleware = SteerMiddleware(session_id="session-p", presenter=_FakePresenter())
+
+    async def handler(_req):
+        return _Response()
+
+    await middleware.awrap_model_call(_Request(), handler)
+
+    assert len(emitted) == 1
+    assert emitted[0]["content"] == "要持久化的插话"
+    assert str(emitted[0]["message_id"]).startswith("steer-")
+
+
+async def test_successful_injection_falls_back_to_dual_writer(monkeypatch) -> None:
+    """无 presenter 时回退 dual_writer 直写（实时 SSE 兜底）。"""
+    from src.infra.task.steer import get_steer_queue
+
+    await get_steer_queue().enqueue("session-p2", "兜底的插话")
 
     written: list[dict] = []
 
@@ -137,12 +161,9 @@ async def test_successful_injection_persists_user_message_events(monkeypatch) ->
         async def write_event(self, **kwargs):
             written.append(kwargs)
 
+    monkeypatch.setattr("src.infra.session.dual_writer.get_dual_writer", lambda: _FakeWriter())
 
-    monkeypatch.setattr(
-        "src.infra.session.dual_writer.get_dual_writer", lambda: _FakeWriter()
-    )
-
-    middleware = SteerMiddleware(session_id="session-p")
+    middleware = SteerMiddleware(session_id="session-p2")
 
     async def handler(_req):
         return _Response()
@@ -150,10 +171,8 @@ async def test_successful_injection_persists_user_message_events(monkeypatch) ->
     await middleware.awrap_model_call(_Request(), handler)
 
     assert len(written) == 1
-    assert written[0]["session_id"] == "session-p"
     assert written[0]["event_type"] == "user:message"
-    assert written[0]["data"]["content"] == "要持久化的插话"
-    assert str(written[0]["data"]["message_id"]).startswith("steer-")
+    assert written[0]["data"]["content"] == "兜底的插话"
 
 
 async def test_persist_failure_does_not_break_injection(monkeypatch) -> None:
@@ -165,9 +184,7 @@ async def test_persist_failure_does_not_break_injection(monkeypatch) -> None:
     def broken_writer():
         raise RuntimeError("dual writer down")
 
-    monkeypatch.setattr(
-        "src.infra.session.dual_writer.get_dual_writer", broken_writer
-    )
+    monkeypatch.setattr("src.infra.session.dual_writer.get_dual_writer", broken_writer)
 
     middleware = SteerMiddleware(session_id="session-pp")
     sentinel = _Response()

--- a/tests/infra/task/test_hitl_resume.py
+++ b/tests/infra/task/test_hitl_resume.py
@@ -78,9 +78,7 @@ async def test_submit_resume_skips_when_not_waiting_human(fake_redis, monkeypatc
                 metadata={"task_status": "completed"},
             )
 
-    monkeypatch.setattr(
-        "src.infra.session.storage.SessionStorage", lambda: _Storage()
-    )
+    monkeypatch.setattr("src.infra.session.storage.SessionStorage", lambda: _Storage())
     result = await submit_hitl_resume_run(_approval(), {"approved": True, "values": {}})
     assert result["submitted"] is False
     assert "等待" in result["message"]
@@ -114,9 +112,7 @@ async def test_submit_resume_submits_run_with_hitl_payload(fake_redis, monkeypat
                 },
             )
 
-    monkeypatch.setattr(
-        "src.infra.session.storage.SessionStorage", lambda: _Storage()
-    )
+    monkeypatch.setattr("src.infra.session.storage.SessionStorage", lambda: _Storage())
 
     async def fake_executor():
         yield
@@ -133,9 +129,7 @@ async def test_submit_resume_submits_run_with_hitl_payload(fake_redis, monkeypat
             submitted["kwargs"] = kwargs
             return "run-2", "trace-2"
 
-    monkeypatch.setattr(
-        "src.infra.task.manager.get_task_manager", lambda: _FakeManager()
-    )
+    monkeypatch.setattr("src.infra.task.manager.get_task_manager", lambda: _FakeManager())
 
     resume_value = {"approved": True, "values": {"choice": "a"}}
     result = await submit_hitl_resume_run(_approval(), resume_value)
@@ -151,5 +145,3 @@ async def test_submit_resume_submits_run_with_hitl_payload(fake_redis, monkeypat
         "approval_id": "approval-1",
         "resume_value": resume_value,
     }
-
-

--- a/tests/infra/tool/test_ask_human_graph_interrupt.py
+++ b/tests/infra/tool/test_ask_human_graph_interrupt.py
@@ -64,19 +64,12 @@ class ApprovalRecorder:
             list_pending=self._list_pending,
         )
 
-        monkeypatch.setattr(
-            "src.api.routes.human.create_approval", fake_create_approval
-        )
+        monkeypatch.setattr("src.api.routes.human.create_approval", fake_create_approval)
         monkeypatch.setattr(hitl_mod, "_send_approval_sse", fake_send_sse)
-        monkeypatch.setattr(
-            "src.infra.storage.mongodb.get_approval_storage", lambda: fake_storage
-        )
+        monkeypatch.setattr("src.infra.storage.mongodb.get_approval_storage", lambda: fake_storage)
 
     async def _list_pending(self, session_id=None, user_id=None, limit=100):
-        return [
-            SimpleNamespace(message=kw["message"])
-            for kw in self.created
-        ]
+        return [SimpleNamespace(message=kw["message"]) for kw in self.created]
 
 
 @pytest.fixture
@@ -269,18 +262,14 @@ async def test_new_ask_after_resume_suspends_again(
         assert len(recorder.created) == 1
 
         # 第一次恢复 → 第二次 ask_human 挂起
-        await _run(
-            graph, Command(resume={"approved": True, "values": {"choice": "a"}}), config
-        )
+        await _run(graph, Command(resume={"approved": True, "values": {"choice": "a"}}), config)
         state = await graph.aget_state(config)
         assert state.next, "第二个 ask_human 应再次挂起"
         await _materialize(graph, config, recorder)
         assert len(recorder.created) == 2
         assert recorder.created[1]["message"] == "第二个问题"
 
-        final_state = await graph.ainvoke(
-            Command(resume={"approved": False, "values": {}}), config
-        )
+        final_state = await graph.ainvoke(Command(resume={"approved": False, "values": {}}), config)
     finally:
         hitl_interrupt_supported.reset(token_supported)
 


### PR DESCRIPTION
两个修复：

1. **刷新后插话消失**：`dual_writer.write_event` 未传 `trace_id`，事件只进 Redis（实时可见）没进 MongoDB（历史从 Mongo 读，`completed_only` 按 trace 聚合）。改为复用 `presenter.emit_user_message`，事件归属当前 run 的 trace，刷新后历史可见。
2. **插话被压在助手消息下面**：实时视图一个 run 的输出流进同一个助手消息（run 级 messageId），插话气泡永远垫底。参考 [Codex TUI 的逐 item 渲染语义](https://github.com/openai/codex/blob/main/codex-rs/tui/src/chatwidget/user_messages.rs)，送达时做轮次分割：封存当前流式轮次，插话后开新轮次接收后续事件，顺序变为 [助手轮1][插话][助手轮2]，与历史加载器一致。

验证：后端 2725 + 前端 1410 测试、lint/mypy/tsc/build、行数预算全过。