### PR TITLE
fix: 重发相同内容用户消息时助手回复错位到旧消息下方

### DIFF
--- a/frontend/src/hooks/useAgent/__tests__/eventHandlers.userMessageTimestamp.test.ts
+++ b/frontend/src/hooks/useAgent/__tests__/eventHandlers.userMessageTimestamp.test.ts
@@ -31,6 +31,66 @@ function createContext(messages: Message[]): {
   };
 }
 
+test("keeps the streaming assistant under the newest user message when resending identical content", () => {
+  const { ctx, getMessages } = createContext([
+    {
+      id: "uuid-a",
+      role: "user",
+      content: "帮我写个 haiku",
+      timestamp: new Date("2026-08-26T10:00:00.000Z"),
+      runId: "run-1",
+    },
+    {
+      id: "run-1",
+      role: "assistant",
+      content: "好的，这是一首诗…",
+      timestamp: new Date("2026-08-26T10:00:05.000Z"),
+      parts: [],
+      isStreaming: false,
+    },
+    {
+      id: "uuid-b",
+      role: "user",
+      content: "帮我写个 haiku",
+      timestamp: new Date("2026-08-26T11:00:00.000Z"),
+    },
+    {
+      id: "run-2",
+      role: "assistant",
+      content: "",
+      timestamp: new Date("2026-08-26T11:00:00.000Z"),
+      parts: [],
+      isStreaming: true,
+      runId: "run-2",
+    },
+  ]);
+
+  handleStreamEvent(
+    {
+      event: "user:message",
+      data: JSON.stringify({
+        content: "帮我写个 haiku",
+        message_id: "run-2:user",
+        run_id: "run-2",
+      }),
+    },
+    "run-2",
+    "redis-event-2",
+    "2026-08-26T11:00:01.000Z",
+    ctx,
+  );
+
+  const messages = getMessages();
+  expect(messages.map((m) => `${m.role}:${m.id}`)).toEqual([
+    "user:uuid-a",
+    "assistant:run-1",
+    "user:uuid-b",
+    "assistant:run-2",
+  ]);
+  expect(messages[0]?.runId).toBe("run-1");
+  expect(messages[2]?.runId).toBe("run-2");
+});
+
 test("replaces the optimistic user message when the backend adds a timestamp prefix", () => {
   const { ctx, getMessages } = createContext([
     {

--- a/frontend/src/hooks/useAgent/eventHandlers.ts
+++ b/frontend/src/hooks/useAgent/eventHandlers.ts
@@ -515,10 +515,18 @@ function handleUserMessage(
             (runId != null && candidate.runId === runId)),
       );
       if (existingUserIndex === -1) {
-        existingUserIndex = prev.findIndex(
-          (candidate) =>
-            candidate.role === "user" && candidate.content === userContent,
-        );
+        // 乐观用户消息总在列表尾部；从头扫描会在重发相同内容时
+        // 误命中上一轮的同内容消息，把流式助手插到旧消息下面。
+        for (let index = prev.length - 1; index >= 0; index -= 1) {
+          const candidate = prev[index];
+          if (
+            candidate?.role === "user" &&
+            candidate.content === userContent
+          ) {
+            existingUserIndex = index;
+            break;
+          }
+        }
       }
 
       const optimisticContent = extractOptimisticContent(userContent);


### PR DESCRIPTION
## 问题

对话完成后重发一条与之前**完全相同**的用户消息时，流式助手回复会渲染到**上一轮**用户消息下面，最新用户消息下方没有助手消息，刷新页面后恢复正常。

## 根因

`handleUserMessage`（`frontend/src/hooks/useAgent/eventHandlers.ts`）用乐观消息（本地 uuid、无 runId）与后端 `user:message` 回显（`message_id`=`{run_id}:user`）做对账：

1. 按 id/runId 匹配失败（乐观消息两者都没有）
2. 走内容回退匹配，但用的是 `findIndex` **从列表头部扫描**
3. 内容重复时命中**最旧的**同内容用户消息（上一轮的）
4. `splice(userIndex + 1, 0, assistant)` 把流式助手插到旧消息正下方

副作用：旧用户消息的 `runId` 还会被覆盖成新 run。

## 修复

内容回退匹配改为**从尾部反向扫描**——乐观消息永远是最新追加的那条。与同函数中 `extractOptimisticContent` 分支已有的反向扫描写法一致。

历史回放路径（`reconstructMessagesFromEvents`）按 message_id/run_id 去重、永远新建消息，不受此修复影响。

## 验证

- [x] TDD：先写复现测试确认 RED（顺序 `user旧→assistant新→assistant旧→user新`），修复后 GREEN
- [x] 前端全量测试 379 文件 / 1544 用例通过
- [x] `pnpm run lint` 通过
- [x] `pnpm run build` 通过