### PR TITLE
fix(frontend): 文档预览复制链接补全为绝对地址

### DIFF
--- a/frontend/src/components/documents/DocumentPreviewToolbar.tsx
+++ b/frontend/src/components/documents/DocumentPreviewToolbar.tsx
@@ -17,6 +17,7 @@ import {
   Share2,
 } from "lucide-react";
 import { formatFileSize as formatFileSizeUtil } from "./utils";
+import { getFullUrl } from "../../services/api/config";
 import type { DocumentPreviewState } from "./useDocumentPreviewState";
 
 type ToolbarProps = Pick<
@@ -89,7 +90,10 @@ export default function DocumentPreviewToolbar({
 }: ToolbarProps) {
   const [linkCopied, setLinkCopied] = useState(false);
 
-  const fileUrl = resolvedUrl || signedUrl || externalImageUrl;
+  const fileUrl =
+    getFullUrl(resolvedUrl) ||
+    getFullUrl(signedUrl) ||
+    getFullUrl(externalImageUrl);
 
   const handleCopyLink = useCallback(() => {
     if (!fileUrl) return;

--- a/frontend/src/components/documents/__tests__/documentPreviewSource.test.ts
+++ b/frontend/src/components/documents/__tests__/documentPreviewSource.test.ts
@@ -21,3 +21,9 @@ test("DocumentPreview fetches file content through the upload proxy", () => {
   expect(source).toMatch(/fetchDocumentArrayBuffer\(readUrl\)/);
   expect(source).toMatch(/fetchDocumentText\(readUrl\)/);
 });
+
+test("DocumentPreview download URL is absolutized for every source", () => {
+  expect(source).toMatch(/getFullUrl\(signedUrl\)/);
+  expect(source).toMatch(/getFullUrl\(resolvedUrl\)/);
+  expect(source).toMatch(/getFullUrl\(externalImageUrl\)/);
+});

--- a/frontend/src/components/documents/__tests__/documentPreviewToolbarCopyLink.test.tsx
+++ b/frontend/src/components/documents/__tests__/documentPreviewToolbarCopyLink.test.tsx
@@ -1,0 +1,93 @@
+/** @vitest-environment jsdom */
+
+import { createRef, type ComponentProps } from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { vi } from "vitest";
+import DocumentPreviewToolbar from "../DocumentPreviewToolbar";
+import { getFileTypeInfo } from "../utils";
+
+vi.mock("react-hot-toast", () => ({
+  default: { success: vi.fn() },
+}));
+
+const writeText = vi.fn().mockResolvedValue(undefined);
+
+beforeEach(() => {
+  writeText.mockClear();
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+});
+
+function renderCopyLinkButton(
+  overrides: Partial<ComponentProps<typeof DocumentPreviewToolbar>> = {},
+) {
+  const fileName = "2d1d8bc2b6d44047.docx";
+  const fileInfo = getFileTypeInfo(fileName);
+  const props = {
+    t: ((key: string, fallback?: unknown) =>
+      typeof fallback === "string" ? fallback : key) as ComponentProps<
+      typeof DocumentPreviewToolbar
+    >["t"],
+    data: { content: "", path: fileName },
+    copied: false,
+    viewSource: false,
+    isSidebar: true,
+    isFullscreen: false,
+    markdownFile: false,
+    codeFile: false,
+    hasTextContent: false,
+    displaySize: 0,
+    fileSize: 279347,
+    fileName,
+    language: "",
+    fileInfo,
+    Icon: fileInfo.icon,
+    s3Key: `document/6999be7275bdd6b1d868075b/${fileName}`,
+    signedUrl: undefined,
+    externalImageUrl: undefined,
+    resolvedUrl: null,
+    unsupportedPreviewFile: false,
+    onUserInteraction: undefined,
+    onClose: vi.fn(),
+    effectiveOnBack: vi.fn(),
+    handleCopy: vi.fn(),
+    handleDownload: vi.fn(),
+    toolbarRef: createRef<HTMLDivElement>(),
+    setViewSource: vi.fn(),
+    setViewMode: vi.fn(),
+    handleFullscreenToggle: vi.fn(),
+    exitFullscreen: vi.fn(),
+    ...overrides,
+  } satisfies ComponentProps<typeof DocumentPreviewToolbar>;
+
+  render(<DocumentPreviewToolbar {...props} />);
+  return screen.getByTitle("Copy link");
+}
+
+test("copy link writes an absolute URL when resolvedUrl is a relative upload path", async () => {
+  const relativePath =
+    "/api/upload/file/document/6999be7275bdd6b1d868075b/2d1d8bc2b6d44047.docx";
+  const button = renderCopyLinkButton({ resolvedUrl: relativePath });
+
+  await act(async () => {
+    fireEvent.click(button);
+  });
+
+  expect(writeText).toHaveBeenCalledWith(
+    `${window.location.origin}${relativePath}`,
+  );
+});
+
+test("copy link keeps absolute URLs unchanged", async () => {
+  const button = renderCopyLinkButton({
+    resolvedUrl: "https://example.test/file.docx",
+  });
+
+  await act(async () => {
+    fireEvent.click(button);
+  });
+
+  expect(writeText).toHaveBeenCalledWith("https://example.test/file.docx");
+});

--- a/frontend/src/components/documents/useDocumentPreviewState.ts
+++ b/frontend/src/components/documents/useDocumentPreviewState.ts
@@ -472,7 +472,9 @@ export function useDocumentPreviewState(props: DocumentPreviewProps) {
 
   const handleDownload = async () => {
     const downloadUrl =
-      getFullUrl(signedUrl) || resolvedUrl || getFullUrl(externalImageUrl);
+      getFullUrl(signedUrl) ||
+      getFullUrl(resolvedUrl) ||
+      getFullUrl(externalImageUrl);
     if (downloadUrl) {
       try {
         const response = await fetchUploadFile(


### PR DESCRIPTION
## Summary

修复文档预览工具栏"复制链接"复制出相对路径的问题。聊天上传的文档（s3Key 形式）在未配置 `VITE_API_BASE` 的同源部署下，`buildUploadProxyUrlFromKey` 返回的是 `/api/upload/file/...` 相对路径，`handleCopyLink` 原样写入剪贴板，用户拿到的链接缺少 origin，无法直接使用。

## Changes

- `DocumentPreviewToolbar.tsx`：复制链接的 URL 改为 `getFullUrl(resolvedUrl) || getFullUrl(signedUrl) || getFullUrl(externalImageUrl)`，写入剪贴板前补全为绝对地址；`getFullUrl` 对完整 URL 幂等，签名链接与外链不受影响。
- `useDocumentPreviewState.ts`：`handleDownload` 的 `resolvedUrl` 同样包上 `getFullUrl`，消除同一处不一致（此前靠相对路径 fetch 碰巧可用）。

## Testing

- [x] 新增 `documentPreviewToolbarCopyLink.test.tsx`：先以失败测试复现 bug（剪贴板收到相对路径），修复后断言收到 `${origin}/api/upload/file/...`；含绝对 URL 原样保留的守卫用例
- [x] `documentPreviewSource.test.ts` 新增断言：下载 URL 三个来源均经 `getFullUrl` 绝对化
- [x] 全量前端测试 411 文件 / 1767 用例通过
- [x] `pnpm run lint` 通过、`pnpm run build` 成功
