### PR TITLE
fix(memory): 自进化调度任务热开关修复——注册与启用解耦

### DIFF
--- a/src/infra/runtime_services.py
+++ b/src/infra/runtime_services.py
@@ -162,10 +162,9 @@ def start_memory_evolution_scheduler() -> None:
     from src.infra.memory.evolution.scheduler import run_scheduled_evolution
     from src.infra.scheduler import ScheduledJob, get_runtime_scheduler
 
-    if not (
-        getattr(settings, "ENABLE_MEMORY", False)
-        and getattr(settings, "NATIVE_MEMORY_SELF_EVOLVE_ENABLED", False)
-    ):
+    # 只按记忆总开关决定注册；NATIVE_MEMORY_SELF_EVOLVE_ENABLED 走任务的
+    # enabled lambda 动态读取——settings 热刷新后无需重启即可开/关自进化。
+    if not getattr(settings, "ENABLE_MEMORY", False):
         return
     get_runtime_scheduler().register_job(
         ScheduledJob.from_interval(

--- a/tests/infra/test_memory_evolution_hot_toggle.py
+++ b/tests/infra/test_memory_evolution_hot_toggle.py
@@ -1,0 +1,53 @@
+"""自进化调度任务的热开关语义——注册与启用解耦。
+
+启动时只要 ENABLE_MEMORY 就注册 memory.evolution 任务；NATIVE_MEMORY_SELF_EVOLVE_ENABLED
+由任务 enabled lambda 动态读取（settings 热刷新后无需重启即可生效）。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.infra import runtime_services
+from src.infra.scheduler import get_runtime_scheduler
+
+
+def _job_enabled(job: Any) -> bool:
+    return job.enabled() if callable(job.enabled) else bool(job.enabled)
+
+
+@pytest.fixture(autouse=True)
+def _clean_scheduler():
+    sched = get_runtime_scheduler()
+    sched.clear()
+    yield
+    sched.clear()
+
+
+def test_evolution_job_registered_when_memory_on_but_evolve_off(monkeypatch):
+    """记忆总开关开、自进化关：任务仍注册（enabled=False），热开立即变 True。"""
+    monkeypatch.setattr(runtime_services.settings, "ENABLE_MEMORY", True)
+    monkeypatch.setattr(runtime_services.settings, "NATIVE_MEMORY_SELF_EVOLVE_ENABLED", False)
+
+    runtime_services.start_memory_evolution_scheduler()
+
+    sched = get_runtime_scheduler()
+    assert sched.has_job("memory.evolution")
+    job = sched._jobs["memory.evolution"]
+    assert _job_enabled(job) is False  # 关着
+
+    # 模拟 settings 热刷新（settings:changed → refresh_settings → setattr）
+    monkeypatch.setattr(runtime_services.settings, "NATIVE_MEMORY_SELF_EVOLVE_ENABLED", True)
+    assert _job_enabled(job) is True  # 立即生效，无需重启
+
+
+def test_evolution_job_not_registered_when_memory_off(monkeypatch):
+    """记忆总开关关：整个记忆体系不启动，任务不注册。"""
+    monkeypatch.setattr(runtime_services.settings, "ENABLE_MEMORY", False)
+    monkeypatch.setattr(runtime_services.settings, "NATIVE_MEMORY_SELF_EVOLVE_ENABLED", True)
+
+    runtime_services.start_memory_evolution_scheduler()
+
+    assert not get_runtime_scheduler().has_job("memory.evolution")


### PR DESCRIPTION
## 问题

`start_memory_evolution_scheduler()` 的启动门控同时要求 `ENABLE_MEMORY` **和** `NATIVE_MEMORY_SELF_EVOLVE_ENABLED`，导致：启动时自进化开关未开 → `memory.evolution` 任务**永不注册**。而任务内部的 `enabled` lambda 本来就是为 settings 热刷新动态设计的——被启动门控废掉了。

生产实测实锤（2026-08-28）：system_settings 热开 `NATIVE_MEMORY_SELF_EVOLVE_ENABLED=true` + `settings:changed` 广播后，双副本 settings 对象均已刷新（日志确认），但任务列表里没有 `memory.evolution`——热开只改了值，管线不会跑，直到下一次进程重启。

## 修复

启动门控只看 `ENABLE_MEMORY`；自进化开关完全交给任务 `enabled` lambda + `run_scheduled_evolution` 执行时的二次校验（既有双层防护不变）。热开/热关从此无需重启。

## 测试

- RED→GREEN：`test_memory_evolution_hot_toggle.py` 钉死语义——记忆开+自进化关时任务**注册但 disabled**，模拟热刷新后 enabled 立即变 True；记忆总开关关时不注册
- 回归：runtime_services + 全部 memory 套件 163 passed；ruff/mypy 干净