### PR TITLE
fix: guard trace terminal status against late cancels and persist interruption error events

### DIFF
--- a/src/infra/session/trace_storage_writes.py
+++ b/src/infra/session/trace_storage_writes.py
@@ -13,6 +13,18 @@ _USAGE_LOGS_ENABLED = True  # 是否在 trace 完成时写入 usage_logs 集合
 _ATTACHMENT_CHUNK_WRITE_FIELD = "attachment_chunk_write_operation"
 _TRACE_EVENT_REVISION_FIELD = "event_revision"
 
+# 终态保护：complete_trace 只允许终结未定稿的 trace（running 或缺失 status）。
+# 迟到的取消信号 / 恢复流程不得把已完成或已失败的 trace 改写成另一种终态。
+_TRACE_FINALIZABLE_STATUSES = ["running", None]
+
+
+def _finalizable_trace_filter(trace_id: str) -> Dict[str, Any]:
+    return {
+        "trace_id": trace_id,
+        "status": {"$in": _TRACE_FINALIZABLE_STATUSES},
+        _ATTACHMENT_CHUNK_WRITE_FIELD: {"$exists": False},
+    }
+
 
 class TraceStorageWriteMixin:
     """Write-side behavior composed into the public TraceStorage class."""
@@ -361,10 +373,7 @@ class TraceStorageWriteMixin:
             if ensure_token_usage:
                 await self._ensure_token_usage_event(trace_id)
             result = await self.collection.update_one(
-                {
-                    "trace_id": trace_id,
-                    _ATTACHMENT_CHUNK_WRITE_FIELD: {"$exists": False},
-                },
+                _finalizable_trace_filter(trace_id),
                 update,
             )
             if result.modified_count == 0:
@@ -415,10 +424,7 @@ class TraceStorageWriteMixin:
             marker = (marker_doc or {}).get(_ATTACHMENT_CHUNK_WRITE_FIELD)
             if not isinstance(marker, dict):
                 result = await self.collection.update_one(
-                    {
-                        "trace_id": trace_id,
-                        _ATTACHMENT_CHUNK_WRITE_FIELD: {"$exists": False},
-                    },
+                    _finalizable_trace_filter(trace_id),
                     update,
                 )
                 if result.modified_count > 0:
@@ -437,10 +443,7 @@ class TraceStorageWriteMixin:
                         },
                     )
                     result = await self.collection.update_one(
-                        {
-                            "trace_id": trace_id,
-                            _ATTACHMENT_CHUNK_WRITE_FIELD: {"$exists": False},
-                        },
+                        _finalizable_trace_filter(trace_id),
                         update,
                     )
                     if result.modified_count > 0:

--- a/src/infra/task/manager.py
+++ b/src/infra/task/manager.py
@@ -27,6 +27,7 @@ from .pubsub import TaskPubSub
 from .recovery import TaskRecoveryService
 from .run_ids import generate_run_id
 from .startup_cleanup import TaskStartupCleanupService, _gather_limited
+from .state_machine import TaskStateMachine
 from .status import TaskStatus
 from .status_queries import TaskStatusQueries
 
@@ -70,6 +71,7 @@ class BackgroundTaskManager:
         self._heartbeat = TaskHeartbeat()
         self._cancellation = TaskCancellation(self._lock, self._tasks)
         self._pubsub = TaskPubSub(self._lock, self._tasks)
+        self._state_machine = TaskStateMachine()
         self._executor: Optional[TaskExecutor] = None  # Lazy init in submit
         self._arq_pool: Any | None = None
         self._release_tasks: set[asyncio.Task[None]] = set()
@@ -648,6 +650,17 @@ class BackgroundTaskManager:
             if session and session.metadata:
                 run_id = session.metadata.get("current_run_id")
                 if run_id:
+                    # current_run_id 在 run 结束后仍保留；任务已终态时取消是
+                    # 迟到的停止请求，不得把已完成的 trace 改写成 error，
+                    # 也不得污染会话的 task_error_code 元数据。
+                    task_status = session.metadata.get("task_status")
+                    if self._state_machine.is_terminal(task_status):
+                        return {
+                            "success": False,
+                            "cancelled_locally": False,
+                            "run_id": None,
+                            "message": "没有正在运行的任务",
+                        }
                     run_info = await self._build_run_info_from_session(
                         session,
                         session_id=session_id,

--- a/src/infra/task/recovery.py
+++ b/src/infra/task/recovery.py
@@ -149,8 +149,29 @@ class TaskRecoveryService:
             )
             traces = await cursor.to_list(length=1)
             if traces:
+                trace_id = traces[0]["trace_id"]
+                # 终态只写 metadata 不写事件时，前端渲染不到失败原因；
+                # 与 executor 失败路径一致，先补一条 error 事件再终结 trace。
+                try:
+                    from src.infra.session.dual_writer import get_dual_writer
+
+                    dual_writer = get_dual_writer()
+                    await dual_writer.write_event(
+                        session_id=session.id,
+                        event_type="error",
+                        data={"error": reason, "error_code": "server_restart", "run_id": run_id},
+                        trace_id=trace_id,
+                        run_id=run_id,
+                    )
+                    await dual_writer.flush_mongo_buffer()
+                except Exception as event_error:
+                    logger.warning(
+                        "Failed to persist interruption error event for run %s: %s",
+                        run_id,
+                        event_error,
+                    )
                 await trace_storage.complete_trace(
-                    traces[0]["trace_id"],
+                    trace_id,
                     status="error",
                     metadata={"error": reason, "error_code": "server_restart"},
                 )

--- a/src/infra/task/state_machine.py
+++ b/src/infra/task/state_machine.py
@@ -93,7 +93,7 @@ class TaskStateMachine:
                 f"Invalid task transition: {current_status!s} -> {target_status!s}"
             )
 
-    def is_terminal(self, status: TaskStatus | str) -> bool:
+    def is_terminal(self, status: TaskStatus | str | None) -> bool:
         return self._coerce_status(status) in self._terminal_statuses
 
     def build_metadata(

--- a/tests/infra/session/test_trace_completion_terminal_guard.py
+++ b/tests/infra/session/test_trace_completion_terminal_guard.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+"""Regression tests: complete_trace must not overwrite a terminal trace status.
+
+Production symptom: traces whose run had already emitted done(status=
+"completed") were later flipped to status="error" (with metadata.
+cancel_reason="Task cancelled via pub/sub") when a stale task:cancel
+message arrived for the finished run. The session's current_run_id stays
+set after completion, so a late cancel resolves to the old run and the
+pubsub fallback called complete_trace(status="error") unconditionally,
+downgrading the finalized trace.
+"""
+
+from copy import deepcopy
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from src.infra.session import trace_storage as trace_storage_module
+from src.infra.session import trace_storage_writes as writes_module
+from src.infra.session.trace_storage import TraceStorage
+
+
+class _AsyncCursor:
+    def __init__(self, docs: list[dict[str, Any]]) -> None:
+        self.docs = docs
+
+    def sort(self, key, direction=None):
+        return self
+
+    def limit(self, limit):
+        return self
+
+    def __aiter__(self):
+        self._iter = iter(self.docs)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._iter)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+    async def to_list(self, length=None):
+        return deepcopy(self.docs)
+
+
+_MISSING = object()
+
+
+def _nested(document: dict[str, Any], path: str) -> Any:
+    value: Any = document
+    for part in path.split("."):
+        if not isinstance(value, dict) or part not in value:
+            return _MISSING
+        value = value[part]
+    return value
+
+
+def _matches(document: dict[str, Any], query: dict[str, Any]) -> bool:
+    for key, expected in query.items():
+        value = _nested(document, key)
+        if isinstance(expected, dict):
+            for op, operand in expected.items():
+                if op == "$exists":
+                    if (value is not _MISSING) != bool(operand):
+                        return False
+                elif op == "$in":
+                    # MongoDB 语义：null 匹配缺失字段
+                    if value is _MISSING:
+                        if None not in operand:
+                            return False
+                    elif value not in operand:
+                        return False
+                else:
+                    raise AssertionError(f"unsupported op {op}")
+        elif value != expected:
+            return False
+    return True
+
+
+def _set_nested(document: dict[str, Any], path: str, value: Any) -> None:
+    parts = path.split(".")
+    node = document
+    for part in parts[:-1]:
+        node = node.setdefault(part, {})
+    node[parts[-1]] = value
+
+
+class _FakeCollection:
+    def __init__(self, doc: dict[str, Any] | None = None) -> None:
+        self.doc = doc
+
+    def find(self, query, projection=None):
+        docs = [self.doc] if self.doc and _matches(self.doc, query) else []
+        return _AsyncCursor(docs)
+
+    async def find_one(self, query, projection=None):
+        if self.doc and _matches(self.doc, query):
+            return deepcopy(self.doc)
+        return None
+
+    async def update_one(self, query, update, upsert=False):
+        if not self.doc or not _matches(self.doc, query):
+            return SimpleNamespace(matched_count=0, modified_count=0)
+        _apply_update(self.doc, update)
+        return SimpleNamespace(matched_count=1, modified_count=1)
+
+
+def _apply_update(document: dict[str, Any], update: dict[str, Any]) -> None:
+    for key, value in update.items():
+        if key == "$set":
+            for path, item in value.items():
+                _set_nested(document, path, deepcopy(item))
+        elif key == "$inc":
+            for path, item in value.items():
+                current = _nested(document, path)
+                _set_nested(document, path, (0 if current is _MISSING else current) + item)
+        else:
+            raise AssertionError(f"unsupported update {key}")
+
+
+def _make_storage(monkeypatch, trace_doc):
+    storage = object.__new__(TraceStorage)
+    collection = _FakeCollection(trace_doc)
+    monkeypatch.setattr(
+        trace_storage_module.TraceStorage, "collection", property(lambda self: collection)
+    )
+    monkeypatch.setattr(
+        trace_storage_module.TraceStorage,
+        "chunks_collection",
+        property(lambda self: _FakeCollection(None)),
+    )
+    monkeypatch.setattr(writes_module, "_USAGE_LOGS_ENABLED", False)
+    storage._merger = None
+    storage._indexes_ensured = True
+    return storage, collection
+
+
+@pytest.mark.asyncio
+async def test_complete_trace_does_not_overwrite_completed_with_error(monkeypatch):
+    """A late cancel must not downgrade a completed trace to error."""
+    trace_doc = {"trace_id": "trace-1", "status": "completed"}
+    storage, collection = _make_storage(monkeypatch, trace_doc)
+
+    updated = await storage.complete_trace(
+        "trace-1",
+        status="error",
+        metadata={"cancel_reason": "Task cancelled via pub/sub"},
+        ensure_token_usage=False,
+    )
+
+    assert updated is False
+    assert collection.doc["status"] == "completed"
+    assert "cancel_reason" not in (collection.doc.get("metadata") or {})
+
+
+@pytest.mark.asyncio
+async def test_complete_trace_does_not_overwrite_error_with_completed(monkeypatch):
+    """First finalization wins: error must not be silently upgraded either."""
+    trace_doc = {"trace_id": "trace-1", "status": "error"}
+    storage, collection = _make_storage(monkeypatch, trace_doc)
+
+    updated = await storage.complete_trace("trace-1", status="completed", ensure_token_usage=False)
+
+    assert updated is False
+    assert collection.doc["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_complete_trace_still_finalizes_running_trace(monkeypatch):
+    trace_doc = {"trace_id": "trace-1", "status": "running"}
+    storage, collection = _make_storage(monkeypatch, trace_doc)
+
+    updated = await storage.complete_trace(
+        "trace-1", status="error", metadata={"error": "boom"}, ensure_token_usage=False
+    )
+
+    assert updated is True
+    assert collection.doc["status"] == "error"
+    assert collection.doc["metadata"]["error"] == "boom"
+
+
+@pytest.mark.asyncio
+async def test_complete_trace_finalizes_trace_without_status(monkeypatch):
+    """Legacy docs missing the status field can still be finalized."""
+    trace_doc = {"trace_id": "trace-1"}
+    storage, collection = _make_storage(monkeypatch, trace_doc)
+
+    updated = await storage.complete_trace("trace-1", status="completed", ensure_token_usage=False)
+
+    assert updated is True
+    assert collection.doc["status"] == "completed"

--- a/tests/infra/session/test_trace_storage_token_usage.py
+++ b/tests/infra/session/test_trace_storage_token_usage.py
@@ -321,6 +321,7 @@ async def test_complete_trace_does_not_duplicate_existing_token_usage() -> None:
     assert _usage_event_from_pipeline(usage_update)["event_type"] == "token:usage"
     assert storage.collection.calls[1][0] == {
         "trace_id": "trace-1",
+        "status": {"$in": ["running", None]},
         "attachment_chunk_write_operation": {"$exists": False},
     }
     assert storage.collection.calls[1][1]["$inc"] == {"event_revision": 1}
@@ -336,6 +337,7 @@ async def test_complete_trace_can_skip_zero_token_usage_placeholder() -> None:
     assert len(storage.collection.calls) == 1
     assert storage.collection.calls[0][0] == {
         "trace_id": "trace-1",
+        "status": {"$in": ["running", None]},
         "attachment_chunk_write_operation": {"$exists": False},
     }
     assert storage.collection.calls[0][1]["$inc"] == {"event_revision": 1}

--- a/tests/infra/task/test_manager_cancel_terminal.py
+++ b/tests/infra/task/test_manager_cancel_terminal.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+"""Cancel must be a no-op for sessions whose task already reached a terminal state.
+
+Production symptom: session.metadata.current_run_id stays set after a run
+completes. A late stop request (stale tab, replayed click, second device)
+resolved to the finished run and the cancellation fallback rewrote session
+metadata (task_error_code="cancelled") and published a task:cancel that
+flipped the completed trace to error.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.infra.task.manager import BackgroundTaskManager
+
+
+class _FakeStorage:
+    def __init__(self, session=None) -> None:
+        self.session = session
+        self.updates: list[tuple[str, object]] = []
+
+    async def get_by_session_id(self, session_id: str):
+        if self.session and self.session.id == session_id:
+            return self.session
+        return None
+
+    async def update(self, session_id, session_update) -> None:
+        self.updates.append((session_id, session_update))
+
+
+class _FakeCancellation:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def cancel_run(self, **kwargs):
+        self.calls.append(kwargs)
+        return {
+            "success": True,
+            "cancelled_locally": False,
+            "run_id": kwargs.get("run_id"),
+            "message": "取消信号已发送，任务将在下次检查点中断",
+        }
+
+
+def _manager_with(session) -> tuple[BackgroundTaskManager, _FakeCancellation, _FakeStorage]:
+    storage = _FakeStorage(session)
+    manager = BackgroundTaskManager()
+    manager._storage = storage
+    cancellation = _FakeCancellation()
+    manager._cancellation = cancellation
+    return manager, cancellation, storage
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("task_status", ["completed", "cancelled", "failed", "expired"])
+async def test_cancel_is_noop_when_task_status_terminal(task_status):
+    session = SimpleNamespace(
+        id="session-1",
+        user_id="user-1",
+        agent_id="search",
+        metadata={
+            "current_run_id": "run-old",
+            "task_status": task_status,
+            "agent_id": "search",
+            "trace_id": "trace-1",
+        },
+    )
+    manager, cancellation, storage = _manager_with(session)
+
+    result = await manager.cancel("session-1", user_id="user-1")
+
+    assert result["success"] is False
+    assert result["run_id"] is None
+    assert "没有正在运行的任务" in result["message"]
+    assert cancellation.calls == []
+    assert storage.updates == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("task_status", ["running", "waiting_human", None])
+async def test_cancel_proceeds_when_task_active_or_status_missing(task_status):
+    metadata = {
+        "current_run_id": "run-active",
+        "agent_id": "search",
+        "trace_id": "trace-1",
+    }
+    if task_status is not None:
+        metadata["task_status"] = task_status
+    session = SimpleNamespace(
+        id="session-1", user_id="user-1", agent_id="search", metadata=metadata
+    )
+    manager, cancellation, _storage = _manager_with(session)
+
+    result = await manager.cancel("session-1", user_id="user-1")
+
+    assert result["success"] is True
+    assert len(cancellation.calls) == 1
+    assert cancellation.calls[0]["run_id"] == "run-active"

--- a/tests/infra/task/test_recovery_error_event.py
+++ b/tests/infra/task/test_recovery_error_event.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+"""Server-restart recovery must persist an error event, not only trace metadata.
+
+Production symptom: traces interrupted by an instance restart ended up with
+status="error" and metadata.error="Task interrupted (instance unavailable)"
+but no error event in the event stream — the run history showed a failure
+with no explanation because the UI renders error events, not trace metadata.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.infra.task import recovery as recovery_module
+from src.infra.task.recovery import TaskRecoveryService
+
+
+class _FakeStorage:
+    def __init__(self, session=None) -> None:
+        self.session = session
+        self.updates: list[tuple[str, object]] = []
+
+    async def update(self, session_id, session_update) -> None:
+        self.updates.append((session_id, session_update))
+
+
+class _FakeExecutor:
+    def __init__(self) -> None:
+        self.status_updates: list[tuple] = []
+
+    async def _update_session_status(self, session_id, status, reason=None, run_id=None):
+        self.status_updates.append((session_id, status, reason, run_id))
+
+
+class _FakeTraceStorage:
+    def __init__(self, trace_id: str) -> None:
+        self.trace_id = trace_id
+        self.completions: list[dict] = []
+        self.collection = SimpleNamespace(find=lambda query, projection=None: _FakeCursor(trace_id))
+
+    async def complete_trace(self, trace_id, status="completed", metadata=None, **kwargs):
+        self.completions.append({"trace_id": trace_id, "status": status, "metadata": metadata})
+        return True
+
+
+class _FakeCursor:
+    def __init__(self, trace_id: str) -> None:
+        self._docs = [{"trace_id": trace_id}]
+
+    def sort(self, key, direction=None):
+        return self
+
+    def limit(self, limit):
+        return self
+
+    async def to_list(self, length=None):
+        return list(self._docs)
+
+    async def complete_trace(self, trace_id, status="completed", metadata=None, **kwargs):
+        self.completions.append({"trace_id": trace_id, "status": status, "metadata": metadata})
+        return True
+
+
+class _FakeDualWriter:
+    def __init__(self) -> None:
+        self.events: list[dict] = []
+
+    async def write_event(self, **kwargs):
+        self.events.append(kwargs)
+        return True
+
+    async def flush_mongo_buffer(self) -> None:
+        self.flushed = True
+
+
+def _make_service(storage, executor, trace_storage):
+    return TaskRecoveryService(
+        storage=storage,
+        run_info={},
+        heartbeat=SimpleNamespace(check_exists=lambda run_id: False),
+        ensure_executor=lambda: executor,
+        submit_task=_stub_submit,
+        mark_run_failed=_stub_mark_failed,
+    )
+
+
+async def _stub_submit(*_args, **_kwargs):
+    return ("", "")
+
+
+async def _stub_mark_failed(*_args, **_kwargs):
+    return None
+
+
+@pytest.mark.asyncio
+async def test_mark_run_failed_writes_error_event_before_completing_trace(monkeypatch):
+    session = SimpleNamespace(id="session-1", user_id="user-1", metadata={})
+    storage = _FakeStorage(session)
+    executor = _FakeExecutor()
+    trace_storage = _FakeTraceStorage("trace-1")
+    dual_writer = _FakeDualWriter()
+    monkeypatch.setattr(recovery_module, "get_trace_storage", lambda: trace_storage)
+    monkeypatch.setattr(
+        "src.infra.session.dual_writer.get_dual_writer", lambda: dual_writer
+    )
+    service = _make_service(storage, executor, trace_storage)
+
+    await service.mark_run_failed(
+        "run-1", "Task interrupted (instance unavailable)", session
+    )
+
+    assert len(dual_writer.events) == 1
+    event = dual_writer.events[0]
+    assert event["event_type"] == "error"
+    assert event["trace_id"] == "trace-1"
+    assert event["run_id"] == "run-1"
+    assert event["session_id"] == "session-1"
+    assert "interrupted" in event["data"]["error"]
+
+    # trace completion still runs and keeps its metadata
+    assert trace_storage.completions[0]["status"] == "error"
+    assert trace_storage.completions[0]["metadata"]["error_code"] == "server_restart"


### PR DESCRIPTION
Fixes #242

## 问题

生产巡检（近 14 天，已脱敏）发现两类应用层错误：

1. **已完成 run 被迟到取消翻转成 error（9 例）**：`current_run_id` 在 run 结束后不清除，迟到的停止请求解析到旧 run，pubsub/cancellation fallback 无条件 `complete_trace(status="error")`，把 `completed` 覆盖成 `error`；顺带污染会话 `task_error_code` 元数据。
2. **重启恢复无 error 事件（5 例）**：`mark_run_failed` 只写 trace metadata，事件流里没有 error 事件，前端渲染不到失败原因。

## 修复

- `trace_storage_writes.complete_trace`：更新过滤器加终态保护 `status $in [running, null]`（含 marker-release 重试路径，三处统一走 `_finalizable_trace_filter`），任何调用方都无法改写已定稿的 trace；
- `TaskManager.cancel`：`task_status` 为终态时直接返回「没有正在运行的任务」，不解析过期 `current_run_id`，不再发无意义的取消广播；
- `TaskRecoveryService.mark_run_failed`：complete 之前补写 `error` 事件（含 `error_code="server_restart"`），与 executor 失败路径一致；写入失败仅告警不阻塞。

## 测试

- 新增 `tests/infra/session/test_trace_completion_terminal_guard.py`（终态不被覆盖 / running 与缺失 status 仍可终结）
- 新增 `tests/infra/task/test_manager_cancel_terminal.py`（终态拒绝、活跃/缺失状态放行）
- 新增 `tests/infra/task/test_recovery_error_event.py`（恢复路径先写 error 事件再 complete）
- `tests/infra/session` + `tests/infra/task`：359 passed；全量后端 2891 passed（4 个失败为本机 `.env` 泄漏导致的存量问题，与本 PR 无关，已在干净 worktree 验证 main 同样复现）
- `make lint` / `make typecheck` 全绿
