### PR TITLE
fix: settings.set 对未注册 key 不再触发广播与刷新

### DIFF
--- a/src/infra/settings/service.py
+++ b/src/infra/settings/service.py
@@ -166,6 +166,9 @@ class SettingsService:
             Updated setting item
         """
         result = await self._storage.set(key, value, user_id)
+        if result is None:
+            # 未注册 key：storage 未持久化，跳过缓存刷新与跨实例广播
+            return None
         self.invalidate_get_all_cache()
 
         # Refresh the global settings object to reflect the change

--- a/tests/infra/settings/test_settings_service.py
+++ b/tests/infra/settings/test_settings_service.py
@@ -199,6 +199,28 @@ async def test_set_and_reset_invalidate_get_all_snapshot(
 
 
 @pytest.mark.asyncio
+async def test_set_unknown_key_skips_refresh_and_broadcast(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Storage:
+        async def set(self, _key, _value, _user_id):
+            return None  # 未注册 key：storage 未持久化任何内容
+
+    service = settings_service.SettingsService()
+    service._storage = _Storage()  # type: ignore[assignment]
+    publish = AsyncMock()
+    refresh = AsyncMock()
+    monkeypatch.setattr(service, "_publish_change", publish)
+    monkeypatch.setattr("src.kernel.config.refresh_settings", refresh)
+
+    result = await service.set("NOT_A_REGISTERED_SETTING", "x", "user-1")
+
+    assert result is None
+    publish.assert_not_awaited()
+    refresh.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_refresh_applies_empty_llm_fallback_model_without_restart(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## 背景

k8s 生产分布式全量测试（T7 配置热更新广播）中发现的 bug：

对未注册的 key 调用 `PUT /api/settings/{key}`：

1. `storage.set()` 因 key 不在 `SETTING_DEFINITIONS` 返回 `None`（什么都没写入）
2. 但 `service.set()` 继续执行 `refresh_settings(key)` + `_publish_change(key, value)`
3. 路由最后才返回 404 `Setting not found`

结果：**失败的请求产生了跨实例副作用**——所有副本收到 `settings:changed` 广播并打印误导性的 `Refreshed local setting: <key>` 日志（实测两副本都收到），但该设置实际不存在。

生产实测日志（修复前）：
```
PUT /api/settings/AGENT_TOKEN_LIMIT → 404
pod-b: [SettingsPubSub] Received setting change: AGENT_TOKEN_LIMIT
pod-b: [SettingsPubSub] Refreshed local setting: AGENT_TOKEN_LIMIT
```

## 修复

`service.set()` 在 `storage.set()` 返回 `None` 时提前返回，跳过缓存刷新与广播。

## 测试

- [x] 新增回归测试 `test_set_unknown_key_skips_refresh_and_broadcast`（RED→GREEN）
- [x] tests/infra/settings/ 全部 27 例通过
- [x] ruff check / format 通过