### PR TITLE
fix: 分享页无法退出护眼模式，切换不到深/浅模式（shared pages stuck in sepia theme）

### DIFF
--- a/frontend/src/components/share/SharedPage.tsx
+++ b/frontend/src/components/share/SharedPage.tsx
@@ -11,6 +11,7 @@ import {
   MessageSquare,
   Sun,
   Moon,
+  Coffee,
   ExternalLink,
   Lock,
   Languages,
@@ -23,6 +24,7 @@ import {
 import { BackIcon } from "../common/BackIcon";
 import { getFullUrl } from "../../services/api";
 import { shareApi } from "../../services/api/share";
+import { useSharedPageTheme } from "./useSharedPageTheme";
 import type { SharedContentResponse } from "../../types";
 import { ChatMessage } from "../chat/ChatMessage";
 import { ImageWithSkeleton } from "../chat/ChatMessage/ImageWithSkeleton";
@@ -146,37 +148,6 @@ function SharedPageLanguageToggle() {
   );
 }
 
-// Theme management for shared page (independent of main app context)
-function useSharedPageTheme() {
-  const [theme, setTheme] = useState<"light" | "dark">(() => {
-    if (typeof window !== "undefined") {
-      const stored = localStorage.getItem("lambchat-theme");
-      if (stored === "light" || stored === "dark") {
-        return stored;
-      }
-      if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-        return "dark";
-      }
-    }
-    return "light";
-  });
-
-  useEffect(() => {
-    const root = document.documentElement;
-    if (theme === "dark") {
-      root.classList.add("dark");
-    } else {
-      root.classList.remove("dark");
-    }
-    localStorage.setItem("lambchat-theme", theme);
-  }, [theme]);
-
-  const toggleTheme = () => {
-    setTheme((prev) => (prev === "light" ? "dark" : "light"));
-  };
-
-  return { theme, toggleTheme };
-}
 
 export function SharedPage({
   initialData,
@@ -603,19 +574,23 @@ export function SharedPage({
             <button
               onClick={toggleTheme}
               className="flex items-center justify-center w-9 h-9 rounded-xl bg-stone-100 dark:bg-stone-800 hover:bg-stone-200 dark:hover:bg-stone-700 transition-all duration-200 hover:scale-105 active:scale-95"
-              title={
+              title={t(
                 theme === "light"
-                  ? t("theme.switchToDark")
-                  : t("theme.switchToLight")
-              }
+                  ? "theme.switchToDark"
+                  : theme === "dark"
+                    ? "theme.switchToSepia"
+                    : "theme.switchToLight",
+              )}
             >
               {theme === "light" ? (
                 <Moon
                   size={18}
                   className="text-stone-600 dark:text-stone-300"
                 />
+              ) : theme === "dark" ? (
+                <Coffee size={18} className="text-amber-400" />
               ) : (
-                <Sun size={18} className="text-amber-400" />
+                <Sun size={18} className="text-amber-500" />
               )}
             </button>
           </div>

--- a/frontend/src/components/share/SharedProjectPage.tsx
+++ b/frontend/src/components/share/SharedProjectPage.tsx
@@ -19,12 +19,14 @@ import {
   AlertCircle,
   ChevronDown,
   ChevronRight,
+  Coffee,
   Folder,
   Loader2,
   MessageSquare,
   Moon,
   Sun,
 } from "lucide-react";
+import { useSharedPageTheme } from "./useSharedPageTheme";
 
 import { shareApi } from "../../services/api/share";
 import type {
@@ -45,43 +47,13 @@ const ChatMessage = lazy(() =>
 // 项目分享 manifest 单次分页大小（后端上限 SHARE_PROJECT_SESSIONS_LIMIT = 50）
 const SESSION_PAGE_SIZE = 50;
 
-// Theme management for shared pages (independent of main app context)
-function useSharedPageTheme() {
-  const [theme, setTheme] = useState<"light" | "dark">(() => {
-    if (typeof window !== "undefined") {
-      const stored = localStorage.getItem("lamb-agent-theme");
-      if (stored === "light" || stored === "dark") {
-        return stored;
-      }
-      if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-        return "dark";
-      }
-    }
-    return "light";
-  });
-
-  useEffect(() => {
-    const root = document.documentElement;
-    if (theme === "dark") {
-      root.classList.add("dark");
-    } else {
-      root.classList.remove("dark");
-    }
-    localStorage.setItem("lamb-agent-theme", theme);
-  }, [theme]);
-
-  // Enable page-level scrolling (global CSS sets overflow:hidden on html/body/#root),
-  // so expanded sessions can scroll the page.
+// Enable page-level scrolling (global CSS sets overflow:hidden on html/body/#root),
+// so expanded sessions can scroll the page.
+function useAllowScroll() {
   useEffect(() => {
     document.documentElement.classList.add("allow-scroll");
     return () => document.documentElement.classList.remove("allow-scroll");
   }, []);
-
-  const toggleTheme = () => {
-    setTheme((prev) => (prev === "light" ? "dark" : "light"));
-  };
-
-  return { theme, toggleTheme };
 }
 
 function isEmojiIcon(icon?: string): boolean {
@@ -98,6 +70,7 @@ export function SharedProjectPage({
   const { shareId } = useParams<{ shareId: string }>();
   const { t } = useTranslation();
   const { theme, toggleTheme } = useSharedPageTheme();
+  useAllowScroll();
 
   const [manifest, setManifest] = useState<SharedProjectContentResponse | null>(
     initialManifest ?? null,
@@ -238,9 +211,21 @@ export function SharedProjectPage({
             type="button"
             onClick={toggleTheme}
             className="p-2 rounded-lg text-theme-text-secondary hover:bg-theme-bg-subtle hover:text-theme-text transition-colors"
-            aria-label="Toggle theme"
+            aria-label={t(
+              theme === "light"
+                ? "theme.switchToDark"
+                : theme === "dark"
+                  ? "theme.switchToSepia"
+                  : "theme.switchToLight",
+            )}
           >
-            {theme === "light" ? <Moon size={18} /> : <Sun size={18} />}
+            {theme === "light" ? (
+              <Moon size={18} />
+            ) : theme === "dark" ? (
+              <Coffee size={18} />
+            ) : (
+              <Sun size={18} />
+            )}
           </button>
         </div>
       </header>

--- a/frontend/src/components/share/__tests__/sharedPageThemeSource.test.ts
+++ b/frontend/src/components/share/__tests__/sharedPageThemeSource.test.ts
@@ -5,6 +5,14 @@ const sharedPageSource = readFileSync(
   join(import.meta.dirname, "../SharedPage.tsx"),
   "utf8",
 );
+const sharedProjectPageSource = readFileSync(
+  join(import.meta.dirname, "../SharedProjectPage.tsx"),
+  "utf8",
+);
+const sharedPageThemeHookSource = readFileSync(
+  join(import.meta.dirname, "../useSharedPageTheme.ts"),
+  "utf8",
+);
 
 test("shared page top-level surfaces use theme tokens for light and dark modes", () => {
   expect(sharedPageSource).toMatch(
@@ -24,4 +32,28 @@ test("shared page top-level surfaces use theme tokens for light and dark modes",
   expect(sharedPageSource).toMatch(/border border-theme-border/);
   expect(sharedPageSource).not.toMatch(/bg-\[#faf9f7\]/);
   expect(sharedPageSource).not.toMatch(/dark:bg-\[#0f0e0d\]/);
+});
+
+test("shared pages route theme switching through the shared hook", () => {
+  for (const source of [sharedPageSource, sharedProjectPageSource]) {
+    expect(source).toMatch(
+      /import \{ useSharedPageTheme \} from "\.\/useSharedPageTheme"/,
+    );
+    expect(source).not.toMatch(/lamb-agent-theme/);
+    expect(source).not.toMatch(/localStorage\.(get|set)Item\("lambchat-theme"/);
+  }
+});
+
+test("shared page theme toggle is a three-state cycle including sepia", () => {
+  for (const source of [sharedPageSource, sharedProjectPageSource]) {
+    expect(source).toMatch(/theme\.switchToSepia/);
+    expect(source).toMatch(/<Coffee/);
+  }
+});
+
+test("shared page theme hook replaces all theme classes via themeDom", () => {
+  expect(sharedPageThemeHookSource).toMatch(/applyThemeToDocument\(theme\)/);
+  expect(sharedPageThemeHookSource).toMatch(/resolveNextTheme/);
+  expect(sharedPageThemeHookSource).toMatch(/getInitialThemePreference/);
+  expect(sharedPageThemeHookSource).toMatch(/THEME_STORAGE_KEY/);
 });

--- a/frontend/src/components/share/__tests__/useSharedPageTheme.test.tsx
+++ b/frontend/src/components/share/__tests__/useSharedPageTheme.test.tsx
@@ -1,0 +1,85 @@
+/** @vitest-environment jsdom */
+import { act } from "react";
+import { renderHook } from "@testing-library/react";
+import { useSharedPageTheme } from "../useSharedPageTheme";
+
+// jsdom does not implement matchMedia; stub it so theme initialization is deterministic.
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({ matches: false, media: query }),
+  });
+});
+
+beforeEach(() => {
+  window.localStorage.clear();
+  document.documentElement.className = "";
+});
+
+test("initializes to stored sepia preference", () => {
+  window.localStorage.setItem("lambchat-theme", "sepia");
+
+  const { result } = renderHook(() => useSharedPageTheme());
+
+  expect(result.current.theme).toBe("sepia");
+});
+
+test("toggling away from sepia removes the stale theme-sepia class from <html>", () => {
+  window.localStorage.setItem("lambchat-theme", "sepia");
+  // Class left on <html> by the index.html boot script / ThemeProvider when
+  // the stored preference is sepia.
+  document.documentElement.classList.add("theme-sepia");
+
+  const { result } = renderHook(() => useSharedPageTheme());
+  expect(result.current.theme).toBe("sepia");
+
+  act(() => result.current.toggleTheme());
+
+  expect(result.current.theme).toBe("light");
+  expect(document.documentElement.classList.contains("theme-sepia")).toBe(
+    false,
+  );
+});
+
+test("toggling away from sepia removes the stale dark class from <html>", () => {
+  window.localStorage.setItem("lambchat-theme", "sepia");
+  document.documentElement.classList.add("dark", "theme-sepia");
+
+  const { result } = renderHook(() => useSharedPageTheme());
+
+  act(() => result.current.toggleTheme());
+  act(() => result.current.toggleTheme());
+
+  expect(result.current.theme).toBe("dark");
+  expect(document.documentElement.classList.contains("dark")).toBe(true);
+  expect(document.documentElement.classList.contains("theme-sepia")).toBe(
+    false,
+  );
+});
+
+test("cycles light -> dark -> sepia -> light and syncs <html> classes", () => {
+  const { result } = renderHook(() => useSharedPageTheme());
+  expect(result.current.theme).toBe("light");
+
+  act(() => result.current.toggleTheme());
+  expect(result.current.theme).toBe("dark");
+  expect(document.documentElement.classList.contains("dark")).toBe(true);
+
+  act(() => result.current.toggleTheme());
+  expect(result.current.theme).toBe("sepia");
+  expect(document.documentElement.classList.contains("dark")).toBe(false);
+  expect(document.documentElement.classList.contains("theme-sepia")).toBe(true);
+
+  act(() => result.current.toggleTheme());
+  expect(result.current.theme).toBe("light");
+  expect(document.documentElement.classList.contains("dark")).toBe(false);
+  expect(document.documentElement.classList.contains("theme-sepia")).toBe(false);
+});
+
+test("persists the active theme to the lambchat-theme storage key", () => {
+  const { result } = renderHook(() => useSharedPageTheme());
+
+  act(() => result.current.toggleTheme());
+
+  expect(window.localStorage.getItem("lambchat-theme")).toBe("dark");
+});

--- a/frontend/src/components/share/useSharedPageTheme.ts
+++ b/frontend/src/components/share/useSharedPageTheme.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+import {
+  applyThemeToDocument,
+  getInitialThemePreference,
+  resolveNextTheme,
+  THEME_STORAGE_KEY,
+  type Theme,
+} from "../../utils/themeDom";
+
+// Theme management for shared pages (independent of main app context).
+// Cycles light -> dark -> sepia like the main app and fully replaces the
+// theme classes on <html>, so a stale theme-sepia left by the boot script
+// cannot trap the page in eye-care mode.
+export function useSharedPageTheme() {
+  const [theme, setTheme] = useState<Theme>(getInitialThemePreference);
+
+  useEffect(() => {
+    applyThemeToDocument(theme);
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
+    // Shared routes render inside the ambient ThemeProvider; keep its state in
+    // sync so in-app navigation back to the main app does not show a stale theme.
+    window.dispatchEvent(
+      new CustomEvent("theme:external-change", { detail: theme }),
+    );
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((prev) => resolveNextTheme(prev));
+  };
+
+  return { theme, toggleTheme };
+}


### PR DESCRIPTION
## 问题描述

公开分享页（`/shared/:shareId`，会话分享与项目分享）上，一旦页面以护眼（sepia）模式渲染，点击主题切换按钮永远无法切回浅色或深色模式。

## 根因

三个因素叠加：

1. 存储的主题偏好为 `sepia` 时，`index.html` 启动脚本和环境中的 `ThemeProvider`（分享路由也渲染在它内部）都会给 `<html>` 挂上 `theme-sepia` class，而 `ThemeProvider` 的 state 停在 `sepia` 不再变化，永远不会重新执行清理逻辑。
2. 分享页各自复制的本地 `useSharedPageTheme` hook（`SharedPage.tsx` 和 `SharedProjectPage.tsx` 中各一份）初始化时只接受 `light`/`dark`，副作用里只增删 `dark` 这一个 class —— 从不移除 `theme-sepia`。
3. `tokens.css` 中 `.theme-sepia` 定义在 `.dark` 之后且优先级相同，残留的 `theme-sepia` class 在级联中持续胜出，无论怎么点按钮页面都停留在护眼配色。

另外，`SharedProjectPage` 读写的是早已废弃的 `lamb-agent-theme` 存储 key（应用实际使用 `lambchat-theme`），导致该页读不到用户的主题偏好。

## 修复方式

- 将两份重复的 hook 合并为共享的 `useSharedPageTheme`，复用现有的 `themeDom` 工具：`getInitialThemePreference`（接受 sepia）、`applyThemeToDocument`（先移除**所有**主题 class 再挂目标 class）、`resolveNextTheme`（浅 → 深 → 护眼三态循环），并统一使用 `lambchat-theme` 存储 key。
- 通过现有的 `theme:external-change` 事件同步环境中的 `ThemeProvider`，避免从分享页应用内导航回主应用时显示过期的主题。
- 切换按钮升级为与主应用 `ThemeToggle` 一致的三态循环（Moon / Coffee / Sun 图标 + 本地化文案）。所有语言包已有 `theme.switchToSepia` 文案，无需新增。

## 测试

- 新增 jsdom 行为测试 `useSharedPageTheme.test.tsx`：先对旧逻辑跑出 RED（残留的 `theme-sepia` 不被移除、sepia 不被接受为初始主题），修复后转 GREEN；覆盖三态循环和 `<html>` 上的 class 管理。
- 扩展 `sharedPageThemeSource.test.ts` 锁定接线：两个页面均使用共享 hook、不再出现 `lamb-agent-theme`、存在三态切换、hook 通过 `themeDom` 应用主题。
- `pnpm vitest run src/components/share src/utils/__tests__/themeDom.test.ts` → 51/51 通过；`pnpm run lint` 无告警；`pnpm run build` 构建成功。