### PR TITLE
style: fix ruff format in responses api switch files

### DIFF
--- a/src/kernel/config/base.py
+++ b/src/kernel/config/base.py
@@ -87,7 +87,9 @@ class Settings(BaseSettings):
     LLM_REQUEST_TIMEOUT: float = 0.0  # 非流式完整响应总超时（秒；<=0 禁用）
     LLM_FIRST_EVENT_TIMEOUT: float = 30.0  # 流式首事件超时（秒；<=0 禁用）
     LLM_FALLBACK_MODEL: str | None = None  # 全局兜底模型（DB 未配置 fallback_model 时使用）
-    LLM_OPENAI_API_FORMAT: str = "chat_completions"  # OpenAI 协议线格式默认值（chat_completions | responses）
+    LLM_OPENAI_API_FORMAT: str = (
+        "chat_completions"  # OpenAI 协议线格式默认值（chat_completions | responses）
+    )
     LLM_MODEL_CACHE_SIZE: int = 50  # 模型实例缓存大小，防止内存泄漏
     DEEPAGENT_SUMMARIZATION_TRIGGER_RATIO: float = 0.70  # 触发摘要的上下文占比（原 0.85）
     DEEPAGENT_SUMMARIZATION_KEEP_RATIO: float = 0.15  # 摘要后保留的上下文占比（原 0.10）

--- a/tests/api/routes/test_model_update_api_format.py
+++ b/tests/api/routes/test_model_update_api_format.py
@@ -34,14 +34,10 @@ def _admin_token() -> TokenPayload:
 async def test_update_model_maps_empty_api_format_to_none(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    model = ModelConfig(
-        id="m1", value="openai/gpt-5.2", label="GPT", api_format="responses"
-    )
+    model = ModelConfig(id="m1", value="openai/gpt-5.2", label="GPT", api_format="responses")
     storage = _FakeModelStorage(model)
     monkeypatch.setattr(model_routes, "get_model_storage", lambda: storage)
-    monkeypatch.setattr(
-        "src.infra.llm.models_service.invalidate_cache", _noop_invalidate
-    )
+    monkeypatch.setattr("src.infra.llm.models_service.invalidate_cache", _noop_invalidate)
 
     await model_routes.update_model("m1", ModelConfigUpdate(api_format=""), _admin_token())
 
@@ -56,13 +52,9 @@ async def test_update_model_keeps_explicit_api_format(
     model = ModelConfig(id="m1", value="openai/gpt-5.2", label="GPT")
     storage = _FakeModelStorage(model)
     monkeypatch.setattr(model_routes, "get_model_storage", lambda: storage)
-    monkeypatch.setattr(
-        "src.infra.llm.models_service.invalidate_cache", _noop_invalidate
-    )
+    monkeypatch.setattr("src.infra.llm.models_service.invalidate_cache", _noop_invalidate)
 
-    await model_routes.update_model(
-        "m1", ModelConfigUpdate(api_format="responses"), _admin_token()
-    )
+    await model_routes.update_model("m1", ModelConfigUpdate(api_format="responses"), _admin_token())
 
     _, update = storage.updates[0]
     assert update["api_format"] == "responses"


### PR DESCRIPTION
PR #240 合入后 CI 的 `ruff format --check src/` 挂在 `LLM_OPENAI_API_FORMAT` 行内注释超长（本地 `make lint` 只跑 `ruff check`，没抓到）。纯格式化，无行为变更。