### PR TITLE
fix: embedded arq worker 监督重启（修副本静默退出队列消费）

### DIFF
--- a/src/infra/task/arq_runtime.py
+++ b/src/infra/task/arq_runtime.py
@@ -80,6 +80,8 @@ class EmbeddedArqRuntime:
     async def _supervise(self) -> None:
         while not self._stopping:
             worker = self._worker
+            if worker is None:  # start() 已保证首个 worker 存在，此处仅类型收窄
+                return
             try:
                 result = worker.async_run()
                 if inspect.isawaitable(result):

--- a/src/infra/task/arq_runtime.py
+++ b/src/infra/task/arq_runtime.py
@@ -17,16 +17,26 @@ logger = get_logger(__name__)
 
 
 class EmbeddedArqRuntime:
-    """Own the lifecycle of an arq worker embedded in the FastAPI process."""
+    """Own the lifecycle of an arq worker embedded in the FastAPI process.
 
-    def __init__(self, worker_factory: Callable[..., Any] = Worker) -> None:
+    Worker 以监督任务运行：异常退出或静默返回都会记录日志并自动重建，
+    避免副本 API 正常但永远不再消费队列（2026-08-27 生产事故根因）。
+    """
+
+    def __init__(
+        self,
+        worker_factory: Callable[..., Any] = Worker,
+        restart_delay_seconds: float = 5.0,
+    ) -> None:
         self._worker_factory = worker_factory
+        self._restart_delay = restart_delay_seconds
         self._worker: Any | None = None
-        self._task: asyncio.Future | None = None
+        self._supervisor: asyncio.Future | None = None
+        self._stopping = False
 
     @property
     def is_running(self) -> bool:
-        return self._task is not None and not self._task.done()
+        return self._supervisor is not None and not self._supervisor.done()
 
     async def start(self) -> None:
         if self.is_running:
@@ -36,7 +46,13 @@ class EmbeddedArqRuntime:
         if not getattr(settings, "ARQ_EMBEDDED_WORKER", True):
             return
 
-        self._worker = self._worker_factory(
+        self._stopping = False
+        self._worker = self._create_worker()
+        self._supervisor = asyncio.ensure_future(self._supervise())
+        logger.info("Embedded arq worker started")
+
+    def _create_worker(self) -> Any:
+        return self._worker_factory(
             [run_agent_task, update_user_message_search_index],
             queue_name=settings.ARQ_QUEUE_NAME,
             redis_settings=build_arq_redis_settings(settings),
@@ -49,26 +65,62 @@ class EmbeddedArqRuntime:
             },
             allow_abort_jobs=True,
         )
-        self._task = asyncio.ensure_future(self._worker.async_run())
-        logger.info("Embedded arq worker started")
 
-    async def stop(self) -> None:
-        if self._worker is not None:
-            close = getattr(self._worker, "close", None)
-            if close is not None:
-                result = close()
+    async def _close_worker_quietly(self, worker: Any) -> None:
+        close = getattr(worker, "close", None)
+        if close is None:
+            return
+        try:
+            result = close()
+            if inspect.isawaitable(result):
+                await result
+        except Exception:
+            logger.warning("Failed to close dead arq worker", exc_info=True)
+
+    async def _supervise(self) -> None:
+        while not self._stopping:
+            worker = self._worker
+            try:
+                result = worker.async_run()
                 if inspect.isawaitable(result):
                     await result
+                if self._stopping:
+                    return
+                logger.warning(
+                    "Embedded arq worker exited silently; restarting in %.1fs",
+                    self._restart_delay,
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                if self._stopping:
+                    return
+                logger.exception(
+                    "Embedded arq worker crashed; restarting in %.1fs",
+                    self._restart_delay,
+                )
+            await self._close_worker_quietly(worker)
+            if self._stopping:
+                return
+            await asyncio.sleep(self._restart_delay)
+            if self._stopping:
+                return
+            self._worker = self._create_worker()
 
-        if self._task is not None and not self._task.done():
-            self._task.cancel()
+    async def stop(self) -> None:
+        self._stopping = True
+        if self._worker is not None:
+            await self._close_worker_quietly(self._worker)
+
+        if self._supervisor is not None and not self._supervisor.done():
+            self._supervisor.cancel()
             try:
-                await self._task
+                await self._supervisor
             except asyncio.CancelledError:
                 pass
 
         self._worker = None
-        self._task = None
+        self._supervisor = None
 
 
 _runtime: EmbeddedArqRuntime | None = None

--- a/tests/infra/task/test_arq_runtime.py
+++ b/tests/infra/task/test_arq_runtime.py
@@ -165,3 +165,86 @@ async def test_stop_arq_runtime_does_not_create_singleton_when_unused() -> None:
     await arq_runtime.stop_arq_runtime()
 
     assert arq_runtime._runtime is None
+
+
+def _arq_settings() -> SimpleNamespace:
+    return SimpleNamespace(
+        TASK_BACKEND="arq",
+        ARQ_EMBEDDED_WORKER=True,
+        ARQ_WORKER_MAX_JOBS=128,
+        ARQ_JOB_TIMEOUT_SECONDS=30,
+        ARQ_QUEUE_NAME="lambchat:arq",
+        REDIS_URL="redis://localhost:6379/0",
+        REDIS_PASSWORD=None,
+    )
+
+
+async def _wait_until(predicate, timeout: float = 2.0) -> None:
+    for _ in range(int(timeout / 0.01)):
+        if predicate():
+            return
+        await asyncio.sleep(0.01)
+
+
+@pytest.mark.asyncio
+async def test_worker_crash_restarts_worker_and_keeps_running(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """worker 异常退出必须自动重建（2026-08-27 生产事故：裸 future 静默死亡，副本退出消费）。"""
+
+    class _CrashOnceWorker(_FakeWorker):
+        runs = 0
+
+        async def async_run(self) -> None:
+            type(self).runs += 1
+            if type(self).runs == 1:
+                raise RuntimeError("simulated worker crash")
+            await self.closed.wait()
+
+    _FakeWorker.instances.clear()
+    monkeypatch.setattr(arq_runtime, "settings", _arq_settings())
+
+    runtime = arq_runtime.EmbeddedArqRuntime(
+        worker_factory=_CrashOnceWorker, restart_delay_seconds=0.01
+    )
+    await runtime.start()
+
+    await _wait_until(lambda: len(_FakeWorker.instances) >= 2)
+
+    assert len(_FakeWorker.instances) == 2
+    assert runtime.is_running is True
+
+    await runtime.stop()
+    assert runtime.is_running is False
+    assert _FakeWorker.instances[1].closed.is_set()
+
+
+@pytest.mark.asyncio
+async def test_worker_silent_exit_restarts_worker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """worker 无异常但返回（静默退出）同样要重建。"""
+
+    class _ExitOnceWorker(_FakeWorker):
+        runs = 0
+
+        async def async_run(self) -> None:
+            type(self).runs += 1
+            if type(self).runs == 1:
+                return
+            await self.closed.wait()
+
+    _FakeWorker.instances.clear()
+    monkeypatch.setattr(arq_runtime, "settings", _arq_settings())
+
+    runtime = arq_runtime.EmbeddedArqRuntime(
+        worker_factory=_ExitOnceWorker, restart_delay_seconds=0.01
+    )
+    await runtime.start()
+
+    await _wait_until(lambda: len(_FakeWorker.instances) >= 2)
+
+    assert len(_FakeWorker.instances) == 2
+    assert runtime.is_running is True
+
+    await runtime.stop()


### PR DESCRIPTION
## 事故（2026-08-27 生产实证）

lambchat-a 的 embedded arq worker 在跨副本取消测试后静默死亡：`asyncio.ensure_future(worker.async_run())` 裸跑、无异常处理——worker 异常退出后无日志、无重启，API 照常服务但该副本永远不再消费 arq 队列。证据：回归 T4 连挂（4 次提交全在 b 执行）、a 近 5 分钟 arq 零抓取、事件循环健康（apscheduler 心跳持平）、无任何 Traceback。重启副本即恢复。

## 修复

- 监督任务：崩溃 → `logger.exception`（CRITICAL 级可被巡检捕获）+ 5s 后重建 worker；静默返回 → WARNING + 重建
- `start()` 同步创建首个 worker，保持既有 stop/close 语义（旧测试零改动通过）
- `stop()` 先置 `_stopping`，关闭当前 worker 后取消监督任务

## 验证

- `tests/infra/task/test_arq_runtime.py` 8/8（含 2 个新 TDD 测试：崩溃重建、静默退出重建）
- `tests/infra/task/` 全量 194/194，ruff 通过