### PR TITLE
fix: /fonts/ 加入鉴权白名单（修复自托管字体匿名 401）

### DIFF
--- a/src/api/middleware/auth.py
+++ b/src/api/middleware/auth.py
@@ -51,6 +51,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
         "/assets/",
         "/icons/",
         "/images/",
+        "/fonts/",
         "/shared/",
         "/api/share/public/",
         "/api/agents",

--- a/tests/api/test_auth_middleware_public_paths.py
+++ b/tests/api/test_auth_middleware_public_paths.py
@@ -22,3 +22,20 @@ async def test_vapid_public_key_path_is_public_without_authorization() -> None:
 
     assert response.status_code == 200
     assert response.json() == {"public_key": "test-key"}
+
+
+@pytest.mark.asyncio
+async def test_static_font_paths_are_public_without_authorization() -> None:
+    """自托管字体 /fonts/*.woff2 必须匿名可访问（否则未登录用户字体全部 401）。"""
+    app = FastAPI()
+    app.add_middleware(AuthMiddleware)
+
+    @app.get("/fonts/source-sans-3-400-latin.woff2")
+    async def font_file() -> dict[str, str]:
+        return {"ok": "font"}
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/fonts/source-sans-3-400-latin.woff2")
+
+    assert response.status_code == 200


### PR DESCRIPTION
PR #258 的配套遗漏：字体自托管后 `/fonts/*.woff2` 不在 AuthMiddleware 公开前缀里，未登录用户全部 401。

- TDD：新增匿名访问 `/fonts/*.woff2` 的测试（先 RED 后 GREEN）
- 验证：auth/spa/shared 相关 14 测试通过，ruff 通过