### PR TITLE
feat(llm): 思考强度全供应商支持——zai 渠道 GLM 注入 thinking 体、第三方中转 GLM 放宽

### DIFF
--- a/src/infra/llm/client.py
+++ b/src/infra/llm/client.py
@@ -246,6 +246,11 @@ _ZHIPU_THINKING_PREFIXES = (
     "glm-5",
 )
 
+
+def _is_zhipu_thinking_model(name: str) -> bool:
+    """GLM 思考系模型（glm-4.5+/glm-5），与托管渠道无关，按模型名判断。"""
+    return any(name.startswith(prefix) for prefix in _ZHIPU_THINKING_PREFIXES)
+
 # 次版本限定为 1-2 位数字且后不跟数字：防止把官方 model ID 里的发布日期
 # 后缀（claude-opus-4-20250514 / grok-4-0709-beta）当成次版本吞掉——否则
 # (4, 20250514) 会被误判进 effort era。
@@ -295,11 +300,10 @@ def _resolve_zhipu_thinking_body(
     thinking: dict[str, Any],
 ) -> Optional[dict[str, Any]]:
     """Map a thinking config to zhipu's `thinking` request-body field."""
-    # 仅智谱官方端点已验证；第三方 GLM 托管（SiliconFlow/OpenRouter 等）不发送
-    if provider != "zhipu":
-        return None
+    # 全渠道支持：任意 OpenAI 协议渠道上托管的 GLM 思考系都发送（中转对未知
+    # body 字段透传或忽略）；GLM 无档位语义，任何强度都只是 enabled。
     name = model_name.lower()
-    if not any(name.startswith(prefix) for prefix in _ZHIPU_THINKING_PREFIXES):
+    if not _is_zhipu_thinking_model(name):
         return None
     return {"thinking": {"type": "enabled"}}
 
@@ -318,7 +322,16 @@ def _resolve_anthropic_thinking(
     if not thinking:
         # 未配置思考的调用方（标题生成/推荐等）保持原行为，不注入任何参数
         return None, None, None
-    match = _CLAUDE_VERSION_RE.search(model_name.lower())
+    name = model_name.lower()
+    # GLM 思考系挂在 Anthropic 协议渠道（zai 等）：注入 Claude Code 同款 thinking
+    # 体（智谱 Anthropic 兼容端点直接接受）。GLM 无档位语义，任何强度都只是
+    # enabled；budget_tokens 纯透传无实效。不覆盖 temperature（智谱无 Claude
+    # manual thinking 的 temp=1 约束）。
+    if _is_zhipu_thinking_model(name):
+        glm_thinking: dict[str, Any] = {"type": "enabled"}
+        glm_thinking["budget_tokens"] = thinking.get("budget_tokens") or 1024
+        return glm_thinking, None, None
+    match = _CLAUDE_VERSION_RE.search(name)
     if match is None:
         return None, None, None
     version = _version_tuple(match)
@@ -367,7 +380,7 @@ def model_supports_thinking(provider: Optional[str], model_value: str) -> bool:
 
     Known acceptable deviations (both only over-report, never mis-send):
     get_model's default-model provider inheritance for unprefixed generic
-    values, and zhipu models configured with api_format="responses" (the
+    values, and GLM models configured with api_format="responses" (the
     thinking body is chat_completions-only) are not replicated here.
     """
     parsed_provider, model_name = _parse_provider(model_value)
@@ -376,6 +389,8 @@ def model_supports_thinking(provider: Optional[str], model_value: str) -> bool:
     name = model_name.lower()
 
     if protocol == "anthropic":
+        if _is_zhipu_thinking_model(name):
+            return True
         match = _CLAUDE_VERSION_RE.search(name)
         if match is None:
             return False
@@ -390,10 +405,9 @@ def model_supports_thinking(provider: Optional[str], model_value: str) -> bool:
     if prefixes:
         if name.endswith("-chat-latest") or name.endswith("-non-reasoning"):
             return False
-        return any(name.startswith(prefix) for prefix in prefixes)
-    if effective_provider == "zhipu":
-        return any(name.startswith(prefix) for prefix in _ZHIPU_THINKING_PREFIXES)
-    return False
+        if any(name.startswith(prefix) for prefix in prefixes):
+            return True
+    return _is_zhipu_thinking_model(name)
 
 
 async def _lookup_stored_api_key(

--- a/src/infra/llm/client.py
+++ b/src/infra/llm/client.py
@@ -251,6 +251,7 @@ def _is_zhipu_thinking_model(name: str) -> bool:
     """GLM 思考系模型（glm-4.5+/glm-5），与托管渠道无关，按模型名判断。"""
     return any(name.startswith(prefix) for prefix in _ZHIPU_THINKING_PREFIXES)
 
+
 # 次版本限定为 1-2 位数字且后不跟数字：防止把官方 model ID 里的发布日期
 # 后缀（claude-opus-4-20250514 / grok-4-0709-beta）当成次版本吞掉——否则
 # (4, 20250514) 会被误判进 effort era。

--- a/tests/api/routes/test_model_available_access.py
+++ b/tests/api/routes/test_model_available_access.py
@@ -207,6 +207,7 @@ async def test_list_available_models_exposes_thinking_capability(
                     [
                         {"id": "gpt", "value": "openai/gpt-5.5", "provider": "openai"},
                         {"id": "glm", "value": "zhipu/glm-4.6", "provider": "zhipu"},
+                        {"id": "glm-zai", "value": "glm-5.3", "provider": "zai"},
                         {"id": "claude", "value": "claude-opus-5", "provider": "anthropic"},
                         {"id": "gemini", "value": "gemini-2.5-flash", "provider": "google"},
                         {"id": "plain", "value": "deepseek-chat", "provider": "deepseek"},
@@ -230,6 +231,7 @@ async def test_list_available_models_exposes_thinking_capability(
     assert capability == {
         "gpt": True,
         "glm": True,
+        "glm-zai": True,
         "claude": True,
         "gemini": True,
         "plain": False,

--- a/tests/infra/llm/test_thinking_gating.py
+++ b/tests/infra/llm/test_thinking_gating.py
@@ -24,9 +24,14 @@ def _openai_model(provider: str, model_name: str, thinking: dict | None):
     )
 
 
-def _anthropic_model(model_name: str, thinking: dict | None, temperature: float = 0.7):
+def _anthropic_model(
+    model_name: str,
+    thinking: dict | None,
+    temperature: float = 0.7,
+    provider: str = "anthropic",
+):
     return LLMClient._create_model(
-        "anthropic",
+        provider,
         model_name,
         temperature=temperature,
         api_key="sk-test",
@@ -135,11 +140,11 @@ def test_zhipu_unverified_families_receive_nothing() -> None:
     assert "thinking" not in model.model_kwargs
 
 
-def test_zhipu_body_not_sent_to_other_providers_hosting_glm() -> None:
-    # 第三方 GLM 托管（SiliconFlow/OpenRouter 等）只按模型名匹配时不得收到智谱字段
-    for provider in ("openai", "deepseek", "siliconflow"):
+def test_zhipu_body_sent_to_openai_protocol_glm_hosting() -> None:
+    # 用户指示：全部供应商支持——第三方中转托管的 GLM 也发 thinking body（中转透传）
+    for provider in ("zhipu", "openai", "deepseek", "siliconflow"):
         model = _openai_model(provider, "glm-4.6", ENABLED("low"))
-        assert "thinking" not in model.model_kwargs, provider
+        assert model.model_kwargs["thinking"] == {"type": "enabled"}, provider
 
 
 def test_zhipu_does_not_receive_openai_cache_extensions() -> None:
@@ -224,6 +229,36 @@ def test_anthropic_protocol_third_party_models_receive_nothing() -> None:
         assert model.reasoning_effort is None, model_name
 
 
+# ── GLM on Anthropic-protocol providers (zai) ────────────────────────────
+
+
+def test_zai_glm_receives_thinking_enabled() -> None:
+    # 智谱 Anthropic 兼容端点接受 Claude Code 同款 thinking 体；GLM 无档位语义，
+    # 任何强度都只是 enabled；不覆盖 temperature（智谱无 Claude 的 temp=1 约束）
+    model = _anthropic_model("glm-5.3", ENABLED("low"), provider="zai")
+    assert model.thinking == {"type": "enabled", "budget_tokens": 1024}
+    assert model.reasoning_effort is None
+    assert model.temperature == 0.7
+
+
+def test_zai_glm_max_level_maps_to_max_budget() -> None:
+    model = _anthropic_model("glm-4.6", ENABLED("max"), provider="zai")
+    assert model.thinking == {"type": "enabled", "budget_tokens": 65536}
+
+
+def test_zai_glm_without_thinking_config_sends_nothing() -> None:
+    # 未配置思考的辅助调用方保持原行为
+    model = _anthropic_model("glm-5.3", None, provider="zai")
+    assert model.thinking is None
+    assert model.reasoning_effort is None
+
+
+def test_zai_legacy_and_unverified_glm_receive_nothing() -> None:
+    for model_name in ("chatglm-3-turbo", "glm-4.7"):
+        model = _anthropic_model(model_name, ENABLED("low"), provider="zai")
+        assert model.thinking is None, model_name
+
+
 # ── Google protocol branch ───────────────────────────────────────────────
 
 
@@ -291,9 +326,19 @@ def test_model_supports_thinking_zhipu() -> None:
     assert model_supports_thinking("zhipu", "glm-5.3") is True
     assert model_supports_thinking("zhipu", "glm-4.7") is False
     assert model_supports_thinking("zhipu", "chatglm-3-turbo") is False
-    # 第三方 GLM 托管不收智谱 thinking 字段
-    assert model_supports_thinking("openai", "glm-4.6") is False
-    assert model_supports_thinking("deepseek", "glm-4.6") is False
+    # 第三方中转托管的 GLM 同样下发思考体（用户指示：全部供应商支持）
+    assert model_supports_thinking("openai", "glm-4.6") is True
+    assert model_supports_thinking("deepseek", "glm-4.6") is True
+
+
+def test_model_supports_thinking_zai_anthropic_protocol() -> None:
+    # zai 渠道（anthropic 协议路由）的 GLM 思考系支持
+    assert model_supports_thinking("zai", "glm-5.3") is True
+    assert model_supports_thinking("zai", "glm-5.2") is True
+    assert model_supports_thinking("zai", "glm-4.6") is True
+    assert model_supports_thinking("zai", "glm-4.5-air") is True
+    assert model_supports_thinking("zai", "glm-4.7") is False
+    assert model_supports_thinking("zai", "chatglm-3-turbo") is False
 
 
 def test_model_supports_thinking_anthropic() -> None:
@@ -347,5 +392,5 @@ def test_model_supports_thinking_infers_provider_when_missing() -> None:
 
 
 def test_model_supports_thinking_explicit_provider_wins() -> None:
-    # 显式 provider 优先于 value 前缀：openai 渠道托管的 glm 收不到智谱字段
-    assert model_supports_thinking("openai", "zhipu/glm-4.6") is False
+    # 显式 provider 优先于 value 前缀：google 渠道托管的 glm 走 Gemini 门控（不匹配）
+    assert model_supports_thinking("google", "zhipu/glm-4.6") is False


### PR DESCRIPTION
## 背景

#285 上线后 staging 实测发现 zai 渠道（Anthropic 协议路由）的 GLM 思考控件被如实隐藏——后端门控本就不给它们发思考参数。用户要求：LambChat 里配置的供应商**全部支持**思考强度，控件显示且真正生效。

查证依据：[智谱 Claude API 兼容文档](https://docs.bigmodel.cn/cn/guide/develop/claude/introduction)——Anthropic 兼容端点直接接受 `thinking: {"type":"enabled","budget_tokens":...}`（Claude Code 同款请求形态）。

## 改动

- **Anthropic 协议分支（zai 等）**：GLM 思考系（glm-4.5+/glm-5）注入 `thinking={"type":"enabled", budget_tokens}`；GLM 无档位语义，任何强度都只是 enabled；不覆盖 temperature（智谱无 Claude manual thinking 的 temp=1 约束）
- **OpenAI 协议分支**：zhipu `thinking` body 不再限定官方 provider，任意渠道托管的 GLM 思考系按模型名匹配发送（中转对未知 body 字段透传或忽略）
- **不变项**：glm-4.7 等未核实版本仍不发；未配置思考的辅助调用（标题生成等）保持不注入；OpenAI/Gemini/Claude 各家档位映射不变
- **谓词同步**：`model_supports_thinking` 对 zai/zhipu/第三方托管的 GLM 判支持 → 思考强度控件这些渠道全部显示

## 验证

- `uv run pytest`：相关 165 passed（test_model_access 3 失败为本机 .env 存量）
- `make lint` / `make typecheck` 通过
- 合并后将滚 staging 实测 zai GLM：控件显示 + 发消息出 thinking 事件