### PR TITLE
ci(workflow): 引入 develop 集成分支——CI/镜像/Merge Gate/开发规范全套升级

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches:
       - main
+      - develop
     tags:
       - 'v*'
   pull_request:
     branches:
       - main
+      - develop
 
 env:
   REGISTRY: ghcr.io
@@ -58,8 +60,9 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=main-{{date 'YYYYMMDD-HHmmss'}},enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=main-{{date 'YYYYMMDD-HHmmss'}},enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=develop-{{date 'YYYYMMDD-HHmmss'}},enable=${{ github.ref == 'refs/heads/develop' }}
 
       - name: Build Docker image for pull request (single platform)
         if: steps.image.outputs.publish != 'true'
@@ -118,8 +121,9 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=main-{{date 'YYYYMMDD-HHmmss'}},enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=main-{{date 'YYYYMMDD-HHmmss'}},enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=develop-{{date 'YYYYMMDD-HHmmss'}},enable=${{ github.ref == 'refs/heads/develop' }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@ name: Lint
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - 'src/**'
       - 'tests/**'
@@ -16,7 +16,7 @@ on:
       - 'main.py'
       - 'run.py'
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - 'src/**'
       - 'tests/**'

--- a/.github/workflows/main-merge-gate.yml
+++ b/.github/workflows/main-merge-gate.yml
@@ -1,0 +1,27 @@
+name: Main Merge Gate
+
+# main 只接受 develop（常规晋升）与 hotfix/*（紧急修复）的 PR，其余来源直接失败。
+# 该检查在 main 分支保护中设为 required status check，配合分支模型使用。
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  main-merge-gate:
+    name: main-merge-gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: 检查 PR 来源分支
+        run: |
+          HEAD="${{ github.head_ref }}"
+          case "$HEAD" in
+            develop|hotfix/*)
+              echo "✅ 允许来源分支: $HEAD"
+              ;;
+            *)
+              echo "❌ main 只接受 develop 或 hotfix/* 的 PR，当前来源: $HEAD"
+              echo "常规改动请先 PR 到 develop，验证稳定后由 develop 晋升；紧急修复从 main 拉 hotfix/* 分支，合入后须回合到 develop。"
+              exit 1
+              ;;
+          esac

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,65 @@ LambChat 是全栈 AI Agent 平台：
 | `deploy/` | Docker, Kubernetes 部署资源 |
 | `docs/` | 项目文档站点 |
 
+## 分支与发布流程
+
+### 分支模型
+
+```
+feat/fix 分支 ──PR──▶ develop ──PR──▶ main ──▶ yang update.sh ──▶ 生产
+                       │
+                 CI 全量检查
+                 出 develop-<时间戳> 镜像
+                       │
+                 update-staging.sh ──▶ staging 验证（yang 8021，仅 SSH 隧道可达）
+```
+
+| 分支 | 用途 | 保护 |
+|------|------|------|
+| `main` | 生产分支，每次合并出 `main-<时间戳>` 镜像 | 必须 PR；Merge Gate 只放行 `develop` 与 `hotfix/*` 来源 |
+| `develop` | 集成分支（默认分支），所有 feature/fix PR 的目标，每次合并出 `develop-<时间戳>` 镜像 | 必须 PR（0 approvals，自合留痕即可） |
+| `feat/*` `fix/*` `perf/*` `docs/*` `chore/*` | 短生命周期工作分支，从 `develop` 拉 | 无 |
+
+### 提交信息规范
+
+Conventional Commits + 中文描述：`类型(范围): 摘要`。
+
+- 类型：`feat` / `fix` / `perf` / `refactor` / `docs` / `chore` / `test` / `ci`
+- 范围可选，用模块名（如 `memory`、`api`、`frontend`）
+- 示例：`fix(chat): 修复 /stream 路由被 helper 劫持`
+
+### PR 规则
+
+- feature/fix 一律 PR 到 `develop`（仓库默认分支）
+- 标题同提交信息规范；关联 issue 用 `Closes #N`
+- CI 绿（ruff / mypy / 前后端测试 / 镜像构建）后才可合并
+
+### 镜像 tag 约定
+
+| tag | 来源 | 用途 |
+|-----|------|------|
+| `develop-YYYYMMDD-HHmmss` | push `develop` | staging 验证 |
+| `main-YYYYMMDD-HHmmss` | push `main` | 生产部署 |
+| `v*` | 发版 tag | 归档 |
+
+### 晋升 checklist（develop → main）
+
+1. develop 上 CI 全绿
+2. staging 验证：yang 上 `/data/lambchat-k8s/update-staging.sh` 滚到目标 tag，本地 `ssh -L 8021:127.0.0.1:8021 yang` 后访问 `http://127.0.0.1:8021` 真实跑一轮对话
+3. 开 PR `develop` → `main`，合并（Merge Gate 会校验来源）
+4. 生产部署：yang 上 `/data/lambchat-k8s/update.sh`（自动取最新 `main-*` tag，滚动失败自动回滚）
+5. 部署后回归：`bash /root/disttest/run-all.sh`
+
+### hotfix 流程
+
+1. 从 `main` 拉 `hotfix/*` 分支修复（不能基于 develop，避免裹挟未验证改动）
+2. PR 到 `main`（Merge Gate 放行 `hotfix/*`）
+3. 生产恢复后，**必须**把同一修复回合（PR）到 `develop`，保持两分支不漂移
+
+### 自动化贡献（巡检等）
+
+自动创建的修复 PR 一律开向 `develop`，走同样的 staging 验证后晋升；禁止直接面向 `main`。生产部署永远人工执行（`update.sh`），自动化不得触碰。
+
 ## 常用命令
 
 ```bash


### PR DESCRIPTION
## 内容

Git-flow 精简版落地（设计已与维护者确认）：

- **CI 触发**：`lint.yml` / `docker-build.yml` 的 push 与 PR 触发加 `develop`；PR 到 develop 只构建不推送
- **develop 镜像**：push develop 出多架构 `develop-<时间戳>` + 浮动 `develop` tag；`latest` / `main-<时间戳>` 改为显式 `github.ref` 判断（配合默认分支切换，语义钉死在 main）
- **Merge Gate**：新增 `main-merge-gate.yml`，main 只接受 `develop` 与 `hotfix/*` 来源的 PR，将设为 main 的 required status check
- **AGENTS.md**：新增「分支与发布流程」章节——分支模型、提交规范、PR 规则、镜像 tag 约定、晋升 checklist、hotfix 流程、自动化贡献规则

## 配套变更（不在本 PR 内）

- develop 分支已从 main 快进重建（fdb31d4a → 6b982979）
- 默认分支将切换为 develop；main 加 required check；develop 开分支保护
- yang 将建 staging 环境（共享 Mongo/Redis/PG 实例、独立库名，8021 仅 SSH 隧道）

## 验证

- 本 PR 合入 develop 后首次 push 应出 `develop-<时间戳>` 镜像
- 生产链路零改动：`update.sh` 只认 `main-2*` 前缀，develop 镜像天然隔离