### PR TITLE
fix: usage log error fields + historical image governance

### DIFF
--- a/frontend/src/components/panels/UsagePanel/UsageLogsTable.tsx
+++ b/frontend/src/components/panels/UsagePanel/UsageLogsTable.tsx
@@ -4,11 +4,12 @@ import { formatDateTimeShort } from "../../../utils/datetime";
 import type { UsageLog } from "../../../types/usage";
 import { fmt, fmtDur } from "./formatters";
 
-function StatusPill({ status }: { status: string }) {
+function StatusPill({ status, title }: { status: string; title?: string }) {
   const { t } = useTranslation();
   const ok = status === "completed";
   return (
     <span
+      title={title}
       className={`inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px] font-medium tabular-nums ${
         ok
           ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
@@ -195,7 +196,7 @@ function DesktopTable({
                     {fmtDur(log.duration)}
                   </div>
                   <div className="min-w-0 whitespace-nowrap px-4 py-3 text-center">
-                    <StatusPill status={log.status} />
+                    <StatusPill status={log.status} title={log.error_message} />
                   </div>
                 </div>
               );
@@ -223,7 +224,7 @@ function TabletRow({ log, isAdmin }: { log: UsageLog; isAdmin: boolean }) {
             <code className="min-w-0 truncate text-[12px] font-semibold text-theme-text tabular-nums">
               {log.model || "-"}
             </code>
-            <StatusPill status={log.status} />
+            <StatusPill status={log.status} title={log.error_message} />
           </div>
           <p className="mt-1 truncate text-[11px] font-medium text-theme-text-secondary">
             {log.agent_name || "-"}
@@ -231,6 +232,14 @@ function TabletRow({ log, isAdmin }: { log: UsageLog; isAdmin: boolean }) {
           <p className="mt-0.5 truncate text-[10px] text-theme-text-tertiary">
             {personaOrTeam || "-"}
           </p>
+          {log.status !== "completed" && log.error_message && (
+            <p
+              className="mt-1 truncate text-[10px] text-red-500 dark:text-red-400"
+              title={log.error_message}
+            >
+              {log.error_message}
+            </p>
+          )}
         </div>
         <div className="shrink-0 text-right">
           <p className="text-[12px] font-medium tabular-nums text-theme-text-secondary">
@@ -311,9 +320,17 @@ function MobileCard({ log, isAdmin }: { log: UsageLog; isAdmin: boolean }) {
                   </span>
                 )}
               </div>
+              {log.status !== "completed" && log.error_message && (
+                <p
+                  className="mt-2 truncate text-[10px] text-red-500 dark:text-red-400"
+                  title={log.error_message}
+                >
+                  {log.error_message}
+                </p>
+              )}
             </div>
           </div>
-          <StatusPill status={log.status} />
+          <StatusPill status={log.status} title={log.error_message} />
         </div>
 
         {/* Token metrics — segmented bar */}

--- a/frontend/src/components/panels/__tests__/usagePanelPresentationSource.test.ts
+++ b/frontend/src/components/panels/__tests__/usagePanelPresentationSource.test.ts
@@ -56,6 +56,11 @@ test("usage table keeps admin-only user column and aligned numeric columns", () 
   );
 });
 
+test("usage table surfaces failure reason for error rows", () => {
+  expect(usageTableSource).toMatch(/log\.error_message/);
+  expect(usageTableSource).toMatch(/title=\{log\.error_message\}/);
+});
+
 test("usage visual accents use theme colors instead of hard-coded chart palette", () => {
   expect(insightSource).not.toMatch(/border-l-(blue|violet|cyan|rose)-500/);
   expect(insightSource).not.toMatch(

--- a/frontend/src/types/usage.ts
+++ b/frontend/src/types/usage.ts
@@ -26,6 +26,8 @@ export interface UsageLog {
   started_at: string | null;
   completed_at: string | null;
   status: string;
+  error_message?: string;
+  error_type?: string;
   step_count?: number;
   tool_calls?: number;
 }

--- a/src/infra/agent/middleware/dead_attachment.py
+++ b/src/infra/agent/middleware/dead_attachment.py
@@ -1,0 +1,304 @@
+"""Drop image blocks whose uploaded file no longer exists before model calls.
+
+模型请求历史会携带所有历史轮次的 image_url；部分上游网关（new-api）在计数 token 时
+会逐个下载这些 URL，任何一个 404（文件已被清理）都会让整个请求失败
+（count_token_failed）。该模块提供两个模型调用前的图片治理中间件：
+
+- ``DeadAttachmentFilterMiddleware``：批量校验自有上传 URL 的存活性，剔除死链图片块。
+- ``HistoricalImageCapMiddleware``：历史图片数超过上限时，将最旧的图片替换为含
+  URL 的文本占位符（KV 缓存友好：迟滞触发 + 确定性替换，不触碰当前轮消息）。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+from urllib.parse import unquote
+
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    ContextT,
+    ModelRequest,
+    ModelResponse,
+    ResponseT,
+)
+from langchain_core.messages import HumanMessage
+
+from src.infra.logging import get_logger
+from src.infra.upload.file_record import FileRecordStorage
+from src.kernel.config import settings
+
+logger = get_logger(__name__)
+
+_UPLOAD_URL_MARKER = "/api/upload/file/"
+_UNAVAILABLE_NOTE = "[image attachment no longer available]"
+_OMITTED_PLACEHOLDER = "[image omitted for context: {url}]"
+_OMITTED_PLACEHOLDER_NO_URL = "[image omitted for context]"
+_MAX_URL_LENGTH_IN_PLACEHOLDER = 512
+
+ExistsChecker = Callable[[list[str]], Awaitable[set[str]]]
+
+
+def _upload_key_from_url(url: str) -> str | None:
+    """Extract the storage key from a LambChat upload file URL, else None."""
+    marker_index = url.find(_UPLOAD_URL_MARKER)
+    if marker_index < 0:
+        return None
+    key = url[marker_index + len(_UPLOAD_URL_MARKER) :]
+    if not key or "/" not in key:
+        return None
+    # 丢掉查询串与锚点后解码（key 以 category/user_id/uuid.ext 形式存在）
+    key = key.split("?", 1)[0].split("#", 1)[0]
+    return unquote(key)
+
+
+async def _default_exists_checker(keys: list[str]) -> set[str]:
+    """Batch-check which storage keys still have file records."""
+    collection = FileRecordStorage().collection
+    cursor = collection.find({"key": {"$in": keys}}, {"key": 1, "_id": 0})
+    docs = await cursor.to_list(length=len(keys))
+    return {str(doc["key"]) for doc in docs if doc.get("key")}
+
+
+def _image_url_from_block(block: Any) -> str | None:
+    if not isinstance(block, dict):
+        return None
+
+    if block.get("type") == "image_url":
+        image_url = block.get("image_url")
+        if isinstance(image_url, dict):
+            url = image_url.get("url")
+        else:
+            url = image_url
+        return url if isinstance(url, str) and url else None
+
+    if block.get("type") == "image":
+        source = block.get("source")
+        if isinstance(source, dict) and source.get("type") == "url":
+            url = source.get("url")
+            return url if isinstance(url, str) and url else None
+
+    return None
+
+
+def _has_text_block(blocks: list[Any]) -> bool:
+    return any(
+        isinstance(block, dict)
+        and block.get("type") == "text"
+        and str(block.get("text", "")).strip()
+        for block in blocks
+    )
+
+
+class DeadAttachmentFilterMiddleware(AgentMiddleware):
+    """Remove image blocks pointing at deleted uploads before each model call."""
+
+    def __init__(self, exists_checker: ExistsChecker | None = None) -> None:
+        super().__init__()
+        self._exists_checker = exists_checker or _default_exists_checker
+        self._alive_cache: dict[str, bool] = {}
+
+    async def _filter_content_blocks(
+        self,
+        content: Any,
+        dead_urls: set[str],
+    ) -> Any:
+        """Drop dead image blocks; keep everything else intact."""
+        if not isinstance(content, list):
+            return content
+
+        filtered: list[Any] = []
+        for block in content:
+            url = _image_url_from_block(block)
+            if url and url in dead_urls:
+                continue
+            filtered.append(block)
+
+        if not _has_text_block(filtered):
+            filtered.append({"type": "text", "text": _UNAVAILABLE_NOTE})
+        return filtered
+
+    async def _collect_dead_urls(self, messages: list[Any]) -> set[str]:
+        """Find upload image URLs whose file records are gone (cached per instance)."""
+        pending: dict[str, str] = {}
+        for message in messages:
+            content = getattr(message, "content", None)
+            if not isinstance(content, list):
+                continue
+            for block in content:
+                url = _image_url_from_block(block)
+                if not url or url.startswith("data:"):
+                    continue
+                key = _upload_key_from_url(url)
+                if key is None or key in self._alive_cache:
+                    continue
+                pending.setdefault(key, url)
+
+        if not pending:
+            return set()
+
+        keys = list(pending)
+        try:
+            alive = await self._exists_checker(keys)
+        except Exception as e:
+            logger.warning(
+                "DeadAttachmentFilter: existence check failed (%s); passing URLs through",
+                type(e).__name__,
+            )
+            return set()
+
+        dead_urls: set[str] = set()
+        for key in keys:
+            is_alive = key in alive
+            self._alive_cache[key] = is_alive
+            if not is_alive:
+                dead_urls.add(pending[key])
+        return dead_urls
+
+    async def _filter_messages(self, messages: list[Any]) -> list[Any]:
+        dead_urls = await self._collect_dead_urls(messages)
+        if not dead_urls:
+            return messages
+
+        logger.warning(
+            "DeadAttachmentFilter: dropping %d deleted attachment image block(s)", len(dead_urls)
+        )
+        filtered_messages: list[Any] = []
+        for message in messages:
+            content = getattr(message, "content", None)
+            if not isinstance(content, list):
+                filtered_messages.append(message)
+                continue
+            filtered_content = await self._filter_content_blocks(content, dead_urls)
+            if filtered_content is content:
+                filtered_messages.append(message)
+            elif hasattr(message, "model_copy"):
+                filtered_messages.append(
+                    message.model_copy(update={"content": filtered_content})
+                )
+            else:
+                clone = message.copy()
+                clone.content = filtered_content
+                filtered_messages.append(clone)
+        return filtered_messages
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[ContextT],
+        handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]],
+    ) -> ModelResponse[ResponseT]:
+        messages = await self._filter_messages(request.messages)
+        if messages is not request.messages:
+            request = request.override(messages=messages)
+        return await handler(request)
+
+
+def _image_block_placeholder(url: str | None) -> dict[str, Any]:
+    """Build the text block replacing an evicted image (URL kept when safe)."""
+    if url and not url.startswith("data:") and len(url) <= _MAX_URL_LENGTH_IN_PLACEHOLDER:
+        return {"type": "text", "text": _OMITTED_PLACEHOLDER.format(url=url)}
+    return {"type": "text", "text": _OMITTED_PLACEHOLDER_NO_URL}
+
+
+def _last_human_message_index(messages: list[Any]) -> int:
+    for index in range(len(messages) - 1, -1, -1):
+        if isinstance(messages[index], HumanMessage):
+            return index
+    return len(messages)
+
+
+class HistoricalImageCapMiddleware(AgentMiddleware):
+    """Cap historical image blocks, replacing the oldest with URL text placeholders.
+
+    KV 缓存友好设计：
+    - 迟滞触发：图片数超过 ``hard_limit`` 才执行一次淘汰（淘汰到 ``keep_limit``），
+      两次淘汰之间请求前缀逐字节稳定，缓存命中不受影响。
+    - 确定性：替换结果是消息列表的纯函数，同一历史每次变换结果相同。
+    - 不触碰最后一条 HumanMessage（当前轮上下文永不淘汰）。
+    - 占位符保留原 URL，模型需要时可按链接取回；纯文本块不会触发上游图片下载。
+    """
+
+    def __init__(
+        self,
+        *,
+        hard_limit: int | None = None,
+        keep_limit: int | None = None,
+    ) -> None:
+        super().__init__()
+        self._hard_limit = hard_limit
+        self._keep_limit = keep_limit
+
+    def _limits(self) -> tuple[int, int]:
+        hard = (
+            int(self._hard_limit)
+            if self._hard_limit is not None
+            else int(getattr(settings, "HISTORY_IMAGE_HARD_LIMIT", 40))
+        )
+        keep = (
+            int(self._keep_limit)
+            if self._keep_limit is not None
+            else int(getattr(settings, "HISTORY_IMAGE_KEEP_LIMIT", 20))
+        )
+        if keep < 1:
+            keep = 1
+        if hard <= keep:  # 上限不构成迟滞区间时不淘汰
+            hard = 0
+        return hard, keep
+
+    def _cap_messages(self, messages: list[Any]) -> list[Any]:
+        hard, keep = self._limits()
+        if hard <= 0:
+            return messages
+
+        last_human = _last_human_message_index(messages)
+        positions: list[tuple[int, int]] = []
+        for message_index, message in enumerate(messages[:last_human]):
+            content = getattr(message, "content", None)
+            if not isinstance(content, list):
+                continue
+            for block_index, block in enumerate(content):
+                if _image_url_from_block(block):
+                    positions.append((message_index, block_index))
+
+        if len(positions) <= hard:
+            return messages
+
+        evict = set(positions[: len(positions) - keep])
+
+        by_message: dict[int, list[tuple[int, Any]]] = {}
+        for message_index, block_index in evict:
+            block = messages[message_index].content[block_index]
+            url = _image_url_from_block(block)
+            by_message.setdefault(message_index, []).append((block_index, url))
+
+        logger.warning(
+            "HistoricalImageCap: replacing %d of %d historical image block(s) with placeholders "
+            "(keep=%d, hard=%d)",
+            len(evict),
+            len(positions),
+            keep,
+            hard,
+        )
+        capped: list[Any] = list(messages)
+        for message_index, replacements in by_message.items():
+            original = messages[message_index]
+            content = list(original.content)
+            for block_index, url in replacements:
+                content[block_index] = _image_block_placeholder(url)
+            if hasattr(original, "model_copy"):
+                capped[message_index] = original.model_copy(update={"content": content})
+            else:
+                clone = original.copy()
+                clone.content = content
+                capped[message_index] = clone
+        return capped
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[ContextT],
+        handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]],
+    ) -> ModelResponse[ResponseT]:
+        messages = self._cap_messages(request.messages)
+        if messages is not request.messages:
+            request = request.override(messages=messages)
+        return await handler(request)

--- a/src/infra/agent/middleware/retry.py
+++ b/src/infra/agent/middleware/retry.py
@@ -18,6 +18,10 @@ from langchain.agents.middleware.types import (
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage
 
+from src.infra.agent.middleware.dead_attachment import (
+    DeadAttachmentFilterMiddleware,
+    HistoricalImageCapMiddleware,
+)
 from src.infra.llm.retry import is_retryable_model_error
 from src.kernel.config import settings
 
@@ -222,13 +226,19 @@ def create_retry_middleware(
 ) -> list[AgentMiddleware[Any, Any, Any]]:
     """Create the retry middleware stack for deep agents.
 
-    Returns [ModelFallbackMiddleware?, ModelRetryMiddleware,
-    EmptyContentRetryMiddleware]:
-    - Outer layer (optional): falls back to an alternate model when primary fails
+    Returns [DeadAttachmentFilterMiddleware, HistoricalImageCapMiddleware,
+    ModelFallbackMiddleware?, ModelRetryMiddleware, EmptyContentRetryMiddleware]:
+    - Outermost layer: drops image blocks whose uploaded file was deleted
+      (dead URLs make upstream token counting fail the whole request)
+    - Cap layer: replaces overly numerous historical images with URL placeholders
+    - Fallback layer (optional): falls back to an alternate model when primary fails
     - Middle layer: retries on 429/5xx/timeout with exponential backoff
     - Inner layer: retries on empty content responses
     """
-    stack: list[AgentMiddleware[Any, Any, Any]] = []
+    stack: list[AgentMiddleware[Any, Any, Any]] = [
+        DeadAttachmentFilterMiddleware(),
+        HistoricalImageCapMiddleware(),
+    ]
 
     if fallback_model:
         stack.append(ModelFallbackMiddleware(fallback_model=fallback_model, thinking=thinking))

--- a/src/infra/agent/middleware/summary_fallback.py
+++ b/src/infra/agent/middleware/summary_fallback.py
@@ -26,9 +26,37 @@ logger = logging.getLogger(__name__)
 
 _FALLBACK_MARKER = "_lambchat_summary_fallback"
 
+# 图片的真实上下文成本估算（对齐 codex RESIZED_IMAGE_BYTES_ESTIMATE=7373 字节 ÷ 4
+# 字节/token ≈ 1844）。langchain 默认按 85 token/张计，图片再多也推不动压缩触发器。
+_IMAGE_TOKEN_ESTIMATE = 1844
+
 # 从 lc SummarizationMiddleware 实例上拷贝到兜底 helper 的配置项，
 # 保证兜底摘要使用与主摘要一致的提示词与裁剪预算。
 _HELPER_SETTINGS = ("summary_prompt", "trim_tokens_to_summarize", "token_counter", "keep")
+
+
+def _image_aware_counter_for(model: Any):
+    """返回按真实成本计价的 token 计数器（保留 langchain 的模型调参与用量校准）。
+
+    等价于 langchain 的 ``_get_approximate_token_counter``，但把每张图片按
+    ``_IMAGE_TOKEN_ESTIMATE`` 计价，使带图会话能正确触发自动摘要压缩。
+    """
+    from functools import partial
+
+    from langchain_core.messages.utils import count_tokens_approximately
+
+    if str(getattr(model, "_llm_type", "")).startswith("anthropic-chat"):
+        return partial(
+            count_tokens_approximately,
+            use_usage_metadata_scaling=True,
+            chars_per_token=3.3,
+            tokens_per_image=_IMAGE_TOKEN_ESTIMATE,
+        )
+    return partial(
+        count_tokens_approximately,
+        use_usage_metadata_scaling=True,
+        tokens_per_image=_IMAGE_TOKEN_ESTIMATE,
+    )
 
 
 async def _summarize_with_fallback(
@@ -105,22 +133,24 @@ def summarization_fallback_patch(
     fallback_model: str | None,
     thinking: dict | None = None,
 ) -> Iterator[None]:
-    """在窗口内让 ``create_deep_agent`` 内部创建的所有摘要中间件带兜底保护。
+    """在窗口内增强 ``create_deep_agent`` 内部创建的所有摘要中间件。
+
+    无论是否配置兜底模型，都注入图片感知 token 计数器（图片按真实成本计价，
+    否则带图会话永远达不到压缩触发线）；配置了兜底模型时额外给摘要调用加
+    "换模型重做"保护。
 
     ``create_deep_agent`` 是同步函数且在事件循环线程上执行，窗口内不存在
-    await 点，因此临时替换模块属性不会与其他协程交错。未配置兜底模型时
-    直接透传。
+    await 点，因此临时替换模块属性不会与其他协程交错。
     """
-    if not fallback_model:
-        yield
-        return
-
     import deepagents.graph as deepagents_graph
 
     original = deepagents_graph.create_summarization_middleware
 
     def patched(model: Any, backend: Any, **kwargs: Any) -> Any:
+        kwargs.setdefault("token_counter", _image_aware_counter_for(model))
         middleware = original(model, backend, **kwargs)
+        if not fallback_model:
+            return middleware
         try:
             return protect_summarization_middleware(
                 middleware, fallback_model=fallback_model, thinking=thinking

--- a/src/infra/session/trace_storage.py
+++ b/src/infra/session/trace_storage.py
@@ -98,13 +98,20 @@ async def _write_usage_log(trace_id: str) -> None:
             {"_id": 0, "events": 0},
         )
         if trace_doc:
-            usage_event = await get_trace_storage().get_last_trace_event(
+            trace_storage = get_trace_storage()
+            usage_event = await trace_storage.get_last_trace_event(
                 trace_id,
                 ["token:usage"],
+            )
+            # 失败的任务也要记录原因（最后一个 error 事件），供用量面板展示
+            error_event = await trace_storage.get_last_trace_event(
+                trace_id,
+                ["error"],
             )
             await storage.upsert_usage_log_from_trace_metadata(
                 trace_doc,
                 (usage_event or {}).get("data", {}),
+                error_data=(error_event or {}).get("data", {}),
             )
     except Exception as e:
         # 写入 usage_logs 失败不应影响主流程

--- a/src/infra/task/executor.py
+++ b/src/infra/task/executor.py
@@ -100,6 +100,7 @@ class TaskExecutor:
             trace_precreated = bool(existing_trace_id and already_written)
 
             # 创建 Presenter 并传递给 agent
+            agent_options = agent_options or {}
             presenter = Presenter(
                 PresenterConfig(
                     session_id=session_id,
@@ -109,6 +110,8 @@ class TaskExecutor:
                     run_id=run_id,  # 传递 run_id
                     trace_id=existing_trace_id,  # reuse trace from queued path
                     enable_storage=True,
+                    model_id=agent_options.get("model_id"),
+                    model=agent_options.get("model"),
                 )
             )
 

--- a/src/infra/usage/storage.py
+++ b/src/infra/usage/storage.py
@@ -167,17 +167,24 @@ class UsageStorage:
 
         # 从 events 中找到最后一个 token:usage 事件
         usage_event = None
+        error_event = None
         for event in reversed(trace_doc.get("events", [])):
-            if event.get("event_type") == "token:usage":
-                usage_event = event.get("data", {})
+            if usage_event is not None and error_event is not None:
                 break
+            if event.get("event_type") == "token:usage" and usage_event is None:
+                usage_event = event.get("data", {})
+            elif event.get("event_type") == "error" and error_event is None:
+                error_event = event.get("data", {})
 
-        return await self.upsert_usage_log_from_trace_metadata(trace_doc, usage_event)
+        return await self.upsert_usage_log_from_trace_metadata(
+            trace_doc, usage_event, error_data=error_event
+        )
 
     async def upsert_usage_log_from_trace_metadata(
         self,
         trace_doc: Dict[str, Any],
         usage_data: Optional[Dict[str, Any]],
+        error_data: Optional[Dict[str, Any]] = None,
     ) -> bool:
         """
         使用 trace 元数据和已解析的 token:usage 数据写入 usage_logs。
@@ -185,6 +192,7 @@ class UsageStorage:
         Args:
             trace_doc: trace 元数据（不需要包含完整 events）
             usage_data: 最后一条 token:usage 事件的 data；缺失时按 0 处理
+            error_data: 最后一条 error 事件的 data；失败任务记录原因
 
         Returns:
             是否写入成功
@@ -206,6 +214,10 @@ class UsageStorage:
         team_name = _merge_metadata_value(
             metadata, session_metadata, "team_name"
         ) or await self._resolve_team_name(team_id)
+
+        error_data = error_data or {}
+        error_message = _as_str(error_data.get("error"))[:300]
+        error_type = _as_str(error_data.get("type"))
 
         doc = {
             "trace_id": trace_id,
@@ -244,6 +256,8 @@ class UsageStorage:
             "started_at": _as_datetime(trace_doc.get("started_at")),
             "completed_at": _as_datetime(trace_doc.get("completed_at")),
             "status": trace_doc.get("status", "unknown"),
+            "error_message": error_message,
+            "error_type": error_type,
             "step_count": _as_int(metadata.get("step_count", 0)),
             "tool_calls": _as_int(metadata.get("tool_calls", 0)),
         }

--- a/src/infra/writer/present.py
+++ b/src/infra/writer/present.py
@@ -342,6 +342,8 @@ def create_presenter(
     run_id: Optional[str] = None,
     trace_id: Optional[str] = None,
     user_id: Optional[str] = None,
+    model_id: Optional[str] = None,
+    model: Optional[str] = None,
 ) -> Presenter:
     """创建 Presenter 实例"""
     config = PresenterConfig(
@@ -351,5 +353,7 @@ def create_presenter(
         run_id=run_id,
         trace_id=trace_id,
         user_id=user_id,
+        model_id=model_id,
+        model=model,
     )
     return Presenter(config)

--- a/src/infra/writer/presenter_config.py
+++ b/src/infra/writer/presenter_config.py
@@ -70,3 +70,5 @@ class PresenterConfig:
     chunk_delay: float = 0.0  # 流式输出延迟 (秒)
     max_result_length: int = 100000  # 结果最大长度
     enable_storage: bool = True  # 是否启用事件存储
+    model_id: Optional[str] = None  # 本次运行使用的模型配置 ID（失败时 usage 日志仍可归属模型）
+    model: Optional[str] = None  # 本次运行使用的模型值

--- a/src/infra/writer/presenter_storage.py
+++ b/src/infra/writer/presenter_storage.py
@@ -423,7 +423,12 @@ class StoragePresenterMixin:
         if not self.config.session_id:
             return
 
-        await self.save_event(self.present_token_usage())  # type: ignore[attr-defined]
+        await self.save_event(
+            self.present_token_usage(  # type: ignore[attr-defined]
+                model_id=self.config.model_id,
+                model=self.config.model,
+            )
+        )
 
     async def complete(self, status: str = "completed") -> None:
         """

--- a/src/kernel/config/base.py
+++ b/src/kernel/config/base.py
@@ -112,6 +112,9 @@ class Settings(BaseSettings):
         False  # True=禁用旧 SHA256 密钥回退解密；迁移完成后由管理员手动开启
     )
     DEEPAGENT_DEFAULT_MAX_INPUT_TOKENS: int = 64000
+    # 历史图片治理（KV 缓存友好的迟滞淘汰）：超过 hard 才淘汰到 keep，区间内不动
+    HISTORY_IMAGE_HARD_LIMIT: int = 40
+    HISTORY_IMAGE_KEEP_LIMIT: int = 20
 
     # Session Settings
     SESSION_MAX_RUNS_PER_SESSION: int = 100

--- a/src/kernel/schemas/usage.py
+++ b/src/kernel/schemas/usage.py
@@ -36,6 +36,8 @@ class UsageLog(BaseModel):
     started_at: Optional[datetime] = None
     completed_at: Optional[datetime] = None
     status: str = "unknown"
+    error_message: str = ""
+    error_type: str = ""
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/tests/api/routes/test_usage_routes.py
+++ b/tests/api/routes/test_usage_routes.py
@@ -29,6 +29,8 @@ class _FakeUsageStorage:
                     "started_at": datetime(2026, 6, 14, tzinfo=timezone.utc),
                     "completed_at": None,
                     "status": "completed",
+                    "error_message": "Error code: 429 - rate limit exceeded",
+                    "error_type": "RateLimitError",
                 }
             ],
             1,
@@ -133,6 +135,8 @@ async def test_list_usage_logs_restricts_non_admin_to_current_user(monkeypatch) 
     )
 
     assert response.total == 1
+    assert response.items[0].error_message == "Error code: 429 - rate limit exceeded"
+    assert response.items[0].error_type == "RateLimitError"
     assert storage.calls == [
         {
             "user_id": "user-1",

--- a/tests/infra/agent/test_dead_attachment_filter_middleware.py
+++ b/tests/infra/agent/test_dead_attachment_filter_middleware.py
@@ -1,0 +1,242 @@
+"""DeadAttachmentFilterMiddleware — drop image blocks whose upload file no longer exists.
+
+背景：模型请求历史携带所有历史轮次的 image_url；上游 new-api 计数 token 时会逐个下载
+这些 URL，任何一个 404（文件已被清理）都会导致整个请求失败（count_token_failed）。
+该中间件在每次模型调用前批量校验自有上传 URL 的存活性，剔除死链图片块。
+"""
+
+import pytest
+from langchain_core.messages import HumanMessage
+
+from src.infra.agent.middleware.dead_attachment import (
+    DeadAttachmentFilterMiddleware,
+)
+
+
+def _upload_url(key: str) -> str:
+    return f"https://lambchat.com/api/upload/file/{key}"
+
+
+class _Request:
+    def __init__(self, messages):
+        self.messages = messages
+
+    def override(self, **kwargs):
+        return _Request(kwargs.get("messages", self.messages))
+
+
+def _message_with_blocks(blocks):
+    return HumanMessage(content=blocks)
+
+
+async def _always_alive(keys):
+    return set(keys)
+
+
+@pytest.mark.asyncio
+async def test_drops_image_block_whose_file_record_is_missing():
+    seen = {}
+
+    async def handler(request):
+        seen["request"] = request
+        return request
+
+    async def exists(keys):
+        assert keys == ["image/u1/dead.png"]
+        return set()  # 数据库中没有该 key
+
+    middleware = DeadAttachmentFilterMiddleware(exists_checker=exists)
+    message = _message_with_blocks(
+        [
+            {"type": "text", "text": "看这张图"},
+            {"type": "image_url", "image_url": {"url": _upload_url("image/u1/dead.png")}},
+        ]
+    )
+
+    await middleware.awrap_model_call(_Request([message]), handler)
+
+    blocks = seen["request"].messages[0].content
+    assert [block["type"] for block in blocks] == ["text"]
+    assert blocks[0]["text"] == "看这张图"
+
+
+@pytest.mark.asyncio
+async def test_keeps_image_block_when_file_record_exists():
+    seen = {}
+
+    async def handler(request):
+        seen["request"] = request
+        return request
+
+    async def exists(keys):
+        return {"image/u1/alive.png"}
+
+    middleware = DeadAttachmentFilterMiddleware(exists_checker=exists)
+    message = _message_with_blocks(
+        [
+            {"type": "text", "text": "看这张图"},
+            {"type": "image_url", "image_url": {"url": _upload_url("image/u1/alive.png")}},
+        ]
+    )
+
+    await middleware.awrap_model_call(_Request([message]), handler)
+
+    blocks = seen["request"].messages[0].content
+    assert [block["type"] for block in blocks] == ["text", "image_url"]
+    assert blocks[1]["image_url"]["url"] == _upload_url("image/u1/alive.png")
+
+
+@pytest.mark.asyncio
+async def test_replaces_image_only_message_with_text_note():
+    seen = {}
+
+    async def handler(request):
+        seen["request"] = request
+        return request
+
+    async def exists(keys):
+        return set()
+
+    middleware = DeadAttachmentFilterMiddleware(exists_checker=exists)
+    message = _message_with_blocks(
+        [{"type": "image_url", "image_url": {"url": _upload_url("image/u1/gone.png")}}]
+    )
+
+    await middleware.awrap_model_call(_Request([message]), handler)
+
+    blocks = seen["request"].messages[0].content
+    assert [block["type"] for block in blocks] == ["text"]
+    assert blocks[0]["text"].strip() != ""
+
+
+@pytest.mark.asyncio
+async def test_ignores_data_urls_and_external_urls_without_db_check():
+    seen = {}
+    checked = []
+
+    async def handler(request):
+        seen["request"] = request
+        return request
+
+    async def exists(keys):
+        checked.extend(keys)
+        return set(keys)
+
+    middleware = DeadAttachmentFilterMiddleware(exists_checker=exists)
+    external = "https://example.com/cat.png"
+    message = _message_with_blocks(
+        [
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,aW1n"}},
+            {"type": "image_url", "image_url": {"url": external}},
+        ]
+    )
+
+    await middleware.awrap_model_call(_Request([message]), handler)
+
+    blocks = seen["request"].messages[0].content
+    assert len(blocks) == 2
+    assert blocks[1]["image_url"]["url"] == external
+    assert checked == []  # 非自有上传 URL 不触发数据库查询
+
+
+@pytest.mark.asyncio
+async def test_anthropic_url_source_blocks_are_filtered_too():
+    seen = {}
+
+    async def handler(request):
+        seen["request"] = request
+        return request
+
+    async def exists(keys):
+        return set()
+
+    middleware = DeadAttachmentFilterMiddleware(exists_checker=exists)
+    message = _message_with_blocks(
+        [
+            {
+                "type": "image",
+                "source": {"type": "url", "url": _upload_url("image/u1/gone.png")},
+            }
+        ]
+    )
+
+    await middleware.awrap_model_call(_Request([message]), handler)
+
+    blocks = seen["request"].messages[0].content
+    assert [block["type"] for block in blocks] == ["text"]
+
+
+@pytest.mark.asyncio
+async def test_passes_messages_through_when_db_check_fails():
+    seen = {}
+
+    async def handler(request):
+        seen["request"] = request
+        return request
+
+    async def broken_exists(keys):
+        raise RuntimeError("mongo down")
+
+    middleware = DeadAttachmentFilterMiddleware(exists_checker=broken_exists)
+    message = _message_with_blocks(
+        [
+            {"type": "text", "text": "hi"},
+            {"type": "image_url", "image_url": {"url": _upload_url("image/u1/maybe.png")}},
+        ]
+    )
+    original = _Request([message])
+
+    await middleware.awrap_model_call(original, handler)
+
+    assert seen["request"].messages[0].content == message.content
+
+
+@pytest.mark.asyncio
+async def test_caches_existence_results_across_calls():
+    calls = []
+
+    async def handler(request):
+        return request
+
+    async def exists(keys):
+        calls.append(list(keys))
+        return set()
+
+    middleware = DeadAttachmentFilterMiddleware(exists_checker=exists)
+    message = _message_with_blocks(
+        [{"type": "image_url", "image_url": {"url": _upload_url("image/u1/dead.png")}}]
+    )
+
+    await middleware.awrap_model_call(_Request([message]), handler)
+    await middleware.awrap_model_call(_Request([message]), handler)
+
+    assert len(calls) == 1  # 第二次调用复用缓存
+
+
+@pytest.mark.asyncio
+async def test_default_checker_uses_file_records_collection(monkeypatch):
+    from src.infra.agent.middleware import dead_attachment
+
+    queried = {}
+
+    class _FakeCursor:
+        def __init__(self, docs):
+            self.docs = docs
+
+        async def to_list(self, length=None):
+            return self.docs
+
+    class _FakeCollection:
+        def find(self, query, projection=None):
+            queried["query"] = query
+            return _FakeCursor([{"key": "image/u1/alive.png"}])
+
+    class _FakeStorage:
+        collection = _FakeCollection()
+
+    monkeypatch.setattr(dead_attachment, "FileRecordStorage", lambda: _FakeStorage())
+
+    alive = await dead_attachment._default_exists_checker(["image/u1/alive.png", "image/u1/dead.png"])
+
+    assert alive == {"image/u1/alive.png"}
+    assert queried["query"] == {"key": {"$in": ["image/u1/alive.png", "image/u1/dead.png"]}}

--- a/tests/infra/agent/test_image_history_cap_middleware.py
+++ b/tests/infra/agent/test_image_history_cap_middleware.py
@@ -1,0 +1,198 @@
+"""HistoricalImageCapMiddleware — 超限历史图片替换为 URL 文本占位符。
+
+约束（KV 缓存友好）：
+- 迟滞触发：图片数超过 hard_limit 才淘汰一次，淘汰到 keep_limit；区间内不动作，
+  保证两次淘汰之间请求前缀完全稳定（缓存不抖动）。
+- 确定性：同样的历史 → 同样的替换结果，纯函数式，不落库。
+- 永不触碰最后一条 HumanMessage（当前轮上下文）。
+- 占位符保留原 URL（模型需要时可按链接取回），纯文本不触发上游图片下载。
+"""
+
+import pytest
+from langchain_core.messages import HumanMessage
+
+from src.infra.agent.middleware.dead_attachment import HistoricalImageCapMiddleware
+
+
+def _upload_url(name: str) -> str:
+    return f"https://lambchat.com/api/upload/file/image/u1/{name}.png"
+
+
+class _Request:
+    def __init__(self, messages):
+        self.messages = messages
+
+    def override(self, **kwargs):
+        return _Request(kwargs.get("messages", self.messages))
+
+
+def _image_message(names, text=None):
+    blocks = []
+    if text:
+        blocks.append({"type": "text", "text": text})
+    blocks.extend({"type": "image_url", "image_url": {"url": _upload_url(n)}} for n in names)
+    return HumanMessage(content=blocks)
+
+
+def _middleware(hard=10, keep=5):
+    return HistoricalImageCapMiddleware(hard_limit=hard, keep_limit=keep)
+
+
+@pytest.mark.asyncio
+async def test_replaces_oldest_images_beyond_hard_limit_with_url_placeholders():
+    seen = {}
+
+    async def handler(request):
+        seen["request"] = request
+        return request
+
+    # 12 条历史图片消息 + 1 条当前消息（当前消息无图片）
+    messages = [_image_message([f"img{i}"], text=f"第{i}轮") for i in range(12)]
+    messages.append(_image_message([], text="当前问题"))
+
+    await _middleware(hard=10, keep=5).awrap_model_call(_Request(messages), handler)
+
+    out = seen["request"].messages
+    urls_in_blocks = []
+    placeholder_texts = []
+    for msg in out:
+        for block in msg.content:
+            if block.get("type") == "image_url":
+                urls_in_blocks.append(block["image_url"]["url"])
+            elif block.get("type") == "text" and "image omitted" in block.get("text", ""):
+                placeholder_texts.append(block["text"])
+    # 只保留最新 5 张图片块（img7..img11），其余 7 张变成占位符
+    assert urls_in_blocks == [_upload_url(f"img{i}") for i in range(7, 12)]
+    assert len(placeholder_texts) == 7
+    assert all(_upload_url(f"img{i}") in t for i, t in zip(range(7), placeholder_texts))
+
+
+@pytest.mark.asyncio
+async def test_no_change_at_or_below_hard_limit_returns_identical_list():
+    seen = {}
+
+    async def handler(request):
+        seen["request"] = request
+        return request
+
+    messages = [_image_message([f"img{i}"]) for i in range(8)]  # keep=5 < 8 < hard=10
+
+    request = _Request(messages)
+    await _middleware(hard=10, keep=5).awrap_model_call(request, handler)
+
+    # 迟滞区间内原样透传（对象同一，零 token 漂移）
+    assert seen["request"].messages is messages
+
+
+@pytest.mark.asyncio
+async def test_replacement_is_deterministic_across_calls():
+    outputs = []
+
+    async def handler(request):
+        outputs.append([m.content for m in request.messages])
+        return request
+
+    messages = [_image_message([f"img{i}"]) for i in range(12)]
+
+    middleware = _middleware(hard=10, keep=5)
+    await middleware.awrap_model_call(_Request(list(messages)), handler)
+    await middleware.awrap_model_call(_Request(list(messages)), handler)
+
+    assert outputs[0] == outputs[1]
+
+
+@pytest.mark.asyncio
+async def test_last_human_message_images_are_never_touched():
+    seen = {}
+
+    async def handler(request):
+        seen["request"] = request
+        return request
+
+    # 历史 12 张（超 hard=10）+ 当前消息 3 张
+    history = [_image_message([f"old{i}"]) for i in range(12)]
+    current = _image_message(["cur0", "cur1", "cur2"], text="看这些图")
+    messages = history + [current]
+
+    await _middleware(hard=10, keep=5).awrap_model_call(_Request(messages), handler)
+
+    out = seen["request"].messages
+    current_blocks = [
+        b for b in out[-1].content if b.get("type") == "image_url"
+    ]
+    assert len(current_blocks) == 3  # 当前轮 3 张全保留
+    # 历史只保留最新 keep=5 张（old7..old11）
+    history_image_urls = [
+        b["image_url"]["url"]
+        for msg in out[:-1]
+        for b in msg.content
+        if b.get("type") == "image_url"
+    ]
+    assert history_image_urls == [_upload_url(f"old{i}") for i in range(7, 12)]
+
+
+@pytest.mark.asyncio
+async def test_current_message_images_do_not_count_toward_trigger():
+    seen = {}
+
+    async def handler(request):
+        seen["request"] = request
+        return request
+
+    # 历史里 9 张（低于 hard=10），当前消息 3 张 —— 历史未超限则不淘汰
+    history = [_image_message([f"old{i}"]) for i in range(9)]
+    current = _image_message(["cur0", "cur1", "cur2"], text="看这些图")
+    messages = history + [current]
+
+    request = _Request(messages)
+    await _middleware(hard=10, keep=5).awrap_model_call(request, handler)
+
+    assert seen["request"].messages is messages
+
+
+@pytest.mark.asyncio
+async def test_data_url_images_get_placeholder_without_payload():
+    seen = {}
+
+    async def handler(request):
+        seen["request"] = request
+        return request
+
+    data_url = "data:image/png;base64," + "A" * 500
+    messages = [
+        HumanMessage(
+            content=[
+                {"type": "image_url", "image_url": {"url": data_url}},
+                *(
+                    {"type": "image_url", "image_url": {"url": _upload_url(f"u{i}")}}
+                    for i in range(11)
+                ),
+            ]
+        ),
+        _image_message([], text="hi"),
+    ]
+
+    await _middleware(hard=10, keep=5).awrap_model_call(_Request(messages), handler)
+
+    texts = [b["text"] for b in seen["request"].messages[0].content if b.get("type") == "text"]
+    # base64 不得出现在请求里，占位符是纯文本
+    assert any("image omitted" in t for t in texts)
+    assert all("base64" not in t for t in texts)
+
+
+def test_settings_defaults_are_hysteresis_safe():
+    from src.kernel.config import settings
+
+    # hard 必须 > keep，否则淘汰永不该发生
+    assert settings.HISTORY_IMAGE_HARD_LIMIT > settings.HISTORY_IMAGE_KEEP_LIMIT
+    assert settings.HISTORY_IMAGE_KEEP_LIMIT > 0
+
+
+def test_retry_stack_registers_cap_after_dead_filter():
+    from src.infra.agent.middleware.retry import create_retry_middleware
+
+    stack = create_retry_middleware()
+    names = [type(item).__name__ for item in stack]
+
+    assert names[0] == "DeadAttachmentFilterMiddleware"
+    assert names[1] == "HistoricalImageCapMiddleware"

--- a/tests/infra/agent/test_retry_middleware.py
+++ b/tests/infra/agent/test_retry_middleware.py
@@ -112,6 +112,8 @@ def test_retry_stack_does_not_bound_the_complete_streaming_call(monkeypatch) -> 
     middleware = create_retry_middleware()
 
     assert [type(item).__name__ for item in middleware] == [
+        "DeadAttachmentFilterMiddleware",
+        "HistoricalImageCapMiddleware",
         "ModelRetryMiddleware",
         "EmptyContentRetryMiddleware",
     ]
@@ -124,7 +126,7 @@ async def test_official_model_retry_middleware_retries_first_event_timeout(
 
     monkeypatch.setattr("src.kernel.config.settings.LLM_MAX_RETRIES", 3)
     monkeypatch.setattr("src.kernel.config.settings.LLM_RETRY_DELAY", 0)
-    retry = create_retry_middleware()[0]
+    retry = create_retry_middleware()[2]
     calls = 0
 
     async def handler(_request):
@@ -138,3 +140,13 @@ async def test_official_model_retry_middleware_retries_first_event_timeout(
 
     assert result.content == "ok"
     assert calls == 4
+
+
+def test_retry_stack_leads_with_dead_attachment_filter() -> None:
+    """Dead attachment filtering must wrap every model call (outermost layer)."""
+    from src.infra.agent.middleware.dead_attachment import DeadAttachmentFilterMiddleware
+    from src.infra.agent.middleware.retry import create_retry_middleware
+
+    stack = create_retry_middleware(fallback_model="glm-5.3")
+
+    assert isinstance(stack[0], DeadAttachmentFilterMiddleware)

--- a/tests/infra/agent/test_summary_fallback.py
+++ b/tests/infra/agent/test_summary_fallback.py
@@ -127,10 +127,80 @@ def test_patch_window_wraps_deepagents_summarization_factory(monkeypatch) -> Non
     assert getattr(built_after._acreate_summary, "_lambchat_summary_fallback", False) is False
 
 
-def test_patch_window_noop_without_fallback_model() -> None:
+def test_patch_window_without_fallback_model_injects_counter_only() -> None:
+    """无兜底模型：工厂仍被替换（注入计数器），但不加摘要兜底保护。"""
     import deepagents.graph as deepagents_graph
+    from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 
     original = deepagents_graph.create_summarization_middleware
+    model = GenericFakeChatModel(messages=iter([AIMessage("ok")] * 10))
 
     with summarization_fallback_patch(None):
-        assert deepagents_graph.create_summarization_middleware is original
+        assert deepagents_graph.create_summarization_middleware is not original
+        built = deepagents_graph.create_summarization_middleware(model, object())
+        assert getattr(built._acreate_summary, "_lambchat_summary_fallback", False) is False
+
+    assert deepagents_graph.create_summarization_middleware is original
+
+
+def test_image_aware_counter_charges_realistic_image_cost() -> None:
+    """图片按真实成本计价（对齐 codex 的 7373 字节 ≈ 1844 token/张），不再按 85 低估。"""
+    from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+
+    from src.infra.agent.middleware.summary_fallback import _image_aware_counter_for
+
+    model = GenericFakeChatModel(messages=iter([AIMessage("ok")] * 10))
+    counter = _image_aware_counter_for(model)
+
+    text_only = HumanMessage(content="same text")
+    with_image = HumanMessage(
+        content=[
+            {"type": "text", "text": "same text"},
+            {"type": "image_url", "image_url": {"url": "https://x/img.png"}},
+        ]
+    )
+
+    assert counter([with_image]) - counter([text_only]) >= 1844
+
+
+def test_patch_injects_image_aware_counter_even_without_fallback(monkeypatch) -> None:
+    """无兜底模型时也要注入图片感知计数器（否则图片对压缩触发器不可见）。"""
+    import deepagents.graph as deepagents_graph
+    from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+
+    model = GenericFakeChatModel(messages=iter([AIMessage("ok")] * 10))
+    original = deepagents_graph.create_summarization_middleware
+    captured: dict = {}
+
+    def fake_original(model, backend, **kwargs):
+        captured.update(kwargs)
+        return original(model, backend, **kwargs)
+
+    monkeypatch.setattr(deepagents_graph, "create_summarization_middleware", fake_original)
+
+    with summarization_fallback_patch(None):
+        deepagents_graph.create_summarization_middleware(model, object())
+
+    assert "token_counter" in captured
+    assert captured["token_counter"] is not None
+
+
+def test_patch_does_not_override_explicit_token_counter(monkeypatch) -> None:
+    import deepagents.graph as deepagents_graph
+    from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+
+    model = GenericFakeChatModel(messages=iter([AIMessage("ok")] * 10))
+    original = deepagents_graph.create_summarization_middleware
+    captured: dict = {}
+
+    def fake_original(model, backend, **kwargs):
+        captured.update(kwargs)
+        return original(model, backend, **kwargs)
+
+    monkeypatch.setattr(deepagents_graph, "create_summarization_middleware", fake_original)
+    explicit = lambda messages: 0  # noqa: E731
+
+    with summarization_fallback_patch(None):
+        deepagents_graph.create_summarization_middleware(model, object(), token_counter=explicit)
+
+    assert captured["token_counter"] is explicit

--- a/tests/infra/memory/test_compaction_agent.py
+++ b/tests/infra/memory/test_compaction_agent.py
@@ -361,6 +361,8 @@ async def test_maybe_compact_after_write_runs_deepagent_compactor(monkeypatch):
     await _wait_for_after_write_tasks(agent)
     assert created["model"] == "fake-compaction-model"
     assert [type(item).__name__ for item in created["middleware"]] == [
+        "DeadAttachmentFilterMiddleware",
+        "HistoricalImageCapMiddleware",
         "ModelRetryMiddleware",
         "EmptyContentRetryMiddleware",
     ]

--- a/tests/infra/session/test_trace_usage_log_write.py
+++ b/tests/infra/session/test_trace_usage_log_write.py
@@ -4,29 +4,37 @@ from src.infra.session import trace_storage as trace_storage_module
 
 
 class _FakeTraceCollection:
+    def __init__(self, doc=None):
+        self.doc = doc or {"trace_id": "trace-1", "session_id": "session-1"}
+
     async def find_one(self, query, projection=None):
         assert query == {"trace_id": "trace-1"}
         assert projection == {"_id": 0, "events": 0}
-        return {"trace_id": "trace-1", "session_id": "session-1"}
+        return self.doc
 
 
 class _FakeDatabase(dict):
+    def __init__(self, trace_doc=None):
+        super().__init__()
+        self.trace_doc = trace_doc
+
     def __getitem__(self, name):
         assert name == trace_storage_module.settings.MONGODB_TRACES_COLLECTION
-        return _FakeTraceCollection()
+        return _FakeTraceCollection(self.trace_doc)
 
 
 class _FakeUsageCollection:
-    database = _FakeDatabase()
+    def __init__(self, trace_doc=None):
+        self.database = _FakeDatabase(trace_doc)
 
 
 class _FakeUsageStorage:
-    def __init__(self):
-        self.collection = _FakeUsageCollection()
+    def __init__(self, trace_doc=None):
+        self.collection = _FakeUsageCollection(trace_doc)
         self.upsert_calls = []
 
-    async def upsert_usage_log_from_trace_metadata(self, trace_doc, usage_data):
-        self.upsert_calls.append((trace_doc, usage_data))
+    async def upsert_usage_log_from_trace_metadata(self, trace_doc, usage_data, error_data=None):
+        self.upsert_calls.append((trace_doc, usage_data, error_data))
         return True
 
 
@@ -42,10 +50,12 @@ async def test_write_usage_log_reads_trace_metadata_and_last_usage_event(monkeyp
     class _FakeTraceStorage:
         async def get_last_trace_event(self, trace_id, event_types):
             usage_event_calls.append((trace_id, event_types))
-            return {
-                "event_type": "token:usage",
-                "data": {"input_tokens": 1, "output_tokens": 2},
-            }
+            if event_types == ["token:usage"]:
+                return {
+                    "event_type": "token:usage",
+                    "data": {"input_tokens": 1, "output_tokens": 2},
+                }
+            return None
 
     monkeypatch.setattr(
         trace_storage_module,
@@ -55,10 +65,64 @@ async def test_write_usage_log_reads_trace_metadata_and_last_usage_event(monkeyp
 
     await trace_storage_module._write_usage_log("trace-1")
 
-    assert usage_event_calls == [("trace-1", ["token:usage"])]
+    assert usage_event_calls == [
+        ("trace-1", ["token:usage"]),
+        ("trace-1", ["error"]),
+    ]
     assert storage.upsert_calls == [
         (
             {"trace_id": "trace-1", "session_id": "session-1"},
             {"input_tokens": 1, "output_tokens": 2},
+            {},
         )
     ]
+
+
+@pytest.mark.asyncio
+async def test_write_usage_log_passes_last_error_event_for_failed_trace(monkeypatch) -> None:
+    trace_doc = {
+        "trace_id": "trace-1",
+        "session_id": "session-1",
+        "status": "error",
+    }
+    storage = _FakeUsageStorage(trace_doc)
+    monkeypatch.setattr(
+        "src.infra.usage.storage.get_usage_storage",
+        lambda: storage,
+    )
+    event_calls = []
+
+    class _FakeTraceStorage:
+        async def get_last_trace_event(self, trace_id, event_types):
+            event_calls.append(list(event_types))
+            if event_types == ["token:usage"]:
+                return {
+                    "event_type": "token:usage",
+                    "data": {"input_tokens": 0, "output_tokens": 0},
+                }
+            if event_types == ["error"]:
+                return {
+                    "event_type": "error",
+                    "data": {
+                        "error": "Error code: 429 - rate limit exceeded",
+                        "type": "RateLimitError",
+                        "run_id": "run-1",
+                    },
+                }
+            return None
+
+    monkeypatch.setattr(
+        trace_storage_module,
+        "get_trace_storage",
+        lambda: _FakeTraceStorage(),
+    )
+
+    await trace_storage_module._write_usage_log("trace-1")
+
+    assert ["token:usage"] in event_calls
+    assert ["error"] in event_calls
+    assert storage.upsert_calls[0][2] == {
+        "error": "Error code: 429 - rate limit exceeded",
+        "type": "RateLimitError",
+        "run_id": "run-1",
+    }

--- a/tests/infra/test_presenter_token_usage.py
+++ b/tests/infra/test_presenter_token_usage.py
@@ -112,6 +112,28 @@ async def test_complete_writes_zero_token_usage_when_missing(monkeypatch) -> Non
     assert usage_events[0]["data"]["total_tokens"] == 0
 
 
+async def test_complete_writes_zero_token_usage_with_configured_model(monkeypatch) -> None:
+    writer = _FakeDualWriter()
+    monkeypatch.setattr("src.infra.session.dual_writer.get_dual_writer", lambda: writer)
+    presenter = create_presenter(
+        session_id="session-1",
+        agent_id="search",
+        agent_name="Search",
+        run_id="run-1",
+        trace_id="trace-1",
+        model_id="m-1",
+        model="glm-5.3",
+    )
+
+    await presenter.complete("error")
+
+    usage_events = [event for event in writer.events if event["event_type"] == "token:usage"]
+    assert len(usage_events) == 1
+    assert usage_events[0]["data"]["input_tokens"] == 0
+    assert usage_events[0]["data"]["model_id"] == "m-1"
+    assert usage_events[0]["data"]["model"] == "glm-5.3"
+
+
 async def test_emit_recommend_questions_is_idempotent(monkeypatch) -> None:
     writer = _FakeDualWriter()
     monkeypatch.setattr("src.infra.session.dual_writer.get_dual_writer", lambda: writer)

--- a/tests/infra/test_task_executor_trace_context.py
+++ b/tests/infra/test_task_executor_trace_context.py
@@ -169,6 +169,55 @@ async def test_task_executor_passes_resolved_agent_name_to_presenter(
 
 
 @pytest.mark.asyncio
+async def test_task_executor_passes_model_options_to_presenter_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _FakePresenter.emitted_user_messages = []
+    executor = TaskExecutor(
+        storage=SimpleNamespace(),
+        run_info={},
+        heartbeat_manager=_FakeHeartbeat(),
+    )
+
+    async def _no_op(*args, **kwargs) -> None:
+        return None
+
+    captured = {}
+
+    async def fake_agent_executor(*args, **kwargs):
+        captured["config"] = kwargs["presenter"].config
+        if False:
+            yield None
+
+    monkeypatch.setattr("src.infra.writer.present.Presenter", _FakePresenter)
+    monkeypatch.setattr(
+        "src.infra.writer.present.PresenterConfig",
+        lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+    monkeypatch.setattr(executor, "_update_session_status", _no_op)
+    monkeypatch.setattr(executor, "_send_task_notification", _no_op)
+    monkeypatch.setattr("src.infra.task.executor.get_dual_writer", lambda: SimpleNamespace())
+    monkeypatch.setattr(
+        "src.infra.task.cancellation.TaskCancellation.clear_interrupt",
+        _no_op,
+    )
+
+    await executor.run_task(
+        session_id="session-1",
+        run_id="run-1",
+        agent_id="search",
+        message="hello",
+        user_id="user-1",
+        executor=fake_agent_executor,
+        existing_trace_id="trace-run-level",
+        agent_options={"model": "glm-5.3", "model_id": "m-1"},
+    )
+
+    assert captured["config"].model == "glm-5.3"
+    assert captured["config"].model_id == "m-1"
+
+
+@pytest.mark.asyncio
 async def test_task_executor_passes_auto_mode_to_agent_executor(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/infra/usage/test_usage_storage.py
+++ b/tests/infra/usage/test_usage_storage.py
@@ -243,6 +243,65 @@ async def test_upsert_usage_log_from_trace_metadata_uses_provided_usage_data() -
 
 
 @pytest.mark.asyncio
+async def test_upsert_usage_log_from_trace_metadata_records_error_summary() -> None:
+    collection = _FakeCollection()
+    storage = UsageStorage()
+    storage._collection = collection
+
+    inserted = await storage.upsert_usage_log_from_trace_metadata(
+        {
+            "trace_id": "trace-err",
+            "session_id": "session-1",
+            "run_id": "run-1",
+            "user_id": "user-1",
+            "agent_id": "search",
+            "started_at": "2026-06-14T00:00:00+00:00",
+            "status": "error",
+            "metadata": {"username": "Ada", "agent_name": "Search Agent"},
+        },
+        {},
+        error_data={
+            "error": "Error code: 429 - rate limit exceeded",
+            "type": "RateLimitError",
+            "run_id": "run-1",
+        },
+    )
+
+    assert inserted is True
+    doc = collection.update_calls[0][1]["$set"]
+    assert doc["model"] == ""
+    assert doc["error_message"].startswith("Error code: 429")
+    assert doc["error_type"] == "RateLimitError"
+
+
+@pytest.mark.asyncio
+async def test_upsert_usage_log_from_trace_metadata_keeps_error_blank_without_error_data() -> None:
+    collection = _FakeCollection()
+    storage = UsageStorage()
+    storage._collection = collection
+
+    inserted = await storage.upsert_usage_log_from_trace_metadata(
+        {
+            "trace_id": "trace-ok",
+            "session_id": "session-1",
+            "run_id": "run-1",
+            "user_id": "user-1",
+            "agent_id": "search",
+            "started_at": "2026-06-14T00:00:00+00:00",
+            "status": "completed",
+            "metadata": {"username": "Ada", "agent_name": "Search Agent"},
+        },
+        {"model": "glm-5.3", "input_tokens": 10, "output_tokens": 5},
+    )
+
+    assert inserted is True
+    doc = collection.update_calls[0][1]["$set"]
+    assert doc["model"] == "glm-5.3"
+    assert doc["error_message"] == ""
+    assert doc["error_type"] == ""
+
+
+@pytest.mark.asyncio
 async def test_list_usage_logs_builds_bounded_query_and_stats() -> None:
     collection = _FakeCollection()
     storage = UsageStorage()


### PR DESCRIPTION
## 问题一：用量面板失败记录全空

失败任务只显示用户名，model/token 为空（生产 608 条 error 里 236 条 model 为空）。

根因：`model` 只从 `token:usage` 事件取，首调即失败的任务没有该事件；错误原因也没有落库。

修复：
- PresenterConfig 携带 model/model_id，零用量兜底事件带上模型归属
- usage_logs 新增 `error_message`/`error_type`（trace 最后一个 error 事件）
- 面板展示失败原因（tooltip + 移动端红字行）

## 问题二：count_token_failed（历史图片死链）

上游 new-api 计数 token 时逐个下载历史消息的图片 URL，附件被清理后（404）整个请求失败，长会话永久瘫痪（生产实测某会话 101 个 URL 中 14 个已失效）。

根因还包括：langchain 估算器按 85 token/张计图片，101 张图 ≈ 9k token，永远触发不了自动压缩。

修复（对齐 codex 的处理方式，三层防线）：
- `DeadAttachmentFilterMiddleware`：file_records 批量校验剔除死链图片块
- `HistoricalImageCapMiddleware`：历史图片超 40 淘汰到 20，替换为含 URL 的文本占位符；迟滞触发 + 确定性 + 不碰当前轮，KV 缓存前缀稳定
- 图片感知 token 计数器（1844 token/张，对齐 codex `RESIZED_IMAGE_BYTES_ESTIMATE`）注入 deepagents 摘要工厂

## 验证

- 后端 2847 通过，ruff + mypy 干净
- 前端 1530 通过，build 成功