### PR TITLE
feat: 周期性孤儿任务接管（分布式 P1：执行实例死亡后任务自动恢复）

### DIFF
--- a/src/infra/runtime_services.py
+++ b/src/infra/runtime_services.py
@@ -158,6 +158,12 @@ def start_memory_compaction_agent() -> None:
     start_memory_compaction_agent()
 
 
+def register_orphan_recovery_job() -> None:
+    from src.infra.task.orphan_recovery import register_orphan_recovery_job
+
+    register_orphan_recovery_job()
+
+
 def register_scheduled_task_reconcile_job(
     scheduled_task_service: ScheduledTaskService,
 ) -> None:
@@ -209,6 +215,8 @@ async def start_runtime_services() -> None:
 
     if settings.ENABLE_MEMORY:
         start_memory_compaction_agent()
+
+    register_orphan_recovery_job()
 
     if settings.ENABLE_SCHEDULED_TASK:
         # Load dynamically-created scheduled tasks from DB only when the feature is enabled.

--- a/src/infra/task/manager.py
+++ b/src/infra/task/manager.py
@@ -836,8 +836,8 @@ class BackgroundTaskManager:
         """
         await self._pubsub.stop_listener()
 
-    async def cleanup_stale_tasks(self) -> None:
-        await self._startup_cleanup_service().cleanup_stale_tasks()
+    async def cleanup_stale_tasks(self, *, running_only: bool = False) -> None:
+        await self._startup_cleanup_service().cleanup_stale_tasks(running_only=running_only)
 
     async def _cleanup_stale_queues(self) -> None:
         await TaskStartupCleanupService(

--- a/src/infra/task/orphan_recovery.py
+++ b/src/infra/task/orphan_recovery.py
@@ -1,0 +1,52 @@
+"""Periodic orphan task takeover for multi-replica deployments.
+
+启动清理（startup_cleanup）只在实例启动时执行——执行实例崩溃后，存活副本
+不会重新扫描孤儿任务（分布式部署测试报告 P1）。本模块把 RUNNING 任务的
+接管挂到统一调度器周期执行：租约互斥与心跳判定沿用 startup_cleanup 的既有
+保护；PENDING/QUEUED 重放与 FAILED 恢复仍仅在启动时运行，避免周期扫描
+误重放排队中的任务。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.infra.logging import get_logger
+from src.infra.scheduler.runtime import ScheduledJob, get_runtime_scheduler
+from src.infra.task.manager import get_task_manager
+from src.kernel.config import settings
+
+logger = get_logger(__name__)
+
+DEFAULT_ORPHAN_RECOVERY_INTERVAL_SECONDS = 120
+
+
+def recovery_interval_seconds() -> int:
+    value = getattr(
+        settings, "TASK_ORPHAN_RECOVERY_INTERVAL_SECONDS", DEFAULT_ORPHAN_RECOVERY_INTERVAL_SECONDS
+    )
+    return int(value or 0)
+
+
+async def run_scheduled_orphan_recovery() -> dict[str, Any]:
+    task_manager = get_task_manager()
+    await task_manager.cleanup_stale_tasks(running_only=True)
+    return {"status": "ok"}
+
+
+def register_orphan_recovery_job() -> None:
+    interval = recovery_interval_seconds()
+    if interval <= 0:
+        logger.info("[OrphanRecovery] Periodic takeover disabled by settings")
+        return
+
+    get_runtime_scheduler().register_job(
+        ScheduledJob.from_interval(
+            id="task.orphan_recovery",
+            name="Orphan task takeover",
+            interval_seconds=interval,
+            enabled=True,
+            handler=run_scheduled_orphan_recovery,
+        )
+    )
+    logger.info("[OrphanRecovery] Periodic takeover registered: interval=%ss", interval)

--- a/src/infra/task/startup_cleanup.py
+++ b/src/infra/task/startup_cleanup.py
@@ -370,9 +370,13 @@ class TaskStartupCleanupService:
             run_id,
         )
 
-    async def cleanup_stale_tasks(self) -> None:
+    async def cleanup_stale_tasks(self, *, running_only: bool = False) -> None:
         """
         Recover stale active tasks and explicitly recoverable failed tasks after restart.
+
+        Args:
+            running_only: 仅接管 RUNNING 且心跳过期的任务（周期调用的保守模式，
+                跳过 PENDING/QUEUED 重放与 FAILED 恢复，避免误重放排队中的任务）。
         """
         from .concurrency import get_concurrency_limiter
 
@@ -393,6 +397,9 @@ class TaskStartupCleanupService:
 
             async for running_sessions in _iter_cursor_batches(cursor):
                 cleaned_count += await self._process_running_sessions(running_sessions)
+
+            if running_only:
+                return
 
             # --- PENDING / QUEUED tasks ---
             cursor = self._storage.collection.find(

--- a/src/kernel/config/_definitions_infra.py
+++ b/src/kernel/config/_definitions_infra.py
@@ -137,6 +137,15 @@ INFRA_SETTING_DEFINITIONS: dict[str, dict] = {
         "depends_on": {"key": "TASK_BACKEND", "value": "arq"},
         "frontend_visible": False,
     },
+    "TASK_ORPHAN_RECOVERY_INTERVAL_SECONDS": {
+        "type": SettingType.NUMBER,
+        "category": SettingCategory.REDIS,
+        "subcategory": "task",
+        "description": "settingDesc.TASK_ORPHAN_RECOVERY_INTERVAL_SECONDS",
+        "default": 120,
+        "depends_on": {"key": "TASK_BACKEND", "value": "arq"},
+        "frontend_visible": False,
+    },
     # ============================================
     # LangSmith Tracing Settings
     # ============================================

--- a/src/kernel/config/base.py
+++ b/src/kernel/config/base.py
@@ -144,6 +144,7 @@ class Settings(BaseSettings):
     ARQ_WORKER_MAX_JOBS: int = 128
     ARQ_JOB_TIMEOUT_SECONDS: int = 86400
     TASK_STARTUP_CLEANUP_CONCURRENCY: int = 16
+    TASK_ORPHAN_RECOVERY_INTERVAL_SECONDS: int = 120
 
     # MongoDB Settings
     MONGODB_URL: str = "mongodb://localhost:27017"

--- a/tests/infra/task/test_orphan_recovery.py
+++ b/tests/infra/task/test_orphan_recovery.py
@@ -1,0 +1,150 @@
+"""周期性孤儿任务接管（分布式部署 P1 修复）的测试。
+
+覆盖测试报告 P1 缺口：执行实例死亡后，存活副本无需重启即可通过周期
+调度接管 RUNNING 且心跳过期的任务；PENDING/QUEUED 与 FAILED 恢复保持
+仅在启动清理时执行，避免周期扫描误重放排队中的任务。
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.infra.task import orphan_recovery
+from src.infra.task.startup_cleanup import TaskStartupCleanupService
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.fetched = False
+
+    async def to_list(self, length: int = 100) -> list:
+        self.fetched = True
+        return []
+
+
+class _FakeCollection:
+    def __init__(self) -> None:
+        self.queries: list[dict] = []
+
+    def find(self, query: dict) -> _FakeCursor:
+        self.queries.append(query)
+        return _FakeCursor()
+
+
+class _FakeStorage:
+    def __init__(self) -> None:
+        self.collection = _FakeCollection()
+
+
+class _FakeHeartbeat:
+    async def check_exists(self, run_id: str) -> bool:  # pragma: no cover - not reached
+        return False
+
+
+class _FakeManager:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def cleanup_stale_tasks(self, **kwargs) -> None:
+        self.calls.append(kwargs)
+
+
+@pytest.mark.asyncio
+async def test_scheduled_recovery_runs_running_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    manager = _FakeManager()
+    monkeypatch.setattr(orphan_recovery, "get_task_manager", lambda: manager)
+
+    result = await orphan_recovery.run_scheduled_orphan_recovery()
+
+    assert manager.calls == [{"running_only": True}]
+    assert result["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_running_only_cleanup_scans_running_but_not_pending_or_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _FakeStorage()
+    service = TaskStartupCleanupService(
+        storage=storage,
+        heartbeat=_FakeHeartbeat(),
+        ensure_executor=lambda: None,
+        load_session_record=None,
+        resume_interrupted_run=None,
+        cleanup_stale_queues=None,
+        replay_pending_queued_tasks=None,
+    )
+
+    async def _fake_acquire_lease(redis):
+        return SimpleNamespace(redis=redis, token=None)
+
+    async def _no_renew(lease) -> None:
+        return None
+
+    async def _no_release(lease) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "src.infra.task.startup_cleanup._acquire_startup_cleanup_lease", _fake_acquire_lease
+    )
+    monkeypatch.setattr(
+        "src.infra.task.startup_cleanup._start_startup_cleanup_lease_renewal",
+        lambda lease: None,
+    )
+    monkeypatch.setattr(
+        "src.infra.task.startup_cleanup._release_startup_cleanup_lease", _no_release
+    )
+    monkeypatch.setattr(
+        "src.infra.task.startup_cleanup._renew_startup_cleanup_lease", _no_renew
+    )
+
+    await service.cleanup_stale_tasks(running_only=True)
+
+    assert len(storage.collection.queries) == 1
+    assert storage.collection.queries[0] == {"metadata.task_status": "running"}
+
+
+def test_recovery_interval_reads_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        orphan_recovery.settings, "TASK_ORPHAN_RECOVERY_INTERVAL_SECONDS", 300
+    )
+    assert orphan_recovery.recovery_interval_seconds() == 300
+
+
+def test_register_orphan_recovery_job_respects_disabled_setting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        orphan_recovery.settings, "TASK_ORPHAN_RECOVERY_INTERVAL_SECONDS", 0
+    )
+    registered: list[object] = []
+    fake_scheduler = SimpleNamespace(register_job=registered.append)
+    monkeypatch.setattr(
+        orphan_recovery, "get_runtime_scheduler", lambda: fake_scheduler
+    )
+
+    orphan_recovery.register_orphan_recovery_job()
+
+    assert registered == []
+
+
+def test_register_orphan_recovery_job_registers_interval_job(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        orphan_recovery.settings, "TASK_ORPHAN_RECOVERY_INTERVAL_SECONDS", 120
+    )
+    registered: list[object] = []
+    fake_scheduler = SimpleNamespace(register_job=registered.append)
+    monkeypatch.setattr(
+        orphan_recovery, "get_runtime_scheduler", lambda: fake_scheduler
+    )
+
+    orphan_recovery.register_orphan_recovery_job()
+
+    assert len(registered) == 1
+    job = registered[0]
+    assert job.id == "task.orphan_recovery"
+    assert job.handler is orphan_recovery.run_scheduled_orphan_recovery


### PR DESCRIPTION
## 背景

分布式部署测试（2 副本实测，报告见 `docs/distributed-deployment-test-report.md`）发现 P1 缺陷：**执行实例死亡时，其上运行中的任务中断后不会被存活副本接管**。

根因：`startup_cleanup` 的恢复机制（RUNNING 无心跳 → `_resume_interrupted_run` 重建 run）只在**实例启动时**执行一次。副本 A 崩溃后，存活的副本 B 不会重新扫描，孤儿任务停留至 B 也重启或用户手动重发。

## 修复方案

新增 `task.orphan_recovery` 周期调度，把孤儿接管从「仅启动」扩展为「持续运行」：

- `src/infra/task/orphan_recovery.py`：调度入口 + 注册（默认 120s，`TASK_ORPHAN_RECOVERY_INTERVAL_SECONDS<=0` 可关闭）
- `startup_cleanup.cleanup_stale_tasks` 新增 `running_only` 保守模式：**周期调度仅接管 RUNNING 且心跳过期的任务**；PENDING/QUEUED 重放与 FAILED 恢复保持仅启动执行，避免周期扫描误重放排队中的任务
- 多副本安全沿用既有保护：Redis 租约互斥（600s TTL + Lua 释放）、心跳存在性判定、用户取消/被更新 run 覆盖过滤

## 测试

- `tests/infra/task/test_orphan_recovery.py`（TDD，5 例）：handler 走保守模式、`running_only` 只发 RUNNING 查询、配置开关与调度注册行为
- 回归：`tests/infra/task/` 192 例全过；ruff/mypy 通过（`test_llm_retry_settings` 存量失败与本地 .env 环境相关，非本次引入）

## 关联

- 分布式测试报告 P1 项（`docs/distributed-test-report` 分支）