### PR TITLE
feat(chat): 对话图片缩略图+文件封面全链路支持，点击才加载原图

### DIFF
--- a/frontend/src/components/chat/ChatMessage/ImageWithSkeleton.tsx
+++ b/frontend/src/components/chat/ChatMessage/ImageWithSkeleton.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { getFullUrl } from "../../../services/api/config";
 
 /** Tracks URLs that have already loaded — skip skeleton for cached images */
@@ -7,6 +7,12 @@ const loadedImages = new Set<string>();
 interface ImageWithSkeletonProps {
   /** Image source URL (will be resolved via getFullUrl if relative) */
   src?: string;
+  /**
+   * Lightweight thumbnail URL (already resolved, used as-is). Rendered in
+   * place of src; when it fails to load the original src is tried once
+   * before the error state kicks in.
+   */
+  thumbSrc?: string;
   alt?: string;
   className?: string;
   loading?: "lazy" | "eager";
@@ -39,6 +45,7 @@ interface ImageWithSkeletonProps {
  */
 export function ImageWithSkeleton({
   src,
+  thumbSrc,
   alt,
   className,
   loading = "lazy",
@@ -53,21 +60,37 @@ export function ImageWithSkeleton({
   onError: onExternalError,
 }: ImageWithSkeletonProps) {
   const resolvedSrc = skipUrlResolve ? src : getFullUrl(src);
+  const [srcUsed, setSrcUsed] = useState<string | undefined>(
+    () => thumbSrc ?? resolvedSrc,
+  );
   const [isLoaded, setIsLoaded] = useState(() =>
-    loadedImages.has(resolvedSrc ?? ""),
+    loadedImages.has((thumbSrc ?? resolvedSrc) ?? ""),
   );
   const [hasError, setHasError] = useState(false);
 
+  useEffect(() => {
+    const initial = thumbSrc ?? resolvedSrc;
+    setSrcUsed(initial);
+    setHasError(false);
+    setIsLoaded(loadedImages.has(initial ?? ""));
+  }, [thumbSrc, resolvedSrc]);
+
   const handleLoad = useCallback(() => {
     setIsLoaded(true);
-    if (resolvedSrc) loadedImages.add(resolvedSrc);
+    if (srcUsed) loadedImages.add(srcUsed);
     onExternalLoad?.();
-  }, [onExternalLoad, resolvedSrc]);
+  }, [onExternalLoad, srcUsed]);
   const handleError = useCallback(() => {
+    if (srcUsed !== resolvedSrc && resolvedSrc) {
+      // Thumbnail unavailable (unsupported provider/format) — try the
+      // original once before reporting failure.
+      setSrcUsed(resolvedSrc);
+      return;
+    }
     setIsLoaded(true);
     setHasError(true);
     onExternalError?.();
-  }, [onExternalError]);
+  }, [srcUsed, resolvedSrc, onExternalError]);
 
   if (!resolvedSrc) return null;
 
@@ -88,7 +111,7 @@ export function ImageWithSkeleton({
           )
         ) : (
           <img
-            src={resolvedSrc}
+            src={srcUsed}
             alt={alt}
             loading={loading}
             onLoad={handleLoad}
@@ -127,7 +150,7 @@ export function ImageWithSkeleton({
       {/* Actual image */}
       {!hasError && (
         <img
-          src={resolvedSrc}
+          src={srcUsed}
           alt={alt}
           loading={loading}
           onLoad={handleLoad}

--- a/frontend/src/components/chat/ChatMessage/MarkdownContent.tsx
+++ b/frontend/src/components/chat/ChatMessage/MarkdownContent.tsx
@@ -18,6 +18,7 @@ import { setActiveRevealPreviewState } from "./items/activeRevealPreviewStore";
 import { createActiveRevealPreviewState } from "./items/revealPreviewState";
 import { shouldInterceptFilePreviewLink } from "./items/revealPreviewLinks";
 import { copyToClipboard } from "../../../utils/clipboard";
+import { buildChatThumbUrl } from "../../../utils/chatThumbs";
 import { useSessionImageGallery } from "./sessionImageGallery";
 import { ImageWithSkeleton } from "./ImageWithSkeleton";
 import { normalizeMarkdownCodeFences } from "./markdownCodeFences";
@@ -571,6 +572,7 @@ export const MarkdownContent = memo(function MarkdownContent({
             return (
               <ImageWithSkeleton
                 src={resolvedSrc}
+                thumbSrc={buildChatThumbUrl(resolvedSrc)}
                 alt={alt}
                 loading="eager"
                 className="max-w-lg h-auto rounded-lg shadow hover:opacity-90 transition-opacity cursor-zoom-in"

--- a/frontend/src/components/chat/ChatMessage/MessageImageGallery.tsx
+++ b/frontend/src/components/chat/ChatMessage/MessageImageGallery.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { ExternalLink } from "lucide-react";
 import { ImageWithSkeleton } from "./ImageWithSkeleton";
 import { useSessionImageGallery } from "./sessionImageGallery";
+import { buildChatThumbUrl } from "../../../utils/chatThumbs";
 import type { RevealFileImageInfo } from "./revealFileImageUtils";
 
 interface MessageImageGalleryProps {
@@ -45,6 +46,7 @@ export function MessageImageGallery({ images }: MessageImageGalleryProps) {
             >
               <ImageWithSkeleton
                 src={image.src}
+                thumbSrc={buildChatThumbUrl(image.src)}
                 alt={image.fileName}
                 skipUrlResolve
                 inline

--- a/frontend/src/components/chat/ChatMessage/__tests__/ImageWithSkeletonThumb.test.tsx
+++ b/frontend/src/components/chat/ChatMessage/__tests__/ImageWithSkeletonThumb.test.tsx
@@ -1,0 +1,57 @@
+/** @vitest-environment jsdom */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { expect, test } from "vitest";
+import { ImageWithSkeleton } from "../ImageWithSkeleton";
+
+const FULL_SRC = "https://app.example/api/upload/file/abc/hero.jpg";
+const THUMB_SRC = "https://app.example/api/upload/file/abc/hero.jpg?thumb=1";
+
+function currentImgSrc(): string {
+  const img = screen.getByAltText("hero") as HTMLImageElement;
+  return img.getAttribute("src") ?? "";
+}
+
+test("renders the thumbnail URL when thumbSrc is provided", () => {
+  render(<ImageWithSkeleton src={FULL_SRC} thumbSrc={THUMB_SRC} alt="hero" />);
+  expect(currentImgSrc()).toBe(THUMB_SRC);
+});
+
+test("renders the original URL when no thumbSrc is provided", () => {
+  render(<ImageWithSkeleton src={FULL_SRC} alt="hero" />);
+  expect(currentImgSrc()).toBe(FULL_SRC);
+});
+
+test("falls back to the original once when the thumbnail fails", () => {
+  render(<ImageWithSkeleton src={FULL_SRC} thumbSrc={THUMB_SRC} alt="hero" />);
+  const img = screen.getByAltText("hero");
+
+  fireEvent.error(img);
+  expect(currentImgSrc()).toBe(FULL_SRC);
+
+  // 原图也失败才进入错误态
+  fireEvent.error(img);
+  expect(screen.getByText("hero")).toBeInTheDocument();
+  expect(screen.queryByAltText("hero")).not.toBeInTheDocument();
+});
+
+test("reports onError only after the original also fails", () => {
+  let reported = 0;
+  render(
+    <ImageWithSkeleton
+      src={FULL_SRC}
+      thumbSrc={THUMB_SRC}
+      alt="hero"
+      onError={() => {
+        reported += 1;
+      }}
+    />,
+  );
+  const img = screen.getByAltText("hero");
+
+  fireEvent.error(img);
+  expect(reported).toBe(0);
+
+  fireEvent.error(img);
+  expect(reported).toBe(1);
+});

--- a/frontend/src/components/chat/ChatMessage/__tests__/chatThumbConsumersSource.test.ts
+++ b/frontend/src/components/chat/ChatMessage/__tests__/chatThumbConsumersSource.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+
+/**
+ * 聊天图片缩略图接入守卫：所有消息内图片渲染点都必须走 buildChatThumbUrl，
+ * 点击放大的 URL 仍然是原图（查看器按需加载原图）。
+ */
+
+function read(relative: string): string {
+  return readFileSync(new URL(relative, import.meta.url), "utf8");
+}
+
+test("markdown 正文图片渲染缩略图、点击仍取原图", () => {
+  const source = read("../MarkdownContent.tsx");
+  expect(source).toMatch(/thumbSrc=\{buildChatThumbUrl\(resolvedSrc\)\}/);
+  expect(source).toMatch(/openImage\(resolvedSrc/);
+});
+
+test("reveal_file 画廊与文件卡片渲染缩略图", () => {
+  const gallery = read("../MessageImageGallery.tsx");
+  expect(gallery).toMatch(/thumbSrc=\{buildChatThumbUrl\(image\.src\)\}/);
+  expect(gallery).toMatch(/openImage\(image\.src/);
+
+  const revealItem = read("../items/FileRevealItem.tsx");
+  expect(revealItem).toMatch(/thumbSrc=\{buildChatThumbUrl\(parsed\.s3Url\)\}/);
+  expect(revealItem).toMatch(/openImagePreview\(parsed\.s3Url\)/);
+});
+
+test("image_generate 参考图与结果图渲染缩略图", () => {
+  const source = read("../items/ImageGenerateItem.tsx");
+  expect(source.match(/buildChatThumbUrl/g)?.length).toBeGreaterThanOrEqual(4);
+  expect(source).toMatch(/openImagePreview\(resolvedUrl\)/);
+  expect(source).toMatch(/openImagePreview\(img\.url\)/);
+});
+
+test("附件卡片：图片缩略图 + 文件封面 + 图标兜底", () => {
+  const source = read("../../../common/AttachmentCard.tsx");
+  expect(source).toMatch(/buildChatThumbUrl\(attachmentUrl\)/);
+  expect(source).toMatch(/buildFileCoverUrl\(attachmentUrl\)/);
+  expect(source).toMatch(/isChatCoverableFile\(fileExt\)/);
+  // 封面加载失败必须回退到文件图标（零流量兜底）
+  expect(source).toMatch(/errorFallback=\{\s*<FileIcon/s);
+});

--- a/frontend/src/components/chat/ChatMessage/items/FileRevealItem.tsx
+++ b/frontend/src/components/chat/ChatMessage/items/FileRevealItem.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../../documents/utils";
 import { ExcalidrawCardPreview } from "../../../documents/previews/ExcalidrawCardPreview";
 import { getFullUrl } from "../../../../services/api";
+import { buildChatThumbUrl } from "../../../../utils/chatThumbs";
 import {
   getFileRevealAutoOpenKey,
   markFileRevealPreviewAutoOpened,
@@ -363,6 +364,7 @@ export function FileRevealItem({
               {isImage ? (
                 <ImageWithSkeleton
                   src={parsed.s3Url}
+                  thumbSrc={buildChatThumbUrl(parsed.s3Url)}
                   alt={fileName}
                   skipUrlResolve
                   inline

--- a/frontend/src/components/chat/ChatMessage/items/ImageGenerateItem.tsx
+++ b/frontend/src/components/chat/ChatMessage/items/ImageGenerateItem.tsx
@@ -13,6 +13,7 @@ import { ToolHoverCopyButton } from "./ToolHoverCopyButton";
 import { ToolDurationFooter } from "./ToolDurationFooter";
 import { useSessionImageGallery } from "../sessionImageGallery";
 import { getFullUrl } from "../../../../services/api/config";
+import { buildChatThumbUrl } from "../../../../utils/chatThumbs";
 
 const ImageGenerateItem = memo(function ImageGenerateItem({
   args,
@@ -258,6 +259,7 @@ const ImageGenerateItem = memo(function ImageGenerateItem({
                 >
                   <ImageWithSkeleton
                     src={resolvedUrl}
+                    thumbSrc={buildChatThumbUrl(resolvedUrl)}
                     alt={t("chat.message.toolImageRefAlt", { index: i + 1 })}
                     skipUrlResolve
                     inline
@@ -295,6 +297,7 @@ const ImageGenerateItem = memo(function ImageGenerateItem({
             >
               <ImageWithSkeleton
                 src={img.url}
+                thumbSrc={buildChatThumbUrl(img.url)}
                 alt={img.name}
                 skipUrlResolve
                 inline
@@ -419,6 +422,7 @@ const ImageGenerateItem = memo(function ImageGenerateItem({
               >
                 <ImageWithSkeleton
                   src={resolvedUrl}
+                  thumbSrc={buildChatThumbUrl(resolvedUrl)}
                   alt={t("chat.message.toolImageRefAltShort", { index: i + 1 })}
                   skipUrlResolve
                   inline
@@ -449,6 +453,7 @@ const ImageGenerateItem = memo(function ImageGenerateItem({
             >
               <ImageWithSkeleton
                 src={img.url}
+                thumbSrc={buildChatThumbUrl(img.url)}
                 alt={img.name}
                 skipUrlResolve
                 inline

--- a/frontend/src/components/common/AttachmentCard.tsx
+++ b/frontend/src/components/common/AttachmentCard.tsx
@@ -11,6 +11,7 @@ import {
   isExcalidrawFile,
 } from "../documents/utils";
 import { getFullUrl } from "../../services/api";
+import { buildChatThumbUrl, buildFileCoverUrl, isChatCoverableFile } from "../../utils/chatThumbs";
 
 // Re-export formatFileSize for external use
 // eslint-disable-next-line react-refresh/only-export-components
@@ -87,7 +88,15 @@ export const AttachmentCard = memo(function AttachmentCard({
       : "";
   }, [attachment.name]);
   const isExcalidraw = isExcalidrawFile(fileExt) && Boolean(attachmentUrl);
-  const isThumbnail = isImage || isExcalidraw;
+  // 服务端封面：PDF 首页/表格前几行/视频首帧，失败回退文件图标（零流量）
+  const coverUrl =
+    !isImage &&
+    !isExcalidraw &&
+    Boolean(attachmentUrl) &&
+    isChatCoverableFile(fileExt)
+      ? buildFileCoverUrl(attachmentUrl)
+      : undefined;
+  const isThumbnail = isImage || isExcalidraw || Boolean(coverUrl);
   const isCompact = size === "compact";
   const isFailed = Boolean(attachment.uploadError);
   const uploadStatusLabel =
@@ -144,12 +153,21 @@ export const AttachmentCard = memo(function AttachmentCard({
           ) : isImage ? (
             <ImageWithSkeleton
               src={attachmentUrl}
+              thumbSrc={buildChatThumbUrl(attachmentUrl)}
               alt={attachment.name}
               skipUrlResolve
               inline
             />
           ) : isExcalidraw ? (
             <ExcalidrawThumbnail url={attachmentUrl} alt={attachment.name} />
+          ) : coverUrl ? (
+            <ImageWithSkeleton
+              src={coverUrl}
+              alt={attachment.name}
+              skipUrlResolve
+              inline
+              errorFallback={<FileIcon size={18} className={iconColor} />}
+            />
           ) : (
             <FileIcon size={18} className={iconColor} />
           )}
@@ -296,6 +314,7 @@ export const AttachmentCard = memo(function AttachmentCard({
           <>
             <ImageWithSkeleton
               src={attachmentUrl}
+              thumbSrc={buildChatThumbUrl(attachmentUrl)}
               alt={attachment.name}
               skipUrlResolve
               inline
@@ -308,6 +327,23 @@ export const AttachmentCard = memo(function AttachmentCard({
             url={attachmentUrl}
             alt={attachment.name}
             className="w-full h-full object-cover"
+          />
+        ) : coverUrl ? (
+          <ImageWithSkeleton
+            src={coverUrl}
+            alt={attachment.name}
+            skipUrlResolve
+            inline
+            className="w-full h-full object-cover"
+            errorFallback={
+              <FileIcon
+                size={18}
+                className={clsx(
+                  iconColor,
+                  "transition-transform duration-300 group-hover:scale-110",
+                )}
+              />
+            }
           />
         ) : (
           <FileIcon

--- a/frontend/src/components/common/__tests__/AttachmentCardCover.test.tsx
+++ b/frontend/src/components/common/__tests__/AttachmentCardCover.test.tsx
@@ -1,0 +1,70 @@
+/** @vitest-environment jsdom */
+
+import { render, screen } from "@testing-library/react";
+import { beforeEach, expect, test } from "vitest";
+import i18n from "../../../i18n";
+import type { MessageAttachment } from "../../../types";
+import { AttachmentCard } from "../AttachmentCard";
+
+function makeAttachment(
+  overrides: Partial<MessageAttachment>,
+): MessageAttachment {
+  return {
+    id: "a1",
+    key: "files/report.pdf",
+    name: "report.pdf",
+    type: "document",
+    mimeType: "application/pdf",
+    size: 2048,
+    ...overrides,
+  };
+}
+
+beforeEach(async () => {
+  await i18n.changeLanguage("en");
+});
+
+test("image attachments load the thumbnail URL, not the original", () => {
+  render(
+    <AttachmentCard
+      attachment={makeAttachment({
+        name: "hero.jpg",
+        mimeType: "image/jpeg",
+        type: "image",
+        url: "/api/upload/file/abc/hero.jpg",
+      })}
+    />,
+  );
+  const img = screen.getByAltText("hero.jpg") as HTMLImageElement;
+  expect(img.getAttribute("src")).toBe(
+    "http://localhost:3000/api/upload/file/abc/hero.jpg?thumb=1",
+  );
+});
+
+test("pdf attachments render the server-side cover preview", () => {
+  render(
+    <AttachmentCard
+      attachment={makeAttachment({
+        url: "/api/upload/file/abc/report.pdf",
+      })}
+    />,
+  );
+  const img = screen.getByAltText("report.pdf") as HTMLImageElement;
+  expect(img.getAttribute("src")).toBe(
+    "http://localhost:3000/api/upload/file/abc/report.pdf?cover=1",
+  );
+});
+
+test("plain text attachments keep the file icon", () => {
+  render(
+    <AttachmentCard
+      attachment={makeAttachment({
+        name: "notes.txt",
+        mimeType: "text/plain",
+        url: "/api/upload/files/notes.txt",
+      })}
+    />,
+  );
+  expect(screen.queryByAltText("notes.txt")).not.toBeInTheDocument();
+  expect(screen.getByText("notes.txt")).toBeInTheDocument();
+});

--- a/frontend/src/utils/__tests__/chatThumbs.test.ts
+++ b/frontend/src/utils/__tests__/chatThumbs.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildChatThumbUrl,
+  buildFileCoverUrl,
+  isChatCoverableFile,
+} from "../chatThumbs";
+
+describe("buildChatThumbUrl", () => {
+  test("appends thumb=1 to app proxy upload URLs", () => {
+    expect(
+      buildChatThumbUrl("http://127.0.0.1:8000/api/upload/file/abc/hero.jpg"),
+    ).toBe("http://127.0.0.1:8000/api/upload/file/abc/hero.jpg?thumb=1");
+  });
+
+  test("supports relative upload URLs and existing query strings", () => {
+    expect(buildChatThumbUrl("/api/upload/file/abc/hero.png")).toBe(
+      "/api/upload/file/abc/hero.png?thumb=1",
+    );
+    expect(buildChatThumbUrl("/api/upload/file/abc/hero.jpg?proxy=true")).toBe(
+      "/api/upload/file/abc/hero.jpg?proxy=true&thumb=1",
+    );
+  });
+
+  test("appends x-oss-process lfit to Aliyun direct URLs", () => {
+    expect(
+      buildChatThumbUrl(
+        "https://bucket.oss-cn-hangzhou.aliyuncs.com/path/hero.jpg",
+      ),
+    ).toBe(
+      "https://bucket.oss-cn-hangzhou.aliyuncs.com/path/hero.jpg" +
+        "?x-oss-process=image%2Fresize%2Cm_lfit%2Cw_560%2Ch_560",
+    );
+  });
+
+  test("returns undefined for formats that must keep the original", () => {
+    expect(buildChatThumbUrl("/api/upload/file/abc/anim.gif")).toBeUndefined();
+    expect(buildChatThumbUrl("/api/upload/file/abc/icon.svg")).toBeUndefined();
+    expect(buildChatThumbUrl("/api/upload/file/abc/anim.apng")).toBeUndefined();
+  });
+
+  test("returns undefined for external and non-upload URLs", () => {
+    expect(
+      buildChatThumbUrl("https://example.com/random/photo.jpg"),
+    ).toBeUndefined();
+    expect(buildChatThumbUrl("data:image/png;base64,xxx")).toBeUndefined();
+    expect(buildChatThumbUrl(undefined)).toBeUndefined();
+    expect(buildChatThumbUrl("")).toBeUndefined();
+  });
+});
+
+describe("buildFileCoverUrl", () => {
+  test("appends cover=1 to app proxy upload URLs", () => {
+    expect(buildFileCoverUrl("/api/upload/file/abc/report.pdf")).toBe(
+      "/api/upload/file/abc/report.pdf?cover=1",
+    );
+    expect(buildFileCoverUrl("/api/upload/file/abc/report.pdf", { t: 0 })).toBe(
+      "/api/upload/file/abc/report.pdf?cover=1&t=0",
+    );
+  });
+
+  test("returns undefined for non upload URLs", () => {
+    expect(
+      buildFileCoverUrl("https://example.com/random/report.pdf"),
+    ).toBeUndefined();
+    expect(buildFileCoverUrl(undefined)).toBeUndefined();
+  });
+});
+
+describe("isChatCoverableFile", () => {
+  test("covers documents and videos, not plain code/text", () => {
+    expect(isChatCoverableFile("pdf")).toBe(true);
+    expect(isChatCoverableFile("xlsx")).toBe(true);
+    expect(isChatCoverableFile("mp4")).toBe(true);
+    expect(isChatCoverableFile("webm")).toBe(true);
+    expect(isChatCoverableFile("txt")).toBe(false);
+    expect(isChatCoverableFile("zip")).toBe(false);
+  });
+});

--- a/frontend/src/utils/chatThumbs.ts
+++ b/frontend/src/utils/chatThumbs.ts
@@ -1,0 +1,87 @@
+/**
+ * 聊天消息缩略图 URL 构造。
+ *
+ * 对话里的图片/文件卡片只加载小图，点击放大才取原图：
+ * - 应用代理 URL（/api/upload/file/…）→ ?thumb=1（等比 m_lfit 小图）
+ * - 阿里云直链 → x-oss-process 等比缩放参数
+ * - 其余 URL（外链/数据 URI/不能缩的格式）返回 undefined，调用方直接用原图
+ */
+
+const THUMB_LFIT_PROCESS = "image/resize,m_lfit,w_560,h_560";
+
+/** 这些格式保持原样：动图丢动画、矢量图本身很小 */
+const SKIP_THUMB_EXT = new Set(["gif", "svg", "svgz", "apng"]);
+
+const OSS_DIRECT_HOST_RE = /^([a-z0-9-]+\.)*aliyuncs\.com$/i;
+
+function parseUrl(url: string): URL | null {
+  try {
+    return new URL(url, "https://placeholder.invalid");
+  } catch {
+    return null;
+  }
+}
+
+function extFromUrl(url: string): string {
+  const parsed = parseUrl(url);
+  if (!parsed) return "";
+  const dot = parsed.pathname.lastIndexOf(".");
+  return dot >= 0 ? parsed.pathname.slice(dot + 1).toLowerCase() : "";
+}
+
+function isAppProxyUploadUrl(url: string): boolean {
+  const parsed = parseUrl(url);
+  return Boolean(parsed && parsed.pathname.includes("/api/upload/file/"));
+}
+
+function isOssDirectUrl(url: string): boolean {
+  const parsed = parseUrl(url);
+  return Boolean(
+    parsed &&
+      parsed.hostname !== "placeholder.invalid" &&
+      OSS_DIRECT_HOST_RE.test(parsed.hostname),
+  );
+}
+
+/** 等比缩略图 URL；不适用时返回 undefined（调用方直接加载原图）。 */
+export function buildChatThumbUrl(
+  url: string | undefined | null,
+): string | undefined {
+  if (!url) return undefined;
+  if (SKIP_THUMB_EXT.has(extFromUrl(url))) return undefined;
+  const joiner = url.includes("?") ? "&" : "?";
+  if (isAppProxyUploadUrl(url)) {
+    return `${url}${joiner}thumb=1`;
+  }
+  if (isOssDirectUrl(url)) {
+    return `${url}${joiner}x-oss-process=${encodeURIComponent(THUMB_LFIT_PROCESS)}`;
+  }
+  return undefined;
+}
+
+/** 文件封面 URL（16:9，PDF 首页/表格前几行/图片裁剪/视频首帧）；不适用返回 undefined。 */
+export function buildFileCoverUrl(
+  url: string | undefined | null,
+  opts: { t?: number } = {},
+): string | undefined {
+  if (!url || !isAppProxyUploadUrl(url)) return undefined;
+  const joiner = url.includes("?") ? "&" : "?";
+  let out = `${url}${joiner}cover=1`;
+  if (opts.t !== undefined) out += `&t=${opts.t}`;
+  return out;
+}
+
+/** 聊天附件卡片可展示服务端封面的文件类型（视频封面仅 Aliyun 生效，失败回退图标）。 */
+export const CHAT_FILE_COVER_EXTS = new Set([
+  "pdf",
+  "xlsx",
+  "xlsm",
+  "mp4",
+  "webm",
+  "mov",
+  "m4v",
+]);
+
+export function isChatCoverableFile(ext: string | undefined | null): boolean {
+  return Boolean(ext && CHAT_FILE_COVER_EXTS.has(ext.toLowerCase()));
+}

--- a/src/api/routes/upload.py
+++ b/src/api/routes/upload.py
@@ -42,6 +42,7 @@ from src.api.routes.upload_signed_urls import (
 from src.api.routes.upload_signed_urls import (
     router as signed_url_router,
 )
+from src.api.routes.upload_thumb import get_file_thumb_response
 from src.infra.async_utils import run_blocking_io
 from src.infra.async_utils.background_tasks import BestEffortTaskLimiter
 from src.infra.auth.rbac import check_permission
@@ -829,6 +830,7 @@ async def get_file_proxy(
     direct: bool = False,
     proxy: bool = False,
     cover: bool = False,
+    thumb: bool = False,
     t: int | None = None,
 ) -> Response:
     """
@@ -845,6 +847,10 @@ async def get_file_proxy(
             (OSS image crop / video first frame; local storage via Pillow).
             Unsupported types return 404 so clients fall back without
             downloading the original file.
+        thumb: If true, serve an aspect-fit chat thumbnail instead of the
+            original (OSS m_lfit resize; local/Pillow; other S3 providers
+            render once and cache beside the original). Unsupported types
+            return 404 so clients fall back to the original.
         t: Video snapshot timestamp in ms for cover (default 1000).
     """
     from fastapi.responses import JSONResponse
@@ -853,6 +859,9 @@ async def get_file_proxy(
 
     if cover:
         return await get_file_cover_response(storage, key, t)
+
+    if thumb:
+        return await get_file_thumb_response(storage, key)
 
     base_url = _get_base_url(request)
     proxy_url = f"{base_url}/api/upload/file/{key}"

--- a/src/api/routes/upload_cover.py
+++ b/src/api/routes/upload_cover.py
@@ -2,8 +2,11 @@
 
 File-library cards must never download the original file just to show a
 cover: Aliyun OSS processes the crop/snapshot server-side behind a
-long-lived signed URL, local storage resizes with Pillow, everything else
-404s so clients can fall back to a generated cover without any traffic.
+long-lived signed URL, local storage resizes with Pillow, and every other
+S3 provider renders once server-side (Pillow) and caches the small JPEG
+beside the original. Video snapshots stay Aliyun-only (no server-side
+ffmpeg) and unsupported types 404 so clients fall back to a generated
+cover without any traffic.
 """
 
 from __future__ import annotations
@@ -306,11 +309,31 @@ def render_sheet_cover(data: bytes) -> bytes:
     return buf.getvalue()
 
 
+async def _serve_cached_cover(storage: Any, thumb_key: str, expires: int) -> Response:
+    """Aliyun 302s to a day-aligned signed URL; other providers stream the
+    small cached JPEG through the app (their presigned URLs rotate per
+    request and self-hosted endpoints are often not browser-reachable)."""
+    provider = getattr(getattr(storage, "_config", None), "provider", None)
+    if provider == S3Provider.ALIYUN:
+        url = await storage.get_cover_presigned_url(thumb_key, expires)
+        return Response(
+            status_code=302,
+            headers={"Location": url, "Cache-Control": "public, max-age=86400"},
+        )
+    data = await storage.download_file(thumb_key)
+    return Response(
+        content=data,
+        media_type="image/jpeg",
+        headers={"Cache-Control": "public, max-age=86400"},
+    )
+
+
 async def _get_rendered_cover_response(storage: Any, key: str, kind: str, render: Any) -> Response:
     """Shared flow for covers rendered server-side from the original file
-    (PDF pages, spreadsheet rows): render once, cache beside the original
-    (uploads are content-addressed and immutable, so the cache never goes
-    stale), and serve the small JPEG from then on."""
+    (PDF pages, spreadsheet rows, images on providers without x-oss-process):
+    render once, cache beside the original (uploads are content-addressed
+    and immutable, so the cache never goes stale), and serve the small JPEG
+    from then on."""
     thumb_key = f"{_COVER_CACHE_PREFIX}/{key}.jpg"
     expires = cover_signature_expiry()
 
@@ -340,22 +363,9 @@ async def _get_rendered_cover_response(storage: Any, key: str, kind: str, render
             headers={"Cache-Control": "public, max-age=86400"},
         )
 
-    # 缓存缩略图的 302 服务依赖绝对过期时间预签名（sign_url_at），只有
-    # Aliyun 后端实现；其他 S3 后端会静默退化为每次请求全量下载原文件重渲染。
-    provider = getattr(getattr(storage, "_config", None), "provider", None)
-    if provider != S3Provider.ALIYUN:
-        raise HTTPException(status_code=404, detail="Cover thumbnail not available")
-
     try:
         if await storage.file_exists(thumb_key):
-            url = await storage.get_cover_presigned_url(thumb_key, expires)
-            return Response(
-                status_code=302,
-                headers={
-                    "Location": url,
-                    "Cache-Control": "public, max-age=86400",
-                },
-            )
+            return await _serve_cached_cover(storage, thumb_key, expires)
     except HTTPException:
         raise
     except Exception as e:
@@ -432,27 +442,31 @@ async def _do_render_and_cache(
             content_type="image/jpeg",
             skip_size_limit=True,
         )
-        url = await storage.get_cover_presigned_url(thumb_key, expires)
-        return Response(
-            status_code=302,
-            headers={"Location": url, "Cache-Control": "public, max-age=86400"},
-        )
+        provider = getattr(getattr(storage, "_config", None), "provider", None)
+        if provider == S3Provider.ALIYUN:
+            url = await storage.get_cover_presigned_url(thumb_key, expires)
+            return Response(
+                status_code=302,
+                headers={"Location": url, "Cache-Control": "public, max-age=86400"},
+            )
     except Exception as e:
         # Cache write is best-effort; serve the rendered bytes directly.
         logger.warning(f"Failed to cache {kind} cover for {key}: {e}")
-        return Response(
-            content=body,
-            media_type="image/jpeg",
-            headers={"Cache-Control": "public, max-age=86400"},
-        )
+    return Response(
+        content=body,
+        media_type="image/jpeg",
+        headers={"Cache-Control": "public, max-age=86400"},
+    )
 
 
-def _render_local_cover(file_path) -> bytes:
+def render_cover_jpeg(data: bytes) -> bytes:
+    """16:9 cover-crop render from raw image bytes (local storage and
+    non-Aliyun S3 providers — no x-oss-process available)."""
     import io
 
     from PIL import Image, ImageOps
 
-    with Image.open(file_path) as opened:
+    with Image.open(io.BytesIO(data)) as opened:
         img: Image.Image = ImageOps.exif_transpose(opened)
         if img.mode != "RGB":
             img = img.convert("RGB")
@@ -482,45 +496,39 @@ async def get_file_cover_response(storage: Any, key: str, t: int | None) -> Resp
 
     if storage.is_local:
         # Local storage has no server-side processing; resize via Pillow.
-        if key.rsplit(".", 1)[-1].lower() not in _COVER_IMAGE_EXTS:
+        # Videos can't be snapshot without ffmpeg — clients fall back.
+        if ext not in _COVER_IMAGE_EXTS:
             raise HTTPException(status_code=404, detail="Cover thumbnail not available")
-        file_path = storage.get_file_path(key)
-        if not await run_blocking_io(_path_exists, file_path):
-            raise HTTPException(status_code=404, detail="File not found")
-        try:
-            body = await run_blocking_io(_render_local_cover, file_path)
-        except Exception as e:
-            logger.error(f"Failed to render local cover for {key}: {e}")
-            raise HTTPException(status_code=500, detail="Failed to render cover")
-        return Response(
-            content=body,
-            media_type="image/jpeg",
-            headers={"Cache-Control": "public, max-age=86400"},
-        )
+        return await _get_rendered_cover_response(storage, key, "image", render_cover_jpeg)
 
     provider = getattr(getattr(storage, "_config", None), "provider", None)
-    if provider != S3Provider.ALIYUN:
-        # Only Aliyun OSS supports x-oss-process; other providers fall back
+    if provider == S3Provider.ALIYUN:
+        try:
+            exists = await storage.file_exists(key)
+            if not exists:
+                raise HTTPException(status_code=404, detail="File not found")
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.warning(f"Failed to check file existence for {key}: {e}")
+
+        try:
+            url = await storage.get_cover_presigned_url(
+                key, cover_signature_expiry(), process=process
+            )
+        except TypeError:
+            raise HTTPException(status_code=404, detail="Cover thumbnail not available")
+        except Exception as e:
+            logger.error(f"Failed to generate cover URL for {key}: {e}")
+            raise HTTPException(status_code=500, detail="Failed to generate file URL")
+
+        return Response(
+            status_code=302,
+            headers={"Location": url, "Cache-Control": "public, max-age=86400"},
+        )
+
+    # Other S3 providers have no x-oss-process: images render and cache
+    # like PDF/sheet covers; videos would need server-side ffmpeg — 404.
+    if ext not in _COVER_IMAGE_EXTS:
         raise HTTPException(status_code=404, detail="Cover thumbnail not available")
-
-    try:
-        exists = await storage.file_exists(key)
-        if not exists:
-            raise HTTPException(status_code=404, detail="File not found")
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.warning(f"Failed to check file existence for {key}: {e}")
-
-    try:
-        url = await storage.get_cover_presigned_url(key, cover_signature_expiry(), process=process)
-    except TypeError:
-        raise HTTPException(status_code=404, detail="Cover thumbnail not available")
-    except Exception as e:
-        logger.error(f"Failed to generate cover URL for {key}: {e}")
-        raise HTTPException(status_code=500, detail="Failed to generate file URL")
-
-    return Response(
-        status_code=302,
-        headers={"Location": url, "Cache-Control": "public, max-age=86400"},
-    )
+    return await _get_rendered_cover_response(storage, key, "image", render_cover_jpeg)

--- a/src/api/routes/upload_thumb.py
+++ b/src/api/routes/upload_thumb.py
@@ -1,0 +1,196 @@
+"""Aspect-fit chat thumbnails for the file proxy route (?thumb=1).
+
+Chat bubbles must never download originals just to render inline: Aliyun
+OSS resizes server-side behind a day-aligned signed URL, local storage
+resizes with Pillow, and every other S3 provider renders once with Pillow
+and caches the small JPEG beside the original (uploads are
+content-addressed and immutable, so the cache never goes stale).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from fastapi import HTTPException
+from fastapi.responses import Response
+
+from src.api.routes.upload_cover import (
+    _RENDER_ACQUIRE_TIMEOUT,
+    _RENDER_MAX_SOURCE_BYTES,
+    _get_render_semaphore,
+    _key_ext,
+    _path_exists,
+    cover_signature_expiry,
+)
+from src.infra.async_utils import run_blocking_io
+from src.infra.logging import get_logger
+from src.infra.storage.s3 import S3Provider
+
+logger = get_logger(__name__)
+
+THUMB_SIZE = 560
+_THUMB_IMAGE_EXTS = {"jpg", "jpeg", "png", "webp", "bmp"}
+# gif keeps its animation and svg is vector data — neither fits a raster thumb
+_THUMB_CACHE_PREFIX = f"thumbs/{THUMB_SIZE}"
+_thumb_inflight: dict[str, asyncio.Task] = {}
+
+
+def thumb_process_for_key(key: str) -> str | None:
+    """OSS processing directive for a chat thumbnail, or None when unsupported."""
+    if _key_ext(key) in _THUMB_IMAGE_EXTS:
+        return f"image/resize,m_lfit,w_{THUMB_SIZE},h_{THUMB_SIZE}"
+    return None
+
+
+def render_chat_thumb(data: bytes) -> bytes:
+    """Aspect-fit thumbnail (m_lfit semantics — never crops, whole image visible).
+
+    Alpha is composited onto white: JPEG has no alpha and a plain convert()
+    would turn transparent pixels black.
+    """
+    import io
+
+    from PIL import Image, ImageOps
+
+    with Image.open(io.BytesIO(data)) as opened:
+        img: Image.Image = ImageOps.exif_transpose(opened)
+        has_alpha = img.mode in ("RGBA", "LA") or (
+            img.mode == "P" and "transparency" in opened.info
+        )
+        if has_alpha:
+            rgba = img.convert("RGBA")
+            background = Image.new("RGB", rgba.size, (255, 255, 255))
+            background.paste(rgba, mask=rgba.split()[-1])
+            img = background
+        elif img.mode != "RGB":
+            img = img.convert("RGB")
+        fitted = ImageOps.contain(img, (THUMB_SIZE, THUMB_SIZE))
+        buf = io.BytesIO()
+        fitted.save(buf, format="JPEG", quality=82)
+        return buf.getvalue()
+
+
+def _thumb_cache_response(data: bytes) -> Response:
+    return Response(
+        content=data,
+        media_type="image/jpeg",
+        headers={"Cache-Control": "public, max-age=86400"},
+    )
+
+
+async def get_file_thumb_response(storage: Any, key: str) -> Response:
+    if not thumb_process_for_key(key):
+        # Unsupported formats (gif/svg/video/…) 404 so the <img> falls back
+        # to the original URL without downloading anything extra.
+        raise HTTPException(status_code=404, detail="Thumb not available")
+
+    if storage.is_local:
+        file_path = storage.get_file_path(key)
+        if not await run_blocking_io(_path_exists, file_path):
+            raise HTTPException(status_code=404, detail="File not found")
+
+        def _read_and_render() -> bytes:
+            with open(file_path, "rb") as fh:
+                return render_chat_thumb(fh.read())
+
+        try:
+            body = await run_blocking_io(_read_and_render)
+        except Exception as e:
+            logger.error(f"Failed to render local thumb for {key}: {e}")
+            raise HTTPException(status_code=500, detail="Failed to render thumb")
+        return _thumb_cache_response(body)
+
+    provider = getattr(getattr(storage, "_config", None), "provider", None)
+    if provider == S3Provider.ALIYUN:
+        try:
+            exists = await storage.file_exists(key)
+            if not exists:
+                raise HTTPException(status_code=404, detail="File not found")
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.warning(f"Failed to check file existence for thumb {key}: {e}")
+
+        try:
+            url = await storage.get_cover_presigned_url(
+                key, cover_signature_expiry(), process=thumb_process_for_key(key)
+            )
+        except Exception as e:
+            logger.error(f"Failed to generate thumb URL for {key}: {e}")
+            raise HTTPException(status_code=500, detail="Failed to generate file URL")
+        return Response(
+            status_code=302,
+            headers={"Location": url, "Cache-Control": "public, max-age=86400"},
+        )
+
+    # Other S3 providers: render once, cache beside the original. The small
+    # JPEG streams through the app (presigned URLs rotate per request and
+    # self-hosted endpoints are often not browser-reachable).
+    thumb_key = f"{_THUMB_CACHE_PREFIX}/{key}.jpg"
+    if await storage.file_exists(thumb_key):
+        data = await storage.download_file(thumb_key)
+        return _thumb_cache_response(data)
+
+    try:
+        source_size = await storage.get_size(key)
+        if source_size and source_size > _RENDER_MAX_SOURCE_BYTES:
+            raise HTTPException(status_code=404, detail="Thumb not available")
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.warning(f"Failed to stat source for thumb {key}: {e}")
+
+    return await _render_and_cache_thumb(storage, key, thumb_key)
+
+
+async def _render_and_cache_thumb(storage: Any, key: str, thumb_key: str) -> Response:
+    """Download → render → cache, guarded against bursts (mirrors the cover
+    flow: in-flight dedup + the shared render semaphore)."""
+    existing = _thumb_inflight.get(thumb_key)
+    if existing is not None:
+        return await asyncio.shield(existing)
+
+    semaphore = _get_render_semaphore()
+    try:
+        await asyncio.wait_for(semaphore.acquire(), timeout=_RENDER_ACQUIRE_TIMEOUT)
+    except asyncio.TimeoutError:
+        logger.info(f"Thumb render slots saturated for {key}; falling back")
+        raise HTTPException(status_code=404, detail="Thumb not available")
+
+    try:
+        existing = _thumb_inflight.get(thumb_key)
+        if existing is not None:
+            return await asyncio.shield(existing)
+
+        task = asyncio.create_task(_do_render_and_cache_thumb(storage, key, thumb_key))
+        _thumb_inflight[thumb_key] = task
+        task.add_done_callback(lambda _t: _thumb_inflight.pop(thumb_key, None))
+        return await asyncio.shield(task)
+    finally:
+        semaphore.release()
+
+
+async def _do_render_and_cache_thumb(storage: Any, key: str, thumb_key: str) -> Response:
+    try:
+        data = await storage.download_file(key)
+    except Exception as e:
+        logger.error(f"Failed to download source for thumb {key}: {e}")
+        raise HTTPException(status_code=500, detail="Failed to generate file URL")
+
+    try:
+        body = await run_blocking_io(render_chat_thumb, data)
+    except Exception as e:
+        logger.error(f"Failed to render thumb for {key}: {e}")
+        raise HTTPException(status_code=500, detail="Failed to render thumb")
+
+    try:
+        await storage.upload_to_key(
+            body,
+            thumb_key,
+            content_type="image/jpeg",
+            skip_size_limit=True,
+        )
+    except Exception as e:
+        logger.warning(f"Failed to cache thumb for {key}: {e}")
+    return _thumb_cache_response(body)

--- a/tests/api/routes/test_upload_chat_thumb.py
+++ b/tests/api/routes/test_upload_chat_thumb.py
@@ -1,0 +1,304 @@
+"""对话消息缩略图（?thumb=1）行为测试。
+
+设计目标：聊天气泡只加载等比小图，点击放大才取原图——
+阿里云走「预签名 URL + x-oss-process m_lfit」302，本地存储用
+Pillow 现场等比缩放，其余 S3 厂商（minio/AWS/腾讯…）下载原文件
+用 Pillow 渲染一次并缓存到原文件旁边，后续请求直接吃缓存小图。
+"""
+
+from __future__ import annotations
+
+import io
+from types import SimpleNamespace
+
+import pytest
+from PIL import Image
+
+from src.api.routes import upload
+
+
+@pytest.fixture(autouse=True)
+def _reset_thumb_concurrency_state():
+    from src.api.routes import upload_thumb
+
+    upload_thumb._thumb_inflight.clear()
+    yield
+    upload_thumb._thumb_inflight.clear()
+
+
+def _fake_request() -> SimpleNamespace:
+    return SimpleNamespace(
+        base_url="http://testserver/",
+        headers={"host": "testserver"},
+        url=SimpleNamespace(scheme="http"),
+    )
+
+
+class _FakeS3Storage:
+    """记录 presigned 调用参数的可配置假后端。"""
+
+    is_local = False
+
+    def __init__(self, provider: str = "aliyun") -> None:
+        self.presigned_calls: list[dict] = []
+        self._config = SimpleNamespace(provider=provider, public_bucket=False)
+
+    async def file_exists(self, key: str) -> bool:
+        return True
+
+    async def get_presigned_url(
+        self, key: str, expires: int = 3600, process: str | None = None
+    ) -> str:
+        self.presigned_calls.append({"key": key, "expires": expires, "process": process})
+        return f"https://signed.example/{key}?sig=1"
+
+    async def get_cover_presigned_url(
+        self, key: str, expires_at: int, process: str | None = None
+    ) -> str:
+        self.presigned_calls.append({"key": key, "expires": expires_at, "process": process})
+        return f"https://signed.example/{key}?Expires={expires_at}&sig=1"
+
+
+def _async_of(value):
+    async def _factory():
+        return value
+
+    return _factory
+
+
+# ── Aliyun: x-oss-process 302 ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_thumb_redirects_to_lfit_presigned_url_on_aliyun(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _FakeS3Storage()
+    monkeypatch.setattr(upload, "get_or_init_storage", _async_of(storage))
+
+    resp = await upload.get_file_proxy("revealed_files/hero.jpg", _fake_request(), thumb=True)
+
+    assert resp.status_code in (302, 307)
+    assert storage.presigned_calls[0]["process"] == "image/resize,m_lfit,w_560,h_560"
+    assert storage.presigned_calls[0]["expires"] >= 86400
+    assert storage.presigned_calls[0]["expires"] % 86400 == 0
+    assert "signed.example" in resp.headers["location"]
+    assert resp.headers["cache-control"] == "public, max-age=86400"
+
+
+@pytest.mark.asyncio
+async def test_thumb_signature_is_day_aligned_and_stable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _FakeS3Storage()
+    monkeypatch.setattr(upload, "get_or_init_storage", _async_of(storage))
+
+    await upload.get_file_proxy("a/b/hero.jpg", _fake_request(), thumb=True)
+    await upload.get_file_proxy("a/b/hero.jpg", _fake_request(), thumb=True)
+
+    expires = [c["expires"] for c in storage.presigned_calls]
+    assert expires[0] == expires[1]
+
+
+@pytest.mark.asyncio
+async def test_thumb_404s_for_unsupported_types_without_traffic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _FakeS3Storage()
+    monkeypatch.setattr(upload, "get_or_init_storage", _async_of(storage))
+
+    for key in ("a/b/anim.gif", "a/b/icon.svg", "a/b/archive.zip", "a/b/clip.mp4"):
+        with pytest.raises(upload.HTTPException) as exc:
+            await upload.get_file_proxy(key, _fake_request(), thumb=True)
+        assert exc.value.status_code == 404
+
+    assert storage.presigned_calls == []
+
+
+# ── Local: Pillow 等比渲染 ────────────────────────────────────────────────
+
+
+def _write_image(path, size: tuple[int, int], mode: str = "RGB") -> None:
+    color = (200, 120, 60) if mode == "RGB" else (200, 120, 60, 0)
+    Image.new(mode, size, color).save(path, format="PNG" if mode != "RGB" else "JPEG")
+
+
+class _FakeLocalStorage:
+    is_local = True
+    _config = SimpleNamespace(public_bucket=False)
+
+    def __init__(self, src) -> None:
+        self._src = src
+
+    def get_file_path(self, key: str):
+        return self._src
+
+
+@pytest.mark.asyncio
+async def test_thumb_local_renders_aspect_fit_without_cropping(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    src = tmp_path / "hero.jpg"
+    _write_image(src, (640, 400))
+
+    monkeypatch.setattr(upload, "get_or_init_storage", _async_of(_FakeLocalStorage(src)))
+
+    resp = await upload.get_file_proxy("revealed_files/hero.jpg", _fake_request(), thumb=True)
+
+    assert resp.status_code == 200
+    assert resp.media_type == "image/jpeg"
+    assert resp.headers["cache-control"] == "public, max-age=86400"
+    thumb = Image.open(io.BytesIO(resp.body))
+    # m_lfit：等比缩放，整图可见（640x400 → 560x350）
+    assert thumb.size == (560, 350)
+
+
+@pytest.mark.asyncio
+async def test_thumb_local_binds_both_dimensions_for_tall_images(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    src = tmp_path / "tall.jpg"
+    _write_image(src, (400, 1600))
+
+    monkeypatch.setattr(upload, "get_or_init_storage", _async_of(_FakeLocalStorage(src)))
+
+    resp = await upload.get_file_proxy("revealed_files/tall.jpg", _fake_request(), thumb=True)
+
+    thumb = Image.open(io.BytesIO(resp.body))
+    assert thumb.size[1] == 560
+    assert thumb.size[0] == 140
+
+
+@pytest.mark.asyncio
+async def test_thumb_local_composites_alpha_onto_white(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    src = tmp_path / "logo.png"
+    _write_image(src, (300, 300), mode="RGBA")
+
+    monkeypatch.setattr(upload, "get_or_init_storage", _async_of(_FakeLocalStorage(src)))
+
+    resp = await upload.get_file_proxy("revealed_files/logo.png", _fake_request(), thumb=True)
+
+    thumb = Image.open(io.BytesIO(resp.body))
+    assert thumb.mode == "RGB"
+    # 透明区域合成到白底，而不是 JPEG 转换的黑色
+    r, g, b = thumb.getpixel((0, 0))
+    assert r > 240 and g > 240 and b > 240
+
+
+@pytest.mark.asyncio
+async def test_thumb_local_missing_file_404s(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    monkeypatch.setattr(
+        upload,
+        "get_or_init_storage",
+        _async_of(_FakeLocalStorage(tmp_path / "nope.jpg")),
+    )
+
+    with pytest.raises(upload.HTTPException) as exc:
+        await upload.get_file_proxy("revealed_files/nope.jpg", _fake_request(), thumb=True)
+    assert exc.value.status_code == 404
+
+
+# ── 其他 S3 厂商：渲染一次 + 缓存到原文件旁边 ────────────────────────────
+
+
+def _jpeg_bytes(size: tuple[int, int] = (1200, 900)) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", size, (90, 60, 30)).save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+class _FakeRenderStorage:
+    """minio 式假后端：完整模拟 缓存检查→下载→渲染→写缓存。"""
+
+    is_local = False
+
+    def __init__(self, cached: bool = False, size: int | None = 500_000) -> None:
+        self._cached = cached
+        self._size = size
+        self._config = SimpleNamespace(provider="minio", public_bucket=False)
+        self.downloads: list[str] = []
+        self.uploads: list[str] = []
+
+    async def file_exists(self, key: str) -> bool:
+        return self._cached if key.startswith("thumbs/") else True
+
+    async def get_size(self, key: str) -> int | None:
+        return self._size
+
+    async def download_file(self, key: str) -> bytes:
+        self.downloads.append(key)
+        return _jpeg_bytes()
+
+    async def upload_to_key(self, data: bytes, key: str, content_type=None, **kwargs) -> None:
+        self.uploads.append(key)
+
+    async def get_presigned_url(self, key, expires=3600, process=None) -> str:
+        return f"https://signed.example/{key}?sig=1"
+
+
+@pytest.mark.asyncio
+async def test_thumb_non_aliyun_renders_and_caches_beside_original(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _FakeRenderStorage()
+    monkeypatch.setattr(upload, "get_or_init_storage", _async_of(storage))
+
+    resp = await upload.get_file_proxy("revealed_files/hero.jpg", _fake_request(), thumb=True)
+
+    assert resp.status_code == 200
+    assert resp.media_type == "image/jpeg"
+    assert resp.headers["cache-control"] == "public, max-age=86400"
+    assert storage.downloads == ["revealed_files/hero.jpg"]
+    assert storage.uploads == ["thumbs/560/revealed_files/hero.jpg.jpg"]
+    thumb = Image.open(io.BytesIO(resp.body))
+    assert thumb.size == (560, 420)
+
+
+@pytest.mark.asyncio
+async def test_thumb_non_aliyun_serves_cache_without_re_render(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _FakeRenderStorage(cached=True)
+    monkeypatch.setattr(upload, "get_or_init_storage", _async_of(storage))
+
+    resp = await upload.get_file_proxy("revealed_files/hero.jpg", _fake_request(), thumb=True)
+
+    assert resp.status_code == 200
+    assert storage.downloads == ["thumbs/560/revealed_files/hero.jpg.jpg"]
+    assert storage.uploads == []
+
+
+@pytest.mark.asyncio
+async def test_thumb_non_aliyun_skips_oversized_sources(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _FakeRenderStorage(size=80 * 1024 * 1024)
+    monkeypatch.setattr(upload, "get_or_init_storage", _async_of(storage))
+
+    with pytest.raises(upload.HTTPException) as exc:
+        await upload.get_file_proxy("revealed_files/huge.jpg", _fake_request(), thumb=True)
+    assert exc.value.status_code == 404
+    assert storage.downloads == []
+
+
+@pytest.mark.asyncio
+async def test_thumb_concurrent_first_requests_render_only_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import asyncio
+
+    storage = _FakeRenderStorage()
+    monkeypatch.setattr(upload, "get_or_init_storage", _async_of(storage))
+
+    responses = await asyncio.gather(
+        *[
+            upload.get_file_proxy("revealed_files/hero.jpg", _fake_request(), thumb=True)
+            for _ in range(4)
+        ]
+    )
+
+    assert all(r.status_code == 200 for r in responses)
+    assert storage.downloads == ["revealed_files/hero.jpg"]
+    assert storage.uploads == ["thumbs/560/revealed_files/hero.jpg.jpg"]

--- a/tests/api/routes/test_upload_cover_thumb.py
+++ b/tests/api/routes/test_upload_cover_thumb.py
@@ -8,6 +8,7 @@ S3/阿里云走「预签名 URL + x-oss-process」302 重定向（图片裁剪 /
 
 from __future__ import annotations
 
+import io
 from types import SimpleNamespace
 
 import pytest
@@ -108,15 +109,45 @@ async def test_cover_returns_404_for_unsupported_types(
 
 
 @pytest.mark.asyncio
-async def test_cover_skips_processing_for_non_aliyun_providers(
+async def test_cover_image_renders_and_caches_for_non_aliyun_providers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    storage = _FakeS3Storage(provider="minio")
+    """minio/AWS/腾讯等没有 x-oss-process：下载原文件 Pillow 裁剪 16:9，
+    缓存到原文件旁边，字节直接经应用返回。"""
+    storage = _FakePdfStorage(payload=_jpeg_payload((1200, 500)))
+    storage._config = SimpleNamespace(provider="minio", public_bucket=False)
+    monkeypatch.setattr(upload, "get_or_init_storage", _async_of(storage))
+
+    resp = await upload.get_file_proxy("a/b/hero.jpg", _fake_request(), cover=True)
+
+    assert resp.status_code == 200
+    assert resp.media_type == "image/jpeg"
+    assert storage.downloaded == ["a/b/hero.jpg"]
+    assert storage.uploads == ["covers/560x315/a/b/hero.jpg.jpg"]
+    cover = Image.open(io.BytesIO(resp.body))
+    assert cover.size == (560, 315)
+
+
+@pytest.mark.asyncio
+async def test_cover_video_non_aliyun_still_404s(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """视频快照需要服务端 ffmpeg，非 Aliyun 厂商维持 404 客户端兜底。"""
+    storage = _FakePdfStorage()
+    storage._config = SimpleNamespace(provider="minio", public_bucket=False)
     monkeypatch.setattr(upload, "get_or_init_storage", _async_of(storage))
 
     with pytest.raises(upload.HTTPException) as exc:
-        await upload.get_file_proxy("a/b/hero.jpg", _fake_request(), cover=True)
+        await upload.get_file_proxy("a/b/clip.mp4", _fake_request(), cover=True)
     assert exc.value.status_code == 404
+    assert storage.downloaded == []
+    assert storage.uploads == []
+
+
+def _jpeg_payload(size: tuple[int, int]) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", size, (80, 120, 200)).save(buf, format="JPEG")
+    return buf.getvalue()
 
 
 @pytest.mark.asyncio
@@ -272,20 +303,37 @@ async def test_cover_pdf_serves_cached_thumbnail_without_re_render(
 
 
 @pytest.mark.asyncio
-async def test_cover_pdf_non_aliyun_provider_404s_without_download(
+async def test_cover_pdf_renders_and_caches_for_non_aliyun_providers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """非 Aliyun 后端不支持绝对过期签名，必须 404 兜底而非每次重下载重渲染。"""
+    """非 Aliyun 后端不再 404：下载→渲染→缓存小图→应用直接回字节。"""
     storage = _FakePdfStorage()
     storage._config = SimpleNamespace(provider="minio", public_bucket=False)
     monkeypatch.setattr(upload, "get_or_init_storage", _async_of(storage))
 
-    with pytest.raises(upload.HTTPException) as exc:
-        await upload.get_file_proxy("revealed_files/report.pdf", _fake_request(), cover=True)
-    assert exc.value.status_code == 404
-    assert storage.downloaded == []
-    assert storage.uploads == []
+    resp = await upload.get_file_proxy("revealed_files/report.pdf", _fake_request(), cover=True)
+
+    assert resp.status_code == 200
+    assert resp.media_type == "image/jpeg"
+    assert storage.downloaded == ["revealed_files/report.pdf"]
+    assert storage.uploads == ["covers/560x315/revealed_files/report.pdf.jpg"]
     assert storage.presigned_calls == []
+
+
+@pytest.mark.asyncio
+async def test_cover_cached_thumbnail_served_as_bytes_for_non_aliyun(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """缓存命中后非 Aliyun 厂商只下载缓存小图，不再重渲染。"""
+    storage = _FakePdfStorage(cached=True, payload=_jpeg_payload((560, 315)))
+    storage._config = SimpleNamespace(provider="minio", public_bucket=False)
+    monkeypatch.setattr(upload, "get_or_init_storage", _async_of(storage))
+
+    resp = await upload.get_file_proxy("revealed_files/report.pdf", _fake_request(), cover=True)
+
+    assert resp.status_code == 200
+    assert storage.downloaded == ["covers/560x315/revealed_files/report.pdf.jpg"]
+    assert storage.uploads == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 背景

对话消息里所有图片（附件卡片、markdown 正文、reveal_file 画廊、image_generate 结果）此前全部直接加载原图，多图会话渲染卡顿；文件附件只有图标。本 PR 让消息列表只加载小图，点击放大才按需取原图。

## 后端

### 新增 `?thumb=1` 等比缩略图端点（复用 #275 封面基建）

| Provider | 方式 |
|---|---|
| Aliyun OSS | `x-oss-process=image/resize,m_lfit,w_560,h_560` 签名 302（日对齐签名 + `max-age=86400`，零后端成本） |
| 本地存储 | Pillow `ImageOps.contain` 实时渲染（PNG 透明合成白底） |
| 其他 S3（minio/AWS/腾讯/COS…） | 下载原文件 Pillow 渲染一次 → 缓存到 `thumbs/560/{key}.jpg`（内容寻址不可变），后续请求直接吃缓存小图 |

复用封面的并发保护：共享渲染信号量（饱和快速 404 回退）+ in-flight 去重（并发首请求只渲染一次）。GIF/SVG/视频 404，前端回退原图。

### `?cover=1` 封面全 provider 化

- 图片封面、PDF/表格封面在非 Aliyun 厂商不再 404：下载 → Pillow 渲染 → 缓存 `covers/` → 应用回字节
- 缓存命中：Aliyun 302 日对齐签名；其他厂商直接流式返回缓存小图
- 视频快照仍限 Aliyun（无服务端 ffmpeg），客户端图标兜底

## 前端

- `ImageWithSkeleton` 新增 `thumbSrc` prop：列表态渲染缩略图，失败一次性回退原图；`onError` 仅在原图也失败时上报
- 新工具 `chatThumbs.ts`：`/api/upload/file/` URL → `?thumb=1`；阿里云直链 → `x-oss-process` 等比参数；gif/svg/外链/data URI → undefined（走原图）
- 五处消费点接入：markdown 正文图片、附件卡片、reveal_file 画廊、FileRevealItem、image_generate（参考图+结果图）；点击放大交互不变，查看器按需加载原图
- 附件卡片：图片附件走缩略图；PDF/表格/视频附件展示服务端 16:9 封面，失败回退文件图标（零流量）

## 测试

- 后端 15 个新用例：三路 provider 路由、lfit 语义（不裁剪/长图双维约束）、PNG 白底、缓存命中不重渲染、超限跳过、并发只渲染一次、日对齐签名稳定；封面非 Aliyun 行为测试按新语义重写
- 前端 24 个：纯函数（各 URL 形态/跳过格式）、组件回退链（RTL）、五处接入守卫（Source）、附件卡片封面渲染

## 验证

- `make lint` / `make typecheck` ✅
- `uv run pytest`：3086 passed（4 个失败为本机 .env 已知存量，与本次无关）
- `pnpm test`：408 文件 / 1753 用例全过 ✅；`pnpm run build` ✅