### PR TITLE
fix: 未配置 temperature 时不再向下游发送该参数

### DIFF
--- a/src/infra/llm/client.py
+++ b/src/infra/llm/client.py
@@ -183,7 +183,7 @@ def _merged_request_headers(
 def _make_cache_key(
     provider: str,
     model_name: str,
-    temperature: float,
+    temperature: Optional[float],
     max_tokens: Optional[int],
     api_key: Optional[str],
     api_base: Optional[str],
@@ -470,7 +470,7 @@ class LLMClient:
         provider: str,
         model_name: str,
         *,
-        temperature: float,
+        temperature: Optional[float] = None,
         max_tokens: Optional[int] = None,
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,
@@ -480,7 +480,11 @@ class LLMClient:
         request_headers: Optional[dict[str, str]] = None,
         **kwargs: Any,
     ) -> BaseChatModel:
-        """根据 provider 创建对应的 LangChain 模型。"""
+        """根据 provider 创建对应的 LangChain 模型。
+
+        temperature=None 表示不发送该参数（三家客户端字段均为 float | None
+        = None，None 不会进入请求 payload），由 provider 默认值接管。
+        """
 
         kwargs.pop("max_retries", None)
         profile = _langchain_profile(profile)
@@ -592,7 +596,7 @@ class LLMClient:
     async def get_model(
         model: Optional[str] = None,
         model_id: Optional[str] = None,
-        temperature: float = 0.7,
+        temperature: Optional[float] = None,
         max_tokens: Optional[int] = None,
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,
@@ -610,8 +614,9 @@ class LLMClient:
             model_id: Model config ID (UUID). When provided, looks up the model
                 config directly by ID, which resolves to a specific channel/provider.
                 This takes priority over the `model` parameter.
-            temperature: Sampling temperature. If use_model_config=True and model config
-                has temperature set, this parameter is ignored.
+            temperature: Sampling temperature. None (default) omits the parameter
+                on the wire so the provider default applies. If use_model_config=True
+                and model config has temperature set, this parameter is ignored.
             max_tokens: Maximum tokens to generate. If use_model_config=True and model config
                 has max_tokens set, this parameter is ignored.
             api_key: API key for the provider. If use_model_config=True and model config

--- a/src/kernel/types.py
+++ b/src/kernel/types.py
@@ -185,7 +185,7 @@ class LLMClientProtocol(Protocol):
     async def complete(
         self,
         messages: List[Dict[str, Any]],
-        temperature: float = 0.7,
+        temperature: Optional[float] = None,
         max_tokens: int = 4096,
     ) -> str:
         """非流式完成"""
@@ -194,7 +194,7 @@ class LLMClientProtocol(Protocol):
     async def stream_complete(
         self,
         messages: List[Dict[str, Any]],
-        temperature: float = 0.7,
+        temperature: Optional[float] = None,
         max_tokens: int = 4096,
     ) -> AsyncGenerator[str, None]:
         """流式完成"""

--- a/tests/infra/llm/test_temperature_default.py
+++ b/tests/infra/llm/test_temperature_default.py
@@ -1,0 +1,115 @@
+"""未配置 temperature 时不应向下游发送该参数。
+
+历史行为：get_model 的 temperature 默认值硬编码 0.7，模型配置未填
+temperature 时 0.7 原样下发到上游 API，覆盖了各 provider 自己的默认值
+（通常为 1.0）。修复后语义：未配置 = 不发送（None），由模型侧默认值接管。
+
+三个 LangChain 客户端（langchain-openai 1.5.0 / langchain-anthropic 1.5.6 /
+langchain-google-genai 4.3.3）的 temperature 字段均为 float | None = None，
+且 None 不会出现在请求 payload 中——本文件用实例属性 + payload 双重锚定
+这一契约。
+"""
+
+import pytest
+from langchain_core.messages import HumanMessage
+
+from src.infra.llm.client import LLMClient, _make_cache_key
+from src.kernel.schemas.model import ModelConfig
+
+
+def _clear_cache():
+    LLMClient._model_cache.clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_model_cache():
+    _clear_cache()
+    yield
+    _clear_cache()
+
+
+# ── get_model：未配置时省略 temperature（回归主测试） ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_model_omits_temperature_when_unset() -> None:
+    model = await LLMClient.get_model(
+        model_config=ModelConfig(
+            value="openai/gpt-4o",
+            label="test",
+            api_key="sk-test",
+        )
+    )
+    assert model.temperature is None
+
+
+@pytest.mark.asyncio
+async def test_get_model_openai_payload_has_no_temperature_when_unset() -> None:
+    model = await LLMClient.get_model(
+        model_config=ModelConfig(
+            value="openai/gpt-4o",
+            label="test",
+            api_key="sk-test",
+        )
+    )
+    payload = model._get_request_payload([HumanMessage(content="hi")], stop=None)
+    assert "temperature" not in payload
+
+
+@pytest.mark.asyncio
+async def test_get_model_configured_temperature_still_applied() -> None:
+    model = await LLMClient.get_model(
+        model_config=ModelConfig(
+            value="openai/gpt-4o",
+            label="test",
+            api_key="sk-test",
+            temperature=0.3,
+        )
+    )
+    assert model.temperature == 0.3
+
+
+# ── _create_model：None 在三种协议分支都直达客户端 ───────────────────────
+
+
+def test_create_model_openai_accepts_none_temperature() -> None:
+    model = LLMClient._create_model(
+        "openai", "gpt-4o", temperature=None, api_key="sk-test"
+    )
+    assert model.temperature is None
+
+
+def test_create_model_anthropic_accepts_none_temperature() -> None:
+    model = LLMClient._create_model(
+        "anthropic", "claude-sonnet-4-5", temperature=None, api_key="sk-test"
+    )
+    assert model.temperature is None
+
+
+def test_create_model_google_accepts_none_temperature() -> None:
+    model = LLMClient._create_model(
+        "google", "gemini-2.5-pro", temperature=None, api_key="sk-test"
+    )
+    assert model.temperature is None
+
+
+def test_anthropic_manual_thinking_still_forces_temperature_one() -> None:
+    # manual thinking 与非 1 的 temperature 不兼容：即使整体未配置
+    # temperature，thinking 开启时仍必须显式发送 1.0
+    model = LLMClient._create_model(
+        "anthropic",
+        "claude-sonnet-4-5",
+        temperature=None,
+        api_key="sk-test",
+        thinking={"type": "enabled", "level": "medium", "budget_tokens": 8192},
+    )
+    assert model.temperature == 1.0
+
+
+# ── 缓存键：None 与显式取值不冲突 ────────────────────────────────────────
+
+
+def test_cache_key_distinguishes_unset_from_explicit_temperature() -> None:
+    base = ("openai", "gpt-test", None, None, "sk", None, None, None, 3)
+    with_temp = ("openai", "gpt-test", 0.7, None, "sk", None, None, None, 3)
+    assert _make_cache_key(*base) != _make_cache_key(*with_temp)


### PR DESCRIPTION
## 问题

用户在模型配置里不填 temperature 时，LambChat 会向所有上游 API 发送 `temperature: 0.7`，覆盖了 provider 自己的默认值（通常 1.0），且没有任何途径回到「不传、用模型默认」。

## 根因

- `src/infra/llm/client.py` 中 `get_model(temperature: float = 0.7)` 硬编码默认值；所有聊天入口调用时均不传该参数
- 模型配置的 `temperature` 字段是 `Optional[float]`，只在非 None 时覆盖——「不填」的语义是「用系统默认 0.7」而非「不发送」
- `_create_model` 对三种协议都无条件把 temperature 放进客户端参数

## 修复

`get_model` / `_create_model` / `_make_cache_key` 的 temperature 改为 `Optional[float] = None`。已实测验证（本仓库锁定的版本）：langchain-openai 1.5.0 / langchain-anthropic 1.5.6 / langchain-google-genai 4.3.3 的 temperature 字段均为 `float | None = None`，且 None 不会出现在请求 payload 中，因此 None 直传即为「不发送」。`kernel/types.py` 中 Protocol 契约的过时默认值一并对齐（该 Protocol 无实现类）。

**保持不变的行为：**
- 配置了 temperature 的模型：仍然按配置值发送
- Claude manual thinking（3.7~4.5）开启时强制 `temperature=1` 的覆盖逻辑不变
- 内部辅助调用（记忆压缩 0.1 / 子代理活动摘要 0.3）显式传值不受影响
- gpt-5 等 reasoning 模型：langchain-openai 本就自动剥离 temperature，行为不变

## 行为变化（有意）

未配置 temperature 的模型请求将不再携带该参数，实际采样温度由 0.7 变为各 provider 默认值（OpenAI/Anthropic 均为 1.0）。

## 测试

TDD：新增 `tests/infra/llm/test_temperature_default.py`（8 个测试，已确认主回归测试修复前失败、修复后通过）：
- 未配置时实例与 OpenAI 请求 payload 均不含 temperature（RED→GREEN）
- 配置覆盖、三协议 None 透传、manual thinking 强制 1.0、缓存键区分 None/显式值（守卫）

验证：
- ✅ `uv run pytest` 全量 2926 passed（仅 4 个本机 .env 环境导致的存量失败，在未改动 main 上同样失败，与本次无关）
- ✅ `make lint` / `make typecheck` 通过