### PR TITLE
perf(steer): 固化 useSteerQueue 引用，恢复 ChatInput 记忆化

### DIFF
--- a/frontend/src/hooks/useAgent/__tests__/steerQueue.test.tsx
+++ b/frontend/src/hooks/useAgent/__tests__/steerQueue.test.tsx
@@ -1,0 +1,25 @@
+/** @vitest-environment jsdom */
+import { renderHook } from "@testing-library/react";
+import { useRef } from "react";
+
+import type { Message } from "../../../types/message";
+import { useSteerQueue } from "../steerQueue";
+
+test("useSteerQueue returns stable references across renders", () => {
+  const setMessages = (updater: (prev: Message[]) => Message[]) => {
+    void updater;
+  };
+  const setError = (error: string | null) => void error;
+
+  const { result, rerender } = renderHook(() => {
+    const sessionIdRef = useRef<string | null>("session-1");
+    return useSteerQueue({ sessionIdRef, setMessages, setError });
+  });
+
+  const first = result.current;
+  rerender();
+
+  // 引用稳定：作为 props 传给 memo(ChatInput) 时不破坏记忆化
+  expect(result.current.steerMessage).toBe(first.steerMessage);
+  expect(result.current.cancelSteer).toBe(first.cancelSteer);
+});

--- a/frontend/src/hooks/useAgent/steerQueue.ts
+++ b/frontend/src/hooks/useAgent/steerQueue.ts
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import type { RefObject } from "react";
 
 import i18n from "../../i18n";
@@ -20,7 +21,9 @@ interface SteerQueueOptions {
  * - 取消：删除排队气泡 + DELETE 后端队列中未送达的消息
  */
 export function useSteerQueue({ sessionIdRef, setMessages, setError }: SteerQueueOptions) {
-  const steerMessage = async (content: string) => {
+  // 引用必须稳定：作为 props 传给 memo(ChatInput)，流式期间父级高频
+  // 重渲染时不能破坏记忆化（否则编辑器每个 token 重渲染一次）
+  const steerMessage = useCallback(async (content: string) => {
     const text = content.trim();
     const currentSessionId = sessionIdRef.current;
     if (!text || !currentSessionId) return;
@@ -34,9 +37,9 @@ export function useSteerQueue({ sessionIdRef, setMessages, setError }: SteerQueu
       setMessages((prev) => prev.filter((m) => m.id !== optimistic.id));
       setError(i18n.t("chat.steerFailed", "插话发送失败，请稍后重试"));
     }
-  };
+  }, [setMessages, setError]);
 
-  const cancelSteer = (content: string) => {
+  const cancelSteer = useCallback((content: string) => {
     setMessages((prev) =>
       prev.filter(
         (m) => !(m.role === "user" && m.metadata?.queued === true && m.content === content),
@@ -46,7 +49,7 @@ export function useSteerQueue({ sessionIdRef, setMessages, setError }: SteerQueu
     if (currentSessionId) {
       sessionApi.cancelSteer(currentSessionId, content).catch(() => {});
     }
-  };
+  }, [setMessages]);
 
   return { steerMessage, cancelSteer };
 }


### PR DESCRIPTION
v3 重构把 steerMessage/cancelSteer 从 useMemo 降级为裸闭包，每次渲染重建并穿透到 `memo(ChatInput)`，记忆化失效——流式期间父级每个 token 重渲染一次富文本编辑器，页面卡顿（用户反馈 lambchat.com 实测会话交互卡）。

修复：useCallback 固化（依赖均为稳定 refs/setters）；新增 renderHook 稳定性回归测试。前端 1413 测试全过。