### PR TITLE
perf: fix long project session open freeze (stop-the-bleach fixes)

### DIFF
--- a/docs/superpowers/plans/2026-08-26-long-session-open-performance.md
+++ b/docs/superpowers/plans/2026-08-26-long-session-open-performance.md
@@ -1,0 +1,180 @@
+# 长会话打开卡死止血 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 消除「打开超长项目会话时页面卡死」的三个前端热点：历史重建 O(n²)、项目预览文件无上限并发全量拉取、派生计算全量重扫。
+
+**Architecture:** 三个独立止血修复，不改 API 契约：(A) `reconstructMessagesFromEvents` 内两处二次方扫描改为线性预扫描/计数；(B) `loadProjectRevealFiles` 加并发上限、结果缓存加 LRU 淘汰；(C) 会话图片库与工具面板派生计算按消息/工具 part 引用做 WeakMap 记忆化。结构性优化（事件分页）另开 issue，不在本计划内。
+
+**Tech Stack:** React 19 + TypeScript + Vitest（纯函数测试，无需 DOM）。
+
+**Spec:** 用户反馈：打开很长、且带文件产物的会话时等待极久甚至卡死。诊断结论见会话记录：`useAgent.ts:309-316` 全量拉事件 + `historyLoader.ts` O(n²) + `revealPreviewData.ts:207-226` 无上限 Promise.all 全量拉项目文件（缓存无淘汰）。
+
+## Global Constraints
+
+- 前端测试位于源码同目录 `__tests__/*.test.ts`，纯函数测试不加 jsdom 注释。
+- 每个任务严格红-绿-重构：先写失败测试并运行确认失败。
+- 不改无关代码；不动后端。
+- 验证：`cd frontend && pnpm test` + `pnpm run lint` + `pnpm run build`。
+
+---
+
+### Task A: historyLoader 两处 O(n²) → O(n)
+
+**Files:**
+- Modify: `frontend/src/hooks/useAgent/historyLoader.ts:337-348`（run_id 归一化）与 `:504-520`（循环内 filter）
+- Test: `frontend/src/hooks/useAgent/__tests__/historyLoader.test.ts`（已存在，追加用例）
+
+**Interfaces:**
+- Produces: `export function normalizeEventRunIds(events: HistoryEvent[]): HistoryEvent[]`（historyLoader.ts 导出，供测试直接调用）；`reconstructMessagesFromEvents` 行为不变。
+
+- [ ] **A1 RED：为 normalizeEventRunIds 写失败测试**（新导出函数尚不存在）：
+
+```ts
+test("normalizeEventRunIds backfills missing run_id from nearest neighbors", () => {
+  const events = [
+    { event_id: "1", event_type: "message", timestamp: "2026-01-01T00:00:01Z", run_id: "run-a" },
+    { event_id: "2", event_type: "thinking", timestamp: "2026-01-01T00:00:02Z" },
+    { event_id: "3", event_type: "thinking", timestamp: "2026-01-01T00:00:03Z" },
+    { event_id: "4", event_type: "message", timestamp: "2026-01-01T00:00:04Z", run_id: "run-b" },
+  ] as unknown as HistoryEvent[];
+  const normalized = normalizeEventRunIds(events);
+  expect(normalized[1].run_id).toBe("run-a"); // 前向就近
+  expect(normalized[2].run_id).toBe("run-a"); // 前向优先于后向
+});
+```
+
+- [ ] **A2 RED：run_id 交替排列断言线性复杂度**（大数组 20k 事件在 1s 内完成，防止回归）：
+
+```ts
+test("normalizeEventRunIds stays linear on large inputs", () => {
+  const events = Array.from({ length: 20000 }, (_, i) => ({
+    event_id: `e${i}`,
+    event_type: "thinking",
+    timestamp: new Date(i * 1000).toISOString(),
+  })) as unknown as HistoryEvent[];
+  const start = performance.now();
+  const normalized = normalizeEventRunIds(events);
+  expect(performance.now() - start).toBeLessThan(1000);
+  expect(normalized.every((e) => e.run_id === undefined)).toBe(true);
+});
+```
+
+- [ ] 运行确认失败：`cd frontend && pnpm vitest run src/hooks/useAgent/__tests__/historyLoader.test.ts`
+
+- [ ] **A3 GREEN：实现 normalizeEventRunIds**，替换 `:337-348` 内联逻辑（排序仍在 reconstructMessagesFromEvents 内完成后传入）：
+
+```ts
+export function normalizeEventRunIds(events: HistoryEvent[]): HistoryEvent[] {
+  const prevRunIdByIndex: Array<string | undefined> = new Array(events.length);
+  let lastSeen: string | undefined;
+  for (let i = 0; i < events.length; i++) {
+    prevRunIdByIndex[i] = lastSeen;
+    if (events[i].run_id) lastSeen = events[i].run_id;
+  }
+  const nextRunIdByIndex: Array<string | undefined> = new Array(events.length);
+  let nextSeen: string | undefined;
+  for (let i = events.length - 1; i >= 0; i--) {
+    nextRunIdByIndex[i] = nextSeen;
+    if (events[i].run_id) nextSeen = events[i].run_id;
+  }
+  return events.map((event, index) => {
+    if (event.run_id) return event;
+    const runId = prevRunIdByIndex[index] || nextRunIdByIndex[index];
+    return runId ? { ...event, run_id: runId } : event;
+  });
+}
+```
+
+- [ ] **A4 GREEN：修 `:504-520` 循环内 filter** — 维护 `assistantTurnCountsByRunId: Map<string, number>`，引入局部 `pushMessage` helper 包裹全部 `reconstructedMessages.push` 助手消息点（365/386/426/433/468/470/523 行），assistant+runId 时计数；三元内改为读 Map：
+
+```ts
+const priorAssistantTurns = event.run_id
+  ? assistantTurnCountsByRunId.get(event.run_id) || 0
+  : 0;
+```
+
+- [ ] 运行全部 historyLoader 测试通过（含既有用例防行为回归）。
+- [ ] **Commit**: `perf: make history reconstruction linear (O(n²) → O(n))`
+
+### Task B: 项目预览文件拉取并发上限 + 缓存 LRU 淘汰
+
+**Files:**
+- Modify: `frontend/src/components/chat/ChatMessage/items/revealPreviewData.ts:189-247`（loadProjectRevealFiles）、`:261-314`（缓存）
+- Test: `frontend/src/components/chat/ChatMessage/items/__tests__/revealPreviewData.test.ts`（追加）
+
+**Interfaces:**
+- Produces: `loadProjectRevealFiles(project, options?: { concurrency?: number })`（默认 6）；缓存 LRU 上限 `PROJECT_REVEAL_FILES_CACHE_MAX_ENTRIES = 4`，`loadProjectRevealFilesCached` / `getCachedProjectRevealFiles` / `clearProjectRevealFilesCache` 签名不变。
+
+- [ ] **B1 RED：并发上限测试**（stub 全局 fetch，记录同时在飞的请求数）：
+
+```ts
+test("loadProjectRevealFiles caps concurrent text file fetches", async () => {
+  const files: Record<string, FileManifestEntry> = {};
+  for (let i = 0; i < 20; i++) {
+    files[`/f${i}.txt`] = { url: `/api/upload/file/f${i}`, is_binary: false, size: 1 };
+  }
+  let inFlight = 0;
+  let maxInFlight = 0;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    inFlight++; maxInFlight = Math.max(maxInFlight, inFlight);
+    await new Promise((r) => setTimeout(r, 5));
+    inFlight--;
+    return new Response(`content`, { status: 200 });
+  }) as typeof fetch;
+  try {
+    const result = await loadProjectRevealFiles(makeV2Project(files));
+    expect(Object.keys(result.files)).toHaveLength(20);
+    expect(result.failed).toHaveLength(0);
+    expect(maxInFlight).toBeLessThanOrEqual(6);
+    expect(maxInFlight).toBeGreaterThan(1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+```
+
+- [ ] **B2 RED：LRU 淘汰测试**（加载 5 个项目后最早项被淘汰、最近使用项保留；`getCachedProjectRevealFiles` 命中刷新新鲜度）。
+- [ ] 运行确认失败。
+- [ ] **B3 GREEN**：实现 `mapWithConcurrency` 局部工具 + `loadProjectRevealFiles` 改用之；缓存 Map set 时超限删除最旧 key，get 命中时 delete+set 刷新。
+- [ ] 全部 revealPreviewData 测试通过。
+- [ ] **Commit**: `perf: cap project reveal file fetch concurrency and evict stale file caches`
+
+### Task C: 派生计算 WeakMap 记忆化（图片库 + 工具面板）
+
+**Files:**
+- Modify: `frontend/src/components/chat/ChatMessage/sessionImageGallery.tsx:196-230`、`frontend/src/components/chat/ChatMessage/toolCallPanelStore.ts:99-150`
+- Test: `frontend/src/components/chat/ChatMessage/__tests__/sessionImageGallery.test.ts`（追加）、`__tests__/toolCallPanelStore.test.tsx`（追加）
+
+**Interfaces:**
+- Consumes: Message/ToolPart 为不可变替换对象（未变消息保持引用），WeakMap 以对象引用为键。
+- Produces: `collectSessionImageGalleryItems`、`syncToolCallPanelStore` 签名不变，行为不变，仅重复调用时跳过已计算消息的重解析。
+
+- [ ] **C1 RED：图片库记忆化测试**（用 getter 计数 content 读取次数）：
+
+```ts
+test("collectSessionImageGalleryItems skips reparsing unchanged messages", () => {
+  let reads = 0;
+  const stable = {
+    id: "m1", role: "assistant", runId: "r1",
+    get content() { reads++; return "![a](/img/a.png)"; },
+  } as unknown as Message;
+  collectSessionImageGalleryItems([stable]);
+  const streaming = { id: "m2", role: "assistant", runId: "r1", content: "![b](/img/b.png)" } as Message;
+  collectSessionImageGalleryItems([stable, streaming]);
+  expect(reads).toBe(1); // 第二次调用未重读 stable.content
+});
+```
+
+- [ ] **C2 RED：工具面板 args.partial JSON.parse 记忆化测试**（同理用 getter 计数）。
+- [ ] 运行确认失败。
+- [ ] **C3 GREEN**：两处各加模块级 `WeakMap`，按消息/工具 part 引用缓存计算结果；dedupe 与 store.set 的 shallowEqual 短路逻辑保持不变。
+- [ ] 全部相关测试通过。
+- [ ] **Commit**: `perf: memoize per-message gallery and tool panel derivations by reference`
+
+### Task D: 验证与收尾
+
+- [ ] `cd frontend && pnpm test`（全量）
+- [ ] `cd frontend && pnpm run lint && pnpm run build`（build 需 ~6G 堆，见 memory）
+- [ ] 建分支 `perf/long-session-open-freeze`，提 PR 到 main；结构性优化（事件分页、Worker 解析、outline 记忆化、TimelineRail 虚拟化）列为 PR 描述中的 follow-up。

--- a/frontend/src/components/chat/ChatMessage/__tests__/sessionImageGallery.test.ts
+++ b/frontend/src/components/chat/ChatMessage/__tests__/sessionImageGallery.test.ts
@@ -260,3 +260,32 @@ test("session image count includes reveal_file cards but not the RevealArtifacts
   expect(revealSummarySource).not.toMatch(/SessionImageGalleryProvider/);
   expect(revealSummarySource).not.toMatch(/sessionImageGallery/);
 });
+
+test("collectSessionImageGalleryItems skips reparsing unchanged messages", () => {
+  let stableReads = 0;
+  const stable = {
+    id: "m-stable",
+    role: "assistant",
+    runId: "r1",
+    get content() {
+      stableReads += 1;
+      return "![stable](/img/stable.png)";
+    },
+  } as unknown as Message;
+
+  collectSessionImageGalleryItems([stable]);
+  expect(stableReads).toBe(1);
+
+  // 流式更新只替换最后一条消息，前面的消息对象引用保持不变
+  const streaming = createMessage({
+    id: "m-streaming",
+    role: "assistant",
+    runId: "r1",
+    content: "![streaming](/img/streaming.png)",
+  });
+  const second = collectSessionImageGalleryItems([stable, streaming]);
+
+  expect(stableReads).toBe(1);
+  expect(second.map((item) => item.src)).toContain("/img/stable.png");
+  expect(second.map((item) => item.src)).toContain("/img/streaming.png");
+});

--- a/frontend/src/components/chat/ChatMessage/__tests__/toolCallPanelStore.test.tsx
+++ b/frontend/src/components/chat/ChatMessage/__tests__/toolCallPanelStore.test.tsx
@@ -187,3 +187,36 @@ test("clears cached tool data at the conversation lifecycle boundary", () => {
   expect(notifications).toEqual(["changed"]);
   unsubscribe();
 });
+
+test("syncToolCallPanelStore parses partial args once per unchanged tool part", () => {
+  let partialReads = 0;
+  const argsWithCountingPartial = {
+    get partial() {
+      partialReads += 1;
+      return JSON.stringify({ command: "ls" });
+    },
+  };
+
+  const message = assistantMessage([
+    {
+      type: "tool",
+      id: "tool-memo",
+      name: "shell",
+      args: argsWithCountingPartial as unknown as Record<string, unknown>,
+      result: "ok",
+      success: true,
+    },
+  ]);
+
+  toolPanelModule.syncToolCallPanelStore([message]);
+  const baselineReads = partialReads;
+  expect(baselineReads).toBeGreaterThan(0);
+
+  // 消息数组变化（如流式更新替换最后一条消息）后，未变 tool part 不应重新 JSON.parse
+  const streaming = assistantMessage([]);
+  toolPanelModule.syncToolCallPanelStore([message, streaming]);
+
+  expect(partialReads).toBe(baselineReads);
+
+  toolCallPanelStore.delete("tool-memo");
+});

--- a/frontend/src/components/chat/ChatMessage/items/__tests__/revealPreviewData.test.ts
+++ b/frontend/src/components/chat/ChatMessage/items/__tests__/revealPreviewData.test.ts
@@ -1,7 +1,60 @@
 import {
+  clearProjectRevealFilesCache,
+  getCachedProjectRevealFiles,
+  loadProjectRevealFiles,
+  loadProjectRevealFilesCached,
   parseProjectRevealSummary,
   shouldShowProjectRevealLoadingError,
+  type FileManifestEntry,
+  type ParsedProjectRevealData,
 } from "../revealPreviewData.ts";
+
+function makeTextManifest(count: number): Record<string, FileManifestEntry> {
+  const files: Record<string, FileManifestEntry> = {};
+  for (let index = 0; index < count; index++) {
+    files[`/file-${index}.txt`] = {
+      url: `/api/upload/file/file-${index}`,
+      is_binary: false,
+      size: 7,
+    };
+  }
+  return files;
+}
+
+function makeV2Project(
+  files: Record<string, FileManifestEntry>,
+): ParsedProjectRevealData {
+  return {
+    version: 2,
+    name: "perf-project",
+    mode: "project",
+    template: "vanilla",
+    fileCount: Object.keys(files).length,
+    files,
+  };
+}
+
+function stubFetchTrackingConcurrency(): {
+  maxInFlight: () => number;
+  restore: () => void;
+} {
+  const originalFetch = globalThis.fetch;
+  let inFlight = 0;
+  let maxInFlight = 0;
+  globalThis.fetch = (async () => {
+    inFlight += 1;
+    maxInFlight = Math.max(maxInFlight, inFlight);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    inFlight -= 1;
+    return new Response(`content`, { status: 200 });
+  }) as typeof fetch;
+  return {
+    maxInFlight: () => maxInFlight,
+    restore: () => {
+      globalThis.fetch = originalFetch;
+    },
+  };
+}
 
 test("parses folder mode from reveal_project results", () => {
   const summary = parseProjectRevealSummary({
@@ -71,4 +124,54 @@ test("does not mark pure binary reveal_project folders as failed loads", () => {
   });
 
   expect(showError).toBe(false);
+});
+
+test("loadProjectRevealFiles caps concurrent text file fetches", async () => {
+  const fetchStub = stubFetchTrackingConcurrency();
+  try {
+    const result = await loadProjectRevealFiles(
+      makeV2Project(makeTextManifest(20)) as Extract<
+        ParsedProjectRevealData,
+        { version: 2 }
+      >,
+    );
+
+    expect(Object.keys(result.files)).toHaveLength(20);
+    expect(result.failed).toHaveLength(0);
+    // 旧实现用无上限 Promise.all，20 个文件会同时全部在飞
+    expect(fetchStub.maxInFlight()).toBeLessThanOrEqual(6);
+    expect(fetchStub.maxInFlight()).toBeGreaterThan(1);
+  } finally {
+    fetchStub.restore();
+  }
+});
+
+test("project reveal file cache evicts least recently used entries", async () => {
+  clearProjectRevealFilesCache();
+  const fetchStub = stubFetchTrackingConcurrency();
+  try {
+    const load = (key: string) =>
+      loadProjectRevealFilesCached({
+        previewKey: key,
+        project: makeV2Project(makeTextManifest(1)) as Extract<
+          ParsedProjectRevealData,
+          { version: 2 }
+        >,
+      });
+
+    await load("project-1");
+    await load("project-2");
+    await load("project-3");
+    await load("project-4");
+    // 命中刷新 project-1 的新鲜度
+    expect(getCachedProjectRevealFiles("project-1")).not.toBeNull();
+    await load("project-5");
+
+    expect(getCachedProjectRevealFiles("project-1")).not.toBeNull();
+    expect(getCachedProjectRevealFiles("project-2")).toBeNull();
+    expect(getCachedProjectRevealFiles("project-5")).not.toBeNull();
+  } finally {
+    fetchStub.restore();
+    clearProjectRevealFilesCache();
+  }
 });

--- a/frontend/src/components/chat/ChatMessage/items/revealPreviewData.ts
+++ b/frontend/src/components/chat/ChatMessage/items/revealPreviewData.ts
@@ -201,7 +201,7 @@ async function mapWithConcurrency<T, R>(
   const results = new Array<R>(items.length);
   let nextIndex = 0;
   const runners = Array.from(
-    { length: Math.min(limit, items.length) },
+    { length: Math.min(Math.max(1, limit), items.length) },
     async () => {
       while (nextIndex < items.length) {
         const index = nextIndex;
@@ -330,7 +330,7 @@ export async function loadProjectRevealFilesCached(input: {
   project: Extract<ParsedProjectRevealData, { version: 2 }>;
 }): Promise<LoadedProjectRevealFiles> {
   const { previewKey, project } = input;
-  const cached = loadedProjectRevealFilesCache.get(previewKey);
+  const cached = getCachedProjectRevealFiles(previewKey);
   if (cached) {
     return cached;
   }

--- a/frontend/src/components/chat/ChatMessage/items/revealPreviewData.ts
+++ b/frontend/src/components/chat/ChatMessage/items/revealPreviewData.ts
@@ -186,6 +186,34 @@ export function parseProjectRevealSummary(input: {
   };
 }
 
+// 项目文件全量预取的并发上限：无上限的 Promise.all 会瞬间打满浏览器
+// 连接池并触发大量同时解析，长项目会话打开时直接卡死页面
+const PROJECT_REVEAL_FETCH_CONCURRENCY = 6;
+// 已加载项目文件内容的内存缓存上限：每个项目可能持有数 MB 文本，
+// 反复切换会话若无淘汰会持续累积（历史上从不清空）
+const PROJECT_REVEAL_FILES_CACHE_MAX_ENTRIES = 4;
+
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  worker: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+  const runners = Array.from(
+    { length: Math.min(limit, items.length) },
+    async () => {
+      while (nextIndex < items.length) {
+        const index = nextIndex;
+        nextIndex += 1;
+        results[index] = await worker(items[index]);
+      }
+    },
+  );
+  await Promise.all(runners);
+  return results;
+}
+
 export async function loadProjectRevealFiles(
   project: Extract<ParsedProjectRevealData, { version: 2 }>,
 ): Promise<{
@@ -204,8 +232,10 @@ export async function loadProjectRevealFiles(
     }
   }
 
-  const entries = await Promise.all(
-    textEntries.map(async ([path, entry]): Promise<[string, string] | null> => {
+  const entries = await mapWithConcurrency(
+    textEntries,
+    PROJECT_REVEAL_FETCH_CONCURRENCY,
+    async ([path, entry]): Promise<[string, string] | null> => {
       try {
         const fullUrl = getFullUrl(entry.url) || entry.url;
         const readUrl = buildUploadProxyUrl(entry.url) || fullUrl;
@@ -222,7 +252,7 @@ export async function loadProjectRevealFiles(
         console.warn(`[reveal_project] Error fetching ${path}:`, error);
         return null;
       }
-    }),
+    },
   );
 
   const rawFiles: Record<string, string> = {};
@@ -275,7 +305,24 @@ export function getCachedProjectRevealFiles(
   previewKey: string | null | undefined,
 ): LoadedProjectRevealFiles | null {
   if (!previewKey) return null;
-  return loadedProjectRevealFilesCache.get(previewKey) || null;
+  const cached = loadedProjectRevealFilesCache.get(previewKey);
+  if (!cached) return null;
+  // Map 按插入序维护 LRU：命中后重新插入刷新新鲜度
+  loadedProjectRevealFilesCache.delete(previewKey);
+  loadedProjectRevealFilesCache.set(previewKey, cached);
+  return cached;
+}
+
+function rememberProjectRevealFiles(
+  previewKey: string,
+  result: LoadedProjectRevealFiles,
+): void {
+  loadedProjectRevealFilesCache.set(previewKey, result);
+  while (loadedProjectRevealFilesCache.size > PROJECT_REVEAL_FILES_CACHE_MAX_ENTRIES) {
+    const oldestKey = loadedProjectRevealFilesCache.keys().next().value;
+    if (oldestKey === undefined) break;
+    loadedProjectRevealFilesCache.delete(oldestKey);
+  }
 }
 
 export async function loadProjectRevealFilesCached(input: {
@@ -295,7 +342,7 @@ export async function loadProjectRevealFilesCached(input: {
 
   const request = loadProjectRevealFiles(project)
     .then((result) => {
-      loadedProjectRevealFilesCache.set(previewKey, result);
+      rememberProjectRevealFiles(previewKey, result);
       inflightProjectRevealFilesCache.delete(previewKey);
       return result;
     })

--- a/frontend/src/components/chat/ChatMessage/sessionImageGallery.tsx
+++ b/frontend/src/components/chat/ChatMessage/sessionImageGallery.tsx
@@ -192,38 +192,56 @@ function dedupeSessionImageGalleryItems(
   });
 }
 
+function collectMessageGalleryItems(
+  message: Message,
+): SessionImageGalleryItem[] {
+  const attachmentItems = (message.attachments || []).flatMap(
+    (attachment): SessionImageGalleryItem[] => {
+      const isImage =
+        attachment.type === "image" ||
+        attachment.mimeType?.startsWith("image/");
+      const src = resolveImageSrc(attachment.url);
+      if (!isImage || !src) return [];
+      return [
+        {
+          id: `${message.id}:attachment:${attachment.id}`,
+          src,
+          alt: attachment.name,
+          group: "conversation",
+        },
+      ];
+    },
+  );
+
+  const contentItems = collectMarkdownImages(
+    message.content,
+    `${message.id}:content`,
+  );
+  const partItems = (message.parts || []).flatMap((part, index) =>
+    collectPartImages(part, `${message.id}:part:${index}`),
+  );
+
+  return [...attachmentItems, ...contentItems, ...partItems];
+}
+
+// 消息对象不可变替换：未变消息保持引用，按引用缓存可跳过对历史消息的
+// markdown 图片正则与工具结果 JSON.parse 重扫（流式期间每次 chunk 都会重算）
+const messageGalleryItemsCache = new WeakMap<
+  Message,
+  SessionImageGalleryItem[]
+>();
+
 // eslint-disable-next-line react-refresh/only-export-components
 export function collectSessionImageGalleryItems(
   messages: Message[],
 ): SessionImageGalleryItem[] {
   const items = messages.flatMap((message) => {
-    const attachmentItems = (message.attachments || []).flatMap(
-      (attachment): SessionImageGalleryItem[] => {
-        const isImage =
-          attachment.type === "image" ||
-          attachment.mimeType?.startsWith("image/");
-        const src = resolveImageSrc(attachment.url);
-        if (!isImage || !src) return [];
-        return [
-          {
-            id: `${message.id}:attachment:${attachment.id}`,
-            src,
-            alt: attachment.name,
-            group: "conversation",
-          },
-        ];
-      },
-    );
-
-    const contentItems = collectMarkdownImages(
-      message.content,
-      `${message.id}:content`,
-    );
-    const partItems = (message.parts || []).flatMap((part, index) =>
-      collectPartImages(part, `${message.id}:part:${index}`),
-    );
-
-    return [...attachmentItems, ...contentItems, ...partItems];
+    let cached = messageGalleryItemsCache.get(message);
+    if (!cached) {
+      cached = collectMessageGalleryItems(message);
+      messageGalleryItemsCache.set(message, cached);
+    }
+    return cached;
   });
 
   return dedupeSessionImageGalleryItems(items);

--- a/frontend/src/components/chat/ChatMessage/toolCallPanelStore.ts
+++ b/frontend/src/components/chat/ChatMessage/toolCallPanelStore.ts
@@ -107,8 +107,15 @@ function normalizeToolArgs(
   }
 }
 
+// tool part 不可变替换：未变 part 保持引用，按引用缓存避免每次
+// messages 变化都重跑 normalizeToolArgs 的 JSON.parse
+const toolPanelDataCache = new WeakMap<ToolPart, ToolCallPanelData>();
+
 function toToolCallPanelData(part: ToolPart): ToolCallPanelData | null {
   if (!part.id) return null;
+  const cached = toolPanelDataCache.get(part);
+  if (cached) return cached;
+
   const colonIndex = part.name.indexOf(":");
   const toolName =
     colonIndex > 0 ? part.name.substring(colonIndex + 1) : part.name;
@@ -117,7 +124,7 @@ function toToolCallPanelData(part: ToolPart): ToolCallPanelData | null {
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
     .join(" ");
 
-  return {
+  const data: ToolCallPanelData = {
     toolCallId: part.id,
     toolName,
     formattedToolName,
@@ -130,6 +137,8 @@ function toToolCallPanelData(part: ToolPart): ToolCallPanelData | null {
     completedAt: part.completedAt,
     status: deriveToolStatus(part),
   };
+  toolPanelDataCache.set(part, data);
+  return data;
 }
 
 function syncToolParts(parts: readonly MessagePart[]): void {

--- a/frontend/src/hooks/useAgent/__tests__/historyLoader.test.ts
+++ b/frontend/src/hooks/useAgent/__tests__/historyLoader.test.ts
@@ -1,4 +1,5 @@
 import {
+  normalizeEventRunIds,
   prepareMessagesForRunningRun,
   reconstructMessagesFromEvents,
 } from "../historyLoader.ts";
@@ -1285,4 +1286,143 @@ test("keeps legacy adjacent steer groups in order when repositioning", () => {
   expect(ids.indexOf("steer-g1")).toBeGreaterThan(firstTurnIndex);
   const replyIndex = ids.indexOf(`${runId}#t1`);
   expect(ids.indexOf("steer-g2")).toBeLessThan(replyIndex);
+});
+
+test("normalizeEventRunIds backfills missing run_id preferring previous neighbor", () => {
+  const events = [
+    {
+      event_type: "message",
+      run_id: "run-a",
+      timestamp: "2026-08-26T00:00:01.000Z",
+      data: { content: "answer" },
+    },
+    {
+      event_type: "recommend:questions",
+      timestamp: "2026-08-26T00:00:02.000Z",
+      data: { questions: ["next?"] },
+    },
+    {
+      event_type: "recommend:questions",
+      timestamp: "2026-08-26T00:00:03.000Z",
+      data: { questions: ["more?"] },
+    },
+    {
+      event_type: "message",
+      run_id: "run-b",
+      timestamp: "2026-08-26T00:00:04.000Z",
+      data: { content: "answer b" },
+    },
+  ] satisfies HistoryEvent[];
+
+  const normalized = normalizeEventRunIds(events);
+
+  expect(normalized[1]?.run_id).toBe("run-a");
+  expect(normalized[2]?.run_id).toBe("run-a");
+  expect(normalized[3]?.run_id).toBe("run-b");
+});
+
+test("normalizeEventRunIds falls back to next neighbor when no previous run exists", () => {
+  const events = [
+    {
+      event_type: "recommend:questions",
+      timestamp: "2026-08-26T00:00:00.000Z",
+      data: { questions: ["hi?"] },
+    },
+    {
+      event_type: "message",
+      run_id: "run-a",
+      timestamp: "2026-08-26T00:00:01.000Z",
+      data: { content: "answer" },
+    },
+  ] satisfies HistoryEvent[];
+
+  const normalized = normalizeEventRunIds(events);
+
+  expect(normalized[0]?.run_id).toBe("run-a");
+});
+
+test("normalizeEventRunIds keeps events without any neighboring run_id untouched", () => {
+  const events = [
+    {
+      event_type: "recommend:questions",
+      timestamp: "2026-08-26T00:00:00.000Z",
+      data: { questions: ["hi?"] },
+    },
+  ] satisfies HistoryEvent[];
+
+  const normalized = normalizeEventRunIds(events);
+
+  expect(normalized[0]?.run_id).toBeUndefined();
+});
+
+test("normalizeEventRunIds stays linear on large runless inputs", () => {
+  const events = Array.from({ length: 20000 }, (_, index) => ({
+    event_type: "recommend:questions",
+    timestamp: new Date(index * 1000).toISOString(),
+    data: { questions: ["next?"] },
+  })) as HistoryEvent[];
+
+  const start = performance.now();
+  const normalized = normalizeEventRunIds(events);
+  const elapsed = performance.now() - start;
+
+  expect(normalized).toHaveLength(20000);
+  // 旧的逐事件 slice+reverse+find 实现在 2 万条无 run_id 事件上远超 1s
+  expect(elapsed).toBeLessThan(1000);
+});
+
+test("multi-turn run ids keep incrementing suffixes per completed assistant turn", () => {
+  const runId = "run-mt";
+  const messages = reconstructMessagesFromEvents(
+    [
+      {
+        event_type: "user:message",
+        run_id: runId,
+        timestamp: "2026-08-26T10:00:00.000Z",
+        data: { content: "q1", message_id: `${runId}:u1` },
+      } satisfies HistoryEvent,
+      {
+        event_type: "message:chunk",
+        run_id: runId,
+        timestamp: "2026-08-26T10:00:01.000Z",
+        data: { content: "a1" },
+      } satisfies HistoryEvent,
+      {
+        event_type: "done",
+        run_id: runId,
+        timestamp: "2026-08-26T10:00:02.000Z",
+        data: { status: "completed" },
+      } satisfies HistoryEvent,
+      {
+        event_type: "steer:message",
+        run_id: runId,
+        timestamp: "2026-08-26T10:00:03.000Z",
+        data: { content: "插话", message_id: "steer-mt1" },
+      } satisfies HistoryEvent,
+      {
+        event_type: "thinking",
+        run_id: runId,
+        timestamp: "2026-08-26T10:00:04.000Z",
+        data: { content: "thinking after steer" },
+      } satisfies HistoryEvent,
+      {
+        event_type: "message:chunk",
+        run_id: runId,
+        timestamp: "2026-08-26T10:00:05.000Z",
+        data: { content: "a2" },
+      } satisfies HistoryEvent,
+      {
+        event_type: "done",
+        run_id: runId,
+        timestamp: "2026-08-26T10:00:06.000Z",
+        data: { status: "completed" },
+      } satisfies HistoryEvent,
+    ],
+    new Set<string>(),
+    { activeSubagentStack: [] },
+  );
+
+  const ids = messages.map((m) => m.id);
+  expect(ids).toContain(runId);
+  expect(ids).toContain(`${runId}#t1`);
 });

--- a/frontend/src/hooks/useAgent/__tests__/historyLoader.test.ts
+++ b/frontend/src/hooks/useAgent/__tests__/historyLoader.test.ts
@@ -1426,3 +1426,38 @@ test("multi-turn run ids keep incrementing suffixes per completed assistant turn
   expect(ids).toContain(runId);
   expect(ids).toContain(`${runId}#t1`);
 });
+
+test("normalizeEventRunIds treats empty-string run_id as missing", () => {
+  const events = [
+    {
+      event_type: "message",
+      run_id: "run-a",
+      timestamp: "2026-08-26T00:00:01.000Z",
+      data: { content: "a" },
+    },
+    {
+      event_type: "thinking",
+      run_id: "",
+      timestamp: "2026-08-26T00:00:02.000Z",
+      data: { content: "legacy empty" },
+    },
+    {
+      event_type: "recommend:questions",
+      timestamp: "2026-08-26T00:00:03.000Z",
+      data: { questions: ["next?"] },
+    },
+    {
+      event_type: "message",
+      run_id: "run-b",
+      timestamp: "2026-08-26T00:00:04.000Z",
+      data: { content: "b" },
+    },
+  ] satisfies HistoryEvent[];
+
+  const normalized = normalizeEventRunIds(events);
+
+  // 空字符串 run_id 视为缺失：自身被回填，也不会作为邻居传播
+  expect(normalized[1]?.run_id).toBe("run-a");
+  expect(normalized[2]?.run_id).toBe("run-a");
+  expect(normalized[3]?.run_id).toBe("run-b");
+});

--- a/frontend/src/hooks/useAgent/historyLoader.ts
+++ b/frontend/src/hooks/useAgent/historyLoader.ts
@@ -317,6 +317,39 @@ function processHistoryEvent(
 }
 
 /**
+ * 为缺失 run_id 的历史事件回填就近 run_id。
+ * 旧记录（如推荐问题）可能缺少 run_id 信封；按时间序取前向最近的
+ * run_id，无前向时回退到后向第一个 run_id，保持与逐事件反向查找一致的语义。
+ */
+export function normalizeEventRunIds(events: HistoryEvent[]): HistoryEvent[] {
+  const prevRunIdByIndex: Array<string | undefined> = new Array(
+    events.length,
+  );
+  let lastSeenRunId: string | undefined;
+  for (let index = 0; index < events.length; index++) {
+    prevRunIdByIndex[index] = lastSeenRunId;
+    const runId = events[index].run_id;
+    if (runId) lastSeenRunId = runId;
+  }
+
+  const nextRunIdByIndex: Array<string | undefined> = new Array(
+    events.length,
+  );
+  let nextSeenRunId: string | undefined;
+  for (let index = events.length - 1; index >= 0; index--) {
+    nextRunIdByIndex[index] = nextSeenRunId;
+    const runId = events[index].run_id;
+    if (runId) nextSeenRunId = runId;
+  }
+
+  return events.map((event, index) => {
+    if (event.run_id) return event;
+    const runId = prevRunIdByIndex[index] || nextRunIdByIndex[index];
+    return runId ? { ...event, run_id: runId } : event;
+  });
+}
+
+/**
  * Reconstruct messages from history events.
  */
 export function reconstructMessagesFromEvents(
@@ -334,22 +367,23 @@ export function reconstructMessagesFromEvents(
   // omit the envelope run_id even though the surrounding trace has one. Keep
   // those events in the same assistant turn instead of creating an orphan
   // message with an undefined run id.
-  const normalizedEvents = sortedEvents.map((event, index) => {
-    if (event.run_id) return event;
-    const previousRunId = [...sortedEvents]
-      .slice(0, index)
-      .reverse()
-      .find((candidate) => candidate.run_id)?.run_id;
-    const nextRunId = sortedEvents
-      .slice(index + 1)
-      .find((candidate) => candidate.run_id)?.run_id;
-    const runId = previousRunId || nextRunId;
-    return runId ? { ...event, run_id: runId } : event;
-  });
+  const normalizedEvents = normalizeEventRunIds(sortedEvents);
 
   const anchoredEvents = anchorLegacySteerMessageEvents(normalizedEvents);
 
   const reconstructedMessages: Message[] = [];
+  // run 内每完成一个 assistant 轮次（入列）计数一次，替代循环内对
+  // reconstructedMessages 的全量 filter（长会话 O(n²) 热点）
+  const assistantTurnCountsByRunId = new Map<string, number>();
+  const pushMessage = (message: Message) => {
+    reconstructedMessages.push(message);
+    if (message.role === "assistant" && message.runId) {
+      assistantTurnCountsByRunId.set(
+        message.runId,
+        (assistantTurnCountsByRunId.get(message.runId) || 0) + 1,
+      );
+    }
+  };
   let currentAssistantMessage: Message | null = null;
   const seenUserMessageIds = new Set<string>();
   const seenUserMessageRunIds = new Set<string>();
@@ -362,7 +396,7 @@ export function reconstructMessagesFromEvents(
     // Handle steer message separately（独立事件，不参与用户消息去重）
     if (eventType === "steer:message") {
       if (currentAssistantMessage) {
-        reconstructedMessages.push(currentAssistantMessage);
+        pushMessage(currentAssistantMessage);
         currentAssistantMessage = null;
       }
       const steerData = eventData as HistoryEventData & {
@@ -383,7 +417,7 @@ export function reconstructMessagesFromEvents(
         continue;
       }
       seenSteerMessageIds.add(steerId);
-      reconstructedMessages.push({
+      pushMessage({
         id: steerId,
         role: "user",
         content: steerData.content || "",
@@ -423,14 +457,14 @@ export function reconstructMessagesFromEvents(
       }
 
       if (currentAssistantMessage) {
-        reconstructedMessages.push(currentAssistantMessage);
+        pushMessage(currentAssistantMessage);
         currentAssistantMessage = null;
       }
       const userAttachments = convertAttachments(eventData.attachments);
       const enabledSkills = Array.isArray(eventData.enabled_skills)
         ? eventData.enabled_skills
         : undefined;
-      reconstructedMessages.push({
+      pushMessage({
         id: userMessageId,
         role: "user",
         content: eventData.content || "",
@@ -465,9 +499,9 @@ export function reconstructMessagesFromEvents(
           cancelled: true,
           parts: [...updatedParts, { type: "cancelled" as const }],
         };
-        reconstructedMessages.push(updatedMessage);
+        pushMessage(updatedMessage);
       } else {
-        reconstructedMessages.push({
+        pushMessage({
           id: uuid(),
           role: "assistant",
           content: "",
@@ -508,10 +542,8 @@ export function reconstructMessagesFromEvents(
       opts,
       !currentAssistantMessage && event.run_id
         ? (() => {
-            const priorAssistantTurns = reconstructedMessages.filter(
-              (message) =>
-                message.role === "assistant" && message.runId === event.run_id,
-            ).length;
+            const priorAssistantTurns =
+              assistantTurnCountsByRunId.get(event.run_id as string) || 0;
             return priorAssistantTurns === 0
               ? event.run_id
               : `${event.run_id}#t${priorAssistantTurns}`;
@@ -521,7 +553,7 @@ export function reconstructMessagesFromEvents(
   }
 
   if (currentAssistantMessage) {
-    reconstructedMessages.push(currentAssistantMessage);
+    pushMessage(currentAssistantMessage);
   }
 
   // Some runs emit lifecycle events (for example `agent:start`) without ever


### PR DESCRIPTION
## 背景

用户反馈：打开历史很长、且带文件产物（项目预览自动弹出）的会话时，等待极久甚至页面卡死。

诊断确认的瓶颈链（均为前端）：

1. **项目预览文件全量预取无并发上限**：历史加载完成后自动打开最近一次项目预览（`useRevealPreview.ts`），`loadProjectRevealFiles` 用无上限 `Promise.all` 同时抓取项目**每一个文本文件全文**，瞬间打满浏览器连接池与主线程；且结果缓存是从不清空的模块级 Map，反复切换项目会话内存持续累积。
2. **历史重建两处 O(n²)**：`reconstructMessagesFromEvents` 中 (a) 每个无 run_id 事件做 `[...events].slice().reverse().find()`；(b) 事件循环内对累积消息数组反复 `filter` 计数。事件数上万时主线程直接冻结。
3. **派生计算全量重扫**：`messages` 引用每次变化（流式期间每个 chunk），会话图片库对全部消息重跑 markdown 图片正则 + 工具结果 `JSON.parse`，工具面板对全部 tool part 重跑 `JSON.parse(partial)`。

## 修复（三项止血，行为不变）

| 修复 | 位置 | 效果 |
|------|------|------|
| run_id 归一化改单遍前/后向扫描 | `historyLoader.ts`（新导出 `normalizeEventRunIds`） | O(n²) → O(n) |
| assistant 轮次计数改 Map 维护 | `historyLoader.ts` | O(n²) → O(n) |
| 项目文件抓取 6 路并发池 + 缓存 LRU（上限 4） | `revealPreviewData.ts` | 消除连接池打满；跨会话内存有界 |
| 图片库 / 工具面板按消息/tool part 引用 WeakMap 记忆化 | `sessionImageGallery.tsx` / `toolCallPanelStore.ts` | 流式期间只重算被替换的消息 |

## 验证

- `pnpm test`：381 文件 / 1568 用例全部通过（含新增 7 个用例；工具面板记忆化用例已验证在旧实现下失败）
- `pnpm run lint` / `pnpm run build`（含 PWA injectInject）：通过
- 后端无改动

## Follow-up（结构性优化，另行开 issue）

- 事件分页 / 轻量「消息视图」端点（剥离工具结果全量文本），打开超长会话先拉最近 N 条
- 巨型 events JSON 移出主线程解析（Web Worker）
- 大纲 / TimelineRail 等其余 O(n) 派生计算同模式记忆化