### PR TITLE
fix: render expanded composer at body level so overlays cannot occlude it

### DIFF
--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -8,13 +8,11 @@ import {
   lazy,
   Suspense,
 } from "react";
+import { createPortal } from "react-dom";
 import toast from "react-hot-toast";
-import { Ban, Maximize2, Minimize2 } from "lucide-react";
+import { Maximize2, Minimize2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import i18n from "../../i18n";
-import { ImageViewer } from "../common";
-import { ConfirmDialog } from "../common/ConfirmDialog";
-import { ContactAdminDialog } from "../common/ContactAdminDialog";
 import { useFileUpload } from "../../hooks/useFileUpload";
 import { useMentionState } from "../../hooks/useMentionState";
 import { useMentionSearch } from "../../hooks/useMentionSearch";
@@ -36,6 +34,7 @@ import { ChatInputDragOverlay } from "./ChatInputDragOverlay";
 import { resolveThinkingPresentation } from "./chatInputThinking";
 import { FILE_CATEGORY_PERMISSIONS } from "./chatInputConstants";
 import { getMentionPopupFixedPlacement } from "./chatInputViewport";
+import { useExpandedComposerHost } from "./chatInputExpandedHost";
 import {
   getMatchingSlashDropdownItems,
   type ChatInputSlashCommand,
@@ -59,6 +58,7 @@ import { getComposerCaretBoundary } from "./chatInputCaret";
 import type { ComposerArrowDirection } from "./richComposer/ArrowKeyPlugin";
 import { selectVisibleDraftAttachments } from "./acceptedDraftCleanup";
 import { ChatInputSteerQueue } from "./ChatInputSteerQueue";
+import { ChatInputDialogLayer } from "./ChatInputDialogLayer";
 import {
   areAttachmentsSendable,
   filterSendableAttachments,
@@ -172,6 +172,9 @@ export const ChatInput = memo(function ChatInput({
   const [stopConfirmOpen, setStopConfirmOpen] = useState(false);
   const [contactAdminOpen, setContactAdminOpen] = useState(false);
   const [composerExpanded, setComposerExpanded] = useState(false);
+  const { host: composerHost, slotRef: composerSlotRef } =
+    useExpandedComposerHost(composerExpanded);
+  const formRef = useRef<HTMLFormElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [cursorPosition, setCursorPosition] = useState(0);
   const [mentionPopupPlacement, setMentionPopupPlacement] =
@@ -553,7 +556,10 @@ export const ChatInput = memo(function ChatInput({
             setStopConfirmOpen(true);
           }
         } else {
-          event.currentTarget.closest("form")?.requestSubmit();
+          // The expanded editor renders outside the form (body-level
+          // portal host), so resolve the form via ref instead of DOM
+          // ancestry.
+          formRef.current?.requestSubmit();
         }
         return;
       }
@@ -672,231 +678,241 @@ export const ChatInput = memo(function ChatInput({
       className="chat-input-shell px-2 sm:px-8 pb-3 sm:pb-5"
       style={{ backgroundColor: "var(--theme-bg)" }}
     >
-      {composerExpanded ? (
-        <div
-          className="fixed inset-0 z-[279] bg-black/45"
-          onClick={() => setComposerExpanded(false)}
-          aria-hidden="true"
-        />
-      ) : null}
+      {composerExpanded
+        ? createPortal(
+            <div
+              className="fixed inset-0 z-[279] bg-black/45"
+              onClick={() => setComposerExpanded(false)}
+              aria-hidden="true"
+            />,
+            document.body,
+          )
+        : null}
       <ChatInputSteerQueue items={steerMessages} onCancel={onCancelSteer} />
       <form
+        ref={formRef}
         onSubmit={handleSubmit}
         className={className ?? "mx-auto max-w-4xl lg:max-w-5xl xl:max-w-6xl"}
       >
-        <div
-          ref={containerRef}
-          onDragOver={handleDragOver}
-          onDragLeave={handleDragLeave}
-          onDrop={handleDrop}
-          className={`chat-input-container flex flex-col relative w-full rounded-3xl px-1 border transition-all duration-300 ${
-            isDraggingOver ? "data-drag-over" : ""
-          }`}
-          data-mention-active={mention.isActive || undefined}
-          data-drag-over={isDraggingOver || undefined}
-          data-composer-expanded={composerExpanded || undefined}
-          style={{
-            backgroundColor: "var(--theme-bg-card)",
-          }}
-        >
-          {isDraggingOver && <ChatInputDragOverlay />}
-          <ActiveGoalBar
-            goal={activeGoal ?? null}
-            label={goalLabel}
-            durationLabel={goalDurationLabel}
-            clearLabel={goalClearLabel}
-            onClear={onClearActiveGoal}
-            disabled={isLoading || !canSend}
-            embedded
-          />
-          {mention.isActive &&
-            !onMentionQueryChange &&
-            mentionMode === "persona" && (
-              <MentionPopup
-                presets={mentionSearch.presets}
-                highlightedIndex={mention.highlightedIndex}
-                selectedPresetId={selectedPersonaPresetId}
-                isLoading={mentionSearch.isLoading}
-                isLoadingMore={mentionSearch.isLoadingMore}
-                hasMore={mentionSearch.hasMore}
-                onSelect={applyMentionSelection}
-                onHover={setMentionHighlight}
-                onClose={dismissMention}
-                onLoadMore={mentionSearch.loadMore}
-                placement={mentionPopupPlacement ?? undefined}
-              />
-            )}
-          {mention.isActive &&
-            !onMentionQueryChange &&
-            mentionMode === "team" && (
-              <TeamMentionPopup
-                teams={teamMentionSearch.teams}
-                highlightedIndex={mention.highlightedIndex}
-                selectedTeamId={selectedTeamId}
-                isLoading={teamMentionSearch.isLoading}
-                onSelect={applyTeamMentionSelection}
-                onHover={setMentionHighlight}
-                onClose={dismissMention}
-                placement={mentionPopupPlacement ?? undefined}
-              />
-            )}
-          <ChatInputAttachments
-            attachments={visibleAttachments}
-            onAttachmentsChange={setAttachments}
-            onCancelUpload={cancelUpload}
-            onImageViewerOpen={(url) => setImageViewerSrc(url)}
-            maxFiles={uploadLimits?.maxFiles}
-            onRestoreLongText={handleRestoreLongTextAttachment}
-            onRemoveReference={(referenceId) => {
-              longTextResourcesRef.current.delete(referenceId);
-              composerRef.current?.removeFileReference(referenceId);
-            }}
-            onRetryUpload={(attachment) => {
-              if (attachment.composerReferenceId) {
-                handleRetryFileReference(attachment.composerReferenceId);
-              }
-            }}
-          />
-          <div className="chat-composer-editor-wrap px-2.5 pt-1">
-            {composerExpanded ? (
-              <div className="flex items-center justify-between border-b px-2 pb-3 pt-1">
-                <div>
-                  <div className="text-sm font-medium text-[var(--theme-text)]">
-                    {t("chat.expandedComposerTitle", "展开编辑")}
-                  </div>
-                  <div className="mt-0.5 text-xs text-[var(--theme-text-secondary)]">
-                    {t(
-                      "chat.expandedComposerHint",
-                      "适合编辑长提示词。Esc 收起，发送快捷键保持不变。",
-                    )}
+        <div ref={composerSlotRef} className="w-full">
+          {composerHost &&
+            createPortal(
+              <div
+                ref={containerRef}
+                onDragOver={handleDragOver}
+                onDragLeave={handleDragLeave}
+                onDrop={handleDrop}
+                className={`chat-input-container flex flex-col relative w-full rounded-3xl px-1 border transition-all duration-300 ${
+                  isDraggingOver ? "data-drag-over" : ""
+                }`}
+                data-mention-active={mention.isActive || undefined}
+                data-drag-over={isDraggingOver || undefined}
+                data-composer-expanded={composerExpanded || undefined}
+                style={{
+                  backgroundColor: "var(--theme-bg-card)",
+                }}
+              >
+                {isDraggingOver && <ChatInputDragOverlay />}
+                <ActiveGoalBar
+                  goal={activeGoal ?? null}
+                  label={goalLabel}
+                  durationLabel={goalDurationLabel}
+                  clearLabel={goalClearLabel}
+                  onClear={onClearActiveGoal}
+                  disabled={isLoading || !canSend}
+                  embedded
+                />
+                {mention.isActive &&
+                  !onMentionQueryChange &&
+                  mentionMode === "persona" && (
+                    <MentionPopup
+                      presets={mentionSearch.presets}
+                      highlightedIndex={mention.highlightedIndex}
+                      selectedPresetId={selectedPersonaPresetId}
+                      isLoading={mentionSearch.isLoading}
+                      isLoadingMore={mentionSearch.isLoadingMore}
+                      hasMore={mentionSearch.hasMore}
+                      onSelect={applyMentionSelection}
+                      onHover={setMentionHighlight}
+                      onClose={dismissMention}
+                      onLoadMore={mentionSearch.loadMore}
+                      placement={mentionPopupPlacement ?? undefined}
+                    />
+                  )}
+                {mention.isActive &&
+                  !onMentionQueryChange &&
+                  mentionMode === "team" && (
+                    <TeamMentionPopup
+                      teams={teamMentionSearch.teams}
+                      highlightedIndex={mention.highlightedIndex}
+                      selectedTeamId={selectedTeamId}
+                      isLoading={teamMentionSearch.isLoading}
+                      onSelect={applyTeamMentionSelection}
+                      onHover={setMentionHighlight}
+                      onClose={dismissMention}
+                      placement={mentionPopupPlacement ?? undefined}
+                    />
+                  )}
+                <ChatInputAttachments
+                  attachments={visibleAttachments}
+                  onAttachmentsChange={setAttachments}
+                  onCancelUpload={cancelUpload}
+                  onImageViewerOpen={(url) => setImageViewerSrc(url)}
+                  maxFiles={uploadLimits?.maxFiles}
+                  onRestoreLongText={handleRestoreLongTextAttachment}
+                  onRemoveReference={(referenceId) => {
+                    longTextResourcesRef.current.delete(referenceId);
+                    composerRef.current?.removeFileReference(referenceId);
+                  }}
+                  onRetryUpload={(attachment) => {
+                    if (attachment.composerReferenceId) {
+                      handleRetryFileReference(attachment.composerReferenceId);
+                    }
+                  }}
+                />
+                <div className="chat-composer-editor-wrap px-2.5 pt-1">
+                  {composerExpanded ? (
+                    <div className="flex items-center justify-between border-b px-2 pb-3 pt-1">
+                      <div>
+                        <div className="text-sm font-medium text-[var(--theme-text)]">
+                          {t("chat.expandedComposerTitle", "展开编辑")}
+                        </div>
+                        <div className="mt-0.5 text-xs text-[var(--theme-text-secondary)]">
+                          {t(
+                            "chat.expandedComposerHint",
+                            "适合编辑长提示词。Esc 收起，发送快捷键保持不变。",
+                          )}
+                        </div>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => setComposerExpanded(false)}
+                        className="inline-flex size-8 items-center justify-center rounded-lg transition hover:bg-[color-mix(in_srgb,var(--theme-text)_8%,transparent)]"
+                        style={{ color: "var(--theme-text-secondary)" }}
+                        title={t("chat.collapseComposer", "收起")}
+                        aria-label={t("chat.collapseComposer", "收起")}
+                      >
+                        <Minimize2 size={16} />
+                      </button>
+                    </div>
+                  ) : null}
+                  <div className="relative min-h-0 flex-1">
+                    <Suspense
+                      fallback={
+                        <div
+                          className="rich-chat-composer__editor"
+                          aria-hidden="true"
+                        />
+                      }
+                    >
+                      <RichChatComposer
+                        ref={composerRef}
+                        ariaLabel={t("chat.messageInput", "Message")}
+                        initialPlainText={input}
+                        placeholder={composerPlaceholder}
+                        availableSkills={availableRunSkills}
+                        onApplySlashCommand={applySlashCommand}
+                        onChange={handleComposerChange}
+                        filePaste={{
+                          validateCount,
+                          onFiles: uploadFiles,
+                          onInvalidImage: () =>
+                            toast.error(
+                              t(
+                                "fileUpload.clipboardImageUnavailable",
+                                "无法读取剪贴板图片，请重新复制或保存后上传",
+                              ),
+                            ),
+                        }}
+                        longTextPaste={{
+                          enabled: !composerExpanded,
+                          validateCount,
+                          onCreate: handleLongTextCreate,
+                        }}
+                        onRetryFileReference={handleRetryFileReference}
+                        onKeyDown={handleComposerKeyDown}
+                        onArrowKey={handleComposerArrowKey}
+                        disabled={disabled || !canSend}
+                      />
+                    </Suspense>
+                    {!composerExpanded && showExpandButton ? (
+                      <button
+                        type="button"
+                        onClick={() => setComposerExpanded(true)}
+                        className="absolute right-1 top-2 inline-flex size-6 items-center justify-center rounded-md opacity-60 transition hover:opacity-100"
+                        style={{ color: "var(--theme-text-secondary)" }}
+                        title={t("chat.expandComposer", "展开编辑")}
+                        aria-label={t("chat.expandComposer", "展开编辑")}
+                        disabled={disabled || !canSend}
+                      >
+                        <Maximize2 size={14} />
+                      </button>
+                    ) : null}
                   </div>
                 </div>
-                <button
-                  type="button"
-                  onClick={() => setComposerExpanded(false)}
-                  className="inline-flex size-8 items-center justify-center rounded-lg transition hover:bg-[color-mix(in_srgb,var(--theme-text)_8%,transparent)]"
-                  style={{ color: "var(--theme-text-secondary)" }}
-                  title={t("chat.collapseComposer", "收起")}
-                  aria-label={t("chat.collapseComposer", "收起")}
-                >
-                  <Minimize2 size={16} />
-                </button>
-              </div>
-            ) : null}
-            <div className="relative min-h-0 flex-1">
-              <Suspense
-                fallback={
-                  <div
-                    className="rich-chat-composer__editor"
-                    aria-hidden="true"
-                  />
-                }
-              >
-                <RichChatComposer
-                  ref={composerRef}
-                  ariaLabel={t("chat.messageInput", "Message")}
-                  initialPlainText={input}
-                  placeholder={composerPlaceholder}
-                  availableSkills={availableRunSkills}
-                  onApplySlashCommand={applySlashCommand}
-                  onChange={handleComposerChange}
-                  filePaste={{
-                    validateCount,
-                    onFiles: uploadFiles,
-                    onInvalidImage: () =>
-                      toast.error(
-                        t(
-                          "fileUpload.clipboardImageUnavailable",
-                          "无法读取剪贴板图片，请重新复制或保存后上传",
-                        ),
-                      ),
-                  }}
-                  longTextPaste={{
-                    enabled: !composerExpanded,
-                    validateCount,
-                    onCreate: handleLongTextCreate,
-                  }}
-                  onRetryFileReference={handleRetryFileReference}
-                  onKeyDown={handleComposerKeyDown}
-                  onArrowKey={handleComposerArrowKey}
-                  disabled={disabled || !canSend}
+      
+                <ChatInputToolbar
+                  activePanel={activePanel}
+                  onActivePanelChange={setActivePanel}
+                  canSend={canSend}
+                  sendBlocked={sendBlocked}
+                  isLoading={isLoading}
+                  hasDraft={!!input.trim() || visibleAttachments.length > 0}
+                  onSteer={
+                    onSteer &&
+                    (() => {
+                      onSteer(input, filterSendableAttachments(visibleAttachments));
+                      clearSteerDraft();
+                    })
+                  }
+                  canSubmit={canSubmit}
+                  hasUploadingAttachment={hasUploadingAttachment}
+                  hasFailedAttachment={hasFailedAttachment}
+                  hasInvalidAttachment={hasInvalidAttachment}
+                  enabledToolsCount={enabledToolsCount}
+                  totalToolsCount={totalToolsCount}
+                  enabledSkillsCount={enabledSkillsCount}
+                  totalSkillsCount={totalSkillsCount}
+                  hasPersonaSelector={!!onUsePersonaPreset}
+                  personaName={selectedPersonaName}
+                  hasAgentSelector={agents.length > 1 && !!onSelectAgent}
+                  agentName={(() => {
+                    const agent = agents.find((a) => a.id === currentAgent);
+                    return agent
+                      ? resolveAgentDisplayName(agent, i18n.language, t)
+                      : undefined;
+                  })()}
+                  agentIcon={agents.find((a) => a.id === currentAgent)?.icon}
+                  hasThinkingOption={
+                    !!(
+                      agentOptions &&
+                      onToggleAgentOption &&
+                      Object.keys(agentOptions).length > 0
+                    )
+                  }
+                  thinkingLabel={thinkingLabel}
+                  thinkingLevel={thinkingLevel}
+                  uploadCategories={uploadCategories}
+                  uploadFiles={uploadFiles}
+                  selectedPersonaName={selectedPersonaName}
+                  personaAvatar={personaAvatar}
+                  onClearPersonaPreset={onClearPersonaPreset}
+                  currentAgent={currentAgent}
+                  selectedTeamId={selectedTeamId}
+                  onSelectTeam={onSelectTeam}
+                  agentOptions={agentOptions}
+                  agentOptionValues={agentOptionValues}
+                  onToggleAgentOption={onToggleAgentOption}
+                  onStopClick={() => setStopConfirmOpen(true)}
+                  onNoPermissionClick={() => setContactAdminOpen(true)}
+                  autoModeEnabled={autoModeEnabled}
+                  goalModeEnabled={goalModeEnabled}
+                  onToggleAutoMode={onToggleAutoMode}
+                  onToggleGoalMode={onToggleGoalMode}
                 />
-              </Suspense>
-              {!composerExpanded && showExpandButton ? (
-                <button
-                  type="button"
-                  onClick={() => setComposerExpanded(true)}
-                  className="absolute right-1 top-2 inline-flex size-6 items-center justify-center rounded-md opacity-60 transition hover:opacity-100"
-                  style={{ color: "var(--theme-text-secondary)" }}
-                  title={t("chat.expandComposer", "展开编辑")}
-                  aria-label={t("chat.expandComposer", "展开编辑")}
-                  disabled={disabled || !canSend}
-                >
-                  <Maximize2 size={14} />
-                </button>
-              ) : null}
-            </div>
-          </div>
-
-          <ChatInputToolbar
-            activePanel={activePanel}
-            onActivePanelChange={setActivePanel}
-            canSend={canSend}
-            sendBlocked={sendBlocked}
-            isLoading={isLoading}
-            hasDraft={!!input.trim() || visibleAttachments.length > 0}
-            onSteer={
-              onSteer &&
-              (() => {
-                onSteer(input, filterSendableAttachments(visibleAttachments));
-                clearSteerDraft();
-              })
-            }
-            canSubmit={canSubmit}
-            hasUploadingAttachment={hasUploadingAttachment}
-            hasFailedAttachment={hasFailedAttachment}
-            hasInvalidAttachment={hasInvalidAttachment}
-            enabledToolsCount={enabledToolsCount}
-            totalToolsCount={totalToolsCount}
-            enabledSkillsCount={enabledSkillsCount}
-            totalSkillsCount={totalSkillsCount}
-            hasPersonaSelector={!!onUsePersonaPreset}
-            personaName={selectedPersonaName}
-            hasAgentSelector={agents.length > 1 && !!onSelectAgent}
-            agentName={(() => {
-              const agent = agents.find((a) => a.id === currentAgent);
-              return agent
-                ? resolveAgentDisplayName(agent, i18n.language, t)
-                : undefined;
-            })()}
-            agentIcon={agents.find((a) => a.id === currentAgent)?.icon}
-            hasThinkingOption={
-              !!(
-                agentOptions &&
-                onToggleAgentOption &&
-                Object.keys(agentOptions).length > 0
-              )
-            }
-            thinkingLabel={thinkingLabel}
-            thinkingLevel={thinkingLevel}
-            uploadCategories={uploadCategories}
-            uploadFiles={uploadFiles}
-            selectedPersonaName={selectedPersonaName}
-            personaAvatar={personaAvatar}
-            onClearPersonaPreset={onClearPersonaPreset}
-            currentAgent={currentAgent}
-            selectedTeamId={selectedTeamId}
-            onSelectTeam={onSelectTeam}
-            agentOptions={agentOptions}
-            agentOptionValues={agentOptionValues}
-            onToggleAgentOption={onToggleAgentOption}
-            onStopClick={() => setStopConfirmOpen(true)}
-            onNoPermissionClick={() => setContactAdminOpen(true)}
-            autoModeEnabled={autoModeEnabled}
-            goalModeEnabled={goalModeEnabled}
-            onToggleAutoMode={onToggleAutoMode}
-            onToggleGoalMode={onToggleGoalMode}
-          />
+              </div>,
+              composerHost,
+            )}
         </div>
       </form>
 
@@ -946,47 +962,17 @@ export const ChatInput = memo(function ChatInput({
 
       {showHelpMenu && <ChatInputHelpMenu className={helpMenuClassName} />}
 
-      {imageViewerSrc && (
-        <ImageViewer
-          src={imageViewerSrc}
-          isOpen={!!imageViewerSrc}
-          onClose={() => setImageViewerSrc(null)}
-        />
-      )}
-
-      <ConfirmDialog
-        isOpen={stopConfirmOpen}
-        title={t("chat.stopConfirmTitle")}
-        message={t("chat.stopConfirmMessage")}
-        confirmText={t("chat.stop")}
-        cancelText={t("common.cancel")}
-        variant="warning"
-        onConfirm={() => {
+      <ChatInputDialogLayer
+        stopConfirmOpen={stopConfirmOpen}
+        onConfirmStop={() => {
           setStopConfirmOpen(false);
           onStop();
-          toast.custom(() => (
-            <div
-              className="flex items-center gap-2 px-4 py-2.5 rounded-xl text-sm font-medium"
-              style={{
-                background:
-                  "color-mix(in srgb, var(--theme-primary) 10%, transparent)",
-                border:
-                  "1px solid color-mix(in srgb, var(--theme-primary) 20%, transparent)",
-                color: "var(--theme-primary)",
-              }}
-            >
-              <Ban size={16} className="shrink-0" />
-              <span>{t("chat.status.cancelled")}</span>
-            </div>
-          ));
         }}
-        onCancel={() => setStopConfirmOpen(false)}
-      />
-
-      <ContactAdminDialog
-        isOpen={contactAdminOpen}
-        onClose={() => setContactAdminOpen(false)}
-        reason="noPermission"
+        onCancelStop={() => setStopConfirmOpen(false)}
+        contactAdminOpen={contactAdminOpen}
+        onCloseContactAdmin={() => setContactAdminOpen(false)}
+        imageViewerSrc={imageViewerSrc}
+        onCloseImageViewer={() => setImageViewerSrc(null)}
       />
     </div>
   );

--- a/frontend/src/components/chat/ChatInputDialogLayer.tsx
+++ b/frontend/src/components/chat/ChatInputDialogLayer.tsx
@@ -1,0 +1,90 @@
+import toast from "react-hot-toast";
+import { Ban } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { createPortal } from "react-dom";
+import { ImageViewer } from "../common";
+import { ConfirmDialog } from "../common/ConfirmDialog";
+import { ContactAdminDialog } from "../common/ContactAdminDialog";
+
+interface ChatInputDialogLayerProps {
+  stopConfirmOpen: boolean;
+  onConfirmStop: () => void;
+  onCancelStop: () => void;
+  contactAdminOpen: boolean;
+  onCloseContactAdmin: () => void;
+  imageViewerSrc: string | null;
+  onCloseImageViewer: () => void;
+}
+
+/**
+ * Chat-input dialogs rendered at body level. The expanded composer paints at
+ * body level (z-280), so these dialogs must portal to document.body as well —
+ * left inside the app shell their z-index is trapped by ancestor stacking
+ * contexts and the composer would cover them.
+ */
+export function ChatInputDialogLayer({
+  stopConfirmOpen,
+  onConfirmStop,
+  onCancelStop,
+  contactAdminOpen,
+  onCloseContactAdmin,
+  imageViewerSrc,
+  onCloseImageViewer,
+}: ChatInputDialogLayerProps) {
+  const { t } = useTranslation();
+  return (
+    <>
+      {imageViewerSrc &&
+        createPortal(
+          <ImageViewer
+            src={imageViewerSrc}
+            isOpen={!!imageViewerSrc}
+            onClose={onCloseImageViewer}
+          />,
+          document.body,
+        )}
+
+      {stopConfirmOpen &&
+        createPortal(
+          <ConfirmDialog
+            isOpen={stopConfirmOpen}
+            title={t("chat.stopConfirmTitle")}
+            message={t("chat.stopConfirmMessage")}
+            confirmText={t("chat.stop")}
+            cancelText={t("common.cancel")}
+            variant="warning"
+            onConfirm={() => {
+              onConfirmStop();
+              toast.custom(() => (
+                <div
+                  className="flex items-center gap-2 px-4 py-2.5 rounded-xl text-sm font-medium"
+                  style={{
+                    background:
+                      "color-mix(in srgb, var(--theme-primary) 10%, transparent)",
+                    border:
+                      "1px solid color-mix(in srgb, var(--theme-primary) 20%, transparent)",
+                    color: "var(--theme-primary)",
+                  }}
+                >
+                  <Ban size={16} className="shrink-0" />
+                  <span>{t("chat.status.cancelled")}</span>
+                </div>
+              ));
+            }}
+            onCancel={onCancelStop}
+          />,
+          document.body,
+        )}
+
+      {contactAdminOpen &&
+        createPortal(
+          <ContactAdminDialog
+            isOpen={contactAdminOpen}
+            onClose={onCloseContactAdmin}
+            reason="noPermission"
+          />,
+          document.body,
+        )}
+    </>
+  );
+}

--- a/frontend/src/components/chat/__tests__/chatInputExpandedComposerLayering.test.tsx
+++ b/frontend/src/components/chat/__tests__/chatInputExpandedComposerLayering.test.tsx
@@ -1,0 +1,136 @@
+/** @vitest-environment jsdom */
+
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, expect, test, vi } from "vitest";
+
+vi.mock("../../../hooks/useAuth", () => ({
+  useAuth: () => ({ hasPermission: () => true }),
+}));
+
+vi.mock("../../../hooks/useFileUpload", () => ({
+  useFileUpload: () => ({
+    uploadFiles: vi.fn(),
+    uploadFile: vi.fn(),
+    uploadLimits: null,
+    validateCount: () => true,
+    cancelUpload: vi.fn(),
+  }),
+}));
+
+vi.mock("../ChatInputToolbar", () => ({
+  ChatInputToolbar: () => null,
+}));
+
+vi.mock("../ChatInputSelectors", () => ({
+  ChatInputSelectors: () => null,
+}));
+
+import { ChatInput } from "../ChatInput";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+const longDraft = "hello expanded composer ".repeat(10);
+
+test("expanded composer renders at body level outside the chat shell", async () => {
+  render(
+    <ChatInput
+      onSend={vi.fn()}
+      onStop={vi.fn()}
+      isLoading={false}
+      pendingInput={longDraft}
+    />,
+  );
+
+  const editor = await screen.findByRole("textbox");
+  const collapsedContainer = editor.closest(".chat-input-container");
+  expect(collapsedContainer).not.toBeNull();
+  // Collapsed: the composer participates in normal form layout.
+  expect(collapsedContainer?.closest("form")).not.toBeNull();
+
+  await act(async () => {
+    fireEvent.click(
+      screen.getByRole("button", { name: /(expand|展开编辑)/i }),
+    );
+  });
+
+  const expandedContainer = document.querySelector(
+    ".chat-input-container[data-composer-expanded]",
+  );
+  expect(expandedContainer).not.toBeNull();
+  // Expanded: must escape the chat shell, where ancestor stacking contexts
+  // (AppShell transform + relative z-0) cap its paint order below body-level
+  // overlays such as the tool console (z-200) portal.
+  expect(expandedContainer?.closest(".chat-input-shell")).toBeNull();
+  expect(expandedContainer?.closest("form")).toBeNull();
+  expect(expandedContainer?.closest("body")).not.toBeNull();
+
+  // The dim backdrop must also live at body level so body-level overlays
+  // cannot float above it while the page is dimmed.
+  const backdrop = document.querySelector(".z-\\[279\\]");
+  expect(backdrop).not.toBeNull();
+  expect(backdrop?.closest(".chat-input-shell")).toBeNull();
+});
+
+test("collapsing restores the composer inside the form without remounting the editor", async () => {
+  render(
+    <ChatInput
+      onSend={vi.fn()}
+      onStop={vi.fn()}
+      isLoading={false}
+      pendingInput={longDraft}
+    />,
+  );
+
+  const editor = await screen.findByRole("textbox");
+  await act(async () => {
+    fireEvent.click(
+      screen.getByRole("button", { name: /(expand|展开编辑)/i }),
+    );
+  });
+  expect(
+    document.querySelector(".chat-input-container[data-composer-expanded]"),
+  ).not.toBeNull();
+
+  await act(async () => {
+    fireEvent.click(
+      screen.getByRole("button", { name: /(collapse|收起)/i }),
+    );
+  });
+
+  const restoredContainer = document.querySelector(".chat-input-container");
+  expect(restoredContainer).not.toBeNull();
+  expect(restoredContainer?.closest("form")).not.toBeNull();
+  // The same editor DOM node survives expand/collapse: reparenting must not
+  // remount the rich composer or the draft (text, file references, undo
+  // history) is lost.
+  expect(editor.isConnected).toBe(true);
+  expect(editor.closest("form")).not.toBeNull();
+  expect(editor).toHaveTextContent(/hello/);
+});
+
+test("Enter still submits from the body-level expanded composer", async () => {
+  const onSend = vi.fn();
+  render(
+    <ChatInput
+      onSend={onSend}
+      onStop={vi.fn()}
+      isLoading={false}
+      pendingInput={longDraft}
+    />,
+  );
+
+  const editor = await screen.findByRole("textbox");
+  await act(async () => {
+    fireEvent.click(
+      screen.getByRole("button", { name: /(expand|展开编辑)/i }),
+    );
+  });
+  editor.focus();
+  await act(async () => {
+    fireEvent.keyDown(editor, { key: "Enter", code: "Enter", ctrlKey: true });
+  });
+
+  expect(onSend).toHaveBeenCalled();
+});

--- a/frontend/src/components/chat/__tests__/teamSelectorPlacement.test.ts
+++ b/frontend/src/components/chat/__tests__/teamSelectorPlacement.test.ts
@@ -70,7 +70,7 @@ test("team selector uses the persona selector interaction surfaces", () => {
   );
   expect(featureMenuSource).toMatch(/onClick=\{\(\) => onOpen\("team"\)\}/);
   expect(teamPickerSource).toMatch(
-    /z-\[250\][\s\S]*sm:max-w-3xl[\s\S]*xl:max-w-6xl/,
+    /z-\[290\][\s\S]*sm:max-w-3xl[\s\S]*xl:max-w-6xl/,
   );
   expect(teamPickerSource).toMatch(/grid auto-grid-cols gap-3/);
   expect(teamPickerSource).toMatch(/pps-card__action/);

--- a/frontend/src/components/chat/chatInputExpandedHost.ts
+++ b/frontend/src/components/chat/chatInputExpandedHost.ts
@@ -1,0 +1,37 @@
+import { useLayoutEffect, useRef, useState } from "react";
+
+/**
+ * Renders the expanded composer at body level without remounting it.
+ *
+ * The expanded composer is `position: fixed; z-index: 280`, a slot between
+ * the body-level tool console (z-200/201) and the dialog band (z-299+).
+ * Inside the app shell those z-indexes are trapped by ancestor stacking
+ * contexts (AppShell `transform` + `relative z-0`), so body-level overlays
+ * paint above the composer no matter how high its z-index is.
+ *
+ * The ChatInput container renders into a stable host through a portal. While
+ * expanded, the host is reparented into `document.body`, restoring the
+ * intended stacking order. Reparenting the host — instead of re-portal-ing
+ * the subtree — keeps the rich composer mounted, preserving the draft (text,
+ * file references, undo history) across expand/collapse.
+ */
+export function useExpandedComposerHost(expanded: boolean) {
+  const [host] = useState<HTMLDivElement | null>(() =>
+    typeof document === "undefined" ? null : document.createElement("div"),
+  );
+  const slotRef = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    if (!host) return;
+    const slot = slotRef.current;
+    if (!host.parentNode && slot) {
+      slot.appendChild(host);
+    }
+    if (!expanded) return;
+    document.body.appendChild(host);
+    return () => {
+      if (slot && slot.isConnected) slot.appendChild(host);
+      else host.remove();
+    };
+  }, [expanded, host]);
+  return { host, slotRef };
+}

--- a/frontend/src/components/persona/PersonaPresetSelector.tsx
+++ b/frontend/src/components/persona/PersonaPresetSelector.tsx
@@ -141,7 +141,7 @@ export function PersonaPresetSelector({
   const selector = createPortal(
     <div
       data-yields-sidebar
-      className="safe-area-viewport-padding fixed inset-0 z-[250] flex items-end justify-center bg-black/30 p-0 sm:items-center sm:p-6"
+      className="safe-area-viewport-padding fixed inset-0 z-[290] flex items-end justify-center bg-black/30 p-0 sm:items-center sm:p-6"
       onClick={() => onOpenChange(false)}
     >
       <div

--- a/frontend/src/components/persona/__tests__/composerOverlayLayeringSource.test.ts
+++ b/frontend/src/components/persona/__tests__/composerOverlayLayeringSource.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "vitest";
+
+// Layering contract for the expanded composer band: body-level pickers that
+// can be opened from the expanded composer (z-280) must sit above it but
+// below the dialog band (z-299+).
+const personaSelectorSource = readFileSync(
+  join(
+    import.meta.dirname,
+    "../PersonaPresetSelector.tsx",
+  ),
+  "utf8",
+);
+
+const teamPickerSource = readFileSync(
+  join(
+    import.meta.dirname,
+    "../../team/TeamPickerModal.tsx",
+  ),
+  "utf8",
+);
+
+test("persona picker overlay sits above the expanded composer band", () => {
+  expect(personaSelectorSource).toContain("z-[290]");
+  expect(personaSelectorSource).not.toContain("z-[250]");
+});
+
+test("team picker overlay sits above the expanded composer band", () => {
+  expect(teamPickerSource).toContain("z-[290]");
+  expect(teamPickerSource).not.toContain("z-[250]");
+});

--- a/frontend/src/components/team/TeamPickerModal.tsx
+++ b/frontend/src/components/team/TeamPickerModal.tsx
@@ -110,7 +110,7 @@ export function TeamPickerModal({
   return createPortal(
     <div
       data-yields-sidebar
-      className="safe-area-viewport-padding fixed inset-0 z-[250] flex items-end justify-center bg-black/30 p-0 sm:items-center sm:p-6"
+      className="safe-area-viewport-padding fixed inset-0 z-[290] flex items-end justify-center bg-black/30 p-0 sm:items-center sm:p-6"
       onClick={onClose}
     >
       <div

--- a/frontend/src/styles/chat.css
+++ b/frontend/src/styles/chat.css
@@ -81,6 +81,12 @@
   }
 }
 
+/* The expanded composer renders at body level (outside the AppShell
+   transform container), so it must track the keyboard inset itself. */
+html[data-mobile-keyboard="true"] .chat-input-container[data-composer-expanded] {
+  bottom: var(--app-keyboard-inset, 0px);
+}
+
 /* Chat input textarea placeholder */
 .chat-input-container textarea::placeholder {
   color: var(--theme-text-secondary);


### PR DESCRIPTION
## Description / 描述

- Render the expanded chat composer in a stable host that is reparented to `document.body`, escaping app-shell stacking contexts.
- Preserve the rich composer instance while expanding and collapsing so drafts, file references, and editor state are not remounted.
- Move chat-input dialogs to a body-level dialog layer and keep persona/team pickers above the expanded composer z-index band.
- Preserve keyboard submission from the body-level composer by submitting through the form ref.
- Add regression coverage for body-level placement, backdrop placement, no-remount collapse behavior, Enter submission, and overlay layering contracts.
- Add mobile keyboard inset handling for the body-level expanded composer.

## Type of Change / 更改类型

- [x] 🐛 Bug fix / Bug 修复
- [ ] ✨ New feature / 新功能
- [ ] 💥 Breaking change / 破坏性更改
- [ ] 📝 Documentation update / 文档更新
- [x] 🔧 Refactoring / 代码重构
- [x] 🎨 Style update / 样式更新
- [ ] ⚡ Performance improvement / 性能优化

## How Has This Been Tested? / 测试情况

- [x] Unit Tests / 单元测试
- [x] Integration Tests / 集成测试
- [ ] Manual Testing / 手动测试

Verification:
- `cd frontend && pnpm test` — 379 test files, 1543 tests passed
- `cd frontend && pnpm run lint`
- `cd frontend && pnpm run build`

## Checklist / 检查清单

- [x] 我的代码遵循项目的代码风格 / My code follows the project's code style
- [x] 我已经进行了自我审查 / I have performed a self-review
- [x] 我已经对必要约束进行了注释 / I have commented non-obvious constraints
- [ ] 我已经更新了相关文档 / Documentation changes are not required for this UI fix
- [x] 我的更改没有产生新的警告 / My changes generate no new warnings
- [x] 我已经添加了测试 / I have added tests
- [x] 新旧测试都通过 / New and existing unit tests pass

## Screenshots (if applicable) / 截图（如适用）

No screenshots attached; the change fixes stacking behavior and is covered by DOM/layering regression tests.

## Related Issues / 相关 Issue

No linked issue.