### PR TITLE
ci: skip docs pages deploy on forks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.repository == 'Yanyutin753/LambChat'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -40,6 +41,7 @@ jobs:
 
   deploy:
     needs: build
+    if: github.repository == 'Yanyutin753/LambChat'
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
## 问题

fork 仓库 push main 后会触发 `Deploy Docs` 工作流，但 fork 不会继承 GitHub Pages 设置（来源: GitHub Actions），导致 `actions/deploy-pages` 创建部署时返回 404，工作流在所有 fork 上必然失败：

```
Error: Failed to create deployment (status: 404)
Ensure GitHub Pages has been enabled: https://github.com/<fork>/LambChat/settings/pages
```

## 修复

给 `docs.yml` 的 `build` 和 `deploy` 两个 job 增加仓库守卫：

```yaml
if: github.repository == 'Yanyutin753/LambChat'
```

- 只挡 `deploy` 的话，fork 上仍会白白构建文档产物、消耗 CI 分钟数，所以两个 job 都挡
- 上游仓库行为完全不变，fork 上该工作流将显示为 skipped 而非 failure

## 验证

- YAML 语法校验通过
- 已在 fork 上实测：修复前 `Deploy Docs` 稳定失败（如 run 32545257756），原因即上述 404