### PR TITLE
fix(frontend): 文件预览全链路应用代理兜底——OSS 直连不可达时 ?proxy=true 重试

### DIFF
--- a/frontend/src/components/chat/ChatMessage/items/revealPreviewData.ts
+++ b/frontend/src/components/chat/ChatMessage/items/revealPreviewData.ts
@@ -3,6 +3,7 @@ import {
   buildUploadProxyUrl,
   getFullUrl,
 } from "../../../../services/api/config";
+import { fetchDocumentText } from "../../../documents/documentFetchCache";
 import { rewriteProjectTextFiles } from "./projectRevealAssetUtils";
 
 export type ProjectTemplate =
@@ -239,14 +240,7 @@ export async function loadProjectRevealFiles(
       try {
         const fullUrl = getFullUrl(entry.url) || entry.url;
         const readUrl = buildUploadProxyUrl(entry.url) || fullUrl;
-        const resp = await fetch(readUrl);
-        if (!resp.ok) {
-          console.warn(
-            `[reveal_project] Failed to fetch ${path}: ${resp.status}`,
-          );
-          return null;
-        }
-        const text = await resp.text();
+        const text = await fetchDocumentText(readUrl);
         return [path, text];
       } catch (error) {
         console.warn(`[reveal_project] Error fetching ${path}:`, error);

--- a/frontend/src/components/common/ExcalidrawThumbnail.tsx
+++ b/frontend/src/components/common/ExcalidrawThumbnail.tsx
@@ -1,5 +1,6 @@
 import { memo, useEffect, useState, useRef } from "react";
 import { buildUploadProxyUrl, getFullUrl } from "../../services/api/config";
+import { fetchDocumentText } from "../documents/documentFetchCache";
 import { ImageWithSkeleton } from "../chat/ChatMessage/ImageWithSkeleton";
 
 // Types for Excalidraw
@@ -50,9 +51,7 @@ export const ExcalidrawThumbnail = memo(function ExcalidrawThumbnail({
     const load = async () => {
       try {
         // Fetch excalidraw file content
-        const res = await fetch(readUrl);
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const raw = await res.text();
+        const raw = await fetchDocumentText(readUrl);
 
         // Parse excalidraw JSON
         const parsed = JSON.parse(raw);

--- a/frontend/src/components/documents/DocumentPreviewContent.tsx
+++ b/frontend/src/components/documents/DocumentPreviewContent.tsx
@@ -3,6 +3,7 @@ import { AlertCircle } from "lucide-react";
 import { LoadingSpinner } from "../common/LoadingSpinner";
 import { ImageViewer } from "../common/ImageViewer";
 import { ImageWithSkeleton } from "../chat/ChatMessage/ImageWithSkeleton";
+import { mediaProxyFallbackSrc } from "./documentFetchCache";
 import CodeRenderer from "./previews/CodeRenderer";
 import MarkdownRenderer from "./previews/MarkdownRenderer";
 import HtmlPreview from "./previews/HtmlPreview";
@@ -214,6 +215,10 @@ export default function DocumentPreviewContent({
             className="w-full max-h-[65dvh] rounded-xl shadow-2xl ring-1 ring-white/10"
             src={videoUrl}
             style={{ margin: "0 auto", display: "block" }}
+            onError={(e) => {
+              const fallback = mediaProxyFallbackSrc(e.currentTarget);
+              if (fallback) e.currentTarget.src = fallback;
+            }}
           >
             <track kind="captions" />
             {t("documents.videoNotSupported")}
@@ -232,7 +237,15 @@ export default function DocumentPreviewContent({
           >
             <Icon size={36} className={fileInfo.color} />
           </div>
-          <audio controls className="w-full" src={audioUrl}>
+          <audio
+            controls
+            className="w-full"
+            src={audioUrl}
+            onError={(e) => {
+              const fallback = mediaProxyFallbackSrc(e.currentTarget);
+              if (fallback) e.currentTarget.src = fallback;
+            }}
+          >
             {t("documents.audioNotSupported", "您的浏览器不支持音频播放")}
           </audio>
         </div>

--- a/frontend/src/components/documents/__tests__/documentFetchProxyCoverage.test.ts
+++ b/frontend/src/components/documents/__tests__/documentFetchProxyCoverage.test.ts
@@ -1,0 +1,68 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { test, expect } from "vitest";
+
+// 所有拉取上传文件内容的调用点必须走 documentFetchCache 的统一入口，
+// 享受 ?proxy=true 兜底（OSS 直连不可达时经应用源代理重试），
+// 禁止裸 fetch() 绕过——新增预览/导出路径时此测试会拦截回归。
+
+const textConsumers = [
+  "../previews/ExcalidrawCardPreview.tsx",
+  "../previews/ExcalidrawDirectViewer.tsx",
+  "../../common/ExcalidrawThumbnail.tsx",
+  "../../fileLibrary/hooks/useCodePreview.ts",
+  "../../chat/ChatMessage/items/revealPreviewData.ts",
+];
+
+const binaryConsumers = ["../../../utils/exportProjectZip.ts"];
+
+const rawFetchPattern = /(^|[^a-zA-Z_.])fetch\(/;
+
+function readSource(relativePath: string): string {
+  return readFileSync(new URL(relativePath, import.meta.url), "utf8");
+}
+
+function listSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(dir)) {
+    if (name === "__tests__" || name.startsWith(".")) continue;
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) {
+      out.push(...listSourceFiles(p));
+    } else if (/\.(ts|tsx)$/.test(name)) {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+test("text consumers fetch document content via fetchDocumentText", () => {
+  for (const path of textConsumers) {
+    const src = readSource(path);
+    expect(src, `${path} 应使用 fetchDocumentText`).toMatch(
+      /fetchDocumentText\(/,
+    );
+    expect(src, `${path} 不应裸 fetch()`).not.toMatch(rawFetchPattern);
+  }
+});
+
+test("binary consumers download via fetchUploadFile", () => {
+  for (const path of binaryConsumers) {
+    const src = readSource(path);
+    expect(src, `${path} 应使用 fetchUploadFile`).toMatch(/fetchUploadFile\(/);
+    expect(src, `${path} 不应裸 fetch()`).not.toMatch(rawFetchPattern);
+  }
+});
+
+test("no source file combines buildUploadProxyUrl with a raw fetch()", () => {
+  const srcDir = new URL("../../../", import.meta.url).pathname;
+  const offenders: string[] = [];
+  for (const file of listSourceFiles(srcDir)) {
+    const src = readFileSync(file, "utf8");
+    if (src.includes("buildUploadProxyUrl(") && rawFetchPattern.test(src)) {
+      offenders.push(file);
+    }
+  }
+  // 允许清单：目前为空；media 元素走 mediaProxyFallbackSrc onError 换源
+  expect(offenders).toEqual([]);
+});

--- a/frontend/src/components/documents/__tests__/documentFetchProxyFallback.test.ts
+++ b/frontend/src/components/documents/__tests__/documentFetchProxyFallback.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  buildProxyFallbackUrl,
+  clearDocumentFetchCaches,
+  fetchDocumentText,
+  fetchUploadFile,
+  mediaProxyFallbackSrc,
+} from "../documentFetchCache";
+
+function okResponse(body: string): Response {
+  return new Response(body, { status: 200 });
+}
+
+beforeEach(() => {
+  clearDocumentFetchCaches();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("buildProxyFallbackUrl", () => {
+  test("appends proxy=true to a relative upload proxy URL", () => {
+    expect(buildProxyFallbackUrl("/api/upload/file/a/b.txt")).toBe(
+      "/api/upload/file/a/b.txt?proxy=true",
+    );
+  });
+
+  test("appends proxy=true to an absolute upload proxy URL", () => {
+    expect(
+      buildProxyFallbackUrl("https://lambchat.com/api/upload/file/a/b.txt"),
+    ).toBe("https://lambchat.com/api/upload/file/a/b.txt?proxy=true");
+  });
+
+  test("merges with an existing query string", () => {
+    expect(
+      buildProxyFallbackUrl("/api/upload/file/a/b.txt?direct=true"),
+    ).toBe("/api/upload/file/a/b.txt?direct=true&proxy=true");
+  });
+
+  test("returns null when proxy=true is already present", () => {
+    expect(
+      buildProxyFallbackUrl("/api/upload/file/a/b.txt?proxy=true"),
+    ).toBeNull();
+  });
+
+  test("returns null for non upload-proxy URLs", () => {
+    expect(buildProxyFallbackUrl("https://oss.example.com/a/b.txt")).toBeNull();
+    expect(buildProxyFallbackUrl("https://example.com/api/other")).toBeNull();
+  });
+});
+
+describe("fetchDocumentText proxy fallback", () => {
+  test("retries through the app proxy when the redirect target is unreachable", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(okResponse("# code"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const text = await fetchDocumentText(
+      "/api/upload/file/revealed_files/x.R",
+    );
+
+    expect(text).toBe("# code");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      "/api/upload/file/revealed_files/x.R?proxy=true",
+    );
+  });
+
+  test("retries through the app proxy when the upstream responds with an error status", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("bad gateway", { status: 502 }))
+      .mockResolvedValueOnce(okResponse("ok"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const text = await fetchDocumentText("/api/upload/file/a.txt");
+
+    expect(text).toBe("ok");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("does not retry non upload-proxy URLs on network failure", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValue(new TypeError("Failed to fetch"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchDocumentText("https://oss.example.com/a.txt"),
+    ).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("throws when the proxy retry also fails", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchDocumentText("/api/upload/file/a.txt"),
+    ).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // 失败后不缓存，下次点击可重试
+    await expect(fetchDocumentText("/api/upload/file/a.txt")).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  test("succeeds on the first attempt without touching the proxy", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse("fine"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const text = await fetchDocumentText("/api/upload/file/a.txt");
+
+    expect(text).toBe("fine");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("fetchUploadFile init passthrough", () => {
+  test("forwards RequestInit (e.g. abort signal) to direct and proxy attempts", async () => {
+    const controller = new AbortController();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("bad gateway", { status: 502 }))
+      .mockResolvedValueOnce(okResponse("ok"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await fetchUploadFile("/api/upload/file/a.bin", {
+      signal: controller.signal,
+    });
+
+    expect(await res.text()).toBe("ok");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/upload/file/a.bin");
+    expect(fetchMock.mock.calls[0][1]).toEqual({ signal: controller.signal });
+    expect(fetchMock.mock.calls[1][0]).toBe("/api/upload/file/a.bin?proxy=true");
+    expect(fetchMock.mock.calls[1][1]).toEqual({ signal: controller.signal });
+  });
+
+  test("does not proxy-retry a request aborted before the call", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const abortError = new DOMException("Aborted", "AbortError");
+    const fetchMock = vi.fn().mockRejectedValue(abortError);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchUploadFile("/api/upload/file/a.bin", {
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow(abortError);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not proxy-retry when the first attempt is aborted mid-flight", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValue(new DOMException("Aborted", "AbortError"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchUploadFile("/api/upload/file/a.bin"),
+    ).rejects.toThrow("Aborted");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("mediaProxyFallbackSrc", () => {
+  test("returns the proxy src once for an upload-file element src", () => {
+    const el = {
+      src: "https://lambchat.com/api/upload/file/a.mp4",
+      dataset: {} as Record<string, string | undefined>,
+    };
+    expect(mediaProxyFallbackSrc(el)).toBe(
+      "https://lambchat.com/api/upload/file/a.mp4?proxy=true",
+    );
+    expect(el.dataset.proxyFallback).toBe("1");
+    expect(mediaProxyFallbackSrc(el)).toBeNull();
+  });
+
+  test("returns null for non upload element srcs", () => {
+    const el = {
+      src: "https://oss.example.com/a.mp4",
+      dataset: {} as Record<string, string | undefined>,
+    };
+    expect(mediaProxyFallbackSrc(el)).toBeNull();
+    expect(el.dataset.proxyFallback).toBeUndefined();
+  });
+});

--- a/frontend/src/components/documents/documentFetchCache.ts
+++ b/frontend/src/components/documents/documentFetchCache.ts
@@ -1,12 +1,97 @@
 const textCache = new Map<string, Promise<string>>();
 const arrayBufferCache = new Map<string, Promise<ArrayBuffer>>();
 
-async function fetchWithValidation(url: string): Promise<Response> {
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`Failed to fetch file: ${response.status}`);
+/**
+ * Build the app-proxy variant (?proxy=true) of an upload file URL.
+ *
+ * The proxy endpoint streams the file through the backend instead of 302
+ * redirecting to object storage; clients that cannot reach the storage
+ * endpoint directly (e.g. mainland networks vs overseas buckets) can still
+ * download through the app origin. Returns null when the URL is not an
+ * upload proxy URL or already requests the proxy.
+ */
+export function buildProxyFallbackUrl(url: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url, "https://placeholder.invalid");
+  } catch {
+    return null;
   }
-  return response;
+  if (!parsed.pathname.startsWith("/api/upload/file/")) {
+    return null;
+  }
+  if (parsed.searchParams.get("proxy") === "true") {
+    return null;
+  }
+  return `${url}${url.includes("?") ? "&" : "?"}proxy=true`;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+async function fetchWithValidation(
+  url: string,
+  init?: RequestInit,
+): Promise<Response> {
+  let response: Response | null = null;
+  let networkError: unknown = null;
+  try {
+    response = await fetch(url, init);
+  } catch (error) {
+    // 主动取消（如导出 ZIP 的超时 abort）不是网络故障，直接透传，不做代理重试
+    if (isAbortError(error)) {
+      throw error;
+    }
+    networkError = error;
+  }
+
+  if (response?.ok) {
+    return response;
+  }
+
+  const fallbackUrl = buildProxyFallbackUrl(url);
+  if (fallbackUrl) {
+    void response?.body?.cancel().catch(() => {});
+    const retried = await fetch(fallbackUrl, init);
+    if (retried.ok) {
+      return retried;
+    }
+    throw new Error(`Failed to fetch file: ${retried.status}`);
+  }
+
+  if (networkError !== null) {
+    throw networkError;
+  }
+  throw new Error(`Failed to fetch file: ${response?.status}`);
+}
+
+/** Fetch an upload file URL with automatic ?proxy=true fallback (no caching). */
+export async function fetchUploadFile(
+  url: string,
+  init?: RequestInit,
+): Promise<Response> {
+  return fetchWithValidation(url, init);
+}
+
+/**
+ * One-shot proxy retry src for media elements (<img>/<video>/<audio>) whose
+ * direct load failed (e.g. the 302 storage target is unreachable). Returns
+ * the ?proxy=true src to assign once, or null when no retry applies.
+ */
+export function mediaProxyFallbackSrc(el: {
+  src: string;
+  dataset: Record<string, string | undefined>;
+}): string | null {
+  if (el.dataset.proxyFallback === "1") {
+    return null;
+  }
+  const fallback = buildProxyFallbackUrl(el.src);
+  if (!fallback) {
+    return null;
+  }
+  el.dataset.proxyFallback = "1";
+  return fallback;
 }
 
 export function fetchDocumentText(url: string): Promise<string> {

--- a/frontend/src/components/documents/previews/ExcalidrawCardPreview.tsx
+++ b/frontend/src/components/documents/previews/ExcalidrawCardPreview.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { buildUploadProxyUrl, getFullUrl } from "../../../services/api/config";
+import { fetchDocumentText } from "../documentFetchCache";
 import { ImageWithSkeleton } from "../../chat/ChatMessage/ImageWithSkeleton";
 
 /**
@@ -18,9 +19,7 @@ export function ExcalidrawCardPreview({ url }: { url: string }) {
 
     const load = async () => {
       try {
-        const res = await fetch(readUrl);
-        if (!res.ok || cancelled) return;
-        const data = await res.text();
+        const data = await fetchDocumentText(readUrl);
         if (cancelled) return;
 
         const parsed = JSON.parse(data);

--- a/frontend/src/components/documents/previews/ExcalidrawDirectViewer.tsx
+++ b/frontend/src/components/documents/previews/ExcalidrawDirectViewer.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { buildUploadProxyUrl, getFullUrl } from "../../../services/api/config";
+import { fetchDocumentText } from "../documentFetchCache";
 import { ExcalidrawFullscreenViewer } from "./ExcalidrawPreview";
 import { LoadingSpinner } from "../../common/LoadingSpinner";
 import { useTranslation } from "react-i18next";
@@ -27,9 +28,7 @@ export function ExcalidrawDirectViewer({
 
     const load = async () => {
       try {
-        const res = await fetch(readUrl);
-        if (!res.ok || cancelled) throw new Error("Failed to fetch");
-        const data = await res.text();
+        const data = await fetchDocumentText(readUrl);
         if (cancelled) return;
 
         // Parse excalidraw JSON

--- a/frontend/src/components/documents/useDocumentPreviewState.ts
+++ b/frontend/src/components/documents/useDocumentPreviewState.ts
@@ -21,6 +21,7 @@ import {
 import {
   fetchDocumentArrayBuffer,
   fetchDocumentText,
+  fetchUploadFile,
 } from "./documentFetchCache";
 import {
   getFileExtension,
@@ -331,7 +332,13 @@ export function useDocumentPreviewState(props: DocumentPreviewProps) {
           const readUrl = buildUploadProxyUrl(url) || url;
 
           if (resolvedImageFile) {
-            setImageUrl(url);
+            // 走应用代理兜底取 blob（与下载按钮一致），失败则退回原始 URL 交给 <img>
+            try {
+              const response = await fetchUploadFile(readUrl);
+              setImageUrl(URL.createObjectURL(await response.blob()));
+            } catch {
+              setImageUrl(url);
+            }
             setData({ content: "", path });
             setLoading(false);
             return;
@@ -362,7 +369,9 @@ export function useDocumentPreviewState(props: DocumentPreviewProps) {
           }
 
           if (cadFile) {
-            setCadUrl(readUrl);
+            // dxf-viewer 内部裸 fetch 该 URL——先经代理兜底取 blob，OSS 不可达也能渲染
+            const cadBuffer = await fetchDocumentArrayBuffer(readUrl);
+            setCadUrl(URL.createObjectURL(new Blob([cadBuffer])));
             setCadKind(dxfFile ? "dxf" : "dwg");
             setData({ content: "", path });
             setLoading(false);
@@ -446,8 +455,11 @@ export function useDocumentPreviewState(props: DocumentPreviewProps) {
       if (pdfUrl?.startsWith("blob:")) {
         URL.revokeObjectURL(pdfUrl);
       }
+      if (imageUrl?.startsWith("blob:")) {
+        URL.revokeObjectURL(imageUrl);
+      }
     };
-  }, [cadUrl, htmlUrl, pdfUrl]);
+  }, [cadUrl, htmlUrl, pdfUrl, imageUrl]);
 
   // Action handlers
   const handleCopy = async () => {
@@ -463,7 +475,7 @@ export function useDocumentPreviewState(props: DocumentPreviewProps) {
       getFullUrl(signedUrl) || resolvedUrl || getFullUrl(externalImageUrl);
     if (downloadUrl) {
       try {
-        const response = await fetch(
+        const response = await fetchUploadFile(
           buildUploadProxyUrl(downloadUrl) || downloadUrl,
         );
         const blob = await response.blob();

--- a/frontend/src/components/fileLibrary/hooks/useCodePreview.ts
+++ b/frontend/src/components/fileLibrary/hooks/useCodePreview.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import type { RevealedFileItem } from "../../../services/api";
 import { buildUploadProxyUrl, getFullUrl } from "../../../services/api/config";
+import { fetchDocumentText } from "../../documents/documentFetchCache";
 
 const PREVIEW_MAX_LINES = 6;
 const PREVIEW_MAX_SIZE = 1024 * 1024; // 1 MB
@@ -43,10 +44,7 @@ export function useCodePreview(file: RevealedFileItem): string | null {
     if (!fullUrl) return;
     const readUrl = buildUploadProxyUrl(file.url) || fullUrl;
 
-    fetch(readUrl)
-      .then((res: Response) =>
-        res.ok ? res.text() : Promise.reject(res.status),
-      )
+    fetchDocumentText(readUrl)
       .then((text: string) => {
         const lines = text.split("\n", PREVIEW_MAX_LINES + 1);
         const snippet = lines.slice(0, PREVIEW_MAX_LINES).join("\n");

--- a/frontend/src/utils/exportProjectZip.ts
+++ b/frontend/src/utils/exportProjectZip.ts
@@ -1,5 +1,6 @@
 import JSZip from "jszip";
 import { buildUploadProxyUrl } from "../services/api/config";
+import { fetchUploadFile } from "../components/documents/documentFetchCache";
 
 export interface ExportProjectZipOptions {
   /** Reject before creating the ZIP if any binary URL cannot be downloaded. */
@@ -135,7 +136,9 @@ export async function exportProjectZip(
           : undefined;
         try {
           const readUrl = buildUploadProxyUrl(sourceUrl) || sourceUrl;
-          const response = await fetch(readUrl, { signal: controller.signal });
+          const response = await fetchUploadFile(readUrl, {
+            signal: controller.signal,
+          });
           if (!response.ok) throw new Error("Binary download failed");
           const remainingBytes = Math.max(maxBytes - downloadedBytes, 0);
           const buffer = await readResponseWithinLimit(


### PR DESCRIPTION
## 背景

大陆等网络环境下，`/api/upload/file/*` 的 302 跳转目标（海外 OSS）经常不可达，导致文件预览/缩略图/导出全部失败。后端 `get_file_proxy` 已支持 `?proxy=true`（经应用源流式转发、不 302），本 PR 让前端所有取文件内容的路径在直连失败时自动走该兜底。

## 改动

**统一入口（documentFetchCache.ts）**
- `buildProxyFallbackUrl`：为上传文件 URL 生成 `?proxy=true` 变体（非上传 URL / 已带 proxy 返回 null）
- `fetchUploadFile(url, init?)`：RequestInit 透传（abort 信号）；直连网络错误或非 2xx → 一次性代理重试；**abort 主动取消直接透传，不做无意义重试**（ZIP 导出的 30s 超时取消场景）
- `mediaProxyFallbackSrc`：媒体元素 onError 一次性换源

**6 处裸 fetch 收口**：Excalidraw 卡片/全屏/缩略图、useCodePreview、revealPreviewData、exportProjectZip（保留 abort）

**媒体预览兜底**：图片走 blob（与下载按钮一致，复用 `fetchDocumentText` 缓存）；视频/音频 onError 换代理源（流式零内存）；DXF/DWG 先取 blob 再交给 dxf-viewer（其内部裸 fetch 不可达即挂）

## 测试

- 18 个单测（URL 构建/重试语义/abort 短路/失败不缓存/RequestInit 透传/媒体换源一次性）
- 源码结构覆盖测试：扫描全 src，禁止 buildUploadProxyUrl 与裸 fetch 共存，新增预览路径自动被拦截
- 全量 1665 通过 + ESLint + tsc -b + vite build 全绿
- 独立 code review 完成（3 个 Important 全修：abort 短路、DXF 绕过、媒体元素直连）

## 已知边界（descope）

- 旧版 .doc 降级面板的下载链接为原生 `<a>`，不走兜底（罕见路径）
- 纯 OSS 外链图片（非 /api/upload/file 前缀）无兜底——代理端点仅覆盖应用上传文件