### PR TITLE
fix: 修复 main CI 红灯——82b841b7 直推的测试对齐与 useAgent 拆分

### DIFF
--- a/frontend/src/components/agent/__tests__/modelSelectorTriggerColor.test.ts
+++ b/frontend/src/components/agent/__tests__/modelSelectorTriggerColor.test.ts
@@ -9,7 +9,7 @@ test("model selector trigger matches the sidebar collapse icon color", () => {
     /className="flex items-center gap-1\.5 text-stone-600 hover:opacity-70 dark:text-stone-300 transition-opacity"/,
   );
   expect(source).toMatch(
-    /className="text-base font-semibold max-w-\[200px\] truncate"/,
+    /className="text-base font-semibold font-serif max-w-\[200px\] truncate"/,
   );
   expect(source).toMatch(/className=\{`transition-transform duration-200 \$\{/);
   expect(source).not.toMatch(/text-\[var\(--theme-text-secondary\)\]/);

--- a/frontend/src/components/chat/ChatMessage/__tests__/userMessageBubbleSkillFlowSource.test.ts
+++ b/frontend/src/components/chat/ChatMessage/__tests__/userMessageBubbleSkillFlowSource.test.ts
@@ -27,8 +27,9 @@ test("user message skill chips and text share the same inline flow", () => {
   expect(chatCss).toMatch(
     /\.skill-chip-node-name\s*\{[^}]*font-size:\s*inherit/s,
   );
-  expect(skillChipSource).not.toMatch(/font-serif/);
-  expect(fileReferenceSource).not.toMatch(/font-serif/);
+  // 名称节点随全局 serif 特性使用 font-serif；字号/字重仍由 CSS inherit 保持内联一致
+  expect(skillChipSource).toMatch(/skill-chip-node-name[^"]*font-serif/);
+  expect(fileReferenceSource).toMatch(/skill-chip-node-name[^"]*font-serif/);
   expect(skillChipSource).not.toMatch(/font-semibold/);
   expect(fileReferenceSource).not.toMatch(/font-semibold/);
   expect(chatCss).toMatch(
@@ -47,6 +48,6 @@ test("user message skill chips and text share the same inline flow", () => {
     /\.user-message-inline-markdown \.markdown-preview > p:first-child\s*\{[^}]*line-height:\s*inherit[^}]*color:\s*inherit/s,
   );
   expect(chatCss).toMatch(
-    /\.skill-chip-node-name\s*\{[^}]*font-size:\s*inherit[^}]**font-weight:\s*inherit[^}]*line-height:\s*inherit/s,
+    /\.skill-chip-node-name\s*\{[^}]*font-size:\s*inherit[^}]*font-weight:\s*inherit[^}]*line-height:\s*inherit/s,
   );
 });

--- a/frontend/src/components/layout/AppContent/__tests__/chatViewHistoryPaginationSource.test.ts
+++ b/frontend/src/components/layout/AppContent/__tests__/chatViewHistoryPaginationSource.test.ts
@@ -45,15 +45,23 @@ test("ChatAppContent passes the older-history pagination props to ChatView", () 
 
 test("useAgent loads the first history page bounded and pages older runs by cursor", () => {
   const source = readSource("../../../../hooks/useAgent.ts");
+  const paginationSource = readSource(
+    "../../../../hooks/useAgent/historyTracePagination.ts",
+  );
 
   // 首屏只取最近一页（按 trace 窗口）
   expect(source).toMatch(/trace_limit: HISTORY_TRACE_PAGE_SIZE/);
+  expect(source).toMatch(/useHistoryTracePagination/);
 
   // 翻页走游标，并在完成后全量重建消息
-  expect(source).toMatch(
+  expect(paginationSource).toMatch(
     /before_trace_started_at: traceWindow\.oldest_trace_started_at/,
   );
-  expect(source).toMatch(/before_trace_id: traceWindow\.oldest_trace_id/);
-  expect(source).toMatch(/mergeOlderHistoryEvents/);
-  expect(source).toMatch(/reconstructMessagesFromEvents\(\s*mergedEvents/);
+  expect(paginationSource).toMatch(
+    /before_trace_id: traceWindow\.oldest_trace_id/,
+  );
+  expect(paginationSource).toMatch(/mergeOlderHistoryEvents/);
+  expect(paginationSource).toMatch(
+    /reconstructMessagesFromEvents\(\s*mergedEvents/,
+  );
 });

--- a/frontend/src/components/layout/AppContent/__tests__/historyScrollPerformanceSource.test.ts
+++ b/frontend/src/components/layout/AppContent/__tests__/historyScrollPerformanceSource.test.ts
@@ -28,9 +28,9 @@ test("does not replay assistant entrance animation for remounted history message
 
 test("derives last-message state from the rendered list including steer items", () => {
   expect(chatViewSource).toMatch(
-    /isLastMessage=\{\s*toDataIndex\(index, firstItemIndexRef\.current\) === renderItems\.length - 1\s*\}/,
+    /isLastMessage=\{\s*toDataIndex\(index,\s*firstItemIndexRef\.current\)\s*===\s*renderItems\.length\s*-\s*1\s*\}/,
   );
-  expect(chatViewSource.indexOf("const renderItems = useMemo")).toBeLessThan(
+  expect(chatViewSource.indexOf("const renderItems = messages")).toBeLessThan(
     chatViewSource.indexOf("const virtuosoItemContent = useCallback"),
   );
 });

--- a/frontend/src/hooks/useAgent.ts
+++ b/frontend/src/hooks/useAgent.ts
@@ -6,12 +6,7 @@
 import { useState, useCallback, useRef, useEffect } from "react";
 import toast from "react-hot-toast";
 import i18n from "../i18n";
-import type {
-  Message,
-  ConnectionStatus,
-  MessageAttachment,
-  Feedback,
-} from "../types";
+import type { Message, ConnectionStatus, MessageAttachment } from "../types";
 import { sessionApi, type BackendSession } from "../services/api";
 import { feedbackApi } from "../services/api/feedback";
 import { useAuth } from "../hooks/useAuth";
@@ -60,12 +55,10 @@ import {
   applyFeedbackToMessages,
   resolveHistoryStreamRunId,
 } from "./useAgent/historyLoadState";
-import {
-  HISTORY_TRACE_PAGE_SIZE,
-  canLoadOlderHistory,
-  mergeOlderHistoryEvents,
-  resolveHistoryTraceWindow,
-} from "./useAgent/historyPagination";
+import { HISTORY_TRACE_PAGE_SIZE } from "./useAgent/historyPagination";
+import { useHistoryTracePagination } from "./useAgent/historyTracePagination";
+import { extractSessionConfig } from "./useAgent/sessionConfig";
+import { useAutoModeSetting } from "./useAgent/autoModeSetting";
 
 export function useAgent(options?: UseAgentOptions): UseAgentReturn {
   const { hasAnyPermission } = useAuth();
@@ -80,8 +73,6 @@ export function useAgent(options?: UseAgentOptions): UseAgentReturn {
   const [isLoading, setIsLoading] = useState(false);
   const [isLoadingHistory, setIsLoadingHistory] = useState(false);
   const [historyLoadGeneration, setHistoryLoadGeneration] = useState(0);
-  const [hasMoreHistoryTraces, setHasMoreHistoryTraces] = useState(false);
-  const [isLoadingOlderHistory, setIsLoadingOlderHistory] = useState(false);
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [currentProjectId, setCurrentProjectId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -98,22 +89,7 @@ export function useAgent(options?: UseAgentOptions): UseAgentReturn {
     Record<string, ActiveGoalSpec>
   >({});
   const [goalModeEnabled, setGoalModeEnabled] = useState(false);
-  const [autoModeEnabled, setAutoModeEnabled] = useState(() => {
-    try {
-      return localStorage.getItem("lamb-chat-auto-mode") === "true";
-    } catch {
-      return false;
-    }
-  });
-
-  // Persist autoModeEnabled to localStorage
-  useEffect(() => {
-    try {
-      localStorage.setItem("lamb-chat-auto-mode", String(autoModeEnabled));
-    } catch {
-      /* storage unavailable */
-    }
-  }, [autoModeEnabled]);
+  const [autoModeEnabled, setAutoModeEnabled] = useAutoModeSetting();
 
   // Refs for connection management
   const abortControllerRef = useRef<AbortController | null>(null);
@@ -135,16 +111,6 @@ export function useAgent(options?: UseAgentOptions): UseAgentReturn {
 
   // Track last event timestamp from history
   const lastHistoryTimestampRef = useRef<Date | null>(null);
-
-  // History trace-window pagination state (older pages prepend on scroll)
-  const historyEventsRef = useRef<HistoryEvent[]>([]);
-  const historyTraceWindowRef = useRef<{
-    oldest_trace_started_at: string;
-    oldest_trace_id: string;
-  } | null>(null);
-  const historyFeedbackRef = useRef<Feedback[]>([]);
-  const hasMoreHistoryTracesRef = useRef(false);
-  const isLoadingOlderHistoryRef = useRef(false);
 
   // Subagent tracking stack
   const activeSubagentStackRef = useRef<SubagentStackItem[]>([]);
@@ -206,6 +172,25 @@ export function useAgent(options?: UseAgentOptions): UseAgentReturn {
   useEffect(() => {
     messagesRef.current = messages;
   }, [messages]);
+
+  // History trace-window pagination (older pages prepend on scroll)
+  const {
+    hasMoreHistoryTraces,
+    isLoadingOlderHistory,
+    recordFirstWindow,
+    recordFeedback,
+    loadOlderHistory,
+    reset: resetHistoryPagination,
+  } = useHistoryTracePagination({
+    options,
+    sessionIdRef,
+    isLoadingHistoryRef,
+    processedEventIdsRef,
+    messagesRef,
+    streamingMessageIdRef,
+    setMessages,
+    setGoalsByRunId,
+  });
 
   // Create event handler context
   const createEventHandlerContext = useCallback(
@@ -315,11 +300,7 @@ export function useAgent(options?: UseAgentOptions): UseAgentReturn {
 
       processedEventIdsRef.current.clear();
       lastHistoryTimestampRef.current = null;
-      historyEventsRef.current = [];
-      historyTraceWindowRef.current = null;
-      historyFeedbackRef.current = [];
-      hasMoreHistoryTracesRef.current = false;
-      setHasMoreHistoryTraces(false);
+      resetHistoryPagination();
       void sessionApi.markRead(targetSessionId).catch(() => {});
       const feedbackPromise = canReadFeedback
         ? feedbackApi
@@ -374,42 +355,11 @@ export function useAgent(options?: UseAgentOptions): UseAgentReturn {
             (sessionData.metadata?.current_run_id as string) ||
             null;
 
-          // 从 metadata 提取配置信息
-          const sessionConfig = {
-            agent_id: (sessionData.metadata?.agent_id as string) || undefined,
-            agent_options:
-              (sessionData.metadata?.agent_options as Record<
-                string,
-                boolean | string | number
-              >) || undefined,
-            disabled_tools:
-              (sessionData.metadata?.disabled_tools as string[]) || undefined,
-            disabled_skills:
-              (sessionData.metadata?.disabled_skills as string[]) || undefined,
-            enabled_skills:
-              (sessionData.metadata?.enabled_skills as string[]) || undefined,
-            persona_preset_id:
-              (sessionData.metadata?.persona_preset_id as string) || undefined,
-            persona_preset_name:
-              (sessionData.metadata?.persona_preset_name as string) ||
-              undefined,
-            persona_snapshot:
-              (sessionData.metadata?.persona_snapshot as
-                | import("../types").PersonaPresetSnapshot
-                | undefined) || undefined,
-            disabled_mcp_tools:
-              (sessionData.metadata?.disabled_mcp_tools as string[]) ||
-              undefined,
-            team_id: (sessionData.metadata?.team_id as string) || undefined,
-          };
+          const sessionConfig = extractSessionConfig(sessionData);
           setGoalModeEnabled(false);
 
           const historyEvents = (eventsData.events || []) as HistoryEvent[];
-          historyEventsRef.current = historyEvents;
-          const firstWindowState = resolveHistoryTraceWindow(eventsData);
-          historyTraceWindowRef.current = firstWindowState.traceWindow;
-          hasMoreHistoryTracesRef.current = firstWindowState.hasMore;
-          setHasMoreHistoryTraces(firstWindowState.hasMore);
+          recordFirstWindow(eventsData);
           let reconstructedMessages = reconstructMessagesFromEvents(
             historyEvents,
             processedEventIdsRef.current,
@@ -444,7 +394,7 @@ export function useAgent(options?: UseAgentOptions): UseAgentReturn {
 
           void feedbackPromise.then((feedbackList) => {
             if (!feedbackList || isStaleHistoryLoad()) return;
-            historyFeedbackRef.current = feedbackList.items;
+            recordFeedback(feedbackList.items);
             setMessages((previous) =>
               applyFeedbackToMessages(previous, feedbackList.items),
             );
@@ -499,97 +449,11 @@ export function useAgent(options?: UseAgentOptions): UseAgentReturn {
       canReadFeedback,
       clearSteerMessages,
       hydrateSteers,
+      recordFirstWindow,
+      recordFeedback,
+      resetHistoryPagination,
     ],
   );
-
-  // Load one more page of older runs and prepend the rebuilt messages.
-  // Runs mid-stream are tolerated: the streaming run's assistant message is
-  // re-marked streaming after the rebuild so SSE updates keep applying.
-  const loadOlderHistory = useCallback(async () => {
-    const traceWindow = historyTraceWindowRef.current;
-    if (!traceWindow || !sessionIdRef.current) return;
-    const targetSessionId = sessionIdRef.current;
-    if (
-      !canLoadOlderHistory({
-        sessionId: targetSessionId,
-        traceWindow,
-        hasMore: hasMoreHistoryTracesRef.current,
-        isLoading:
-          isLoadingOlderHistoryRef.current || isLoadingHistoryRef.current,
-      })
-    ) {
-      return;
-    }
-    isLoadingOlderHistoryRef.current = true;
-    setIsLoadingOlderHistory(true);
-    try {
-      const olderData = await sessionApi.getEvents(targetSessionId, {
-        // 与首屏一致：带上活动 run 语义，避免深页因 status 过滤
-        // 丢掉写入方已死（stale running）的历史轮次
-        include_active_user_message: true,
-        compact_message_chunks: true,
-        trace_limit: HISTORY_TRACE_PAGE_SIZE,
-        before_trace_started_at: traceWindow.oldest_trace_started_at,
-        before_trace_id: traceWindow.oldest_trace_id,
-      });
-      if (sessionIdRef.current !== targetSessionId) return;
-
-      const olderEvents = (olderData.events || []) as HistoryEvent[];
-      if (olderEvents.length === 0) {
-        hasMoreHistoryTracesRef.current = false;
-        setHasMoreHistoryTraces(false);
-        return;
-      }
-
-      const mergedEvents = mergeOlderHistoryEvents(
-        olderEvents,
-        historyEventsRef.current,
-      );
-      historyEventsRef.current = mergedEvents;
-      const windowState = resolveHistoryTraceWindow(olderData);
-      historyTraceWindowRef.current = windowState.traceWindow;
-      hasMoreHistoryTracesRef.current = windowState.hasMore;
-      setHasMoreHistoryTraces(windowState.hasMore);
-
-      // 全量重建（而非仅重建旧页）：同一 run 可能跨多条 trace（重试回放），
-      // 按页独立重建会产生重复消息 id。重建使用全新的 subagent 栈。
-      let reconstructedMessages = reconstructMessagesFromEvents(
-        mergedEvents,
-        processedEventIdsRef.current,
-        { options, activeSubagentStack: [] },
-      );
-      const streamingRunId =
-        messagesRef.current.find(
-          (message) =>
-            message.role === "assistant" &&
-            message.isStreaming &&
-            message.runId,
-        )?.runId ?? null;
-      if (streamingRunId) {
-        const prepared = prepareMessagesForRunningRun(
-          reconstructedMessages,
-          streamingRunId,
-          undefined,
-          messagesRef.current,
-        );
-        reconstructedMessages = prepared.messages;
-        streamingMessageIdRef.current = prepared.streamingMessageId;
-      }
-      if (historyFeedbackRef.current.length > 0) {
-        reconstructedMessages = applyFeedbackToMessages(
-          reconstructedMessages,
-          historyFeedbackRef.current,
-        );
-      }
-      setGoalsByRunId(extractGoalsByRunFromEvents(mergedEvents));
-      setMessages(reconstructedMessages);
-    } catch (err) {
-      console.warn("[loadOlderHistory] Failed to load older history:", err);
-    } finally {
-      isLoadingOlderHistoryRef.current = false;
-      setIsLoadingOlderHistory(false);
-    }
-  }, [options]);
 
   // Send message
   const sendMessage = useCallback(
@@ -998,13 +862,7 @@ export function useAgent(options?: UseAgentOptions): UseAgentReturn {
     setConnectionStatus("disconnected");
     processedEventIdsRef.current.clear();
     lastHistoryTimestampRef.current = null;
-    historyEventsRef.current = [];
-    historyTraceWindowRef.current = null;
-    historyFeedbackRef.current = [];
-    hasMoreHistoryTracesRef.current = false;
-    setHasMoreHistoryTraces(false);
-    isLoadingOlderHistoryRef.current = false;
-    setIsLoadingOlderHistory(false);
+    resetHistoryPagination();
     streamingMessageIdRef.current = null;
     sessionIdRef.current = null;
     currentRunIdRef.current = null;
@@ -1017,7 +875,7 @@ export function useAgent(options?: UseAgentOptions): UseAgentReturn {
       abortControllerRef.current = null;
     }
     clearReconnectTimeout(reconnectTimeoutRef);
-  }, [clearSteerMessages]);
+  }, [clearSteerMessages, resetHistoryPagination]);
 
   const clearActiveGoal = useCallback(() => {
     setGoalModeEnabled(false);

--- a/frontend/src/hooks/useAgent/autoModeSetting.ts
+++ b/frontend/src/hooks/useAgent/autoModeSetting.ts
@@ -1,0 +1,24 @@
+/** 自动执行模式的 localStorage 持久化状态。 */
+
+import { useEffect, useState } from "react";
+
+export function useAutoModeSetting() {
+  const [autoModeEnabled, setAutoModeEnabled] = useState(() => {
+    try {
+      return localStorage.getItem("lamb-chat-auto-mode") === "true";
+    } catch {
+      return false;
+    }
+  });
+
+  // Persist autoModeEnabled to localStorage
+  useEffect(() => {
+    try {
+      localStorage.setItem("lamb-chat-auto-mode", String(autoModeEnabled));
+    } catch {
+      /* storage unavailable */
+    }
+  }, [autoModeEnabled]);
+
+  return [autoModeEnabled, setAutoModeEnabled] as const;
+}

--- a/frontend/src/hooks/useAgent/historyTracePagination.ts
+++ b/frontend/src/hooks/useAgent/historyTracePagination.ts
@@ -1,0 +1,196 @@
+/**
+ * 历史消息分页加载的编排 hook：持有已加载事件与 trace 窗口游标，
+ * 向上滚动时按游标取更早一页并全量重建消息。
+ * 游标解析/合并/门控等纯逻辑见 ./historyPagination。
+ */
+
+import { useCallback, useRef, useState } from "react";
+import type { Dispatch, RefObject, SetStateAction } from "react";
+import type { Feedback, Message, SessionEventsResponse } from "../../types";
+import { sessionApi } from "../../services/api";
+import type { ActiveGoalSpec, HistoryEvent, UseAgentOptions } from "./types";
+import { applyFeedbackToMessages } from "./historyLoadState";
+import {
+  extractGoalsByRunFromEvents,
+  prepareMessagesForRunningRun,
+  reconstructMessagesFromEvents,
+} from "./historyLoader";
+import {
+  HISTORY_TRACE_PAGE_SIZE,
+  canLoadOlderHistory,
+  mergeOlderHistoryEvents,
+  resolveHistoryTraceWindow,
+  type HistoryTraceWindow,
+} from "./historyPagination";
+
+interface HistoryTracePaginationDeps {
+  options: UseAgentOptions | undefined;
+  sessionIdRef: RefObject<string | null>;
+  isLoadingHistoryRef: RefObject<boolean>;
+  processedEventIdsRef: RefObject<Set<string>>;
+  messagesRef: RefObject<Message[]>;
+  streamingMessageIdRef: RefObject<string | null>;
+  setMessages: Dispatch<SetStateAction<Message[]>>;
+  setGoalsByRunId: Dispatch<SetStateAction<Record<string, ActiveGoalSpec>>>;
+}
+
+export function useHistoryTracePagination(deps: HistoryTracePaginationDeps) {
+  const {
+    options,
+    sessionIdRef,
+    isLoadingHistoryRef,
+    processedEventIdsRef,
+    messagesRef,
+    streamingMessageIdRef,
+    setMessages,
+    setGoalsByRunId,
+  } = deps;
+
+  const [hasMoreHistoryTraces, setHasMoreHistoryTraces] = useState(false);
+  const [isLoadingOlderHistory, setIsLoadingOlderHistory] = useState(false);
+
+  // History trace-window pagination state (older pages prepend on scroll)
+  const historyEventsRef = useRef<HistoryEvent[]>([]);
+  const historyTraceWindowRef = useRef<HistoryTraceWindow | null>(null);
+  const historyFeedbackRef = useRef<Feedback[]>([]);
+  const hasMoreHistoryTracesRef = useRef(false);
+  const isLoadingOlderHistoryRef = useRef(false);
+
+  /** 首屏加载后记录事件快照与游标窗口 */
+  const recordFirstWindow = useCallback(
+    (
+      eventsData: Pick<
+        SessionEventsResponse,
+        "events" | "has_more_traces" | "trace_window"
+      >,
+    ) => {
+      historyEventsRef.current = (eventsData.events || []) as HistoryEvent[];
+      const firstWindowState = resolveHistoryTraceWindow(eventsData);
+      historyTraceWindowRef.current = firstWindowState.traceWindow;
+      hasMoreHistoryTracesRef.current = firstWindowState.hasMore;
+      setHasMoreHistoryTraces(firstWindowState.hasMore);
+    },
+    [],
+  );
+
+  const recordFeedback = useCallback((items: Feedback[]) => {
+    historyFeedbackRef.current = items;
+  }, []);
+
+  const reset = useCallback(() => {
+    historyEventsRef.current = [];
+    historyTraceWindowRef.current = null;
+    historyFeedbackRef.current = [];
+    hasMoreHistoryTracesRef.current = false;
+    setHasMoreHistoryTraces(false);
+    isLoadingOlderHistoryRef.current = false;
+    setIsLoadingOlderHistory(false);
+  }, []);
+
+  // Load one more page of older runs and prepend the rebuilt messages.
+  // Runs mid-stream are tolerated: the streaming run's assistant message is
+  // re-marked streaming after the rebuild so SSE updates keep applying.
+  const loadOlderHistory = useCallback(async () => {
+    const traceWindow = historyTraceWindowRef.current;
+    if (!traceWindow || !sessionIdRef.current) return;
+    const targetSessionId = sessionIdRef.current;
+    if (
+      !canLoadOlderHistory({
+        sessionId: targetSessionId,
+        traceWindow,
+        hasMore: hasMoreHistoryTracesRef.current,
+        isLoading:
+          isLoadingOlderHistoryRef.current || isLoadingHistoryRef.current,
+      })
+    ) {
+      return;
+    }
+    isLoadingOlderHistoryRef.current = true;
+    setIsLoadingOlderHistory(true);
+    try {
+      const olderData = await sessionApi.getEvents(targetSessionId, {
+        // 与首屏一致：带上活动 run 语义，避免深页因 status 过滤
+        // 丢掉写入方已死（stale running）的历史轮次
+        include_active_user_message: true,
+        compact_message_chunks: true,
+        trace_limit: HISTORY_TRACE_PAGE_SIZE,
+        before_trace_started_at: traceWindow.oldest_trace_started_at,
+        before_trace_id: traceWindow.oldest_trace_id,
+      });
+      if (sessionIdRef.current !== targetSessionId) return;
+
+      const olderEvents = (olderData.events || []) as HistoryEvent[];
+      if (olderEvents.length === 0) {
+        hasMoreHistoryTracesRef.current = false;
+        setHasMoreHistoryTraces(false);
+        return;
+      }
+
+      const mergedEvents = mergeOlderHistoryEvents(
+        olderEvents,
+        historyEventsRef.current,
+      );
+      historyEventsRef.current = mergedEvents;
+      const windowState = resolveHistoryTraceWindow(olderData);
+      historyTraceWindowRef.current = windowState.traceWindow;
+      hasMoreHistoryTracesRef.current = windowState.hasMore;
+      setHasMoreHistoryTraces(windowState.hasMore);
+
+      // 全量重建（而非仅重建旧页）：同一 run 可能跨多条 trace（重试回放），
+      // 按页独立重建会产生重复消息 id。重建使用全新的 subagent 栈。
+      let reconstructedMessages = reconstructMessagesFromEvents(
+        mergedEvents,
+        processedEventIdsRef.current,
+        { options, activeSubagentStack: [] },
+      );
+      const streamingRunId =
+        messagesRef.current.find(
+          (message) =>
+            message.role === "assistant" &&
+            message.isStreaming &&
+            message.runId,
+        )?.runId ?? null;
+      if (streamingRunId) {
+        const prepared = prepareMessagesForRunningRun(
+          reconstructedMessages,
+          streamingRunId,
+          undefined,
+          messagesRef.current,
+        );
+        reconstructedMessages = prepared.messages;
+        streamingMessageIdRef.current = prepared.streamingMessageId;
+      }
+      if (historyFeedbackRef.current.length > 0) {
+        reconstructedMessages = applyFeedbackToMessages(
+          reconstructedMessages,
+          historyFeedbackRef.current,
+        );
+      }
+      setGoalsByRunId(extractGoalsByRunFromEvents(mergedEvents));
+      setMessages(reconstructedMessages);
+    } catch (err) {
+      console.warn("[loadOlderHistory] Failed to load older history:", err);
+    } finally {
+      isLoadingOlderHistoryRef.current = false;
+      setIsLoadingOlderHistory(false);
+    }
+  }, [
+    options,
+    sessionIdRef,
+    isLoadingHistoryRef,
+    processedEventIdsRef,
+    messagesRef,
+    streamingMessageIdRef,
+    setMessages,
+    setGoalsByRunId,
+  ]);
+
+  return {
+    hasMoreHistoryTraces,
+    isLoadingOlderHistory,
+    recordFirstWindow,
+    recordFeedback,
+    loadOlderHistory,
+    reset,
+  };
+}

--- a/frontend/src/hooks/useAgent/sessionConfig.ts
+++ b/frontend/src/hooks/useAgent/sessionConfig.ts
@@ -1,0 +1,31 @@
+/** 从会话 metadata 提取请求配置（agent/工具/技能/人设/团队）。 */
+
+import type { BackendSession } from "../../services/api";
+import type { PersonaPresetSnapshot } from "../../types";
+
+export function extractSessionConfig(sessionData: BackendSession) {
+  return {
+    agent_id: (sessionData.metadata?.agent_id as string) || undefined,
+    agent_options:
+      (sessionData.metadata?.agent_options as Record<
+        string,
+        boolean | string | number
+      >) || undefined,
+    disabled_tools:
+      (sessionData.metadata?.disabled_tools as string[]) || undefined,
+    disabled_skills:
+      (sessionData.metadata?.disabled_skills as string[]) || undefined,
+    enabled_skills:
+      (sessionData.metadata?.enabled_skills as string[]) || undefined,
+    persona_preset_id:
+      (sessionData.metadata?.persona_preset_id as string) || undefined,
+    persona_preset_name:
+      (sessionData.metadata?.persona_preset_name as string) || undefined,
+    persona_snapshot:
+      (sessionData.metadata?.persona_snapshot as PersonaPresetSnapshot) ||
+      undefined,
+    disabled_mcp_tools:
+      (sessionData.metadata?.disabled_mcp_tools as string[]) || undefined,
+    team_id: (sessionData.metadata?.team_id as string) || undefined,
+  };
+}


### PR DESCRIPTION
## 背景

直推 main 的 commit `82b841b7`（trace 窗口分页 + serif 特性）未经 PR/CI（push 路径过滤跳过），GitHub Actions 故障恢复后 main 第一次完整 CI 暴露 4 个失败。

## 修复（特性全部保留，无回退）

| 失败 | 根因 | 修复 |
|------|------|------|
| userMessageBubbleSkillFlowSource 套件炸 | 删 `font-family:inherit` 时残留 `[^}]**` 双星号，正则语法错误 | 修正正则；`not font-serif` 过时断言（serif 特性已给 chip 加 font-serif）改为 pin 现状 |
| modelSelectorTriggerColor | 82b841b7 给模型名加 `font-serif` 漏更新测试 | 断言补 font-serif |
| historyScrollPerformanceSource | prettier 换行 + `renderItems` 定义方式变化 | 正则兼容换行；ordering 断言同步 |
| Large File Check | useAgent.ts 1130 行 >1000 | 拆出 `useHistoryTracePagination`（分页编排 hook）/ `extractSessionConfig` / `useAutoModeSetting`，逻辑逐字搬移，988 行 |

chatViewHistoryPaginationSource 的分页断言同步改读新 hook 文件（意图不变）。另补齐 3 处 react-hooks/exhaustive-deps warning（均为稳定 refs/setters，无行为影响）。

## 验证

- `pnpm test`：1641/1641 通过
- `pnpm run lint`：0 error 0 warning
- `pnpm run find-large-files`：0 files
- `pnpm run build`：成功