### PR TITLE
fix: write steer:message event at injection time for correct ordering

### DIFF
--- a/frontend/src/hooks/useAgent/__tests__/eventHandlers.test.ts
+++ b/frontend/src/hooks/useAgent/__tests__/eventHandlers.test.ts
@@ -203,6 +203,30 @@ test("renders a delivered steer event and removes its optimistic duplicate", () 
   expect(marked).toEqual(["继续做这个"]);
 });
 
+test("uses the steer created_at send time for the delivered message timestamp", () => {
+  const ctx = createContext([], null);
+
+  handleStreamEvent(
+    {
+      event: "steer:message",
+      data: JSON.stringify({
+        content: "中途插话",
+        message_id: "steer-ts",
+        created_at: "2026-08-22T15:14:55.000Z",
+      }),
+    },
+    "assistant-1",
+    "steer-ts-event",
+    "2026-08-22T15:14:56.100Z",
+    ctx,
+  );
+
+  const delivered = ctx
+    .messages()
+    .find((message) => message.id === "steer-ts");
+  expect(delivered?.timestamp?.toISOString()).toBe("2026-08-22T15:14:55.000Z");
+});
+
 test("keeps distinct steer events with the same content when IDs differ", () => {
   const ctx = createContext([], null);
   const first = {

--- a/frontend/src/hooks/useAgent/__tests__/historyLoader.test.ts
+++ b/frontend/src/hooks/useAgent/__tests__/historyLoader.test.ts
@@ -1018,7 +1018,11 @@ test("reconstructs steer:message events as standalone steer items between turns"
         event_type: "steer:message",
         run_id: "run-s",
         timestamp: "2026-08-20T10:00:30.000Z",
-        data: { content: "插话", message_id: "steer-abc" },
+        data: {
+          content: "插话",
+          message_id: "steer-abc",
+          created_at: "2026-08-20T10:00:20.000Z",
+        },
       } satisfies HistoryEvent,
       {
         event_type: "message:chunk",
@@ -1044,4 +1048,241 @@ test("reconstructs steer:message events as standalone steer items between turns"
     "steer-abc",
     "run-s#t1",
   ]);
+});
+
+test("uses the steer created_at send time as the message timestamp", () => {
+  const messages = reconstructMessagesFromEvents(
+    [
+      {
+        event_type: "user:message",
+        run_id: "run-ts",
+        timestamp: "2026-08-22T15:14:35.000Z",
+        data: { content: "任务", message_id: "run-ts:user", attachments: [] },
+      } satisfies HistoryEvent,
+      {
+        event_type: "message:chunk",
+        run_id: "run-ts",
+        timestamp: "2026-08-22T15:14:50.000Z",
+        data: { content: "第一轮" },
+      } satisfies HistoryEvent,
+      {
+        event_type: "steer:message",
+        run_id: "run-ts",
+        // 事件信封时间是注入时刻，created_at 才是用户真正发送的时刻
+        timestamp: "2026-08-22T15:14:56.100Z",
+        data: {
+          content: "插话",
+          message_id: "steer-ts",
+          created_at: "2026-08-22T15:14:55.000Z",
+        },
+      } satisfies HistoryEvent,
+      {
+        event_type: "message:chunk",
+        run_id: "run-ts",
+        timestamp: "2026-08-22T15:14:57.000Z",
+        data: { content: "回复插话" },
+      } satisfies HistoryEvent,
+    ],
+    new Set<string>(),
+    { activeSubagentStack: [] },
+  );
+
+  const steer = messages.find((m) => m.id === "steer-ts");
+  expect(steer?.timestamp?.toISOString()).toBe("2026-08-22T15:14:55.000Z");
+});
+
+test("renders a retried steer:message only once by message_id", () => {
+  const messages = reconstructMessagesFromEvents(
+    [
+      {
+        event_type: "user:message",
+        run_id: "run-retry",
+        timestamp: "2026-08-22T15:00:00.000Z",
+        data: { content: "任务", message_id: "run-retry:user", attachments: [] },
+      } satisfies HistoryEvent,
+      {
+        event_type: "message:chunk",
+        run_id: "run-retry",
+        timestamp: "2026-08-22T15:00:05.000Z",
+        data: { content: "第一轮" },
+      } satisfies HistoryEvent,
+      {
+        // 首次注入写出的事件（该次模型调用失败，消息回队）
+        event_type: "steer:message",
+        run_id: "run-retry",
+        timestamp: "2026-08-22T15:00:10.000Z",
+        data: {
+          content: "插话",
+          message_id: "steer-retry",
+          created_at: "2026-08-22T15:00:08.000Z",
+        },
+      } satisfies HistoryEvent,
+      {
+        // 重试送达时再次写出同 message_id 事件
+        event_type: "steer:message",
+        run_id: "run-retry",
+        timestamp: "2026-08-22T15:00:20.000Z",
+        data: {
+          content: "插话",
+          message_id: "steer-retry",
+          created_at: "2026-08-22T15:00:08.000Z",
+        },
+      } satisfies HistoryEvent,
+      {
+        event_type: "message:chunk",
+        run_id: "run-retry",
+        timestamp: "2026-08-22T15:00:25.000Z",
+        data: { content: "回复插话" },
+      } satisfies HistoryEvent,
+    ],
+    new Set<string>(),
+    { activeSubagentStack: [] },
+  );
+
+  const steerMessages = messages.filter((m) => m.id === "steer-retry");
+  expect(steerMessages).toHaveLength(1);
+  expect(steerMessages[0]?.timestamp?.toISOString()).toBe(
+    "2026-08-22T15:00:08.000Z",
+  );
+});
+
+test("places a legacy tail steer:message before the reply turn it answers", () => {
+  // 旧版后端在模型调用成功后才写出 steer:message，事件落在 run 尾部
+  // 且不带 created_at；重建时应移回其回答文本轮次之前
+  const runId = "run-legacy";
+  const messages = reconstructMessagesFromEvents(
+    [
+      {
+        event_type: "user:message",
+        run_id: runId,
+        timestamp: "2026-08-22T15:14:35.186Z",
+        data: { content: "搜索 今日新闻", message_id: `${runId}:user`, attachments: [] },
+      } satisfies HistoryEvent,
+      {
+        event_type: "thinking",
+        run_id: runId,
+        timestamp: "2026-08-22T15:14:41.375Z",
+        data: { content: "User wants today's news." },
+      } satisfies HistoryEvent,
+      {
+        event_type: "tool:start",
+        run_id: runId,
+        timestamp: "2026-08-22T15:14:41.476Z",
+        data: { tool: "web-search", args: { query: "今日新闻" }, tool_call_id: "t1" },
+      } satisfies HistoryEvent,
+      {
+        event_type: "tool:result",
+        run_id: runId,
+        timestamp: "2026-08-22T15:14:42.100Z",
+        data: { tool: "web-search", result: "结果", tool_call_id: "t1", success: true },
+      } satisfies HistoryEvent,
+      {
+        event_type: "thinking",
+        run_id: runId,
+        timestamp: "2026-08-22T15:14:56.228Z",
+        data: { content: "User asks what else I can do." },
+      } satisfies HistoryEvent,
+      {
+        event_type: "message:chunk",
+        run_id: runId,
+        timestamp: "2026-08-22T15:14:56.500Z",
+        data: { content: "我主要还能做这些" },
+      } satisfies HistoryEvent,
+      {
+        event_type: "steer:message",
+        run_id: runId,
+        timestamp: "2026-08-22T15:15:03.800Z",
+        data: { content: "你还能干啥", message_id: "steer-legacy" },
+      } satisfies HistoryEvent,
+      {
+        event_type: "token:usage",
+        run_id: runId,
+        timestamp: "2026-08-22T15:15:03.846Z",
+        data: { input_tokens: 1 },
+      } satisfies HistoryEvent,
+      {
+        event_type: "done",
+        run_id: runId,
+        timestamp: "2026-08-22T15:15:03.864Z",
+        data: { status: "completed" },
+      } satisfies HistoryEvent,
+    ],
+    new Set<string>(),
+    { activeSubagentStack: [] },
+  );
+
+  const steerIndex = messages.findIndex((m) => m.id === "steer-legacy");
+  expect(steerIndex).toBeGreaterThan(-1);
+  // 插话位于第一轮（搜索）之后、针对插话的回答轮次之前
+  const firstTurnIndex = messages.findIndex((m) => m.id === runId);
+  const replyIndex = messages.findIndex((m) => m.id === `${runId}#t1`);
+  expect(firstTurnIndex).toBeGreaterThan(-1);
+  expect(replyIndex).toBeGreaterThan(-1);
+  expect(steerIndex).toBeGreaterThan(firstTurnIndex);
+  expect(steerIndex).toBeLessThan(replyIndex);
+  // 回答轮次的内容是"针对插话的回答"而不是搜索结果
+  const reply = messages[replyIndex];
+  expect(reply?.content).toContain("我主要还能做这些");
+});
+
+test("keeps legacy adjacent steer groups in order when repositioning", () => {
+  const runId = "run-legacy-group";
+  const messages = reconstructMessagesFromEvents(
+    [
+      {
+        event_type: "user:message",
+        run_id: runId,
+        timestamp: "2026-08-22T15:00:00.000Z",
+        data: { content: "任务", message_id: `${runId}:user`, attachments: [] },
+      } satisfies HistoryEvent,
+      {
+        event_type: "message:chunk",
+        run_id: runId,
+        timestamp: "2026-08-22T15:00:05.000Z",
+        data: { content: "回答前半" },
+      } satisfies HistoryEvent,
+      {
+        event_type: "thinking",
+        run_id: runId,
+        timestamp: "2026-08-22T15:00:20.000Z",
+        data: { content: "回复两条插话" },
+      } satisfies HistoryEvent,
+      {
+        event_type: "message:chunk",
+        run_id: runId,
+        timestamp: "2026-08-22T15:00:21.000Z",
+        data: { content: "回答后半" },
+      } satisfies HistoryEvent,
+      {
+        event_type: "steer:message",
+        run_id: runId,
+        timestamp: "2026-08-22T15:00:30.000Z",
+        data: { content: "插话一", message_id: "steer-g1" },
+      } satisfies HistoryEvent,
+      {
+        event_type: "steer:message",
+        run_id: runId,
+        timestamp: "2026-08-22T15:00:30.100Z",
+        data: { content: "插话二", message_id: "steer-g2" },
+      } satisfies HistoryEvent,
+      {
+        event_type: "done",
+        run_id: runId,
+        timestamp: "2026-08-22T15:00:31.000Z",
+        data: { status: "completed" },
+      } satisfies HistoryEvent,
+    ],
+    new Set<string>(),
+    { activeSubagentStack: [] },
+  );
+
+  const ids = messages.map((m) => m.id);
+  // 两条插话一起移到回答（thinking + 回答后半）之前，且保持先后顺序
+  expect(ids.indexOf("steer-g1")).toBeGreaterThan(-1);
+  expect(ids.indexOf("steer-g2")).toBeGreaterThan(ids.indexOf("steer-g1"));
+  // 回答前半属于插话之前的轮次
+  const firstTurnIndex = ids.indexOf(runId);
+  expect(ids.indexOf("steer-g1")).toBeGreaterThan(firstTurnIndex);
+  const replyIndex = ids.indexOf(`${runId}#t1`);
+  expect(ids.indexOf("steer-g2")).toBeLessThan(replyIndex);
 });

--- a/frontend/src/hooks/useAgent/eventHandlers.ts
+++ b/frontend/src/hooks/useAgent/eventHandlers.ts
@@ -270,7 +270,13 @@ export function handleStreamEvent(
           role: "user" as const,
           content: steerContent,
           attachments: steerAttachments,
-          timestamp: eventTimestamp ? parseDate(eventTimestamp) : new Date(),
+          // created_at 是用户发送时刻；事件信封时间（注入时刻）只作回退
+          timestamp:
+            typeof data.created_at === "string"
+              ? parseDate(data.created_at)
+              : eventTimestamp
+                ? parseDate(eventTimestamp)
+                : new Date(),
           runId: data.run_id,
           metadata: { steer: true, queued: false },
         };

--- a/frontend/src/hooks/useAgent/historyLoader.ts
+++ b/frontend/src/hooks/useAgent/historyLoader.ts
@@ -78,6 +78,55 @@ function canAttachToPreviousAssistant(
   );
 }
 
+const STEER_REPLY_TEXT_EVENTS = new Set(["thinking", "message:chunk"]);
+
+/**
+ * 旧版后端把 steer:message 事件写在模型调用成功之后，事件落在 run 尾部
+ * 且不带 created_at，直接按序重建会把插话渲染在它自己的回答之后。
+ * 重建前把这类事件（组）移回其回答文本轮次之前：向前跳过同 run 的连续
+ * 文本事件（thinking / message:chunk），插到该文本块开始处。带
+ * created_at 的新版事件按注入时刻写入，位置天然正确，直接跳过。
+ */
+function anchorLegacySteerMessageEvents(events: HistoryEvent[]): HistoryEvent[] {
+  const anchored = [...events];
+  for (let i = 0; i < anchored.length; i += 1) {
+    const event = anchored[i];
+    if (event.event_type !== "steer:message") continue;
+    const data = event.data as HistoryEventData | null | undefined;
+    if (data && typeof data.created_at === "string") continue;
+
+    // 连续多条插话一起移动，保持相对顺序
+    let groupEnd = i;
+    while (
+      groupEnd + 1 < anchored.length &&
+      anchored[groupEnd + 1].event_type === "steer:message" &&
+      anchored[groupEnd + 1].run_id === event.run_id
+    ) {
+      groupEnd += 1;
+    }
+
+    let anchor = i;
+    while (
+      anchor - 1 >= 0 &&
+      anchored[anchor - 1].run_id === event.run_id &&
+      STEER_REPLY_TEXT_EVENTS.has(anchored[anchor - 1].event_type)
+    ) {
+      anchor -= 1;
+      // thinking 通常开启一次模型调用：把插话放到回答轮次的 thinking
+      // 之前即停止，不越过轮次边界吞并上一轮的纯文本
+      if (anchored[anchor].event_type === "thinking") {
+        break;
+      }
+    }
+    if (anchor === i) continue;
+
+    const group = anchored.splice(i, groupEnd - i + 1);
+    anchored.splice(anchor, 0, ...group);
+    i = anchor + group.length - 1;
+  }
+  return anchored;
+}
+
 /**
  * Process a single history event and update message state.
  * Returns updated currentAssistantMessage or new message.
@@ -298,12 +347,15 @@ export function reconstructMessagesFromEvents(
     return runId ? { ...event, run_id: runId } : event;
   });
 
+  const anchoredEvents = anchorLegacySteerMessageEvents(normalizedEvents);
+
   const reconstructedMessages: Message[] = [];
   let currentAssistantMessage: Message | null = null;
   const seenUserMessageIds = new Set<string>();
   const seenUserMessageRunIds = new Set<string>();
+  const seenSteerMessageIds = new Set<string>();
 
-  for (const event of normalizedEvents) {
+  for (const event of anchoredEvents) {
     const eventType = event.event_type;
     const eventData = event.data as HistoryEventData;
 
@@ -321,12 +373,25 @@ export function reconstructMessagesFromEvents(
         typeof steerData.message_id === "string" && steerData.message_id.trim()
           ? steerData.message_id
           : `steer-h-${sortedEvents.indexOf(event)}`;
+      // 模型调用失败后消息原 ID 回队，重试送达会再次写出同
+      // message_id 事件；按 ID 去重只渲染第一次（即用户发送位置）
+      if (
+        typeof steerData.message_id === "string" &&
+        steerData.message_id.trim() &&
+        seenSteerMessageIds.has(steerId)
+      ) {
+        continue;
+      }
+      seenSteerMessageIds.add(steerId);
       reconstructedMessages.push({
         id: steerId,
         role: "user",
         content: steerData.content || "",
         attachments: convertAttachments(steerData.attachments),
-        timestamp: parseEventTimestamp(event.timestamp, Date.now()),
+        timestamp:
+          typeof steerData.created_at === "string"
+            ? parseEventTimestamp(steerData.created_at, Date.now())
+            : parseEventTimestamp(event.timestamp, Date.now()),
         runId: event.run_id,
         metadata: { steer: true },
       });

--- a/frontend/src/hooks/useAgent/types.ts
+++ b/frontend/src/hooks/useAgent/types.ts
@@ -102,6 +102,8 @@ export interface EventData {
   // user:cancel event fields
   user_id?: string;
   run_id?: string;
+  // steer:message 事件字段：用户发送时刻
+  created_at?: string;
   // skills:changed event fields
   action?: string;
   skill_name?: string;
@@ -227,6 +229,8 @@ export interface HistoryEventData {
   }>;
   message_id?: string;
   enabled_skills?: string[];
+  // steer:message 事件字段：用户发送时刻（区别于事件信封的注入时刻）
+  created_at?: string;
 }
 
 // History event from backend

--- a/src/infra/agent/middleware/steer.py
+++ b/src/infra/agent/middleware/steer.py
@@ -2,9 +2,10 @@
 
 用户在任务运行期间发送的消息（POST /chat/sessions/{id}/steer）先进入
 ``SteerQueue``；本中间件在每次主 agent 模型调用前取出该会话的排队消息，
-追加到本次请求的消息末尾（模型在当前步骤后即可看到），并通过
-``Command(update)`` 把它们持久化进图状态，落盘到 checkpoint，
-刷新/重载后历史不丢。
+在调用开始前写出 ``steer:message`` 事件（事件先于本次调用的输出进入
+Redis/MongoDB，实时 SSE 与历史回放中插话都排在回答之前），再追加到本次
+请求的消息末尾（模型在当前步骤后即可看到），并通过 ``Command(update)``
+把它们持久化进图状态，落盘到 checkpoint，刷新/重载后历史不丢。
 """
 
 from __future__ import annotations
@@ -29,15 +30,20 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-async def _persist_delivered_steer_messages(
+async def _persist_injected_steer_messages(
     session_id: str, items: list[Any], presenter: Any = None
 ) -> None:
-    """把已注入的插话消息写入独立的 steer:message 事件（尽力而为）。
+    """在注入时刻把插话消息写入独立的 steer:message 事件（尽力而为）。
 
     插话与用户消息管线完全解耦：自有事件类型，不参与 user:message
-    的语义（去重/轮次归属/回放）。优先复用当前 run 的 presenter
-    （事件归属该 run 的 trace，MongoDB 历史刷新后可见）；无 presenter
-    时回退 dual_writer 直写（仅实时 SSE 兜底）。失败只记日志。
+    的语义（去重/轮次归属/回放）。事件在模型调用开始前写出，保证在
+    Redis 实时流与 MongoDB 历史中都排在回答事件之前；``created_at``
+    记录用户发送时刻，供前端作为消息时间戳。优先复用当前 run 的
+    presenter（事件归属该 run 的 trace）；无 presenter 时回退
+    dual_writer 直写（仅实时 SSE 兜底）。失败只记日志。
+
+    若注入的模型调用失败，消息带原 ID 回队重试，送达时会再次写出
+    同 ``message_id`` 的事件，由前端按 ID 去重。
     """
     import uuid
 
@@ -48,6 +54,8 @@ async def _persist_delivered_steer_messages(
                 "message_id": item.id or f"steer-{uuid.uuid4().hex[:12]}",
                 "attachments": item.attachments,
             }
+            if getattr(item, "created_at", None):
+                data["created_at"] = item.created_at.isoformat()
             run_id = getattr(presenter, "run_id", None)
             if run_id:
                 data["run_id"] = run_id
@@ -64,7 +72,7 @@ async def _persist_delivered_steer_messages(
             )
         except Exception:
             logger.warning(
-                "[Steer] session=%s failed to persist delivered steer message %s",
+                "[Steer] session=%s failed to persist injected steer message %s",
                 session_id,
                 getattr(item, "id", "unknown"),
                 exc_info=True,
@@ -97,21 +105,23 @@ class SteerMiddleware(AgentMiddleware):
             self._session_id,
             len(injected),
         )
+
+        # 注入时刻先写 steer:message 事件：事件先于本次调用的输出进入
+        # Redis/MongoDB，插话在实时流与历史回放中均排在回答之前
+        if self._session_id:
+            await _persist_injected_steer_messages(
+                self._session_id, pending, presenter=self._presenter
+            )
+
         try:
             response = await handler(request.override(messages=[*request.messages, *injected]))
         except BaseException:
-            # 整体失败（含取消）：放回队首，等重试或下次运行送达，不丢失
+            # 整体失败（含取消）：放回队首，等重试或下次运行送达，不丢失。
+            # 重试送达会再次写出同 message_id 事件，前端按 ID 去重。
             await queue.requeue_front_items(self._session_id, pending)
             raise
 
         await queue.ack_items(self._session_id)
-
-        # 注入成功：写 user:message 事件（SSE + 历史持久化），
-        # 再把插话消息写入图状态，checkpoint 持久化
-        if self._session_id:
-            await _persist_delivered_steer_messages(
-                self._session_id, pending, presenter=self._presenter
-            )
 
         from langchain.agents.middleware.types import ExtendedModelResponse
         from langgraph.types import Command as LangCommand

--- a/tests/infra/agent/test_steer_middleware.py
+++ b/tests/infra/agent/test_steer_middleware.py
@@ -125,6 +125,96 @@ async def test_failed_model_call_requeues_messages() -> None:
     assert await get_steer_queue().drain("session-fail") == ["重要插话"]
 
 
+async def test_steer_event_persisted_before_model_call_runs() -> None:
+    """steer:message 事件在模型调用开始前写出。
+
+    事件必须先于本次调用的输出事件进入 Redis/MongoDB，实时 SSE 与
+    历史回放中插话才会排在回答之前（而不是落在 run 尾部）。
+    """
+    from src.infra.task.steer import get_steer_queue
+
+    await get_steer_queue().enqueue("session-order", "插话")
+
+    saved: list[dict] = []
+
+    class _FakePresenter:
+        async def save_event(self, event):
+            saved.append(event)
+
+    middleware = SteerMiddleware(session_id="session-order", presenter=_FakePresenter())
+    observed_save_counts: list[int] = []
+
+    async def handler(_req):
+        observed_save_counts.append(len(saved))
+        return _Response()
+
+    await middleware.awrap_model_call(_Request(), handler)
+
+    assert observed_save_counts == [1]
+    assert saved[0]["event"] == "steer:message"
+    assert saved[0]["data"]["content"] == "插话"
+
+
+async def test_steer_event_carries_created_at_send_time() -> None:
+    """事件附带 created_at（用户发送时刻），前端用它作为消息时间戳。"""
+    from datetime import datetime, timezone
+
+    from src.infra.task.steer import SteerItem, get_steer_queue
+
+    sent_at = datetime(2026, 8, 22, 15, 14, 55, tzinfo=timezone.utc)
+    await get_steer_queue().enqueue_item(
+        "session-created-at",
+        SteerItem(id="steer-ts", content="插话", created_at=sent_at),
+    )
+
+    saved: list[dict] = []
+
+    class _FakePresenter:
+        async def save_event(self, event):
+            saved.append(event)
+
+    middleware = SteerMiddleware(
+        session_id="session-created-at", presenter=_FakePresenter()
+    )
+
+    async def handler(_req):
+        return _Response()
+
+    await middleware.awrap_model_call(_Request(), handler)
+
+    assert saved[0]["data"]["created_at"] == "2026-08-22T15:14:55+00:00"
+
+
+async def test_failed_model_call_keeps_injected_event_and_requeues() -> None:
+    """调用失败时注入事件已按注入时刻写出（消息确已发送）；消息原 ID 回队重试。"""
+    from src.infra.task.steer import SteerItem, get_steer_queue
+
+    await get_steer_queue().enqueue_item(
+        "session-fail-order",
+        SteerItem(id="steer-retry-me", content="重要插话"),
+    )
+
+    saved: list[dict] = []
+
+    class _FakePresenter:
+        async def save_event(self, event):
+            saved.append(event)
+
+    middleware = SteerMiddleware(
+        session_id="session-fail-order", presenter=_FakePresenter()
+    )
+
+    async def handler(_req):
+        raise RuntimeError("model down")
+
+    with pytest.raises(RuntimeError):
+        await middleware.awrap_model_call(_Request(), handler)
+
+    assert [event["data"]["message_id"] for event in saved] == ["steer-retry-me"]
+    requeued = await get_steer_queue().drain("session-fail-order")
+    assert requeued == ["重要插话"]
+
+
 async def test_successful_injection_persists_via_presenter(monkeypatch) -> None:
     """注入成功后经 presenter.save_event 写独立 steer:message 事件（归属当前 run 的 trace）。"""
     from src.infra.task.steer import get_steer_queue
@@ -176,11 +266,17 @@ async def test_successful_injection_preserves_client_message_id() -> None:
 
 async def test_queued_steer_survives_hitl_pause_and_uses_same_resumed_run() -> None:
     """挂起前已接收的 steer 在同 Run 恢复后仍只注入、持久化一次。"""
+    from datetime import datetime, timezone
+
     from src.infra.task.steer import SteerItem, get_steer_queue
 
     queue = get_steer_queue()
+    sent_at = datetime(2026, 8, 22, 15, 0, 0, tzinfo=timezone.utc)
     await queue.enqueue_item(
-        "session-hitl", SteerItem(id="steer-before-pause", content="继续时按这个方向")
+        "session-hitl",
+        SteerItem(
+            id="steer-before-pause", content="继续时按这个方向", created_at=sent_at
+        ),
     )
 
     saved: list[dict] = []
@@ -211,6 +307,7 @@ async def test_queued_steer_survives_hitl_pause_and_uses_same_resumed_run() -> N
                 "content": "继续时按这个方向",
                 "message_id": "steer-before-pause",
                 "attachments": [],
+                "created_at": "2026-08-22T15:00:00+00:00",
                 "run_id": "run-same",
             },
         }


### PR DESCRIPTION
## 问题

运行中插话（steer）的 `steer:message` 事件原先在**注入的模型调用成功之后**才写出，导致：

- **历史回放错位**：刷新后插话渲染在它自己的回答之后（事件按写入顺序排在 run 尾部）。实例子：会话 `e159535f` 中 15:14:55 发出的"你还能干啥"，回答 15:14:56 已输出，事件 15:15:03 才落盘
- **实时视图错位**：前端 `eventHandlers` 本就按"事件先于回答到达"设计（送达即分割轮次），后端晚发使回答先流入当前轮次，插话被插在回答之后
- **时间戳失真**：消息时间显示落盘时刻，且 `SteerItem.created_at`（发送时刻）在落盘时被丢弃

## 修复

**后端** `src/infra/agent/middleware/steer.py`
- `steer:message` 事件改在**模型调用开始前**（注入时刻）写出，事件先于本次调用的输出进入 Redis 实时流与 MongoDB trace，两个视图同时归位
- 事件附带 `created_at`（用户发送时刻）
- 失败语义：调用失败时消息原 ID 回队重试，重试送达会再次写出同 `message_id` 事件，由前端按 ID 去重（不丢消息、不重复渲染）

**前端**
- `historyLoader.ts`：按 `message_id` 去重重试事件；插话时间戳优先 `created_at`；对旧格式事件（无 `created_at`、被旧版后端写在 run 尾部）做归位预处理——移回回答轮次首个 `thinking` 之前，连续插话成组移动保持相对顺序
- `eventHandlers.ts`：实时视图送达消息时间戳优先 `created_at`

## 测试

- 后端新增 3 个中间件测试（注入前落盘、`created_at` 传递、失败后事件保留+回队），更新 1 个精确匹配测试
- 前端新增 5 个测试（旧数据归位、成组归位、`created_at` 时间戳×2、重试去重）
- 全量验证：pytest 2816 passed / ruff / mypy 全过；vitest 1523 passed / tsc -b / eslint / vite build 全过