### PR TITLE
fix(frontend): RunStepsCollapse 导入显式 .tsx 扩展名——修复 v2.7.0 客户端构建

### DIFF
--- a/frontend/src/components/chat/ChatMessage/index.tsx
+++ b/frontend/src/components/chat/ChatMessage/index.tsx
@@ -22,7 +22,7 @@ import {
 } from "./revealFileImageUtils";
 import { MessageImageGallery } from "./MessageImageGallery";
 import { RevealArtifactsSummary } from "./RevealArtifactsSummary";
-import { RunStepsCollapse } from "./RunStepsCollapse";
+import { RunStepsCollapse } from "./RunStepsCollapse.tsx";
 import {
   countRunSteps,
   getRunElapsedMs,


### PR DESCRIPTION
## 问题

v2.7.0 tag 的 App Release 中 iOS / Desktop macOS / Desktop Windows 构建失败：

```
index.tsx(25): TS2305 Module '"./RunStepsCollapse"' has no exported member 'RunStepsCollapse'
index.tsx(25): TS1261 'RunStepsCollapse.ts' differs from 'runStepsCollapse.ts' only in casing
```

## 根因

`RunStepsCollapse.tsx`（组件）与 `runStepsCollapse.ts`（纯逻辑）basename 仅差大小写。大小写不敏感文件系统（macOS/Windows）上，TS 解析不带扩展名的 `'./RunStepsCollapse'` 时先探 `.ts` 后缀，命中了 `runStepsCollapse.ts` → 组件导入失败。Linux（大小写敏感）正确落到 `.tsx`，所以 develop/main 的 Web CI 与生产一直全绿。

## 修复

一行：`from "./RunStepsCollapse"` → `from "./RunStepsCollapse.tsx"`，对齐仓库既有先例（modelIcon.tsx/modelIcon.ts 同款碰撞的解法）。

- tsc -b 干净，ChatMessage 目录 156 测试全过
- Web 产物无变化（Linux 解析结果不变），生产无需重新部署
- 合并后重指 v2.7.0 tag 并重跑 App Release