### PR TITLE
fix: rewrite replayed response ids to prevent KeyError 'model' routing crash

### DIFF
--- a/src/infra/agent/middleware/retry.py
+++ b/src/infra/agent/middleware/retry.py
@@ -241,13 +241,9 @@ class UniqueResponseIdMiddleware(AgentMiddleware):
         response = await handler(request)
 
         state_messages = (request.state or {}).get("messages", [])
-        existing_ids = {
-            message.id for message in state_messages if getattr(message, "id", None)
-        }
+        existing_ids = {message.id for message in state_messages if getattr(message, "id", None)}
         answered_call_ids = {
-            message.tool_call_id
-            for message in state_messages
-            if isinstance(message, ToolMessage)
+            message.tool_call_id for message in state_messages if isinstance(message, ToolMessage)
         }
 
         for message in _extract_messages(response):

--- a/src/infra/agent/middleware/retry.py
+++ b/src/infra/agent/middleware/retry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import uuid
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
@@ -16,7 +17,7 @@ from langchain.agents.middleware.types import (
     ResponseT,
 )
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import AIMessage
+from langchain_core.messages import AIMessage, ToolMessage
 
 from src.infra.agent.middleware.dead_attachment import (
     DeadAttachmentFilterMiddleware,
@@ -220,6 +221,47 @@ class EmptyContentRetryMiddleware(AgentMiddleware):
         return last_response  # type: ignore[return-value]
 
 
+class UniqueResponseIdMiddleware(AgentMiddleware):
+    """Ensure model response ids stay unique within the conversation.
+
+    部分上游中转（如 ChatGPT 反代）会在同一会话的多次补全里返回重复或恒定的
+    响应 id，甚至原样重放同一条 tool_call。deepagents 的 messages 通道
+    （DeltaChannel reducer）按 id 去重——同 id 的新 AIMessage 会原位替换历史
+    消息；重复的 tool_call id 则会被已有 ToolMessage"回答"。两者都会让
+    model→tools 路由误判"所有 tool_calls 已被回答"，走进 destinations 里不存在
+    的 ``"model"``，整个 run 以 ``KeyError: 'model'`` 崩溃（2026-08-25 生产
+    6 例）。这里在响应进入 state 前改写冲突的响应 id 与 tool_call id。
+    """
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[ContextT],
+        handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]],
+    ) -> ModelResponse[ResponseT]:
+        response = await handler(request)
+
+        state_messages = (request.state or {}).get("messages", [])
+        existing_ids = {
+            message.id for message in state_messages if getattr(message, "id", None)
+        }
+        answered_call_ids = {
+            message.tool_call_id
+            for message in state_messages
+            if isinstance(message, ToolMessage)
+        }
+
+        for message in _extract_messages(response):
+            if not isinstance(message, AIMessage):
+                continue
+            if not message.id or message.id in existing_ids:
+                message.id = str(uuid.uuid4())
+            for tool_call in message.tool_calls:
+                if tool_call["id"] in answered_call_ids:
+                    tool_call["id"] = f"call_{uuid.uuid4().hex[:24]}"
+
+        return response
+
+
 def create_retry_middleware(
     fallback_model: str | None = None,
     thinking: dict | None = None,
@@ -227,13 +269,16 @@ def create_retry_middleware(
     """Create the retry middleware stack for deep agents.
 
     Returns [DeadAttachmentFilterMiddleware, HistoricalImageCapMiddleware,
-    ModelFallbackMiddleware?, ModelRetryMiddleware, EmptyContentRetryMiddleware]:
+    ModelFallbackMiddleware?, ModelRetryMiddleware, EmptyContentRetryMiddleware,
+    UniqueResponseIdMiddleware]:
     - Outermost layer: drops image blocks whose uploaded file was deleted
       (dead URLs make upstream token counting fail the whole request)
     - Cap layer: replaces overly numerous historical images with URL placeholders
     - Fallback layer (optional): falls back to an alternate model when primary fails
     - Middle layer: retries on 429/5xx/timeout with exponential backoff
     - Inner layer: retries on empty content responses
+    - Innermost layer: rewrites replayed/empty response ids so add_messages
+      always appends (prevents KeyError 'model' routing crashes)
     """
     stack: list[AgentMiddleware[Any, Any, Any]] = [
         DeadAttachmentFilterMiddleware(),
@@ -257,6 +302,7 @@ def create_retry_middleware(
             EmptyContentRetryMiddleware(
                 max_retries=settings.LLM_MAX_RETRIES, retry_delay=settings.LLM_RETRY_DELAY
             ),
+            UniqueResponseIdMiddleware(),
         ]
     )
     return stack

--- a/tests/infra/agent/middleware/test_unique_response_id.py
+++ b/tests/infra/agent/middleware/test_unique_response_id.py
@@ -1,0 +1,127 @@
+"""重放响应 id 防护测试（2026-08-25 生产 KeyError: 'model' 事故）。
+
+事故链路（已在生产堆栈与本地复现证实）：
+
+1. 上游中转（chat.oaifree.cn 反代）在同一会话的多次补全里返回重复的响应 id；
+2. langgraph 的 ``add_messages`` 按 id 去重——同 id 的新 AIMessage 会**原位替换**
+   历史消息而不是追加；
+3. deepagents 的 model→tools 条件边发现"最后一条 AIMessage 的 tool_calls 已
+   全部有 ToolMessage 回答"，走进"人工注入 tool 消息"分支并返回 ``"model"``；
+4. deepagents 默认图没有 before_model/after_model 中间件也没有 response_format，
+   该条件边的 destinations 不含 ``"model"`` → ``Branch._finish`` 抛
+   ``KeyError: 'model'``，整个 run 失败。
+
+``UniqueResponseIdMiddleware`` 在响应进入 state 前改写冲突/空 id，保证
+add_messages 永远追加，毒状态无从形成。
+"""
+
+from types import SimpleNamespace
+from typing import Any
+
+from deepagents import create_deep_agent
+from langchain.agents.middleware.types import ModelResponse
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.tools import tool
+from langgraph.checkpoint.memory import InMemorySaver
+
+from src.infra.agent.middleware.retry import (
+    UniqueResponseIdMiddleware,
+    create_retry_middleware,
+)
+
+
+class ScriptedModel(GenericFakeChatModel):
+    """按脚本顺序返回消息的假模型（支持 bind_tools）。"""
+
+    def bind_tools(self, tools: Any, **kwargs: Any) -> "ScriptedModel":  # noqa: ARG002
+        return self
+
+
+@tool
+def noop(text: str) -> str:
+    """No-op tool for exercising the tools loop."""
+    return "ok"
+
+
+def _tool_call(call_id: str) -> dict:
+    return {"name": "noop", "args": {"text": "x"}, "id": call_id, "type": "tool_call"}
+
+
+async def test_replayed_response_id_does_not_crash_deepagents_graph() -> None:
+    """上游重放同一条响应（同 id 同 tool_call）时 run 必须照常完成。"""
+    replayed = AIMessage(id="resp-dup", content="", tool_calls=[_tool_call("call-a")])
+    model = ScriptedModel(
+        messages=iter([replayed, replayed, AIMessage(content="done")])
+    )
+    graph = create_deep_agent(
+        model=model,
+        tools=[noop],
+        checkpointer=InMemorySaver(),
+        middleware=create_retry_middleware(),
+    )
+    config = {"configurable": {"thread_id": "t-replay"}}
+
+    result = await graph.ainvoke({"messages": [HumanMessage(content="hi")]}, config)
+
+    messages = result["messages"]
+    contents = [m.content for m in messages if isinstance(m, AIMessage)]
+    assert "done" in contents
+    # 重放的 tool_call 被改写为未回答的新 id → 工具重新执行（两条 ToolMessage）
+    tool_messages = [m for m in messages if type(m).__name__ == "ToolMessage"]
+    assert len(tool_messages) == 2
+    # 所有 AIMessage id 必须唯一
+    ids = [m.id for m in messages if isinstance(m, AIMessage)]
+    assert len(ids) == len(set(ids))
+
+
+async def test_unique_response_id_rewrites_colliding_and_empty_ids() -> None:
+    """与历史冲突或为空的响应 id 改写为新 uuid，正常 id 保持不变。"""
+    middleware = UniqueResponseIdMiddleware()
+    history = [
+        HumanMessage(id="h1", content="hi"),
+        AIMessage(id="resp-dup", content="old"),
+        ToolMessage(id="t1", content="ok", tool_call_id="call-answered"),
+    ]
+    request = SimpleNamespace(state={"messages": history}, messages=history)
+    colliding = AIMessage(id="resp-dup", content="replayed")
+    empty_id = AIMessage(id="", content="empty id")
+    fresh = AIMessage(id="resp-fresh", content="fresh")
+
+    async def handler(_req: Any) -> ModelResponse:
+        return ModelResponse(result=[colliding, empty_id, fresh])
+
+    await middleware.awrap_model_call(request, handler)  # type: ignore[arg-type]
+
+    assert colliding.id not in {"resp-dup", "", None}
+    assert empty_id.id not in {"resp-dup", "", None}
+    assert colliding.id != empty_id.id
+    assert fresh.id == "resp-fresh"
+
+
+async def test_unique_response_id_rewrites_replayed_tool_call_ids() -> None:
+    """已被 ToolMessage 回答过的 tool_call id 改写为新 id，未回答的保持不变。"""
+    middleware = UniqueResponseIdMiddleware()
+    history = [
+        HumanMessage(id="h1", content="hi"),
+        ToolMessage(id="t1", content="ok", tool_call_id="call-answered"),
+    ]
+    request = SimpleNamespace(state={"messages": history}, messages=history)
+    replayed_call = AIMessage(
+        id="resp-new",
+        content="",
+        tool_calls=[
+            {"name": "noop", "args": {}, "id": "call-answered", "type": "tool_call"},
+            {"name": "noop", "args": {}, "id": "call-open", "type": "tool_call"},
+        ],
+    )
+
+    async def handler(_req: Any) -> ModelResponse:
+        return ModelResponse(result=[replayed_call])
+
+    await middleware.awrap_model_call(request, handler)  # type: ignore[arg-type]
+
+    call_ids = [c["id"] for c in replayed_call.tool_calls]
+    assert call_ids[0] not in {"call-answered", "call-open", None}
+    assert call_ids[1] == "call-open"
+    assert len(set(call_ids)) == 2

--- a/tests/infra/agent/test_retry_middleware.py
+++ b/tests/infra/agent/test_retry_middleware.py
@@ -116,6 +116,7 @@ def test_retry_stack_does_not_bound_the_complete_streaming_call(monkeypatch) -> 
         "HistoricalImageCapMiddleware",
         "ModelRetryMiddleware",
         "EmptyContentRetryMiddleware",
+        "UniqueResponseIdMiddleware",
     ]
 
 

--- a/tests/infra/memory/test_compaction_agent.py
+++ b/tests/infra/memory/test_compaction_agent.py
@@ -365,6 +365,7 @@ async def test_maybe_compact_after_write_runs_deepagent_compactor(monkeypatch):
         "HistoricalImageCapMiddleware",
         "ModelRetryMiddleware",
         "EmptyContentRetryMiddleware",
+        "UniqueResponseIdMiddleware",
     ]
     tool_names = {tool.name for tool in created["tools"]}
     assert tool_names == {


### PR DESCRIPTION
## 背景

2026-08-25 生产出现 6 例 search agent run 以 `KeyError: 'model'` 失败（两个用户、模型 gpt-5.6-sol / gpt-5.6-luna，均走 chat.oaifree.cn 反代；trace 事件序均为「模型回答 → token:usage → error」）。

## 根因（已在本地用真实 deepagents 图精确复现）

1. 上游反代在**同一会话的多次补全中重放相同响应**：AIMessage id 相同、tool_call id 相同。
2. deepagents 的 messages 通道是 `DeltaChannel(_messages_delta_reducer)`（非 `add_messages`）：同 id 的新消息**原位替换**历史消息；tool_call id 已被 ToolMessage 回答过的视为已完成。
3. langchain 的 `_make_model_to_tools_edge` 路由发现「最后一条 AIMessage 的 tool_calls 已全部被回答」，走进「人工注入 tool 消息」分支，返回 `"model"`。
4. deepagents 默认图没有 before_model / after_model 中间件、没有 response_format，该条件边的 destinations **不含 `"model"`** → `Branch._finish` 里 `self.ends['model']` → `KeyError: 'model'`，整个 run 失败。

**为何现有换模型重试救不了**：模型调用本身是「成功」的（返回了合法的重放响应），崩溃发生在响应之后的图路由；`ModelFallbackMiddleware` 只在调用抛异常或空内容时介入。这也是为什么 8/25 的 429 风暴全部成功回退、而这类失败一条都没被兜住。

**为何 8/25 才爆发**：langchain 1.3.15 / langgraph 1.2.11 是 8/13 进入 uv.lock（7cadb4c6），但 8/24 晚镜像 `main-20260824-160701` 才首次部署上生产；巡检前 14 天该错误为 0 例。

## 修复

新增 `UniqueResponseIdMiddleware`，挂在 `create_retry_middleware` 栈最内层（search / fast agent 与 rubric grader 全部生效）：

- 响应消息 id 与会话已有 id 冲突、或为空时 → 改写为新 uuid；
- tool_call id 已被 ToolMessage 回答过时 → 改写为新 id（工具会重新执行一次，语义与「模型再次发起同一调用」一致）。

不改变正常（非重放）响应的任何 id。

## 测试

- `tests/infra/agent/middleware/test_unique_response_id.py`：真实 deepagents 图 + 脚本化模型重放同一条响应，完整复现事故链路并验证修复后 run 正常完成；单测覆盖消息 id 与 tool_call id 两种改写。
- `tests/infra/agent/test_retry_middleware.py`：栈结构断言补入新中间件。
- 相关目录 773 例全部通过；`make lint` / `make typecheck` 干净。