### PR TITLE
fix(memory): 解决 #278——backfill 自动入口/维度校验/缓存上界/审计测试补齐

### DIFF
--- a/docs/superpowers/specs/2026-08-28-memory-self-evolution-design.md
+++ b/docs/superpowers/specs/2026-08-28-memory-self-evolution-design.md
@@ -58,7 +58,7 @@ Codex（v0.100+ Memories）与 Claude Code 收敛出的专业模式，正是本�
 
 ### 3. 进化式小抄层（注入升级，零新注入机制）
 
-`indexing.py` 的 `<memory_index>` 增加一个 `### Lessons` 子块：feedback_rule 类记忆按 `(命中次数×新鲜度×manual优先)` 排序取 top-3，每条一行 `rule`（Why/How 留给 memory_recall）。**骑现有 30 分钟快照机制**——KV 缓存纪律零新增（tools 前缀字节稳定性由既有快照保证）。子块预算 ≤400 字符，超预算从尾部裁。
+`indexing.py` 的 `<memory_index>` 增加一个 `## Lessons` 子块：feedback_rule 类记忆按 `updated_at` 倒序取 top-3（**刻意不用命中次数排序**：`access_count` 每次召回都会自增，一旦进入排序键，快照 TTL 过期重建时前缀字节会变、击穿 KV 缓存——与类型区 `choose_index_memories` 的稳定性纪律一致；manual 优先已在类型区实现），每条一行 `rule`（Why/How 留给 memory_recall）。**骑现有 30 分钟快照机制**——KV 缓存纪律零新增（tools 前缀字节稳定性由既有快照保证）。子块预算 ≤400 字符，超预算从尾部裁。
 
 ### 4. 治理与护栏
 

--- a/src/infra/agent/middleware/prompt_injection.py
+++ b/src/infra/agent/middleware/prompt_injection.py
@@ -38,8 +38,25 @@ _MEMORY_INDEX_EMPTY_TTL_SECONDS = 60
 _MEMORY_INDEX_BUILD_TIMEOUT_SECONDS = 2.0
 _MEMORY_INDEX_SNAPSHOT_MAX_SIZE = 2000
 
-# 用户级 fallback（无 session_id 的场景，如 sub-agent）
+# 用户级 fallback（无 session_id 的场景，如 sub-agent）；同样有上界防膨胀
 _MEMORY_INDEX_USER_SNAPSHOTS: dict[str, tuple[float, str]] = {}
+_MEMORY_INDEX_USER_SNAPSHOT_MAX_SIZE = 2000
+
+
+def _evict_oldest_user_snapshots() -> None:
+    """LRU-style：先清过期（>60s），仍超限再按最旧淘汰——与会话快照同策略。"""
+    import time as _time
+
+    now = _time.monotonic()
+    expired = [k for k, (t, _) in _MEMORY_INDEX_USER_SNAPSHOTS.items() if (now - t) > 60]
+    for k in expired:
+        _MEMORY_INDEX_USER_SNAPSHOTS.pop(k, None)
+    if len(_MEMORY_INDEX_USER_SNAPSHOTS) > _MEMORY_INDEX_USER_SNAPSHOT_MAX_SIZE:
+        sorted_keys = sorted(
+            _MEMORY_INDEX_USER_SNAPSHOTS, key=lambda k: _MEMORY_INDEX_USER_SNAPSHOTS[k][0]
+        )
+        for k in sorted_keys[: len(sorted_keys) - _MEMORY_INDEX_USER_SNAPSHOT_MAX_SIZE]:
+            _MEMORY_INDEX_USER_SNAPSHOTS.pop(k, None)
 
 
 def invalidate_memory_index_snapshot(user_id: str) -> None:
@@ -176,6 +193,8 @@ async def _build_memory_index_for_user(user_id: str, *, session_id: str | None =
             _evict_oldest_snapshots()
     else:
         _MEMORY_INDEX_USER_SNAPSHOTS[cache_key] = (now, index)  # type: ignore[index,assignment]
+        if len(_MEMORY_INDEX_USER_SNAPSHOTS) > _MEMORY_INDEX_USER_SNAPSHOT_MAX_SIZE:
+            _evict_oldest_user_snapshots()
     return index
 
 

--- a/src/infra/memory/client/native/indexing.py
+++ b/src/infra/memory/client/native/indexing.py
@@ -103,7 +103,9 @@ async def build_memory_index(backend, user_id: str) -> str:
         MemoryType.REFERENCE.value: "Reference",
     }
 
-    # Lessons 子块：feedback_rule 教训一行一条，独立预算（自进化小抄）
+    # Lessons 子块：feedback_rule 教训一行一条，独立预算（自进化小抄）。
+    # 刻意只按 updated_at 排序：access_count 每次召回自增，若进排序键会在
+    # 快照重建时改变前缀字节、击穿 KV 缓存（与 choose_index_memories 同纪律）。
     lessons_max_chars = 400
     lesson_docs = [d for d in docs if d.get("context") == "feedback_rule"]
     lesson_docs.sort(key=lambda d: str(d.get("updated_at") or ""), reverse=True)

--- a/src/infra/memory/client/native/vector_store.py
+++ b/src/infra/memory/client/native/vector_store.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 import uuid
@@ -53,19 +54,54 @@ class QdrantVectorIndex:
             await self.ensure_collection()
             self._ensured = True
 
-    async def ensure_collection(self) -> None:
+    async def ensure_collection(self) -> bool:
+        """确保 collection 存在且维度与配置一致。
+
+        返回 True = 本次新建（调用方可据此触发回填）；False = 已存在且一致。
+        维度不一致时抛 RuntimeError 且不删库——存量 Mongo embedding 已随旧
+        维度失配，自动重建也无法正确回填，需管理员显式处置（换嵌入模型后
+        应清理旧 embedding 重嵌，或删除该 collection 后重建）。
+        """
         from qdrant_client.models import Distance, VectorParams
 
-        if not await self._client.collection_exists(COLLECTION):
-            await self._client.create_collection(
-                collection_name=COLLECTION,
-                vectors_config=VectorParams(size=self._dims, distance=Distance.COSINE),
-            )
-            logger.info(
-                "[MemoryVector] Qdrant collection created: %s (%d dims, cosine)",
+        if await self._client.collection_exists(COLLECTION):
+            existing_size = await self._existing_vector_size()
+            if existing_size is None or existing_size == self._dims:
+                return False
+            logger.error(
+                "[MemoryVector] collection %s dimension mismatch: existing=%s configured=%d "
+                "— vector index degraded to mongo fallback. Re-embed memories or drop the "
+                "collection to recover.",
                 COLLECTION,
+                existing_size,
                 self._dims,
             )
+            raise RuntimeError(
+                f"vector collection dimension mismatch: {existing_size} != {self._dims}"
+            )
+        await self._client.create_collection(
+            collection_name=COLLECTION,
+            vectors_config=VectorParams(size=self._dims, distance=Distance.COSINE),
+        )
+        logger.info(
+            "[MemoryVector] Qdrant collection created: %s (%d dims, cosine)",
+            COLLECTION,
+            self._dims,
+        )
+        return True
+
+    async def _existing_vector_size(self) -> Optional[int]:
+        """读取既有 collection 的向量维度；读不出（结构异常）返回 None 视为兼容。"""
+        try:
+            info = await self._client.get_collection(COLLECTION)
+            vectors = getattr(getattr(info.config, "params", None), "vectors", None)
+            size = getattr(vectors, "size", None)
+            if size is None and isinstance(vectors, dict):
+                size = vectors.get("size")
+            return int(size) if size is not None else None
+        except Exception as e:
+            logger.warning("[MemoryVector] failed to read existing vector size: %s", e)
+            return None
 
     async def upsert(
         self,
@@ -166,9 +202,65 @@ _vector_index: Optional[QdrantVectorIndex] = None
 _index_failed_until = 0.0  # monotonic 时间戳；冷却期内不再重试建连
 _INDEX_RETRY_COOLDOWN_SECONDS = 60.0
 
+# 自动回填（issue #278）：切到 qdrant 后存量 Mongo embedding 自动灌入，
+# 完成标记持久在 Redis——跨副本至多跑一次；首建/重建 force 重跑。
+_BACKFILL_DONE_KEY = "memory:vector_backfill:done"
+_BACKFILL_LOCK_KEY = "memory:vector_backfill:lock"
+_BACKFILL_LOCK_TTL = 1800  # 覆盖最大预期回填时长
+_RELEASE_LOCK_LUA = (
+    "if redis.call('get', KEYS[1]) == ARGV[1] then "
+    "return redis.call('del', KEYS[1]) else return 0 end"
+)
+_backfill_task: Optional[asyncio.Task] = None
+
 
 def vector_backend_enabled() -> bool:
     return getattr(settings, "NATIVE_MEMORY_VECTOR_BACKEND", "mongo") == "qdrant"
+
+
+async def _run_backfill_once(*, force: bool = False) -> None:
+    """幂等自动回填：Redis 完成标记 + token 锁防跨副本重跑。
+
+    回填只搬运 Mongo 已存的 embedding（不重算），成本低；任何故障静默
+    降级（下次建库重试），绝不影响主链路。
+    """
+    try:
+        from src.infra.storage.redis import get_redis_client
+
+        rc = get_redis_client()
+        if force:
+            await rc.delete(_BACKFILL_DONE_KEY)
+        elif await rc.get(_BACKFILL_DONE_KEY):
+            return
+        token = uuid.uuid4().hex[:8]
+        if not await rc.set(_BACKFILL_LOCK_KEY, token, nx=True, ex=_BACKFILL_LOCK_TTL):
+            return  # 其他副本在灌
+        try:
+            from src.infra.memory.tools import _get_backend
+
+            backend = await _get_backend()
+            collection = getattr(backend, "_collection", None) if backend is not None else None
+            if collection is None:
+                return
+            result = await backfill_from_mongo(collection)
+            await rc.set(_BACKFILL_DONE_KEY, "1")  # type: ignore[misc]
+            logger.info("[MemoryVector] auto backfill completed: %s", result)
+        finally:
+            await rc.eval(_RELEASE_LOCK_LUA, 1, _BACKFILL_LOCK_KEY, token)  # type: ignore[misc]
+    except Exception as e:
+        logger.warning("[MemoryVector] auto backfill failed (will retry next init): %s", e)
+
+
+def _schedule_backfill_once(*, force: bool = False) -> None:
+    """后台调度回填；持引用防 GC 中断，单例存续期内至多一个在途任务。"""
+    global _backfill_task
+    if _backfill_task is not None and not _backfill_task.done():
+        return
+    try:
+        loop = asyncio.get_event_loop()
+        _backfill_task = loop.create_task(_run_backfill_once(force=force))
+    except RuntimeError:
+        pass
 
 
 async def get_vector_index() -> Optional[QdrantVectorIndex]:
@@ -184,13 +276,15 @@ async def get_vector_index() -> Optional[QdrantVectorIndex]:
             return None
         candidate = QdrantVectorIndex()
         try:
-            await candidate.ensure_collection()
+            created = await candidate.ensure_collection()
         except Exception as e:
             logger.warning("[MemoryVector] Qdrant unavailable, vector backend degraded: %s", e)
             await candidate.close()
             _index_failed_until = time.monotonic() + _INDEX_RETRY_COOLDOWN_SECONDS
             return None
         _vector_index = candidate
+        # 首建（或 done 标记缺失的上次未完成回填）→ 后台自动回填存量
+        _schedule_backfill_once(force=created)
     return _vector_index
 
 

--- a/src/infra/memory/user_pref.py
+++ b/src/infra/memory/user_pref.py
@@ -17,7 +17,23 @@ from src.kernel.config import settings
 logger = logging.getLogger(__name__)
 
 PREF_CACHE_TTL_SECONDS = 30
+_PREF_CACHE_MAX_SIZE = 2000  # 上界防用户量异常膨胀；超限先清过期再淘汰最旧
 _pref_cache: dict[str, tuple[datetime, bool]] = {}
+
+
+def _evict_pref_cache() -> None:
+    now = datetime.now(timezone.utc)
+    expired = [
+        uid
+        for uid, (t, _) in _pref_cache.items()
+        if (now - t).total_seconds() >= PREF_CACHE_TTL_SECONDS
+    ]
+    for uid in expired:
+        _pref_cache.pop(uid, None)
+    if len(_pref_cache) > _PREF_CACHE_MAX_SIZE:
+        oldest = sorted(_pref_cache, key=lambda uid: _pref_cache[uid][0])
+        for uid in oldest[: len(_pref_cache) - _PREF_CACHE_MAX_SIZE]:
+            _pref_cache.pop(uid, None)
 
 
 def _get_users_collection():
@@ -54,4 +70,6 @@ async def user_memory_enabled(user_id: str) -> bool:
         logger.debug("[MemoryUserPref] lookup failed, defaulting enabled: %s", e)
         enabled = True
     _pref_cache[user_id] = (now, enabled)
+    if len(_pref_cache) > _PREF_CACHE_MAX_SIZE:
+        _evict_pref_cache()
     return enabled

--- a/tests/infra/agent/middleware/test_prompt_injection_memory.py
+++ b/tests/infra/agent/middleware/test_prompt_injection_memory.py
@@ -1,0 +1,52 @@
+"""记忆索引注入的缓存上界与 2s 硬超时（issue #278 补测）。"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from src.infra.agent.middleware import prompt_injection as pi
+
+
+@pytest.fixture(autouse=True)
+def _clear_snapshot_caches():
+    """模块级 dict 是共享状态——测试前后都清，防跨文件状态泄漏。"""
+    pi._MEMORY_INDEX_SNAPSHOTS.clear()
+    pi._MEMORY_INDEX_USER_SNAPSHOTS.clear()
+    yield
+    pi._MEMORY_INDEX_SNAPSHOTS.clear()
+    pi._MEMORY_INDEX_USER_SNAPSHOTS.clear()
+
+
+def test_user_snapshot_cache_bounded():
+    cap = pi._MEMORY_INDEX_USER_SNAPSHOT_MAX_SIZE
+    now = time.monotonic()
+    for i in range(cap + 500):
+        pi._MEMORY_INDEX_USER_SNAPSHOTS[f"u{i}"] = (now - i, "idx")
+    pi._evict_oldest_user_snapshots()
+    assert len(pi._MEMORY_INDEX_USER_SNAPSHOTS) <= cap
+
+
+def test_user_snapshot_eviction_prefers_expired():
+    cap = pi._MEMORY_INDEX_USER_SNAPSHOT_MAX_SIZE
+    now = time.monotonic()
+    for i in range(cap + 500):
+        pi._MEMORY_INDEX_USER_SNAPSHOTS[f"stale-{i}"] = (now - 3600, "idx")
+    pi._MEMORY_INDEX_USER_SNAPSHOTS["fresh"] = (now, "idx")
+    pi._evict_oldest_user_snapshots()
+    assert "fresh" in pi._MEMORY_INDEX_USER_SNAPSHOTS
+
+
+@pytest.mark.asyncio
+async def test_build_memory_index_times_out_to_empty(monkeypatch):
+    async def slow(_uid):
+        await asyncio.sleep(30)
+        return "should never appear"
+
+    monkeypatch.setattr(pi, "_build_memory_index_full", slow)
+    t0 = time.monotonic()
+    result = await pi._build_memory_index_for_user("u-timeout", session_id="s1")
+    assert result == ""
+    assert time.monotonic() - t0 < 5  # 远小于 30s，说明 2s 超时生效

--- a/tests/infra/agent/test_tool_search_middleware.py
+++ b/tests/infra/agent/test_tool_search_middleware.py
@@ -769,7 +769,9 @@ async def test_memory_index_snapshotted_per_user_with_ttl(monkeypatch) -> None:
     every turn."""
     from src.infra.agent.middleware import prompt_injection
 
+    # 模块级 dict 是共享状态——两个都要清，防前序测试污染（见下方 test_memory_index_skipped_when_user_disabled）
     prompt_injection._MEMORY_INDEX_SNAPSHOTS.clear()
+    prompt_injection._MEMORY_INDEX_USER_SNAPSHOTS.clear()
     calls = {"n": 0}
 
     async def _uncached(_user_id: str) -> str:

--- a/tests/infra/memory/evolution/test_scheduler.py
+++ b/tests/infra/memory/evolution/test_scheduler.py
@@ -1,0 +1,98 @@
+"""自进化调度器——扫描锁 token 语义（issue #278 补测）。"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.infra.memory.evolution import scheduler
+
+
+class _FakeRedis:
+    def __init__(self, initial: dict | None = None):
+        self.store: dict = dict(initial or {})
+        self.eval_calls: list = []
+
+    async def set(self, key, value, nx=False, ex=None):
+        if nx and key in self.store:
+            return None
+        self.store[key] = value
+        return True
+
+    async def eval(self, _script, _numkeys, key, token):
+        self.eval_calls.append((key, token))
+        if self.store.get(key) == token:
+            self.store.pop(key)
+
+
+@pytest.mark.asyncio
+async def test_acquire_returns_token_stored_in_redis(monkeypatch):
+    fake = _FakeRedis()
+    monkeypatch.setattr("src.infra.storage.redis.get_redis_client", lambda: fake)
+    token = await scheduler._acquire_scan_lock()
+    assert isinstance(token, str) and token
+    assert fake.store[scheduler.EVOLUTION_SCAN_LOCK_KEY] == token
+
+
+@pytest.mark.asyncio
+async def test_acquire_returns_none_when_held(monkeypatch):
+    fake = _FakeRedis({scheduler.EVOLUTION_SCAN_LOCK_KEY: "other"})
+    monkeypatch.setattr("src.infra.storage.redis.get_redis_client", lambda: fake)
+    assert await scheduler._acquire_scan_lock() is None
+
+
+@pytest.mark.asyncio
+async def test_release_uses_given_token(monkeypatch):
+    fake = _FakeRedis({scheduler.EVOLUTION_SCAN_LOCK_KEY: "tok-1"})
+    monkeypatch.setattr("src.infra.storage.redis.get_redis_client", lambda: fake)
+    await scheduler._release_scan_lock("tok-1")
+    assert fake.eval_calls == [(scheduler.EVOLUTION_SCAN_LOCK_KEY, "tok-1")]
+    assert scheduler.EVOLUTION_SCAN_LOCK_KEY not in fake.store
+
+
+@pytest.mark.asyncio
+async def test_release_with_wrong_token_keeps_lock(monkeypatch):
+    fake = _FakeRedis({scheduler.EVOLUTION_SCAN_LOCK_KEY: "tok-real"})
+    monkeypatch.setattr("src.infra.storage.redis.get_redis_client", lambda: fake)
+    await scheduler._release_scan_lock("tok-stale")
+    assert scheduler.EVOLUTION_SCAN_LOCK_KEY in fake.store  # 他人的锁不被误删
+
+
+@pytest.mark.asyncio
+async def test_release_empty_token_is_noop(monkeypatch):
+    def _boom():
+        raise AssertionError("eval must not be called for empty token")
+
+    monkeypatch.setattr("src.infra.storage.redis.get_redis_client", _boom)
+    await scheduler._release_scan_lock("")
+
+
+@pytest.mark.asyncio
+async def test_run_scheduled_evolution_releases_own_token(monkeypatch):
+    fake = _FakeRedis()
+    monkeypatch.setattr("src.infra.storage.redis.get_redis_client", lambda: fake)
+    monkeypatch.setattr(scheduler.settings, "ENABLE_MEMORY", True)
+    monkeypatch.setattr(scheduler.settings, "NATIVE_MEMORY_SELF_EVOLVE_ENABLED", True)
+
+    async def fake_collect(_cutoff):
+        return ["u1"]
+
+    monkeypatch.setattr(scheduler, "_collect_signal_user_ids", fake_collect)
+
+    async def fake_backend():
+        return SimpleNamespace()
+
+    monkeypatch.setattr("src.infra.memory.tools._get_backend", fake_backend)
+
+    async def fake_evolve(_backend, uid):
+        return {"stored": 1}
+
+    monkeypatch.setattr("src.infra.memory.evolution.reflector.evolve_user", fake_evolve)
+
+    result = await scheduler.run_scheduled_evolution()
+    assert result == {"users": 1, "users_evolved": 1, "stored": 1}
+    # 释放的 token 与获取时写入的一致（token-checked 释放）
+    assert len(fake.eval_calls) == 1
+    released_token = fake.eval_calls[0][1]
+    assert released_token  # 用的是本次持有者 token（而非全局残留）

--- a/tests/infra/memory/native/test_search.py
+++ b/tests/infra/memory/native/test_search.py
@@ -175,3 +175,137 @@ async def test_recall_memories_threads_context_filter(monkeypatch):
     assert captured["text"] == "project_constraint"
     assert captured["fallback"] == "project_constraint"  # overview 查询走 fallback 也带过滤
     assert "vector" not in captured  # 无 embedding 时不调向量检索
+
+
+# ---------------------------------------------------------------------------
+# Qdrant 索引分支（issue #278 补测：水合排序 / 空结果权威 / None 回退）
+# ---------------------------------------------------------------------------
+
+from types import SimpleNamespace
+
+
+def _mem_doc(mid: str, content: str = "内容", embedding=None) -> dict:
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc)
+    return {
+        "memory_id": mid,
+        "user_id": "u1",
+        "content": content,
+        "summary": content,
+        "title": content[:10],
+        "memory_type": "user",
+        "source": "manual",
+        "content_storage_mode": "inline",
+        "content_store_key": None,
+        "created_at": now,
+        "updated_at": now,
+        "embedding": embedding,
+    }
+
+
+class _FakeCursor:
+    def __init__(self, docs):
+        self._docs = docs
+
+    def sort(self, *a, **k):
+        return self
+
+    def limit(self, n):
+        return self
+
+    async def to_list(self, length=None):
+        return self._docs
+
+
+class _FakeCollection:
+    def __init__(self, docs):
+        self.docs = docs
+        self.find_queries: list = []
+
+    def find(self, query, projection=None):
+        self.find_queries.append(query)
+        return _FakeCursor(list(self.docs))
+
+    def aggregate(self, pipeline):
+        raise RuntimeError("aggregate unavailable in fake")
+
+
+@pytest.mark.asyncio
+async def test_vector_search_qdrant_hits_hydrate_in_score_order(monkeypatch):
+    from src.infra.memory.client.native import search, vector_store
+    from src.infra.memory.client.native.vector_store import VectorHit
+
+    async def fake_index_search(**kw):
+        return [VectorHit(memory_id="b" * 32, score=0.9), VectorHit(memory_id="a" * 32, score=0.5)]
+
+    monkeypatch.setattr(vector_store, "index_search", fake_index_search)
+
+    col = _FakeCollection([_mem_doc("a" * 32, "低分"), _mem_doc("b" * 32, "高分")])
+
+    async def embed(_q):
+        return [1.0, 0.0]
+
+    backend = SimpleNamespace(_maybe_embed=embed, _collection=col)
+
+    out = await search.vector_search(backend, "u1", "查询", 5, None)
+
+    assert [d["memory_id"] for d in out] == ["b" * 32, "a" * 32]  # 高分在前
+    assert out[0]["score"] == 0.9
+    # 水合查询带 user 过滤 + id 集合 + 排除 session_summary
+    q = col.find_queries[0]
+    assert q["user_id"] == "u1"
+    assert set(q["memory_id"]["$in"]) == {"a" * 32, "b" * 32}
+    assert q["source"] == {"$ne": "session_summary"}
+
+
+@pytest.mark.asyncio
+async def test_vector_search_qdrant_empty_is_authoritative(monkeypatch):
+    from src.infra.memory.client.native import search, vector_store
+
+    async def fake_index_search(**kw):
+        return []
+
+    monkeypatch.setattr(vector_store, "index_search", fake_index_search)
+    col = _FakeCollection([_mem_doc("a" * 32)])
+
+    async def embed(_q):
+        return [1.0, 0.0]
+
+    backend = SimpleNamespace(_maybe_embed=embed, _collection=col)
+
+    out = await search.vector_search(backend, "u1", "查询", 5, None)
+    assert out == []
+    assert col.find_queries == []  # 权威空：不再回退打 Mongo
+
+
+@pytest.mark.asyncio
+async def test_vector_search_qdrant_none_falls_back_to_cosine(monkeypatch):
+    from src.infra.memory.client.native import search, vector_store
+
+    async def fake_index_search(**kw):
+        return None  # 未启用/故障 → 走既有链路
+
+    monkeypatch.setattr(vector_store, "index_search", fake_index_search)
+
+    docs = [
+        _mem_doc("a" * 32, "正交", embedding=[0.0, 1.0]),
+        _mem_doc("b" * 32, "同向", embedding=[1.0, 0.0]),
+    ]
+    col = _FakeCollection(docs)
+
+    async def embed(_q):
+        return [1.0, 0.0]
+
+    backend = SimpleNamespace(
+        _maybe_embed=embed,
+        _collection=col,
+        _logger=SimpleNamespace(debug=lambda *a, **k: None),
+    )
+
+    out = await search.vector_search(backend, "u1", "查询", 5, None)
+    # 余弦兜底：同向高分在前、正交低分在后（按相似度降序）
+    assert [d["memory_id"] for d in out] == ["b" * 32, "a" * 32]
+    assert out[0]["score"] == pytest.approx(1.0)
+    assert out[1]["score"] == pytest.approx(0.0)
+    assert col.find_queries  # 走了 Mongo find 兜底

--- a/tests/infra/memory/native/test_vector_store.py
+++ b/tests/infra/memory/native/test_vector_store.py
@@ -138,3 +138,190 @@ async def test_get_vector_index_returns_none_when_unreachable(monkeypatch):
         assert await vs.index_search(vector=[0.1] * 4, user_id="u1", limit=3) is None
     finally:
         await _teardown()
+
+
+# ---------------------------------------------------------------------------
+# 维度校验与自动回填（issue #278）
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ensure_collection_returns_created_flag():
+    idx = _mk_index()
+    assert await idx.ensure_collection() is True  # 首建
+    assert await idx.ensure_collection() is False  # 已存在且维度一致
+
+
+@pytest.mark.asyncio
+async def test_dimension_mismatch_raises_without_deleting():
+    idx = _mk_index()
+    await idx.ensure_collection()
+    idx._dims = DIMS // 2  # 模拟改了 EMBEDDING_DIMENSIONS
+    with pytest.raises(RuntimeError, match="[Dd]imension"):
+        await idx.ensure_collection()
+    # 保守处理：不自动删库，原样保留待管理员处置
+    info = await idx._client.get_collection("native_memories")
+    assert info.config.params.vectors.size == DIMS
+
+
+class _FakeRedis:
+    """dict 后端的极简 redis 假件（set nx / get / delete / token-eval）。"""
+
+    def __init__(self, initial: dict | None = None):
+        self.store: dict = dict(initial or {})
+        self.eval_calls: list = []
+
+    async def get(self, key):
+        return self.store.get(key)
+
+    async def set(self, key, value, nx=False, ex=None):
+        if nx and key in self.store:
+            return None
+        self.store[key] = value
+        return True
+
+    async def delete(self, *keys):
+        for k in keys:
+            self.store.pop(k, None)
+
+    async def eval(self, _script, _numkeys, key, token):
+        self.eval_calls.append((key, token))
+        if self.store.get(key) == token:
+            self.store.pop(key)
+
+
+@pytest.mark.asyncio
+async def test_run_backfill_once_skips_when_done_flag_set(monkeypatch):
+    from src.infra.memory.client.native import vector_store as vs
+
+    fake = _FakeRedis({vs._BACKFILL_DONE_KEY: "1"})
+    monkeypatch.setattr("src.infra.storage.redis.get_redis_client", lambda: fake)
+    called = []
+    monkeypatch.setattr(
+        vs, "backfill_from_mongo", lambda coll, batch_size=100: called.append(coll) or _ok(0)
+    )
+    await vs._run_backfill_once(force=False)
+    assert called == []
+
+
+async def _ok(n):
+    return {"upserted": n}
+
+
+@pytest.mark.asyncio
+async def test_run_backfill_once_runs_locks_and_marks_done(monkeypatch):
+    from types import SimpleNamespace
+
+    from src.infra.memory.client.native import vector_store as vs
+
+    fake = _FakeRedis()
+    monkeypatch.setattr("src.infra.storage.redis.get_redis_client", lambda: fake)
+    coll = object()
+    calls = []
+
+    async def fake_backfill(collection, batch_size=100):
+        calls.append(collection)
+        return {"upserted": 7}
+
+    monkeypatch.setattr(vs, "backfill_from_mongo", fake_backfill)
+
+    async def fake_backend():
+        return SimpleNamespace(_collection=coll)
+
+    monkeypatch.setattr("src.infra.memory.tools._get_backend", fake_backend)
+
+    await vs._run_backfill_once(force=False)
+
+    assert calls == [coll]
+    assert fake.store.get(vs._BACKFILL_DONE_KEY) == "1"  # 完成标记
+    assert vs._BACKFILL_LOCK_KEY not in fake.store  # 锁已释放
+
+
+@pytest.mark.asyncio
+async def test_run_backfill_once_force_overrides_done_flag(monkeypatch):
+    from types import SimpleNamespace
+
+    from src.infra.memory.client.native import vector_store as vs
+
+    fake = _FakeRedis({vs._BACKFILL_DONE_KEY: "1"})
+    monkeypatch.setattr("src.infra.storage.redis.get_redis_client", lambda: fake)
+    calls = []
+
+    async def fake_backfill(collection, batch_size=100):
+        calls.append(collection)
+        return {"upserted": 1}
+
+    monkeypatch.setattr(vs, "backfill_from_mongo", fake_backfill)
+
+    async def fake_backend():
+        return SimpleNamespace(_collection=object())
+
+    monkeypatch.setattr("src.infra.memory.tools._get_backend", fake_backend)
+
+    await vs._run_backfill_once(force=True)  # 首建/重建 → 忽略旧完成标记
+    assert calls != []
+    assert fake.store.get(vs._BACKFILL_DONE_KEY) == "1"
+
+
+@pytest.mark.asyncio
+async def test_run_backfill_once_skips_when_lock_held(monkeypatch):
+    from src.infra.memory.client.native import vector_store as vs
+
+    fake = _FakeRedis({vs._BACKFILL_LOCK_KEY: "other-replica"})
+    monkeypatch.setattr("src.infra.storage.redis.get_redis_client", lambda: fake)
+    called = []
+    monkeypatch.setattr(
+        vs,
+        "backfill_from_mongo",
+        lambda coll, batch_size=100: called.append(coll) or _ok(0),
+    )
+    await vs._run_backfill_once(force=True)
+    assert called == []
+    assert fake.store.get(vs._BACKFILL_DONE_KEY) is None  # 未被误标完成
+
+
+@pytest.mark.asyncio
+async def test_run_backfill_once_redis_failure_is_silent(monkeypatch):
+    from src.infra.memory.client.native import vector_store as vs
+
+    def _boom():
+        raise RuntimeError("redis down")
+
+    monkeypatch.setattr("src.infra.storage.redis.get_redis_client", _boom)
+    called = []
+    monkeypatch.setattr(
+        vs,
+        "backfill_from_mongo",
+        lambda coll, batch_size=100: called.append(coll) or _ok(0),
+    )
+    await vs._run_backfill_once(force=True)  # 不抛
+    assert called == []
+
+
+@pytest.mark.asyncio
+async def test_get_vector_index_schedules_backfill_task_once(monkeypatch):
+    import asyncio
+
+    from src.infra.memory.client.native import vector_store as vs
+
+    await vs.reset_vector_index()
+    monkeypatch.setattr(vs, "vector_backend_enabled", lambda: True)
+    monkeypatch.setattr(vs, "QdrantVectorIndex", _mk_index)
+    forces: list[bool] = []
+
+    async def fake_run(force: bool = False):
+        forces.append(force)
+
+    monkeypatch.setattr(vs, "_run_backfill_once", fake_run)
+    try:
+        idx = await vs.get_vector_index()
+        assert idx is not None
+        await asyncio.sleep(0.05)
+        assert forces == [True]  # 首建 → force 回填
+
+        idx2 = await vs.get_vector_index()
+        assert idx2 is idx
+        await asyncio.sleep(0.05)
+        assert forces == [True]  # 单例复用，不重复调度
+    finally:
+        await vs.reset_vector_index()

--- a/tests/infra/memory/test_user_pref.py
+++ b/tests/infra/memory/test_user_pref.py
@@ -164,3 +164,20 @@ async def test_auto_capture_gated_for_disabled_user(monkeypatch):
     await memory_tools._auto_retain_user_memory("u1", "一条不该被评估的消息")
 
     assert events == []  # 关闭用户直接短路，连分布式锁都不碰
+
+
+@pytest.mark.asyncio
+async def test_pref_cache_bounded_under_burst(monkeypatch):
+    """缓存上界：超限时先清过期再淘汰最旧，条目数不超过上限。"""
+    cap = getattr(user_pref, "_PREF_CACHE_MAX_SIZE", None)
+    if cap is None:
+        cap = 2000
+    stale = datetime.now(timezone.utc) - timedelta(seconds=9999)
+    for i in range(cap + 500):
+        user_pref._pref_cache[f"old-{i}"] = (stale, True)
+
+    monkeypatch.setattr(user_pref, "_get_users_collection", lambda: _FakeUserCollection({}))
+    await user_pref.user_memory_enabled("fresh-user")
+
+    assert len(user_pref._pref_cache) <= cap
+    assert "fresh-user" in user_pref._pref_cache


### PR DESCRIPTION
Closes #278

## P2

### backfill_from_mongo 自动入口
- 切 `NATIVE_MEMORY_VECTOR_BACKEND=qdrant` 后**不再需要任何手工步骤**：首建 collection 即后台自动回填 Mongo 存量 embedding（只搬运已存向量，零重算、低成本）
- Redis 完成标记（`memory:vector_backfill:done`）+ token 锁跨副本至多跑一次；首建/重建 force 重跑；任何故障静默降级下次初始化重试
- 测试覆盖：done 标记跳过 / force 覆盖 / 锁被持跳过 / Redis 故障静默 / 单例存续期不重复调度

### ensure_collection 维度校验
- 既有 collection 维度 ≠ `NATIVE_MEMORY_EMBEDDING_DIMENSIONS` 时：ERROR 告警（含处置指引）+ 降级到 mongo 链路，**不自动删库**——存量 Mongo embedding 已随旧维度失配，自动重建也无法正确回填
- `ensure_collection()` 返回"本次是否新建"，作为回填触发依据

## P3

- **缓存上界**：`user_pref._pref_cache` 与 `_MEMORY_INDEX_USER_SNAPSHOTS` 补 2000 上界（先清过期再淘汰最旧，与会话快照同策略）
- **补测试**：`vector_search` qdrant 分支三分支语义（水合按分排序 / 空结果=权威不回退 / None=余弦兜底）、调度扫描锁 token 语义（含误删他人锁防护）、2s 索引硬超时、快照 LRU 上界
- **Lessons 排序文档对齐**：设计文档改为与实现一致（`updated_at` 倒序）——`access_count` 每次召回自增，进排序键会在快照重建时改变前缀字节、击穿 KV 缓存；代码注释双向注明

## 验证

- 新增 20 个测试全绿（TDD：先红后绿）
- 全量后端 3073 passed；4 个失败为本机 .env 已知存量（llm/kernel 配置，develop 基线同样失败，与本 PR 无关）
- ruff / mypy 干净
- 顺手加固 `test_memory_index_snapshotted_per_user_with_ttl` 的共享状态清理（全量跑时被本 PR 新测试暴露的潜在污染面）