### PR TITLE
feat: 运行中输入框 placeholder 提示「继续输入以排队有序修改」

### DIFF
--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -17,6 +17,7 @@ import { useFileUpload } from "../../hooks/useFileUpload";
 import { useMentionState } from "../../hooks/useMentionState";
 import { useMentionSearch } from "../../hooks/useMentionSearch";
 import { resolveAgentDisplayName } from "../agent/agentCatalog";
+import { resolveComposerPlaceholder } from "./composerPlaceholder";
 import { useTeamMentionSearch } from "../../hooks/useTeamMentionSearch";
 import { useInputHistory } from "../../hooks/useInputHistory";
 import { useLongTextConversion } from "../../hooks/useLongTextConversion";
@@ -650,11 +651,9 @@ export const ChatInput = memo(function ChatInput({
     setAttachments,
     setComposerExpanded,
   });
-  const composerPlaceholder = !canSend
-    ? t("chat.noPermission")
-    : mentionMode === "team"
-      ? t("chat.teamPlaceholder")
-      : t("chat.placeholder");
+  const composerPlaceholder = t(
+    resolveComposerPlaceholder({ canSend, mentionMode, isLoading }),
+  );
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault();
     setIsDraggingOver(true);

--- a/frontend/src/components/chat/__tests__/composerPlaceholder.test.ts
+++ b/frontend/src/components/chat/__tests__/composerPlaceholder.test.ts
@@ -1,0 +1,25 @@
+import { resolveComposerPlaceholder } from "../composerPlaceholder";
+
+test("returns no-permission copy when sending is not allowed", () => {
+  expect(
+    resolveComposerPlaceholder({ canSend: false, mentionMode: "persona", isLoading: false }),
+  ).toBe("chat.noPermission");
+});
+
+test("returns default placeholder when idle", () => {
+  expect(
+    resolveComposerPlaceholder({ canSend: true, mentionMode: "persona", isLoading: false }),
+  ).toBe("chat.placeholder");
+});
+
+test("returns team placeholder while composing a team mention", () => {
+  expect(
+    resolveComposerPlaceholder({ canSend: true, mentionMode: "team", isLoading: true }),
+  ).toBe("chat.teamPlaceholder");
+});
+
+test("returns running-queue placeholder while the agent is running", () => {
+  expect(
+    resolveComposerPlaceholder({ canSend: true, mentionMode: "persona", isLoading: true }),
+  ).toBe("chat.runningPlaceholder");
+});

--- a/frontend/src/components/chat/__tests__/teamMentionMode.test.ts
+++ b/frontend/src/components/chat/__tests__/teamMentionMode.test.ts
@@ -3,6 +3,10 @@ const chatInputSource = readFileSync(
   new URL("../ChatInput.tsx", import.meta.url),
   "utf8",
 );
+const composerPlaceholderSource = readFileSync(
+  new URL("../composerPlaceholder.ts", import.meta.url),
+  "utf8",
+);
 
 test("team agent mention switches teams instead of persona presets", () => {
   expect(chatInputSource).toMatch(/useTeamMentionSearch/);
@@ -19,8 +23,10 @@ test("team agent mention switches teams instead of persona presets", () => {
 });
 
 test("team agent placeholder says @ switches teams", () => {
-  expect(chatInputSource).toMatch(/chat\.teamPlaceholder/);
-  expect(chatInputSource).toMatch(
+  // placeholder 决策已提取到纯函数（composerPlaceholder.ts），ChatInput 经其接线
+  expect(chatInputSource).toMatch(/resolveComposerPlaceholder/);
+  expect(composerPlaceholderSource).toMatch(/chat\.teamPlaceholder/);
+  expect(composerPlaceholderSource).toMatch(
     /mentionMode === "team"[\s\S]*chat\.teamPlaceholder/,
   );
 });

--- a/frontend/src/components/chat/composerPlaceholder.ts
+++ b/frontend/src/components/chat/composerPlaceholder.ts
@@ -1,0 +1,17 @@
+/**
+ * 输入框 placeholder 的选择逻辑（纯函数，返回 i18n key）。
+ *
+ * 运行中发送会进入 steer 排队、按序生效，此时 placeholder 提示
+ * 「继续输入以排队有序修改」；团队提及编辑中保持团队提示不被覆盖。
+ */
+
+export function resolveComposerPlaceholder(input: {
+  canSend: boolean;
+  mentionMode: "persona" | "team";
+  isLoading: boolean;
+}): string {
+  if (!input.canSend) return "chat.noPermission";
+  if (input.mentionMode === "team") return "chat.teamPlaceholder";
+  if (input.isLoading) return "chat.runningPlaceholder";
+  return "chat.placeholder";
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -817,6 +817,7 @@
     "stopConfirmTitle": "Stop generating",
     "subagentStatus": "Subagent status: {{status}}",
     "teamPlaceholder": "Type a message to start, @ to switch team…",
+    "runningPlaceholder": "Keep typing to queue ordered edits…",
     "teamSelected": "Team selected",
     "textAutoUploaded": "Long text automatically converted to file upload",
     "thinkingIntensity": "Thinking Intensity",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -817,6 +817,7 @@
     "stopConfirmTitle": "生成を停止",
     "subagentStatus": "サブエージェントステータス: {{status}}",
     "teamPlaceholder": "メッセージを入力して会話を開始、@ でチームを切替…",
+    "runningPlaceholder": "入力を続けると修正が順番にキューされます…",
     "teamSelected": "チーム選択済み",
     "textAutoUploaded": "長いテキストがファイルとして自動アップロードされました",
     "thinkingIntensity": "思考強度",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -817,6 +817,7 @@
     "stopConfirmTitle": "생성 중단",
     "subagentStatus": "서브에이전트 상태: {{status}}",
     "teamPlaceholder": "메시지를 입력하여 대화를 시작, @ 로 팀 전환…",
+    "runningPlaceholder": "계속 입력하면 수정이 순서대로 대기열에 추가됩니다…",
     "teamSelected": "팀 선택됨",
     "textAutoUploaded": "긴 텍스트가 파일로 자동 업로드되었습니다",
     "thinkingIntensity": "사고 강도",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -817,6 +817,7 @@
     "stopConfirmTitle": "Остановить генерацию",
     "subagentStatus": "Статус субагента: {{status}}",
     "teamPlaceholder": "Введите сообщение, @ — выбрать команду…",
+    "runningPlaceholder": "Продолжайте вводить — правки встанут в очередь по порядку…",
     "teamSelected": "Команда выбрана",
     "textAutoUploaded": "Длинный текст автоматически загружен как файл",
     "thinkingIntensity": "Интенсивность мышления",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -817,6 +817,7 @@
     "stopConfirmTitle": "停止生成",
     "subagentStatus": "子代理状态: {{status}}",
     "teamPlaceholder": "输入消息开始对话，@ 可切换团队…",
+    "runningPlaceholder": "继续输入以排队有序修改…",
     "teamSelected": "已选择团队",
     "textAutoUploaded": "长文本已自动转为文件上传",
     "thinkingIntensity": "思考强度",


### PR DESCRIPTION
## 变更

agent 运行中（`isLoading`）时，输入框 placeholder 切换为提示排队语义：

- 决策提取为纯函数 `resolveComposerPlaceholder`（返回 i18n key），优先级：无权限 > 团队提及 > 运行中 > 默认
- 新增 `chat.runningPlaceholder`，五个语言包（zh/en/ja/ko/ru）同步
- `teamMentionMode` Source 测试随接线更新（意图不变：团队提及用团队提示）

zh 文案：**继续输入以排队有序修改…**

## 验证（TDD）

- 先写 `composerPlaceholder.test.ts`（RED：模块不存在），实现后 4/4 GREEN
- 全量：390 文件 / 1645 测试通过；ESLint 0 warning；build 成功