### PR TITLE
fix(infra): 修复分布式多副本 5 项缺陷——调度器死开关/校验k8s识别/HITL静态订阅/worker重启死区/取消文案

### DIFF
--- a/src/infra/distributed_validation.py
+++ b/src/infra/distributed_validation.py
@@ -37,7 +37,10 @@ def is_distributed_runtime(environ: dict[str, str] | None = None) -> bool:
         except ValueError:
             return False
 
-    return False
+    # k8s Pod 内该变量由 kubelet 注入且必然存在：容器文件系统为临时层，
+    # 上传/密钥等配置必须满足多副本约束。显式 LAMBCHAT_DISTRIBUTED_MODE
+    # 仍可覆盖（例如单副本 k8s 调试场景设为 false）。
+    return bool(env.get("KUBERNETES_SERVICE_HOST"))
 
 
 def _was_generated(settings: Any, attr_name: str) -> bool:

--- a/src/infra/runtime_services.py
+++ b/src/infra/runtime_services.py
@@ -225,7 +225,10 @@ async def start_runtime_services() -> None:
         await scheduled_task_service.load_persisted_tasks()
         register_scheduled_task_reconcile_job(scheduled_task_service)
 
-        get_runtime_scheduler().start()
+    # Runtime scheduler 承载基础设施 job（task.orphan_recovery、
+    # memory.compaction），必须无条件启动；ENABLE_SCHEDULED_TASK 只控制
+    # 用户定时任务功能（reconcile job 与 DB 加载）。
+    get_runtime_scheduler().start()
 
 
 async def stop_runtime_services() -> None:

--- a/src/infra/storage/mongodb.py
+++ b/src/infra/storage/mongodb.py
@@ -478,6 +478,55 @@ async def notify_approval_response(approval_id: str, response: ApprovalResponse)
         logger.warning("Failed to publish approval response notification: %s", e)
 
 
+# 静态订阅的等待者注册表：approval_id -> 等待事件集合。
+# 订阅/退订频道会让共享 pubsub hub 重启整条连接（窗口内所有频道消息丢失），
+# 因此频道只订阅一次，由 handler 按 approval_id 分发唤醒。
+_approval_waiters_lock = asyncio.Lock()
+_approval_waiters: dict[str, set[asyncio.Event]] = {}
+_approval_channel_subscribed = False
+
+
+async def _reset_approval_notification_state() -> None:
+    """测试辅助：清空静态订阅状态与等待者。"""
+    global _approval_channel_subscribed
+    async with _approval_waiters_lock:
+        _approval_waiters.clear()
+        _approval_channel_subscribed = False
+
+
+async def _on_approval_response_message(message: dict[str, Any]) -> None:
+    try:
+        data = await run_blocking_io(json.loads, message.get("data") or "{}")
+    except json.JSONDecodeError:
+        logger.warning("Invalid approval response notification: %s", message.get("data"))
+        return
+    approval_id = data.get("approval_id")
+    if not approval_id:
+        return
+    async with _approval_waiters_lock:
+        events = list(_approval_waiters.get(approval_id, ()))
+    for event in events:
+        event.set()
+
+
+async def _ensure_approval_channel_subscribed() -> bool:
+    """确保审批频道已静态订阅；失败时返回 False（等待方退化为 Mongo 轮询兜底）。"""
+    global _approval_channel_subscribed
+    async with _approval_waiters_lock:
+        if _approval_channel_subscribed:
+            return True
+    try:
+        hub = get_pubsub_hub()
+        hub.subscribe(APPROVAL_RESPONSE_CHANNEL, _on_approval_response_message)
+        await hub.start()
+    except Exception as e:
+        logger.warning("Failed to subscribe approval response notifications: %s", e)
+        return False
+    async with _approval_waiters_lock:
+        _approval_channel_subscribed = True
+    return True
+
+
 async def wait_for_response_distributed(
     approval_id: str,
     timeout: float = 300,
@@ -498,25 +547,11 @@ async def wait_for_response_distributed(
     max_interval = 3.0
     current_interval = min_interval
     notification_event = asyncio.Event()
-    subscription_token: str | None = None
-    hub = None
 
-    async def _handle_notification(message: dict[str, Any]) -> None:
-        try:
-            data = await run_blocking_io(json.loads, message.get("data") or "{}")
-            if data.get("approval_id") == approval_id:
-                notification_event.set()
-        except json.JSONDecodeError:
-            logger.warning("Invalid approval response notification: %s", message.get("data"))
-
-    try:
-        hub = get_pubsub_hub()
-        subscription_token = hub.subscribe(APPROVAL_RESPONSE_CHANNEL, _handle_notification)
-        await hub.start()
-    except Exception as e:
-        logger.warning("Failed to subscribe approval response notifications: %s", e)
-        hub = None
-        subscription_token = None
+    # 先注册等待者再订阅：hub.start() 可能在订阅完成前即投递消息。
+    async with _approval_waiters_lock:
+        _approval_waiters.setdefault(approval_id, set()).add(notification_event)
+    await _ensure_approval_channel_subscribed()
 
     try:
         while True:
@@ -544,6 +579,9 @@ async def wait_for_response_distributed(
             if response:
                 return response
     finally:
-        if hub is not None and subscription_token is not None:
-            hub.unsubscribe(subscription_token)
-            await hub.stop_if_idle()
+        async with _approval_waiters_lock:
+            events = _approval_waiters.get(approval_id)
+            if events is not None:
+                events.discard(notification_event)
+                if not events:
+                    _approval_waiters.pop(approval_id, None)

--- a/src/infra/task/arq_runtime.py
+++ b/src/infra/task/arq_runtime.py
@@ -155,9 +155,7 @@ async def _recover_stale_tasks_after_worker_restart() -> None:
 def get_arq_runtime() -> EmbeddedArqRuntime:
     global _runtime
     if _runtime is None:
-        _runtime = EmbeddedArqRuntime(
-            on_worker_restarted=_recover_stale_tasks_after_worker_restart
-        )
+        _runtime = EmbeddedArqRuntime(on_worker_restarted=_recover_stale_tasks_after_worker_restart)
     return _runtime
 
 

--- a/src/infra/task/arq_runtime.py
+++ b/src/infra/task/arq_runtime.py
@@ -27,12 +27,15 @@ class EmbeddedArqRuntime:
         self,
         worker_factory: Callable[..., Any] = Worker,
         restart_delay_seconds: float = 5.0,
+        on_worker_restarted: Callable[[], Any] | None = None,
     ) -> None:
         self._worker_factory = worker_factory
         self._restart_delay = restart_delay_seconds
+        self._on_worker_restarted = on_worker_restarted
         self._worker: Any | None = None
         self._supervisor: asyncio.Future | None = None
         self._stopping = False
+        self._recovery_tasks: set[asyncio.Task[None]] = set()
 
     @property
     def is_running(self) -> bool:
@@ -108,6 +111,14 @@ class EmbeddedArqRuntime:
             if self._stopping:
                 return
             self._worker = self._create_worker()
+            # worker 崩溃时在途 run 会被标为 FAILED+recoverable（payload 已删），
+            # 周期孤儿接管是 running_only 会跳过它们——重启后主动补一次恢复，
+            # 否则这些会话要等任意 Pod 重启才能恢复。
+            callback = self._on_worker_restarted
+            if callback is not None:
+                recovery_task = asyncio.create_task(callback())
+                self._recovery_tasks.add(recovery_task)
+                recovery_task.add_done_callback(self._recovery_tasks.discard)
 
     async def stop(self) -> None:
         self._stopping = True
@@ -121,6 +132,9 @@ class EmbeddedArqRuntime:
             except asyncio.CancelledError:
                 pass
 
+        if self._recovery_tasks:
+            await asyncio.gather(*self._recovery_tasks, return_exceptions=True)
+
         self._worker = None
         self._supervisor = None
 
@@ -128,10 +142,22 @@ class EmbeddedArqRuntime:
 _runtime: EmbeddedArqRuntime | None = None
 
 
+async def _recover_stale_tasks_after_worker_restart() -> None:
+    """Worker 崩溃重启后补一次全量恢复（与启动清理等价，有租约互斥保护）。"""
+    try:
+        from .manager import get_task_manager
+
+        await get_task_manager().cleanup_stale_tasks(running_only=False)
+    except Exception:
+        logger.exception("Post-restart stale task recovery failed")
+
+
 def get_arq_runtime() -> EmbeddedArqRuntime:
     global _runtime
     if _runtime is None:
-        _runtime = EmbeddedArqRuntime()
+        _runtime = EmbeddedArqRuntime(
+            on_worker_restarted=_recover_stale_tasks_after_worker_restart
+        )
     return _runtime
 
 

--- a/src/infra/task/manager.py
+++ b/src/infra/task/manager.py
@@ -647,38 +647,44 @@ class BackgroundTaskManager:
         # 获取 current_run_id
         try:
             session = await self.storage.get_by_session_id(session_id)
-            if session and session.metadata:
-                run_id = session.metadata.get("current_run_id")
-                if run_id:
-                    # current_run_id 在 run 结束后仍保留；任务已终态时取消是
-                    # 迟到的停止请求，不得把已完成的 trace 改写成 error，
-                    # 也不得污染会话的 task_error_code 元数据。
-                    task_status = session.metadata.get("task_status")
-                    if self._state_machine.is_terminal(task_status):
-                        return {
-                            "success": False,
-                            "cancelled_locally": False,
-                            "run_id": None,
-                            "message": "没有正在运行的任务",
-                        }
-                    run_info = await self._build_run_info_from_session(
-                        session,
-                        session_id=session_id,
-                        run_id=str(run_id),
-                        user_id=user_id,
-                    )
-                    return await self.cancel_run(
-                        str(run_id),
-                        user_id=user_id,
-                        run_info_override=run_info,
-                    )
-                else:
+            if not session or not session.metadata:
+                return {
+                    "success": False,
+                    "cancelled_locally": False,
+                    "run_id": None,
+                    "message": "没有正在运行的任务",
+                }
+            run_id = session.metadata.get("current_run_id")
+            if run_id:
+                # current_run_id 在 run 结束后仍保留；任务已终态时取消是
+                # 迟到的停止请求，不得把已完成的 trace 改写成 error，
+                # 也不得污染会话的 task_error_code 元数据。
+                task_status = session.metadata.get("task_status")
+                if self._state_machine.is_terminal(task_status):
                     return {
                         "success": False,
                         "cancelled_locally": False,
                         "run_id": None,
                         "message": "没有正在运行的任务",
                     }
+                run_info = await self._build_run_info_from_session(
+                    session,
+                    session_id=session_id,
+                    run_id=str(run_id),
+                    user_id=user_id,
+                )
+                return await self.cancel_run(
+                    str(run_id),
+                    user_id=user_id,
+                    run_info_override=run_info,
+                )
+            else:
+                return {
+                    "success": False,
+                    "cancelled_locally": False,
+                    "run_id": None,
+                    "message": "没有正在运行的任务",
+                }
         except Exception as e:
             logger.warning(f"Failed to cancel session {session_id}: {e}")
         return {

--- a/tests/infra/task/test_arq_runtime.py
+++ b/tests/infra/task/test_arq_runtime.py
@@ -248,3 +248,65 @@ async def test_worker_silent_exit_restarts_worker(
     assert runtime.is_running is True
 
     await runtime.stop()
+
+
+@pytest.mark.asyncio
+async def test_worker_crash_triggers_post_restart_recovery_callback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """worker 崩溃重启后必须触发一次 FAILED-recoverable 恢复。
+
+    回归防护：worker 被掐断的 run 落在 FAILED+recoverable（payload 已删），
+    周期孤儿接管 running_only=True 会跳过它们——没有这个回调，会话只能
+    等到下一次 Pod 重启才被恢复（分布式 P1 死区）。
+    """
+
+    class _CrashOnceWorker(_FakeWorker):
+        runs = 0
+
+        async def async_run(self) -> None:
+            type(self).runs += 1
+            if type(self).runs == 1:
+                raise RuntimeError("simulated worker crash")
+            await self.closed.wait()
+
+    _FakeWorker.instances.clear()
+    monkeypatch.setattr(arq_runtime, "settings", _arq_settings())
+    recovery_calls: list[int] = []
+
+    async def _on_worker_restarted() -> None:
+        recovery_calls.append(1)
+
+    runtime = arq_runtime.EmbeddedArqRuntime(
+        worker_factory=_CrashOnceWorker,
+        restart_delay_seconds=0.01,
+        on_worker_restarted=_on_worker_restarted,
+    )
+    await runtime.start()
+
+    await _wait_until(lambda: len(recovery_calls) >= 1)
+    await asyncio.sleep(0.05)
+
+    assert len(recovery_calls) == 1
+    await runtime.stop()
+
+
+@pytest.mark.asyncio
+async def test_recovery_callback_not_invoked_without_worker_crash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _FakeWorker.instances.clear()
+    monkeypatch.setattr(arq_runtime, "settings", _arq_settings())
+    recovery_calls: list[int] = []
+
+    async def _on_worker_restarted() -> None:
+        recovery_calls.append(1)
+
+    runtime = arq_runtime.EmbeddedArqRuntime(
+        worker_factory=_FakeWorker, on_worker_restarted=_on_worker_restarted
+    )
+    await runtime.start()
+    await asyncio.sleep(0.05)
+
+    assert recovery_calls == []
+    await runtime.stop()

--- a/tests/infra/task/test_manager_cancel_terminal.py
+++ b/tests/infra/task/test_manager_cancel_terminal.py
@@ -98,3 +98,23 @@ async def test_cancel_proceeds_when_task_active_or_status_missing(task_status):
     assert result["success"] is True
     assert len(cancellation.calls) == 1
     assert cancellation.calls[0]["run_id"] == "run-active"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("empty_metadata", [None, {}])
+async def test_cancel_reports_no_running_task_when_session_metadata_empty(empty_metadata):
+    """新建会话 metadata 为空 dict/None：取消应报"没有正在运行的任务"而非"取消失败"。
+
+    空 metadata 会掉进 fall-through 返回通用失败文案，前端会误展示为系统错误。
+    """
+    session = SimpleNamespace(
+        id="session-1", user_id="user-1", agent_id="search", metadata=empty_metadata
+    )
+    manager, cancellation, _storage = _manager_with(session)
+
+    result = await manager.cancel("session-1", user_id="user-1")
+
+    assert result["success"] is False
+    assert result["run_id"] is None
+    assert "没有正在运行的任务" in result["message"]
+    assert cancellation.calls == []

--- a/tests/infra/test_distributed_validation.py
+++ b/tests/infra/test_distributed_validation.py
@@ -78,3 +78,25 @@ def test_is_distributed_runtime_detects_replica_count(monkeypatch: pytest.Monkey
     monkeypatch.setenv("LAMBCHAT_REPLICA_COUNT", "2")
 
     assert is_distributed_runtime() is True
+
+
+def test_is_distributed_runtime_detects_kubernetes_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """k8s Pod 内 KUBERNETES_SERVICE_HOST 一定存在，应自动启用分布式校验。
+
+    回归防护：此前仅在显式设置 LAMBCHAT_DISTRIBUTED_MODE / REPLICA_COUNT 时
+    校验才生效，生产 k8s 双 Pod 未设这两个变量 → S3 关闭等危险配置静默上线。
+    """
+    monkeypatch.delenv("LAMBCHAT_DISTRIBUTED_MODE", raising=False)
+    monkeypatch.delenv("LAMBCHAT_REPLICA_COUNT", raising=False)
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.43.0.1")
+
+    assert is_distributed_runtime() is True
+
+
+def test_is_distributed_runtime_kubernetes_env_overridable_by_explicit_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.43.0.1")
+    monkeypatch.setenv("LAMBCHAT_DISTRIBUTED_MODE", "false")
+
+    assert is_distributed_runtime() is False

--- a/tests/infra/test_mongodb_storage.py
+++ b/tests/infra/test_mongodb_storage.py
@@ -407,12 +407,8 @@ async def test_static_approval_notification_routes_by_approval_id(
     monkeypatch.setattr(mongodb, "get_pubsub_hub", lambda: _FakeHub(), raising=False)
 
     await mongodb._reset_approval_notification_state()
-    task_a = asyncio.create_task(
-        mongodb.wait_for_response_distributed("approval-a", timeout=3)
-    )
-    task_b = asyncio.create_task(
-        mongodb.wait_for_response_distributed("approval-b", timeout=3)
-    )
+    task_a = asyncio.create_task(mongodb.wait_for_response_distributed("approval-a", timeout=3))
+    task_b = asyncio.create_task(mongodb.wait_for_response_distributed("approval-b", timeout=3))
     await asyncio.sleep(0.1)  # 让两个等待者都注册完毕
 
     handler = handler_holder["handler"]

--- a/tests/infra/test_mongodb_storage.py
+++ b/tests/infra/test_mongodb_storage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 
 import pytest
@@ -302,13 +303,130 @@ async def test_wait_for_response_distributed_returns_on_pubsub_notification(
     monkeypatch.setattr(mongodb, "get_approval_storage", lambda: storage)
     monkeypatch.setattr(mongodb, "get_pubsub_hub", lambda: _FakeHub(), raising=False)
 
+    await mongodb._reset_approval_notification_state()
     result = await mongodb.wait_for_response_distributed("approval-1", timeout=1)
 
     assert result == response
     assert subscribed["channel"] == mongodb.APPROVAL_RESPONSE_CHANNEL
-    assert subscribed["unsubscribed"] == "token-1"
-    assert subscribed["stopped_if_idle"] is True
+    # 静态订阅：等待结束不退订、不尝试停连接——退订会触发 pubsub hub
+    # 重订整条连接，窗口内所有频道消息丢失（分布式 P1）。
+    assert "unsubscribed" not in subscribed
+    assert "stopped_if_idle" not in subscribed
     assert storage.get_response_calls == 1
+    await mongodb._reset_approval_notification_state()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_response_distributed_subscribes_channel_only_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """两个连续等待只应 subscribe 一次，且永不 unsubscribe/stop_if_idle。
+
+    回归防护：动态订阅/退订会让共享 pubsub hub 杀掉整条连接重订，
+    每次 HITL 审批等待制造两次全频道消息丢失窗口。
+    """
+    response = ApprovalResponse(approved=True, response={"ok": True})
+    subscribe_calls: list[str] = []
+    unsubscribe_calls: list[str] = []
+    stop_if_idle_calls = 0
+    handler_holder: dict[str, object] = {}
+
+    class _FakeStorage:
+        async def has_response(self, _approval_id: str) -> bool:
+            return True
+
+        async def get_response(self, _approval_id: str):
+            return response
+
+    class _FakeHub:
+        def subscribe(self, channel: str, handler):
+            subscribe_calls.append(channel)
+            handler_holder["handler"] = handler
+            return f"token-{len(subscribe_calls)}"
+
+        def unsubscribe(self, token: str) -> None:
+            unsubscribe_calls.append(token)
+
+        async def start(self) -> None:
+            handler_holder["started"] = True
+
+        async def stop_if_idle(self) -> None:
+            nonlocal stop_if_idle_calls
+            stop_if_idle_calls += 1
+
+    storage = _FakeStorage()
+    hub = _FakeHub()
+    monkeypatch.setattr(mongodb, "get_approval_storage", lambda: storage)
+    monkeypatch.setattr(mongodb, "get_pubsub_hub", lambda: hub, raising=False)
+
+    await mongodb._reset_approval_notification_state()
+    first = await mongodb.wait_for_response_distributed("approval-a", timeout=1)
+    second = await mongodb.wait_for_response_distributed("approval-b", timeout=1)
+
+    assert first == response
+    assert second == response
+    assert subscribe_calls == [mongodb.APPROVAL_RESPONSE_CHANNEL]
+    assert unsubscribe_calls == []
+    assert stop_if_idle_calls == 0
+    await mongodb._reset_approval_notification_state()
+
+
+@pytest.mark.asyncio
+async def test_static_approval_notification_routes_by_approval_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """静态 handler 只唤醒匹配 approval_id 的等待者，不误醒其他等待者。"""
+    response_a = ApprovalResponse(approved=True, response={"which": "a"})
+    handler_holder: dict[str, object] = {}
+
+    class _FakeStorage:
+        async def has_response(self, approval_id: str) -> bool:
+            return approval_id == "approval-a"
+
+        async def get_response(self, approval_id: str):
+            if approval_id == "approval-a":
+                return response_a
+            return None
+
+    class _FakeHub:
+        def subscribe(self, channel: str, handler):
+            handler_holder["handler"] = handler
+            return "token-1"
+
+        def unsubscribe(self, token: str) -> None:
+            pass
+
+        async def start(self) -> None:
+            pass
+
+        async def stop_if_idle(self) -> None:
+            pass
+
+    storage = _FakeStorage()
+    monkeypatch.setattr(mongodb, "get_approval_storage", lambda: storage)
+    monkeypatch.setattr(mongodb, "get_pubsub_hub", lambda: _FakeHub(), raising=False)
+
+    await mongodb._reset_approval_notification_state()
+    task_a = asyncio.create_task(
+        mongodb.wait_for_response_distributed("approval-a", timeout=3)
+    )
+    task_b = asyncio.create_task(
+        mongodb.wait_for_response_distributed("approval-b", timeout=3)
+    )
+    await asyncio.sleep(0.1)  # 让两个等待者都注册完毕
+
+    handler = handler_holder["handler"]
+    await handler({"data": '{"approval_id": "approval-a"}'})
+    await asyncio.sleep(0.1)
+
+    assert task_a.done() and task_a.result() is response_a
+    assert not task_b.done(), "approval-b 不应被 approval-a 的通知唤醒"
+    task_b.cancel()
+    try:
+        await task_b
+    except asyncio.CancelledError:
+        pass
+    await mongodb._reset_approval_notification_state()
 
 
 @pytest.mark.asyncio
@@ -351,10 +469,12 @@ async def test_wait_for_response_distributed_offloads_notification_json_parse(
     monkeypatch.setattr(mongodb, "get_pubsub_hub", lambda: _FakeHub(), raising=False)
     monkeypatch.setattr(mongodb, "run_blocking_io", fake_run_blocking_io)
 
+    await mongodb._reset_approval_notification_state()
     result = await mongodb.wait_for_response_distributed("approval-1", timeout=1)
 
     assert result == response
     assert calls == [json.loads]
+    await mongodb._reset_approval_notification_state()
 
 
 @pytest.mark.asyncio

--- a/tests/infra/test_runtime_services.py
+++ b/tests/infra/test_runtime_services.py
@@ -313,7 +313,61 @@ async def test_start_runtime_services_skips_scheduled_task_runtime_when_disabled
     assert scheduled_task_storage.ensure_indexes_calls == 0
     assert scheduled_task_service.load_calls == 0
     assert scheduler.registered_job_ids == []
-    assert scheduler.start_calls == 0
+    # ENABLE_SCHEDULED_TASK 只应关掉用户定时任务功能（reconcile/DB 加载）；
+    # 基础设施 job（task.orphan_recovery / memory.compaction）依赖的
+    # runtime scheduler 必须仍然启动，否则孤儿接管在默认部署下永不运行。
+    assert scheduler.start_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_start_runtime_services_registers_orphan_recovery_when_scheduled_task_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ENABLE_SCHEDULED_TASK=false 时孤儿接管 job 仍要注册并启动调度器。
+
+    回归防护：register_orphan_recovery_job() 无条件注册，但调度器 start()
+    曾只在 ENABLE_SCHEDULED_TASK 分支内调用，导致默认部署下孤儿接管
+    （PR #249）与 memory.compaction 从不执行。
+    """
+    task_manager = _FakeTaskManager()
+    settings_pubsub = _FakeAsyncService()
+    model_config_pubsub = _FakeAsyncService()
+    memory_pubsub = _FakeAsyncService()
+    websocket_manager = _FakeWebSocketManager()
+    channel_pubsub = _FakeAsyncService()
+    tool_cache_pubsub = _FakeAsyncService()
+    mcp_cache_pubsub = _FakeAsyncService()
+    scheduler = _FakeRuntimeScheduler()
+    scheduled_task_storage = _FakeScheduledTaskStorage()
+    scheduled_task_service = _FakeScheduledTaskService()
+
+    _patch_runtime_service_dependencies(
+        monkeypatch,
+        enable_memory=False,
+        enable_scheduled_task=False,
+        task_manager=task_manager,
+        settings_pubsub=settings_pubsub,
+        model_config_pubsub=model_config_pubsub,
+        memory_pubsub=memory_pubsub,
+        websocket_manager=websocket_manager,
+        channel_pubsub=channel_pubsub,
+        tool_cache_pubsub=tool_cache_pubsub,
+        mcp_cache_pubsub=mcp_cache_pubsub,
+        scheduler=scheduler,
+        scheduled_task_storage=scheduled_task_storage,
+        scheduled_task_service=scheduled_task_service,
+    )
+    # 让 register_orphan_recovery_job 真实执行并把 job 注册到 fake scheduler
+    monkeypatch.setattr(
+        "src.infra.task.orphan_recovery.get_runtime_scheduler", lambda: scheduler
+    )
+
+    await runtime_services.start_runtime_services()
+
+    assert "task.orphan_recovery" in scheduler.registered_job_ids
+    assert scheduler.start_calls == 1
+    assert scheduled_task_storage.ensure_indexes_calls == 0
+    assert scheduled_task_service.load_calls == 0
 
 
 @pytest.mark.asyncio

--- a/tests/infra/test_runtime_services.py
+++ b/tests/infra/test_runtime_services.py
@@ -358,9 +358,7 @@ async def test_start_runtime_services_registers_orphan_recovery_when_scheduled_t
         scheduled_task_service=scheduled_task_service,
     )
     # 让 register_orphan_recovery_job 真实执行并把 job 注册到 fake scheduler
-    monkeypatch.setattr(
-        "src.infra.task.orphan_recovery.get_runtime_scheduler", lambda: scheduler
-    )
+    monkeypatch.setattr("src.infra.task.orphan_recovery.get_runtime_scheduler", lambda: scheduler)
 
     await runtime_services.start_runtime_services()
 


### PR DESCRIPTION
## 背景

第三轮分布式排查（2026-08-28）：本地双节点（8003/8004 + 独立 Redis 6381 + fork 库）动态实测 + 4 路静态审计（memory 层 / 任务队列 / 实时推送 / 跨副本缓存）。本 PR 修复其中 5 项已确认缺陷（全部 TDD，先写失败测试），其余 P1/P2 backlog 见排查报告另行跟进。

## 修复清单

### 1. runtime scheduler 无条件启动（最严重，生产实锤）
- `get_runtime_scheduler().start()` 全仓唯一调用点在 `ENABLE_SCHEDULED_TASK` 分支内，生产 k8s 未设该变量（已核实 yang deployment）→ **PR #249 的孤儿接管与 memory.compaction 在生产从未运行**，副本崩溃后 RUNNING 会话只能等 Pod 重启。
- 修复：`start()` 移出条件块；开关语义收窄为只控制用户定时任务功能（reconcile job 与 DB 加载）。
- 动态验证：关开关启动 `Scheduler started with 2 jobs`；SIGKILL 执行节点后存活副本 ~230s 完成接管、终态 failed 不悬挂。

### 2. 分布式启动校验自动识别 k8s
- 校验需显式 `LAMBCHAT_DISTRIBUTED_MODE` 才生效，生产未设 → 上传 local 模式（文件落 Pod 本地盘）静默上线。实测：S3 关闭时 A 节点上传 200、B 节点（独立文件系统）GET 同一文件 404。
- 修复：kubelet 必然注入的 `KUBERNETES_SERVICE_HOST` 自动启用校验；显式 `LAMBCHAT_DISTRIBUTED_MODE=false` 仍可覆盖。

### 3. HITL 审批等待改静态订阅
- `wait_for_response_distributed` 每次等待动态 subscribe/unsubscribe `approval:response`，共享 pubsub hub 的频道增删通过杀整条连接重订实现 → 每个 HITL 轮次制造两次全频道消息丢失窗口（ws:deliver / task:cancel / settings:changed 全丢）。
- 修复：进程级静态订阅一次 + approval_id 等待者注册表分发唤醒；等待者先注册后订阅（hub.start() 可能提前投递）；Mongo 轮询兜底语义不变。

### 4. arq worker 崩溃重启后的恢复死区
- worker 被监督器重建后，被掐断的 in-flight run 停在 FAILED+recoverable（payload 已删），周期接管 `running_only=True` 跳过 FAILED 段 → 只能等任意 Pod 重启。
- 修复：`EmbeddedArqRuntime` 新增 `on_worker_restarted` 回调，崩溃重建后补跑 `cleanup_stale_tasks`（与启动清理等价，Redis 租约互斥保护）；正常启动不触发。

### 5. 取消空 metadata 会话误报「取消失败」
- 新建会话 metadata 为空 dict/None 掉进异常 fall-through，前端误展示系统错误；提前分支返回「没有正在运行的任务」。

## 测试

- 新增/修改测试：`tests/infra/test_runtime_services.py`（+1 改 1）、`test_distributed_validation.py`（+2）、`test_mongodb_storage.py`（+2 改 2）、`test_manager_cancel_terminal.py`（+1）、`test_arq_runtime.py`（+2）
- `make lint` ✅ `make typecheck` ✅
- 后端全量 pytest **2963 passed / 1 skipped**（4 个失败为本机 .env 已知存量问题，stash 对照确认与本 PR 无关）

## 部署注意

- 修复 1 上线后 `memory.compaction` 将首次真正周期运转（12h 间隔），建议 staging 观察一轮压缩行为；孤儿接管 120s 周期生效，Pod 滚动更新期间接管延迟约 2~4 分钟属预期。
- 修复 2 对 k8s 环境默认开启校验：当前生产清单已配 S3 ✅，不会拦截；如单副本 k8s 调试需绕过，显式设 `LAMBCHAT_DISTRIBUTED_MODE=false`。