### PR TITLE
fix(pwa): 加载时自动激活等待中的 service worker

### DIFF
--- a/frontend/src/__tests__/pwaAutoActivateSource.test.ts
+++ b/frontend/src/__tests__/pwaAutoActivateSource.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { expect, test } from "vitest";
+
+test("pwa.ts activates a waiting worker at page load", () => {
+  const source = readFileSync(
+    resolve(import.meta.dirname, "../pwa.ts"),
+    "utf8",
+  );
+
+  // 页面加载时若存在 waiting 的新版本 worker，直接激活并重载一次，
+  // 避免用户浏览器长期停留在旧缓存 bundle（旧版本的性能/行为修复不生效）
+  expect(source).toMatch(
+    /activateWaitingLambChatPwaUpdate\(registration\)/,
+  );
+  // 仅在存在旧 controller（即确实在跑旧版本）且成功触发激活时重载
+  expect(source).toMatch(
+    /navigator\.serviceWorker\.controller\s*&&\s*registration\.waiting/,
+  );
+});

--- a/frontend/src/pwa.ts
+++ b/frontend/src/pwa.ts
@@ -73,9 +73,19 @@ export function registerLambChatPwa(): void {
 
     navigator.serviceWorker
       .register("/sw.js", { scope: "/", updateViaCache: "none" })
-      .then((registration) => {
+      .then(async (registration) => {
         watchForPwaUpdates(registration);
-        return registration.update().catch(() => undefined);
+        // 页面加载即激活等待中的新版本：旧 controller 在跑且已有 waiting
+        // worker 时立即接管并重载一次，确保用户拿到最新 bundle，
+        // 而不是等提示被确认期间一直运行旧缓存
+        if (
+          navigator.serviceWorker.controller &&
+          registration.waiting &&
+          activateWaitingLambChatPwaUpdate(registration)
+        ) {
+          return;
+        }
+        await registration.update().catch(() => undefined);
       })
       .catch((error) => {
         console.warn("[PWA] Service worker registration failed:", error);


### PR DESCRIPTION
生产实测（Playwright）：最新 bundle 在用户报告卡顿的会话页空闲/加载/滚动/打字各阶段 **0 个 longtask**。用户仍卡的原因是 PWA 更新陷阱：更新提示需确认，硬刷新只在当次生效，下次导航由旧 SW 提供旧缓存 bundle（含 memo 缺陷版本）。

修复：注册后若存在旧 controller + waiting worker，加载时立即 skipWaiting 并重载一次。前端 1414 测试全过。