### PR TITLE
fix(history): run 级去重误杀插话消息（刷新后可见）

### DIFF
--- a/frontend/src/hooks/useAgent/__tests__/historyLoader.test.ts
+++ b/frontend/src/hooks/useAgent/__tests__/historyLoader.test.ts
@@ -582,3 +582,77 @@ test("reconstructMessagesFromEvents keeps late run events after cancel on the ca
     "thinking",
   ]);
 });
+
+test("keeps steer user messages sharing the run with the initial user message", () => {
+  const runId = "run-1";
+  const messages = reconstructMessagesFromEvents(
+    [
+      {
+        event_type: "user:message",
+        run_id: runId,
+        timestamp: "2026-08-20T10:34:41.000Z",
+        data: {
+          content: "搜索今日新闻",
+          message_id: `${runId}:user`,
+          attachments: [],
+        },
+      } satisfies HistoryEvent,
+      {
+        event_type: "message:chunk",
+        run_id: runId,
+        timestamp: "2026-08-20T10:34:45.000Z",
+        data: { content: "第一轮回复" },
+      } satisfies HistoryEvent,
+      {
+        event_type: "user:message",
+        run_id: runId,
+        timestamp: "2026-08-20T10:34:55.000Z",
+        data: {
+          content: "给我多一点中国的",
+          message_id: "steer-d8f46d22bcf5",
+          attachments: [],
+        },
+      } satisfies HistoryEvent,
+      {
+        event_type: "message:chunk",
+        run_id: runId,
+        timestamp: "2026-08-20T10:35:02.000Z",
+        data: { content: "针对插话的回复" },
+      } satisfies HistoryEvent,
+    ],
+    new Set<string>(),
+    { activeSubagentStack: [] },
+  );
+
+  const users = messages.filter((m) => m.role === "user");
+  expect(users.map((m) => m.content)).toEqual(["搜索今日新闻", "给我多一点中国的"]);
+  // 顺序：首轮回复在插话前，插话后的回复在其后
+  const steerIndex = messages.findIndex((m) => m.id === "steer-d8f46d22bcf5");
+  const assistants = messages.filter((m) => m.role === "assistant");
+  expect(assistants.length).toBe(2);
+  expect(messages[steerIndex - 1].role).toBe("assistant");
+  expect(messages[steerIndex + 1].role).toBe("assistant");
+});
+
+test("still deduplicates replayed canonical user messages within one run", () => {
+  const runId = "run-2";
+  const messages = reconstructMessagesFromEvents(
+    [
+      {
+        event_type: "user:message",
+        run_id: runId,
+        timestamp: "2026-08-20T10:00:00.000Z",
+        data: { content: "hello", message_id: `${runId}:user`, attachments: [] },
+      } satisfies HistoryEvent,
+      {
+        event_type: "user:message",
+        run_id: runId,
+        timestamp: "2026-08-20T10:00:01.000Z",
+        data: { content: "hello", message_id: `${runId}:user`, attachments: [] },
+      } satisfies HistoryEvent,
+    ],
+    new Set<string>(),
+    { activeSubagentStack: [] },
+  );
+  expect(messages.filter((m) => m.role === "user")).toHaveLength(1);
+});

--- a/frontend/src/hooks/useAgent/historyLoader.ts
+++ b/frontend/src/hooks/useAgent/historyLoader.ts
@@ -257,14 +257,20 @@ export function reconstructMessagesFromEvents(
         typeof event.run_id === "string" && event.run_id.trim()
           ? event.run_id
           : null;
+      // run 级去重用于压制同 run 的重复回放（不同 id 的重复消息）；
+      // 插话消息（steer-* 前缀，由注入时生成）与首条用户消息同 run
+      // 但不是重复，不参与 run 级去重
+      const isSteerMessage = userMessageId.startsWith("steer-");
       if (
         seenUserMessageIds.has(userMessageId) ||
-        (userMessageRunId && seenUserMessageRunIds.has(userMessageRunId))
+        (!isSteerMessage &&
+          userMessageRunId != null &&
+          seenUserMessageRunIds.has(userMessageRunId))
       ) {
         continue;
       }
       seenUserMessageIds.add(userMessageId);
-      if (userMessageRunId) {
+      if (!isSteerMessage && userMessageRunId) {
         seenUserMessageRunIds.add(userMessageRunId);
       }
 


### PR DESCRIPTION
插话事件（`steer-*` message_id）与 run 首条用户消息共享 run_id，被 `seenUserMessageRunIds` 判定为重复回放丢弃——刷新后插话从历史消失（事件已正确写入 Mongo，仅前端历史重建过滤）。

修复：run 级去重跳过 `steer-*` 前缀；插话仍按自身 message_id 去重（回放安全）。新增 2 个回归测试（同 run 插话保留 + 原有去重行为不变）。