### PR TITLE
chore: bump version to 2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## v2.7.0 (2026-08-28)
+
+### ✨ New Features
+
+- Add a production memory system: auto-capture of full exchanges with a daily cap, query-time relevance injection with write-time persistence (sent bytes == stored bytes), context-field scope filtering across recall/tools/API/panels, an opt-in VFS working-memory layer, embedding model hot-swap, and automatic vector index creation (#264).
+- Fold assistant mid-run process output into a Codex-style status summary line with working/done states and design-aligned default expansion (#267).
+- Add trace window pagination for session events to keep long sessions responsive.
+- Add SEO foundations: a real sitemap, self-hosted fonts, compressed og images, HEAD request support, www 301, and hreflang with real paths (#258, #259, #260).
+- Add Git-flow release infrastructure: a develop integration branch with dated images, a staging environment, and a main merge gate (#263); AGENTS.md becomes the single source of development conventions (#262).
+- Add a running-state composer placeholder hinting that typed follow-ups queue as ordered steers.
+
+### 🐛 Bug Fixes
+
+- Fix previews and exports for networks that cannot reach object storage: every upload-file fetch (document/excalidraw/code previews, project reveal, ZIP export) retries once through the app proxy (`?proxy=true`) when the direct redirect target fails; image previews switch to blobs and video/audio/DXF gain fallback paths (#269).
+- Fix the embedded arq worker silently dropping out of queue consumption after unsupervised future failures — workers are now supervised and restarted (#261).
+- Fix GPT 401s from upstream key exhaustion by routing auth errors into the fallback chain (#252); stop sending the hardcoded 0.7 temperature so unset models use provider defaults (#250); split first-byte and total stream timeouts for unstable relays (#239); deduplicate replayed upstream response ids via UniqueResponseIdMiddleware (#245).
+- Fix assistant-reply misalignment when resending the same user message (#247).
+- Fix long-session open freezes caused by full prefetch and quadratic rebuilds (#248).
+- Fix distributed-runtime configuration: connection settings are env-authoritative with masked alerts, and upload URLs follow the actual entry origin (#249, #253).
+- Fix the /stream route being hijacked by a helper, with route-binding regression tests.
+- Fix settings.set on unregistered keys no longer triggering cross-instance broadcasts.
+- Fix streaming timers frozen behind a static elapsed value and align the collapse summary color with body text (#267).
+- Fix share pages stuck in the sepia theme and add /fonts/ to the anonymous auth whitelist.
+
+### ♻️ Refactors
+
+- Unify scroll behavior and font styles (font-serif) across components; format the whole repository with ruff, docs code blocks included.
+
+### 🧪 Tests & Infrastructure
+
+- Add a production distributed regression suite (load balancing, auth, sessions, arq consumption, SSE/WS delivery, checkpoints, uploads, scheduled tasks); repair the CI reds from an escaped direct push and split oversized frontend hooks (#255, #257).
+
+---
+
 ## v2.6.0 (2026-08-23)
 
 ### ✨ New Features

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 title: "LambChat"
-version: 2.6.0
+version: 2.7.0
 date-released: 2026-08-23
 url: "https://github.com/Yanyutin753/LambChat"
 abstract: Full-featured AI DeepAgents system with FastAPI, LangGraph, and LangSmith

--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.lambchat.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 260
-        versionName "2.6.0"
+        versionCode 270
+        versionName "2.7.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/frontend/ios/App/App.xcodeproj/project.pbxproj
+++ b/frontend/ios/App/App.xcodeproj/project.pbxproj
@@ -352,7 +352,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 2.6.0;
+				MARKETING_VERSION = 2.7.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.lambchat.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -372,7 +372,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 2.6.0;
+				MARKETING_VERSION = 2.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lambchat.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lambchat-frontend",
   "private": true,
-  "version": "2.6.0",
+  "version": "2.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambchat"
-version = "2.6.0"
+version = "2.7.0"
 description = "LambChat desktop app"
 authors = ["LambChat"]
 license = ""

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LambChat",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "identifier": "com.lambchat.app",
   "build": {
     "frontendDist": "../dist",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lambchat"
-version = "2.6.0"
+version = "2.7.0"
 description = "Full-featured AI Agent system with FastAPI, LangGraph, and LangSmith"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1942,7 +1942,7 @@ wheels = [
 
 [[package]]
 name = "lambchat"
-version = "2.6.0"
+version = "2.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
发布 v2.7.0：自 v2.6.0（2026-08-23）以来 31+ PR 的功能合集——记忆系统增强（#264）、助手消息过程折叠（#267）、文件预览全链路代理兜底（#269）、SEO 基础（#258-#260）、arq worker 监督（#261）、Git-flow 发布流水线（#263）等。

- 9 个版本文件同步 2.6.0 → 2.7.0（CITATION/android/ios/tauri/package.json/pyproject/uv.lock）
- CHANGELOG.md 新增 v2.7.0 段落
- 合并后随本 release 晋升 main 并打 v2.7.0 tag