### PR TITLE
fix: keep the chat scroller mounted when a run completes

### DIFF
--- a/frontend/src/components/layout/AppContent/ChatView.tsx
+++ b/frontend/src/components/layout/AppContent/ChatView.tsx
@@ -365,48 +365,64 @@ export function ChatView({
     [isLoadingHistory, manualDetachFromStreamRef],
   );
 
+  // The Scroller identity must stay stable for the lifetime of the list:
+  // react-virtuoso remounts the whole scroller subtree (resetting scroll to
+  // the first message) whenever components.Scroller changes identity. The
+  // completion commit — streaming stops + connectionStatus flips to
+  // "disconnected" while isLoading is still true until sendMessage's finally
+  // runs — toggles the skeleton flag, which must never reach the Scroller.
+  // Only the Footer may be recreated; its remount cannot move scroll position.
+  const virtuosoScrollerComponent = useCallback(
+    (
+      scrollerProps: React.HTMLAttributes<HTMLDivElement> & {
+        children?: React.ReactNode;
+        ref?: React.Ref<HTMLDivElement>;
+      },
+    ) => {
+      const { children, ref: vRef, ...props } = scrollerProps;
+      return (
+        <div
+          {...props}
+          className={`chat-message-scroller ${props.className ?? ""}`}
+          ref={(el: HTMLDivElement | null) => {
+            handleVirtuosoScrollerElementChange(el);
+            if (typeof vRef === "function") vRef(el);
+            else if (vRef)
+              (
+                vRef as React.MutableRefObject<HTMLDivElement | null>
+              ).current = el;
+          }}
+        >
+          {children}
+        </div>
+      );
+    },
+    [handleVirtuosoScrollerElementChange],
+  );
+
+  const virtuosoFooterComponent = useCallback(
+    () => (
+      <>
+        {showStreamingFooterSkeleton && (
+          <div className="pb-4">
+            <ChatSkeletonMessagesOnly count={3} />
+          </div>
+        )}
+        <div
+          ref={messagesEndRef}
+          className={getMessageListFooterSpacerClass(isMobileViewport)}
+        />
+      </>
+    ),
+    [showStreamingFooterSkeleton, isMobileViewport, messagesEndRef],
+  );
+
   const virtuosoComponents = useMemo(
     () => ({
-      Scroller: (
-        scrollerProps: React.HTMLAttributes<HTMLDivElement> & {
-          children?: React.ReactNode;
-          ref?: React.Ref<HTMLDivElement>;
-        },
-      ) => {
-        const { children, ref: vRef, ...props } = scrollerProps;
-        return (
-          <div
-            {...props}
-            className={`chat-message-scroller ${props.className ?? ""}`}
-            ref={(el: HTMLDivElement | null) => {
-              handleVirtuosoScrollerElementChange(el);
-              if (typeof vRef === "function") vRef(el);
-              else if (vRef)
-                (
-                  vRef as React.MutableRefObject<HTMLDivElement | null>
-                ).current = el;
-            }}
-          >
-            {children}
-          </div>
-        );
-      },
-      Footer: () => (
-        <>
-          {showStreamingFooterSkeleton && (
-            <div className="pb-4">
-              <ChatSkeletonMessagesOnly count={3} />
-            </div>
-          )}
-          <div
-            ref={messagesEndRef}
-            className={getMessageListFooterSpacerClass(isMobileViewport)}
-          />
-        </>
-      ),
+      Scroller: virtuosoScrollerComponent,
+      Footer: virtuosoFooterComponent,
     }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [showStreamingFooterSkeleton],
+    [virtuosoScrollerComponent, virtuosoFooterComponent],
   );
 
   // Pending steer items belong to the composer queue, not the conversation

--- a/frontend/src/components/layout/AppContent/__tests__/ChatViewScrollerIdentitySource.test.ts
+++ b/frontend/src/components/layout/AppContent/__tests__/ChatViewScrollerIdentitySource.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const chatViewSource = readFileSync(
+  resolve(
+    process.cwd(),
+    "src",
+    "components",
+    "layout",
+    "AppContent",
+    "ChatView.tsx",
+  ),
+  "utf8",
+);
+
+test("chat scroller component identity never depends on the skeleton flag", () => {
+  // components.Scroller identity changes make react-virtuoso remount the
+  // scroller subtree and reset scroll to the first message. The completion
+  // commit (streaming stops + "disconnected" while isLoading is still true)
+  // toggles showStreamingFooterSkeleton, so that flag must stay out of the
+  // Scroller's dependency array; only the Footer may follow it.
+  const scrollerStart = chatViewSource.indexOf(
+    "const virtuosoScrollerComponent = useCallback(",
+  );
+  const scrollerEnd = chatViewSource.indexOf(
+    "\n  );",
+    scrollerStart,
+  );
+
+  expect(scrollerStart).toBeGreaterThan(-1);
+  expect(scrollerEnd).toBeGreaterThan(scrollerStart);
+
+  const scrollerBlock = chatViewSource.slice(scrollerStart, scrollerEnd);
+  expect(scrollerBlock).not.toMatch(/showStreamingFooterSkeleton/);
+  expect(scrollerBlock).toMatch(
+    /\[handleVirtuosoScrollerElementChange\],?\s*$/,
+  );
+
+  const componentsStart = chatViewSource.indexOf(
+    "const virtuosoComponents = useMemo(",
+  );
+  const componentsEnd = chatViewSource.indexOf(
+    "\n  );",
+    componentsStart,
+  );
+  const componentsBlock = chatViewSource.slice(componentsStart, componentsEnd);
+  expect(componentsStart).toBeGreaterThan(-1);
+  expect(componentsBlock).toMatch(/Scroller: virtuosoScrollerComponent/);
+  expect(componentsBlock).toMatch(/Footer: virtuosoFooterComponent/);
+});

--- a/frontend/src/components/layout/AppContent/__tests__/runCompletionScrollerStability.test.tsx
+++ b/frontend/src/components/layout/AppContent/__tests__/runCompletionScrollerStability.test.tsx
@@ -1,0 +1,213 @@
+/** @vitest-environment jsdom */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { act, render } from "@testing-library/react";
+import { Virtuoso } from "react-virtuoso";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { useMessageScroll } from "../useMessageScroll.hook";
+import type { UseMessageScrollReturn } from "../useMessageScroll.hook";
+import {
+  isSessionRunning,
+  shouldShowStreamingFooterSkeleton,
+} from "../sessionState";
+import type { ConnectionStatus } from "../../../../types";
+
+type HarnessMessage = {
+  id: string;
+  role: "assistant" | "user";
+  isStreaming: boolean;
+  parts: [];
+  runId: string | null;
+};
+
+type HarnessProps = {
+  messages: HarnessMessage[];
+  connectionStatus: ConnectionStatus;
+  isLoading: boolean;
+};
+
+let lastScrollApi: UseMessageScrollReturn | null = null;
+
+/**
+ * Mirrors ChatView's Virtuoso wiring. The components handed to Virtuoso are
+ * memoized the same way ChatView does it, so a skeleton toggle changes the
+ * Scroller/Footer component identities exactly like the real chat view.
+ */
+function CapturingHarness({
+  messages,
+  connectionStatus,
+  isLoading,
+}: HarnessProps) {
+  const [messageListSessionKey] = useState("session-run");
+
+  const scroll = useMessageScroll(messages, "session-run", null, null, null, false, false, false, 1, null);
+  lastScrollApi = scroll;
+
+  const sessionRunning = isSessionRunning(messages, isLoading);
+  const hasVisibleStreamingMessage = messages.some(
+    (message) => message.role === "assistant" && message.isStreaming,
+  );
+  const showStreamingFooterSkeleton = shouldShowStreamingFooterSkeleton({
+    connectionStatus,
+    sessionRunning,
+    messageCount: messages.length,
+    hasVisibleStreamingMessage,
+  });
+
+  const handleScrollerElementChange = scroll.handleVirtuosoScrollerElementChange;
+  const footerRef = scroll.messagesEndRef;
+
+  // ChatView keeps the Scroller identity stable (useCallback on the stable
+  // element-change callback only) so skeleton toggles can never remount the
+  // scroller; only the Footer is recreated with the skeleton flag.
+  const virtuosoScrollerComponent = useCallback(
+    (
+      scrollerProps: React.HTMLAttributes<HTMLDivElement> & {
+        children?: React.ReactNode;
+        ref?: React.Ref<HTMLDivElement>;
+      },
+    ) => {
+      const { children, ref: vRef, ...props } = scrollerProps;
+      return (
+        <div
+          {...props}
+          ref={(el: HTMLDivElement | null) => {
+            handleScrollerElementChange(el);
+            if (typeof vRef === "function") vRef(el);
+            else if (vRef)
+              (
+                vRef as React.MutableRefObject<HTMLDivElement | null>
+              ).current = el;
+          }}
+        >
+          {children}
+        </div>
+      );
+    },
+    [handleScrollerElementChange],
+  );
+
+  const virtuosoFooterComponent = useCallback(
+    () => (
+      <>
+        {showStreamingFooterSkeleton && (
+          <div data-testid="footer-skeleton" />
+        )}
+        <div ref={footerRef} />
+      </>
+    ),
+    [footerRef, showStreamingFooterSkeleton],
+  );
+
+  const virtuosoComponents = useMemo(
+    () => ({
+      Scroller: virtuosoScrollerComponent,
+      Footer: virtuosoFooterComponent,
+    }),
+    [virtuosoScrollerComponent, virtuosoFooterComponent],
+  );
+
+  return (
+    <Virtuoso
+      key={messageListSessionKey}
+      ref={scroll.virtuosoRef}
+      data={messages}
+      computeItemKey={(_, message) => message.id}
+      atBottomStateChange={scroll.handleVirtuosoAtBottomChange}
+      components={virtuosoComponents}
+      itemContent={(_, message) => <div>{message.id}</div>}
+    />
+  );
+}
+
+function message(id: string, role: "user" | "assistant", isStreaming = false) {
+  return { id, role, isStreaming, parts: [] as [], runId: null };
+}
+
+describe("run completion keeps the chat scroller mounted", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    lastScrollApi = null;
+  });
+
+  test("scroller element survives the completion commit where isLoading is still true", async () => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    window.scrollTo = () => {};
+
+    const currentProps: HarnessProps = {
+      messages: [
+        message("run-user-1", "user"),
+        message("run-assistant-1", "assistant", true),
+      ],
+      connectionStatus: "connected",
+      isLoading: true,
+    };
+    const listeners: Array<() => void> = [];
+    function emit() {
+      for (const listener of [...listeners]) listener();
+    }
+
+    function Controller() {
+      const [, setTick] = useState(0);
+      useEffect(() => {
+        const bump = () => setTick((t) => t + 1);
+        listeners.push(bump);
+        return () => {
+          const index = listeners.indexOf(bump);
+          if (index !== -1) listeners.splice(index, 1);
+        };
+      }, []);
+      return <CapturingHarness {...currentProps} />;
+    }
+
+    render(<Controller />);
+    const commit = () =>
+      act(() => {
+        emit();
+      });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const scrollerDuringRun = lastScrollApi!.virtuosoScrollerRef.current;
+    expect(scrollerDuringRun).not.toBeNull();
+    expect(scrollerDuringRun!.isConnected).toBe(true);
+
+    // --- Completion commit: the complete/done SSE event sets
+    // isStreaming=false + connectionStatus="disconnected" together, while
+    // isLoading stays true until sendMessage's finally runs (after the SSE
+    // stream closes). This transiently satisfies every
+    // shouldShowStreamingFooterSkeleton condition. ---
+    currentProps.messages = [
+      message("run-user-1", "user"),
+      message("run-assistant-1", "assistant", false),
+    ];
+    currentProps.connectionStatus = "disconnected";
+    commit();
+
+    // The scroller DOM element must NOT be recreated: react-virtuoso remounts
+    // the whole scroller subtree (resetting scroll to the first message) when
+    // components.Scroller changes identity.
+    expect(lastScrollApi!.virtuosoScrollerRef.current).toBe(
+      scrollerDuringRun,
+    );
+    expect(scrollerDuringRun!.isConnected).toBe(true);
+
+    // --- finally commit: isLoading flips false, skeleton hides again. ---
+    currentProps.isLoading = false;
+    commit();
+
+    expect(lastScrollApi!.virtuosoScrollerRef.current).toBe(
+      scrollerDuringRun,
+    );
+    expect(scrollerDuringRun!.isConnected).toBe(true);
+  });
+});

--- a/frontend/src/components/layout/AppContent/__tests__/sessionSwitchStreamFollow.test.tsx
+++ b/frontend/src/components/layout/AppContent/__tests__/sessionSwitchStreamFollow.test.tsx
@@ -85,8 +85,9 @@ function CapturingHarness({
     };
   }, [isLoadingHistory, manualDetachFromStreamRef]);
 
-  // ChatView memoizes components on [showStreamingFooterSkeleton] — constant
-  // while streaming without a lost connection, so identity stays stable here.
+  // ChatView keeps the Scroller component identity stable for the list's
+  // lifetime (only the Footer may be recreated), so identity stays stable here
+  // across skeleton toggles too.
   const virtuosoComponents = useMemo(
     () => ({
       Scroller: (


### PR DESCRIPTION
## 问题

对话运行结束后，视图会跳回到会话最开头的消息，严重影响阅读体验。

## 根因

`complete`/`done` SSE 事件在一个 commit 里同时落下 `isStreaming=false` 和 `connectionStatus="disconnected"`（`eventHandlers.ts`），而 `isLoading` 要等 `sendMessage` 的 `finally`（`fetchEventSource` resolve、即服务端关流之后）才清 false（`useAgent.ts:759`）。这个瞬时 commit 恰好满足 `shouldShowStreamingFooterSkeleton` 的全部条件（断连 + sessionRunning(isLoading) + 有消息 + 无流式消息），而该标志是 ChatView 单个 `components` useMemo 的依赖 → `components.Scroller` 函数身份变化 → react-virtuoso 重挂整个 scroller 子树 → **scrollTop 归零、视图跳到第一条消息**。此时底部锁定循环仍持有已脱离的旧 scroller 元素，永远无法恢复位置。

## 修复

拆分 memo：
- `virtuosoScrollerComponent` 只依赖稳定的 `handleVirtuosoScrollerElementChange`（useCallback），列表生命周期内身份恒定，scroller DOM 永不重挂；
- `virtuosoFooterComponent` 单独随骨架屏标志重建——Footer 重挂在列表末尾，不影响滚动位置。

## 验证（TDD）

1. **RED**：`runCompletionScrollerStability.test.tsx` 镜像 ChatView 旧接线，驱动「运行中 → complete 提交（isLoading 仍 true）→ finally 提交」序列，断言 scroller 元素不被重建 —— 修复前失败（元素被重建），证实根因。
2. **GREEN**：修复后同一序列 scroller 元素保持同一 DOM 节点且始终 connected。
3. `ChatViewScrollerIdentitySource.test.ts` 源码结构测试锁住 Scroller 依赖数组不得包含骨架屏标志，防镜像 harness 与真实代码漂移。
4. 全量：`pnpm test` 375 文件 / 1533 用例通过；`pnpm run lint` 无告警；`pnpm run build` 成功。

已知限制：IAB 内嵌浏览器里 react-virtuoso 不渲染（此前会话已验证），无法在 IAB 做端到端滚动验证，故采用 jsdom + 真实 Virtuoso 的集成测试路线（与 f35cf8dc 相同做法）。