### PR TITLE
perf(cache): freeze deferred-tool stub list at session scope

### DIFF
--- a/src/infra/tool/deferred_manager.py
+++ b/src/infra/tool/deferred_manager.py
@@ -43,8 +43,8 @@ class DeferredToolStub:
 class DeferredToolManager:
     """管理延迟 MCP 工具的发现和提升
 
-    内置 dirty flag 机制：stubs 和 prompt string 仅在 discover_tools() 后才重建，
-    避免每次 LLM 调用时重复分配。
+    会话级冻结：stubs 列表和 prompt string 从完整候选集构建一次后不再重建，
+    保证 search_tools 描述（provider prompt-cache 前缀的一部分）跨请求稳定。
     """
 
     def __init__(
@@ -105,14 +105,13 @@ class DeferredToolManager:
         self._session_id = session_id
         self._parent = parent
 
-        # Backward-compatible aggregate dirty flag.
-        self.stale: bool = True
-        self._stubs_stale: bool = True
-        self._prompt_stale: bool = True
-
-        # 缓存
-        self._cached_stubs: list[DeferredToolStub] = []
-        self._cached_stubs_string: str = ""
+        # Frozen stub caches: the stub list is part of the search_tools tool
+        # description (provider prompt-cache prefix), so it is built once from
+        # the full deferred tool set and never rebuilt — discovery state must
+        # not leak into it. Searching an already-loaded tool simply reports
+        # "already available", so freezing costs nothing functionally.
+        self._cached_stubs: list[DeferredToolStub] | None = None
+        self._cached_stubs_string: str | None = None
 
         logger.info(
             "[DeferredToolManager] Created: %d deferred tools for session %s "
@@ -154,9 +153,6 @@ class DeferredToolManager:
 
         self._discovered_names.update(new_names)
         self._discovered_order.extend(sorted(new_names))
-        self.stale = True
-        self._stubs_stale = True
-        self._prompt_stale = True
 
     @property
     def total_deferred(self) -> int:
@@ -182,15 +178,12 @@ class DeferredToolManager:
         return self.total_deferred - self.discovered_count
 
     def get_deferred_stubs(self) -> list[DeferredToolStub]:
-        """获取未发现工具的轻量描述列表（带脏标记缓存）"""
-        self._sync_parent_discoveries()
-        if not self._stubs_stale:
+        """全部延迟工具的轻量描述列表（会话级冻结，不随发现状态变化）"""
+        if self._cached_stubs is not None:
             return self._cached_stubs
 
         stubs: list[DeferredToolStub] = []
         for tool in self._all_tools:
-            if tool.name in self._discovered_names:
-                continue
             desc = getattr(tool, "description", "") or ""
             hint = desc.split("\n")[0].strip()[:120]
             stubs.append(
@@ -204,14 +197,11 @@ class DeferredToolManager:
             )
 
         self._cached_stubs = sorted(stubs, key=lambda stub: (stub.server, stub.name))
-        self._stubs_stale = False
-        self.stale = self._stubs_stale or self._prompt_stale
         return self._cached_stubs
 
     def get_deferred_stubs_string(self) -> str:
-        """返回可直接拼入系统提示的预格式化字符串（带脏标记缓存）。"""
-        self._sync_parent_discoveries()
-        if not self._prompt_stale:
+        """返回可直接拼入 search_tools 描述的预格式化字符串（会话级冻结）。"""
+        if self._cached_stubs_string is not None:
             return self._cached_stubs_string
 
         stubs = self.get_deferred_stubs()
@@ -234,8 +224,6 @@ class DeferredToolManager:
             result = ""
 
         self._cached_stubs_string = result
-        self._prompt_stale = False
-        self.stale = self._stubs_stale or self._prompt_stale
         return self._cached_stubs_string
 
     def get_discovered_tools(self) -> list["BaseTool"]:
@@ -266,9 +254,6 @@ class DeferredToolManager:
                 newly_discovered.append(self._tool_map[name])
 
         if newly_discovered:
-            self.stale = True
-            self._stubs_stale = True
-            self._prompt_stale = True
             logger.info(
                 "[DeferredToolManager] Discovered %d tools: %s (session %s)",
                 len(newly_discovered),

--- a/tests/infra/agent/test_tool_search_middleware.py
+++ b/tests/infra/agent/test_tool_search_middleware.py
@@ -103,9 +103,95 @@ def test_deferred_manager_fork_rebuilds_prompt_after_parent_discovery() -> None:
     manager.discover_tools(["alpha:create"])
     after = forked.get_deferred_stubs_string()
 
-    assert "- alpha:create" in before
-    assert "- alpha:create" not in after
+    # The stub list is frozen at session scope: discovery must never rewrite
+    # the search_tools description, or the provider prompt-cache prefix
+    # breaks exactly at the search_tools position.
+    assert before == after
+    assert "- alpha:create" in after
     assert "- beta:list" in after
+
+
+def test_deferred_stubs_string_is_frozen_across_discovery() -> None:
+    manager = DeferredToolManager(
+        all_deferred_tools=[
+            _FakeTool(name="alpha:create", description="alpha create", server="alpha"),
+            _FakeTool(name="beta:list", description="beta list", server="beta"),
+        ],
+        session_id="session-1",
+    )
+
+    before = manager.get_deferred_stubs_string()
+    manager.discover_tools(["alpha:create"])
+    after = manager.get_deferred_stubs_string()
+
+    assert before == after
+
+
+def test_deferred_stubs_string_is_identical_for_fork_and_parent() -> None:
+    manager = DeferredToolManager(
+        all_deferred_tools=[
+            _FakeTool(name="alpha:create", description="alpha create", server="alpha"),
+            _FakeTool(name="beta:list", description="beta list", server="beta"),
+        ],
+        session_id="session-1",
+    )
+    manager.discover_tools(["alpha:create"])
+    forked = manager.fork_for_scope("subagent")
+
+    # Main and sub agents alternate requests against the same cache prefix;
+    # their stub lists must be byte-identical regardless of discovery state.
+    assert forked.get_deferred_stubs_string() == manager.get_deferred_stubs_string()
+
+
+def test_deferred_stubs_string_ignores_pre_discovered_restore_state() -> None:
+    fresh = DeferredToolManager(
+        all_deferred_tools=[
+            _FakeTool(name="alpha:create", description="alpha create", server="alpha"),
+        ],
+        session_id="session-1",
+    )
+    restored = DeferredToolManager(
+        all_deferred_tools=[
+            _FakeTool(name="alpha:create", description="alpha create", server="alpha"),
+        ],
+        session_id="session-1",
+        pre_discovered_names=["alpha:create"],
+    )
+
+    assert restored.get_deferred_stubs_string() == fresh.get_deferred_stubs_string()
+
+
+async def test_search_tools_description_is_stable_across_model_calls() -> None:
+    manager = DeferredToolManager(
+        all_deferred_tools=[
+            _FakeTool(name="alpha:create", description="alpha create", server="alpha"),
+            _FakeTool(name="beta:list", description="beta list", server="beta"),
+        ],
+        session_id="session-1",
+    )
+    middleware = ToolSearchMiddleware(deferred_manager=manager, search_limit=5)
+
+    class _Request:
+        def __init__(self) -> None:
+            self.system_message = SystemMessage(content="base")
+            self.tools = []
+
+        def override(self, **kwargs):
+            clone = _Request()
+            clone.tools = kwargs.get("tools", self.tools)
+            return clone
+
+    async def _handler(request):
+        return request
+
+    first = await middleware.awrap_model_call(_Request(), _handler)
+    first_desc = next(t for t in first.tools if t.name == "search_tools").description
+
+    manager.discover_tools(["alpha:create"])
+    second = await middleware.awrap_model_call(_Request(), _handler)
+    second_desc = next(t for t in second.tools if t.name == "search_tools").description
+
+    assert first_desc == second_desc
 
 
 async def test_tool_search_middleware_intercepts_registered_search_tool_with_own_manager() -> None:
@@ -237,8 +323,13 @@ async def test_tool_search_middleware_does_not_duplicate_existing_search_tool() 
 
     result = await middleware.awrap_model_call(_Request(), _handler)
 
-    assert result.tools == [existing, search_tool, discovered]
-    assert [tool.name for tool in result.tools].count("search_tools") == 1
+    # The search_tools entry is replaced by an enriched copy (frozen stubs now
+    # include already-discovered names), but it must never be duplicated.
+    assert [tool.name for tool in result.tools] == [
+        "existing",
+        "search_tools",
+        "zeta:lookup",
+    ]
 
 
 async def test_tool_search_middleware_skips_duplicate_search_guide_when_already_present() -> None:
@@ -288,7 +379,7 @@ def test_deferred_search_guide_has_compact_budget() -> None:
     assert len(DEFERRED_TOOL_SEARCH_GUIDE) <= 300
 
 
-def test_deferred_prompt_does_not_repeat_loaded_tool_names() -> None:
+def test_deferred_prompt_keeps_loaded_tool_names_as_search_hints() -> None:
     manager = DeferredToolManager(
         all_deferred_tools=[
             _FakeTool(name="alpha:create", description="alpha create", server="alpha"),
@@ -300,8 +391,10 @@ def test_deferred_prompt_does_not_repeat_loaded_tool_names() -> None:
 
     prompt = manager.get_deferred_stubs_string()
 
+    # Frozen stub list: names remain as searchable hints even after loading;
+    # descriptions stay hidden and no "(Loaded)" section is introduced.
     assert "## MCP Tools (Loaded)" not in prompt
-    assert "- alpha:create" not in prompt
+    assert "- alpha:create" in prompt
     assert "- beta:list" in prompt
     assert "beta list" not in prompt
 
@@ -323,7 +416,7 @@ def test_deferred_prompt_string_contains_complete_guide_and_tool_list() -> None:
     assert "beta list" not in prompt
 
 
-def test_deferred_prompt_rebuilds_complete_string_after_discovery() -> None:
+def test_deferred_prompt_string_is_unchanged_after_discovery() -> None:
     manager = DeferredToolManager(
         all_deferred_tools=[
             _FakeTool(name="alpha:create", description="alpha create", server="alpha"),
@@ -337,10 +430,7 @@ def test_deferred_prompt_rebuilds_complete_string_after_discovery() -> None:
     after = manager.get_deferred_stubs_string()
 
     assert before.startswith("## Tool Search Guide")
-    assert after.startswith("## Tool Search Guide")
-    assert "- alpha:create" in before
-    assert "- alpha:create" not in after
-    assert "- beta:list" in after
+    assert before == after
 
 
 async def test_tool_search_middleware_appends_one_complete_deferred_prompt_block() -> None:


### PR DESCRIPTION
## 背景

生产 Langfuse 逐请求哈希 diff（deepseek-v4-flash 会话，10 次模型调用）发现缓存命中率两次骤降（23.3%、62.5%），且断点精确落在 `search_tools` 位置（命中的 3328 token = system + 前 26 个工具）。

**根因**：`search_tools` 描述内嵌的 `<deferred_tools>` 存根列表随发现状态收缩重写。该描述位于 tools 前缀前部，一次改写即作废其后全部缓存。消息区纯追加、未重排，此前修的 env_ctx / 记忆索引问题不在此会话（has_env=false、has_memory_index=false）。

## 修复

`DeferredToolManager` 存根列表会话级冻结（与记忆索引快照同款策略）：

- `get_deferred_stubs()` / `get_deferred_stubs_string()` 从**完整候选集**构建一次后永久缓存，不随发现状态、fork、重启恢复路径变化
- 删除 `_stubs_stale` / `_prompt_stale` / `stale` 脏标记机制（仓库内无其他使用方）
- 主/子 agent manager 现在生成字节相同的存根列表，顺带缓解跨 agent 前缀抖动

功能无副作用：模型搜到已加载工具时 `search_tools` 返回 "already available"，中间件 `existing_names` 去重保证工具不重复注入。

## 验证

- TDD：先加 4 个冻结行为测试确认 RED，再实现转 GREEN
- `uv run pytest tests/infra tests/agents` — 2148 passed
- `make lint` / `make typecheck` — 通过

## 未包含（后续观察）

- 主/子 agent 工具集交替（如 `text_to_image` 出现又消失）属结构性成本，等冻结上线后的命中率数据再决定是否收敛工具集
- `tool_count` 遥测盲区：该指标不在本仓库（Langfuse 侧/临时脚本），无可改代码目标