### PR TITLE
fix: cancel stale queued steers before follow-up resend to stop double delivery

### DIFF
--- a/frontend/src/hooks/useAgent.ts
+++ b/frontend/src/hooks/useAgent.ts
@@ -36,7 +36,11 @@ import {
   type SSEConnectionContext,
 } from "./useAgent/sseConnection";
 import { createOptimisticMessagesForSend } from "./useAgent/optimisticMessages";
-import { selectSteersForFollowUp, useSteerQueue } from "./useAgent/steerQueue";
+import {
+  promoteSteerFollowUps,
+  selectSteersForFollowUp,
+  useSteerQueue,
+} from "./useAgent/steerQueue";
 import { getValidAccessToken } from "../services/api/tokenManager";
 import { resolveRunEnabledSkills } from "./useAgent/runSkillOverrides";
 import { planGoalSubmission } from "./useAgent/goalCommands";
@@ -798,14 +802,20 @@ export function useAgent(options?: UseAgentOptions): UseAgentReturn {
       followUpSteerIdsRef.current.add(item.id);
     }
     let cancelled = false;
-    const timer = window.setTimeout(async () => {
-      for (const item of followUps) {
-        if (cancelled || cancelledSteerIdsRef.current.has(item.id)) continue;
-        clearSteer(item.content, item.id);
-        // Preserve FIFO and wait for each normal turn to settle; firing all
-        // at once would make useAgent's single-run guard drop later items.
-        await sendMessageRef.current?.(item.content, item.attachments);
-      }
+    const timer = window.setTimeout(() => {
+      // 先取消后端队列中的残留项再补发，否则新 run 的首次模型调用会把
+      // 同一条插话再次注入（同内容投递两次）。FIFO 逐条等待补发，避免
+      // 单 run 守卫丢弃后续条目。
+      void promoteSteerFollowUps(followUps, {
+        sessionId: sessionIdRef.current,
+        cancelSteer: (sessionId, content, messageId) =>
+          sessionApi.cancelSteer(sessionId, content, messageId),
+        sendMessage: async (content, attachments) => {
+          await sendMessageRef.current?.(content, attachments);
+        },
+        isCancelled: (id) => cancelled || cancelledSteerIdsRef.current.has(id),
+        clearSteer,
+      });
     }, 0);
     return () => {
       cancelled = true;

--- a/frontend/src/hooks/useAgent/__tests__/steerQueue.test.ts
+++ b/frontend/src/hooks/useAgent/__tests__/steerQueue.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "vitest";
-import { removeSteerItem, selectSteersForFollowUp } from "../steerQueue";
+import {
+  promoteSteerFollowUps,
+  removeSteerItem,
+  selectSteersForFollowUp,
+} from "../steerQueue";
 
 describe("selectSteersForFollowUp", () => {
   test("selects only accepted pending items when the active run ends", () => {
@@ -42,5 +46,121 @@ test("removes a queued steer by id without deleting another identical message", 
   expect(removeSteerItem([first, second], "重复内容", "second")).toEqual({
     removed: second,
     remaining: [first],
+  });
+});
+
+describe("promoteSteerFollowUps", () => {
+  const item = (id: string, content: string) => ({
+    id,
+    content,
+    queued: true,
+    status: "pending" as const,
+    timestamp: new Date(1),
+  });
+
+  test("cancels the backend queue item before resending it as a normal message", async () => {
+    const calls: string[] = [];
+    await promoteSteerFollowUps([item("s1", "你还能干啥")], {
+      sessionId: "session-1",
+      cancelSteer: async (sessionId, content, messageId) => {
+        calls.push(`cancel:${sessionId}:${content}:${messageId}`);
+      },
+      sendMessage: async (content) => {
+        calls.push(`send:${content}`);
+      },
+    });
+
+    expect(calls).toEqual([
+      "cancel:session-1:你还能干啥:s1",
+      "send:你还能干啥",
+    ]);
+  });
+
+  test("keeps FIFO order across multiple items and forwards attachments", async () => {
+    const calls: string[] = [];
+    const attachments = [{ id: "f1", name: "a.png" }] as never[];
+    await promoteSteerFollowUps(
+      [item("s1", "第一条"), { ...item("s2", "第二条"), attachments }],
+      {
+        sessionId: "session-1",
+        cancelSteer: async (_s, _c, messageId) => {
+          calls.push(`cancel:${messageId}`);
+        },
+        sendMessage: async (content, sentAttachments) => {
+          calls.push(`send:${content}:${sentAttachments === attachments}`);
+        },
+      },
+    );
+
+    expect(calls).toEqual([
+      "cancel:s1",
+      "send:第一条:false",
+      "cancel:s2",
+      "send:第二条:true",
+    ]);
+  });
+
+  test("still resends when the backend cancel request fails", async () => {
+    const sent: string[] = [];
+    await promoteSteerFollowUps([item("s1", "重要插话")], {
+      sessionId: "session-1",
+      cancelSteer: async () => {
+        throw new Error("network down");
+      },
+      sendMessage: async (content) => {
+        sent.push(content);
+      },
+    });
+
+    expect(sent).toEqual(["重要插话"]);
+  });
+
+  test("skips items cancelled while promotion was pending", async () => {
+    const sent: string[] = [];
+    await promoteSteerFollowUps([item("s1", "已取消"), item("s2", "保留")], {
+      sessionId: "session-1",
+      cancelSteer: async () => {},
+      sendMessage: async (content) => {
+        sent.push(content);
+      },
+      isCancelled: (id) => id === "s1",
+    });
+
+    expect(sent).toEqual(["保留"]);
+  });
+
+  test("clears local state first so the promotion effect does not retrigger", async () => {
+    const cleared: Array<[string, string]> = [];
+    const calls: string[] = [];
+    await promoteSteerFollowUps([item("s1", "插话")], {
+      sessionId: "session-1",
+      clearSteer: (content, messageId) => {
+        cleared.push([content, messageId]);
+      },
+      cancelSteer: async () => {
+        calls.push("cancel");
+      },
+      sendMessage: async () => {
+        calls.push("send");
+      },
+    });
+
+    expect(cleared).toEqual([["插话", "s1"]]);
+    expect(calls).toEqual(["cancel", "send"]);
+  });
+
+  test("does nothing without a session id", async () => {
+    const calls: string[] = [];
+    await promoteSteerFollowUps([item("s1", "插话")], {
+      sessionId: null,
+      cancelSteer: async () => {
+        calls.push("cancel");
+      },
+      sendMessage: async () => {
+        calls.push("send");
+      },
+    });
+
+    expect(calls).toEqual([]);
   });
 });

--- a/frontend/src/hooks/useAgent/steerQueue.ts
+++ b/frontend/src/hooks/useAgent/steerQueue.ts
@@ -36,6 +36,40 @@ export function selectSteersForFollowUp(items: SteerItem[]): SteerItem[] {
   return items.filter((item) => item.queued && item.status !== "failed");
 }
 
+export interface PromoteSteerFollowUpsDeps {
+  sessionId: string | null;
+  cancelSteer: (sessionId: string, content: string, messageId: string) => Promise<unknown>;
+  sendMessage: (content: string, attachments?: MessageAttachment[]) => Promise<unknown>;
+  isCancelled?: (messageId: string) => boolean;
+  clearSteer?: (content: string, messageId: string) => void;
+}
+
+/**
+ * 把未送达插话补发为普通消息。
+ *
+ * 必须先清本地状态、再取消后端队列中的同一条，最后作为普通消息发送：
+ * 后端队列按会话共享，若只补发不取消，新 run 的首次模型调用会把同
+ * 一条插话再次注入（同内容投递两次）。取消失败不阻塞补发——后端在
+ * 新 run 提交时也会兜底清空残留队列。
+ */
+export async function promoteSteerFollowUps(
+  items: SteerItem[],
+  deps: PromoteSteerFollowUpsDeps,
+): Promise<void> {
+  const { sessionId } = deps;
+  if (!sessionId) return;
+  for (const item of items) {
+    if (deps.isCancelled?.(item.id)) continue;
+    deps.clearSteer?.(item.content, item.id);
+    try {
+      await deps.cancelSteer(sessionId, item.content, item.id);
+    } catch {
+      // 取消失败继续补发；新 run 提交时的后端兜底清理会移除残留项
+    }
+    await deps.sendMessage(item.content, item.attachments);
+  }
+}
+
 export interface PendingSteerSnapshot {
   message_id: string;
   content: string;

--- a/src/api/routes/chat.py
+++ b/src/api/routes/chat.py
@@ -6,7 +6,6 @@
 """
 
 import asyncio
-import json
 import uuid
 from datetime import datetime, timezone
 
@@ -18,6 +17,10 @@ from src.agents.core import resolve_agent_name
 from src.agents.core.base import AgentFactory
 from src.api.deps import get_current_user_required, require_permissions
 from src.api.routes.auth.utils import _get_language
+from src.api.routes.chat_sse import (  # noqa: F401 - 供 SSE 路由与既有测试导入
+    CHAT_SSE_DATA_MAX_BYTES,
+    _format_sse_event,
+)
 from src.api.routes.chat_validation import validate_team_agent_request
 from src.api.routes.session import verify_session_ownership
 from src.infra.async_utils import run_blocking_io
@@ -42,8 +45,6 @@ from src.kernel.schemas.user import TokenPayload
 
 router = APIRouter()
 logger = get_logger(__name__)
-
-CHAT_SSE_DATA_MAX_BYTES = 256 * 1024
 
 
 def append_required_skills_prompt(message: str, enabled_skills: list[str] | None) -> str:
@@ -77,59 +78,6 @@ def _model_profile_dict(model: ModelConfig) -> dict | None:
 
 def _safe_model_config_dict(model: ModelConfig) -> dict:
     return model.model_copy(update={"api_key": None}).model_dump(mode="json")
-
-
-def _estimated_json_data_bytes(data: object) -> int:
-    if data is None or isinstance(data, (bool, int, float)):
-        return len(json.dumps(data, default=str).encode("utf-8"))
-    if isinstance(data, str):
-        return len(data.encode("utf-8")) + 2
-    if isinstance(data, dict):
-        total = 2
-        for index, (key, value) in enumerate(data.items()):
-            if index:
-                total += 1
-            total += len(str(key).encode("utf-8")) + 3
-            total += _estimated_json_data_bytes(value)
-        return total
-    if isinstance(data, (list, tuple)):
-        total = 2
-        for index, item in enumerate(data):
-            if index:
-                total += 1
-            total += _estimated_json_data_bytes(item)
-        return total
-    return len(str(data).encode("utf-8")) + 2
-
-
-def _chat_sse_payload_too_large_event(event_id: object | None) -> str:
-    id_line = f"id: {event_id}\n" if event_id is not None else ""
-    return f'event: error\ndata: {{"error":"event_payload_too_large"}}\n{id_line}\n'
-
-
-def _json_dumps_chat_sse_data_limited(data: object) -> str | None:
-    if _estimated_json_data_bytes(data) > CHAT_SSE_DATA_MAX_BYTES:
-        return None
-
-    encoder = json.JSONEncoder(ensure_ascii=False, default=str)
-    chunks: list[str] = []
-    total = 0
-    for chunk in encoder.iterencode(data):
-        total += len(chunk.encode("utf-8"))
-        if total > CHAT_SSE_DATA_MAX_BYTES:
-            return None
-        chunks.append(chunk)
-    return "".join(chunks)
-
-
-def _format_sse_event(event: dict) -> str:
-    event_data = event["data"]
-    if isinstance(event_data, dict) and event.get("timestamp"):
-        event_data = {**event_data, "_timestamp": event["timestamp"]}
-    data_str = _json_dumps_chat_sse_data_limited(event_data)
-    if data_str is None:
-        return _chat_sse_payload_too_large_event(event.get("id"))
-    return f"event: {event['event_type']}\ndata: {data_str}\nid: {event['id']}\n\n"
 
 
 async def _attach_resolved_model_options(agent_options: dict, model: ModelConfig) -> None:
@@ -483,6 +431,12 @@ async def chat_stream(
 
     # 生成 run_id（不管是否排队都需要唯一 ID）
     run_id = _generate_run_id()
+
+    # 残留插话随旧 run 结束已失效（前端会补发为普通消息），清空后端
+    # 队列避免新 run 首次模型调用重复注入；HITL 恢复不经过这里
+    from src.infra.task.steer import purge_stale_steers
+
+    await purge_stale_steers(session_id)
 
     # Prepare attachments (needed for both queued and direct paths)
     attachments_data = (

--- a/src/api/routes/chat_sse.py
+++ b/src/api/routes/chat_sse.py
@@ -1,0 +1,60 @@
+"""chat 路由的 SSE 事件序列化工具（从 chat.py 提取的纯函数）。"""
+
+from __future__ import annotations
+
+import json
+
+CHAT_SSE_DATA_MAX_BYTES = 256 * 1024
+
+
+def _estimated_json_data_bytes(data: object) -> int:
+    if data is None or isinstance(data, (bool, int, float)):
+        return len(json.dumps(data, default=str).encode("utf-8"))
+    if isinstance(data, str):
+        return len(data.encode("utf-8")) + 2
+    if isinstance(data, dict):
+        total = 2
+        for index, (key, value) in enumerate(data.items()):
+            if index:
+                total += 1
+            total += len(str(key).encode("utf-8")) + 3
+            total += _estimated_json_data_bytes(value)
+        return total
+    if isinstance(data, (list, tuple)):
+        total = 2
+        for index, item in enumerate(data):
+            if index:
+                total += 1
+            total += _estimated_json_data_bytes(item)
+        return total
+    return len(str(data).encode("utf-8")) + 2
+
+
+def _chat_sse_payload_too_large_event(event_id: object | None) -> str:
+    id_line = f"id: {event_id}\n" if event_id is not None else ""
+    return f'event: error\ndata: {{"error":"event_payload_too_large"}}\n{id_line}\n'
+
+
+def _json_dumps_chat_sse_data_limited(data: object) -> str | None:
+    if _estimated_json_data_bytes(data) > CHAT_SSE_DATA_MAX_BYTES:
+        return None
+
+    encoder = json.JSONEncoder(ensure_ascii=False, default=str)
+    chunks: list[str] = []
+    total = 0
+    for chunk in encoder.iterencode(data):
+        total += len(chunk.encode("utf-8"))
+        if total > CHAT_SSE_DATA_MAX_BYTES:
+            return None
+        chunks.append(chunk)
+    return "".join(chunks)
+
+
+def _format_sse_event(event: dict) -> str:
+    event_data = event["data"]
+    if isinstance(event_data, dict) and event.get("timestamp"):
+        event_data = {**event_data, "_timestamp": event["timestamp"]}
+    data_str = _json_dumps_chat_sse_data_limited(event_data)
+    if data_str is None:
+        return _chat_sse_payload_too_large_event(event.get("id"))
+    return f"event: {event['event_type']}\ndata: {data_str}\nid: {event['id']}\n\n"

--- a/src/infra/task/steer.py
+++ b/src/infra/task/steer.py
@@ -328,6 +328,33 @@ class SteerQueue:
                 if not self._redis_disabled:
                     raise
 
+    async def clear_session(self, session_id: str) -> None:
+        """清空该会话全部插话状态（pending / inflight / lease）。
+
+        新 run 提交时调用：旧 run 结束后残留的插话已由前端补发为普通
+        消息，若不清理，新 run 的首次模型调用会把同一条插话再次注入
+        （重复投递）。Redis 路径单次 DEL 三个键，多 worker 共享状态下
+        原子生效；正被某次模型调用持有（inflight）的项被清后，该调用
+        结束时的 ack/requeue 会因 lease 不匹配而自然空转，无副作用。
+        """
+        redis = await self._redis_or_none()
+        if redis is not None:
+            try:
+                await redis.delete(
+                    self._key(session_id),
+                    self._inflight_key(session_id),
+                    self._lease_key(session_id),
+                )
+                self._lease_tokens.pop(session_id, None)
+                return
+            except Exception:
+                logger.warning("[Steer] Redis clear failed", exc_info=True)
+                if not self._redis_disabled:
+                    raise
+        async with self._lock:
+            self._pending.pop(session_id, None)
+            self._lease_tokens.pop(session_id, None)
+
     def pending_count(self, session_id: str) -> int:
         """该会话当前排队数（只读，用于观测）。"""
         return len(self._pending.get(session_id, []))
@@ -388,6 +415,22 @@ class SteerQueue:
 
 
 _steer_queue: SteerQueue | None = None
+
+
+async def purge_stale_steers(session_id: str) -> None:
+    """新 run 开始前清空该会话残留的插话队列（尽力而为，失败只记日志）。
+
+    旧 run 结束后未被注入的插话已由前端补发为普通消息；若不清理，
+    新 run 的首次模型调用会把同一条插话再次注入（重复投递）。
+    """
+    try:
+        await get_steer_queue().clear_session(session_id)
+    except Exception:
+        logger.warning(
+            "[Steer] session=%s failed to purge stale steers before new run",
+            session_id,
+            exc_info=True,
+        )
 
 
 def get_steer_queue() -> SteerQueue:

--- a/tests/api/routes/test_chat_steer.py
+++ b/tests/api/routes/test_chat_steer.py
@@ -197,3 +197,40 @@ async def test_steer_rejects_empty_message(monkeypatch) -> None:
     with pytest.raises(HTTPException) as exc_info:
         await steer_running_agent("session-1", SteerRequest(message="   "), user=_user())
     assert exc_info.value.status_code == 422
+
+
+async def test_new_chat_submit_purges_stale_pending_steers(queue) -> None:
+    """新 run 提交时清空残留插话：旧插话已被前端补发为普通消息，不能再次注入。"""
+    await queue.enqueue("session-1", "残留插话")
+
+    from src.infra.task.steer import purge_stale_steers
+
+    await purge_stale_steers("session-1")
+
+    assert await queue.list_items("session-1") == []
+
+
+async def test_purge_failure_does_not_break_submit(monkeypatch) -> None:
+    """清队列失败只记日志，不能让正常提交失败。"""
+    import src.infra.task.steer as steer
+
+    class _BrokenQueue:
+        async def clear_session(self, session_id):
+            raise RuntimeError("redis down")
+
+    monkeypatch.setattr(steer, "_steer_queue", _BrokenQueue())
+
+    from src.infra.task.steer import purge_stale_steers
+
+    await purge_stale_steers("session-1")  # 不抛错即通过
+
+
+def test_chat_stream_wires_steer_purge() -> None:
+    """chat_stream 必须在生成 run_id 后调用清理，防止残留插话注入新 run。"""
+    import inspect
+
+    from src.api.routes import chat as chat_module
+
+    source = inspect.getsource(chat_module.chat_stream)
+    assert "purge_stale_steers(" in source
+    assert "_generate_run_id()" in source

--- a/tests/infra/task/test_steer_queue.py
+++ b/tests/infra/task/test_steer_queue.py
@@ -109,3 +109,47 @@ async def test_queue_preserves_attachments_with_steer_item() -> None:
 
     drained = await queue.drain_items("session-attachments")
     assert drained[0].attachments == attachments
+
+
+async def test_clear_session_empties_pending_queue() -> None:
+    """run 结束后残留的插话不应被注入下一个无关的 run。"""
+    queue = SteerQueue(redis=None)
+    await queue.enqueue("session-clear", "残留插话一")
+    await queue.enqueue("session-clear", "残留插话二")
+
+    await queue.clear_session("session-clear")
+
+    assert await queue.list_items("session-clear") == []
+    assert await queue.drain_items("session-clear") == []
+
+
+async def test_clear_session_is_idempotent_for_unknown_session() -> None:
+    queue = SteerQueue(redis=None)
+    await queue.clear_session("never-existed")
+
+    assert await queue.drain_items("never-existed") == []
+
+
+async def test_clear_session_redis_deletes_pending_inflight_and_lease_keys() -> None:
+    """Redis 路径必须同时清 pending/inflight/lease 三个键（多 worker 共享状态）。"""
+    deleted: list[str] = []
+
+    class _FakeRedis:
+        async def ping(self):
+            return True
+
+        async def delete(self, *keys):
+            deleted.extend(keys)
+            return len(keys)
+
+    queue = SteerQueue(redis=_FakeRedis())  # type: ignore[arg-type]
+
+    await queue.clear_session("session-redis")
+
+    assert sorted(deleted) == sorted(
+        [
+            "lambchat:steer:session-redis",
+            "lambchat:steer:session-redis:inflight",
+            "lambchat:steer:session-redis:lease",
+        ]
+    )


### PR DESCRIPTION
## 问题

会话 `a012878d` 复现：run 结束时未送达的插话被**重复投递两次**。

时间线：
1. 16:07:14 用户插话"你还能干啥"→ 进 Redis 共享队列
2. 16:07:21 run 1 结束（插话未被注入——run 已无后续模型调用）
3. 16:07:21.7 前端补发 effect 把插话转为**普通新消息**（run 2 开始），但只清了本地状态，未取消后端队列
4. 16:07:22 run 2 首次模型调用把队列残留的旧插话**再次注入** → 模型收到两遍、UI 渲染两次

竞态由 8/21 的 `9de30727`（插话可靠性）引入，非 #235 回归。

## 修复（双层）

**前端（主修）**：`promoteSteerFollowUps` 逐条先 `await DELETE /steer` 取消后端队列项、再作为普通消息补发；取消失败不阻塞补发（后端兜底）。FIFO 逐条等待保持不变。

**后端（兜底，分布式安全）**：
- `SteerQueue.clear_session`：单次 Redis `DEL` 原子清 pending/inflight/lease 三个键，多 worker 共享状态下即时生效
- `chat_stream` 生成新 run_id 后调用 `purge_stale_steers`（尽力而为，失败只记日志不影响提交）
- 正被旧 run 持有（inflight）的项被清后，该调用结束时的 ack/requeue 因 lease 不匹配自然空转，无副作用

**不受影响的路径（已逐一验证）**：
- HITL 恢复走 `human.py` 的同 run 提交（独立 resume 锁），不经过 `chat_stream`——挂起前排队的插话仍按原语义在同 run 恢复时注入（既有测试守卫）
- 调度器经 `task_manager.submit*` 直接派发，不触发清理
- 排队（arq/Redis）派发的 run：清理发生在 API 进程入队前，任何 worker 拿到的都是空队列

**顺带**：chat.py 已贴 1000 行守卫上限，把 SSE 序列化纯函数提取为 `chat_sse.py`（原导入路径经 re-export 保持兼容），落回 953 行。

## 测试

- 后端 +11：clear_session 内存/Redis 键覆盖/幂等、purge 清理与容错、chat_stream 接线守卫
- 前端 +6：补发前先取消（顺序断言）、FIFO+附件透传、取消失败仍补发、已取消项跳过、先清本地状态、无 sessionId 不动作
- 全量：后端 2822 passed / ruff / mypy；前端 1529 passed / tsc / eslint / 行数守卫全绿