### PR TITLE
chore(release): 晋升 #288/#289（文档预览复制链接修复等巡检改动）

### DIFF
--- a/frontend/src/components/documents/DocumentPreviewToolbar.tsx
+++ b/frontend/src/components/documents/DocumentPreviewToolbar.tsx
@@ -17,6 +17,7 @@ import {
   Share2,
 } from "lucide-react";
 import { formatFileSize as formatFileSizeUtil } from "./utils";
+import { getFullUrl } from "../../services/api/config";
 import type { DocumentPreviewState } from "./useDocumentPreviewState";
 
 type ToolbarProps = Pick<
@@ -89,7 +90,10 @@ export default function DocumentPreviewToolbar({
 }: ToolbarProps) {
   const [linkCopied, setLinkCopied] = useState(false);
 
-  const fileUrl = resolvedUrl || signedUrl || externalImageUrl;
+  const fileUrl =
+    getFullUrl(resolvedUrl) ||
+    getFullUrl(signedUrl) ||
+    getFullUrl(externalImageUrl);
 
   const handleCopyLink = useCallback(() => {
     if (!fileUrl) return;

--- a/frontend/src/components/documents/__tests__/documentPreviewSource.test.ts
+++ b/frontend/src/components/documents/__tests__/documentPreviewSource.test.ts
@@ -21,3 +21,9 @@ test("DocumentPreview fetches file content through the upload proxy", () => {
   expect(source).toMatch(/fetchDocumentArrayBuffer\(readUrl\)/);
   expect(source).toMatch(/fetchDocumentText\(readUrl\)/);
 });
+
+test("DocumentPreview download URL is absolutized for every source", () => {
+  expect(source).toMatch(/getFullUrl\(signedUrl\)/);
+  expect(source).toMatch(/getFullUrl\(resolvedUrl\)/);
+  expect(source).toMatch(/getFullUrl\(externalImageUrl\)/);
+});

--- a/frontend/src/components/documents/__tests__/documentPreviewToolbarCopyLink.test.tsx
+++ b/frontend/src/components/documents/__tests__/documentPreviewToolbarCopyLink.test.tsx
@@ -1,0 +1,93 @@
+/** @vitest-environment jsdom */
+
+import { createRef, type ComponentProps } from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { vi } from "vitest";
+import DocumentPreviewToolbar from "../DocumentPreviewToolbar";
+import { getFileTypeInfo } from "../utils";
+
+vi.mock("react-hot-toast", () => ({
+  default: { success: vi.fn() },
+}));
+
+const writeText = vi.fn().mockResolvedValue(undefined);
+
+beforeEach(() => {
+  writeText.mockClear();
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+});
+
+function renderCopyLinkButton(
+  overrides: Partial<ComponentProps<typeof DocumentPreviewToolbar>> = {},
+) {
+  const fileName = "2d1d8bc2b6d44047.docx";
+  const fileInfo = getFileTypeInfo(fileName);
+  const props = {
+    t: ((key: string, fallback?: unknown) =>
+      typeof fallback === "string" ? fallback : key) as ComponentProps<
+      typeof DocumentPreviewToolbar
+    >["t"],
+    data: { content: "", path: fileName },
+    copied: false,
+    viewSource: false,
+    isSidebar: true,
+    isFullscreen: false,
+    markdownFile: false,
+    codeFile: false,
+    hasTextContent: false,
+    displaySize: 0,
+    fileSize: 279347,
+    fileName,
+    language: "",
+    fileInfo,
+    Icon: fileInfo.icon,
+    s3Key: `document/6999be7275bdd6b1d868075b/${fileName}`,
+    signedUrl: undefined,
+    externalImageUrl: undefined,
+    resolvedUrl: null,
+    unsupportedPreviewFile: false,
+    onUserInteraction: undefined,
+    onClose: vi.fn(),
+    effectiveOnBack: vi.fn(),
+    handleCopy: vi.fn(),
+    handleDownload: vi.fn(),
+    toolbarRef: createRef<HTMLDivElement>(),
+    setViewSource: vi.fn(),
+    setViewMode: vi.fn(),
+    handleFullscreenToggle: vi.fn(),
+    exitFullscreen: vi.fn(),
+    ...overrides,
+  } satisfies ComponentProps<typeof DocumentPreviewToolbar>;
+
+  render(<DocumentPreviewToolbar {...props} />);
+  return screen.getByTitle("Copy link");
+}
+
+test("copy link writes an absolute URL when resolvedUrl is a relative upload path", async () => {
+  const relativePath =
+    "/api/upload/file/document/6999be7275bdd6b1d868075b/2d1d8bc2b6d44047.docx";
+  const button = renderCopyLinkButton({ resolvedUrl: relativePath });
+
+  await act(async () => {
+    fireEvent.click(button);
+  });
+
+  expect(writeText).toHaveBeenCalledWith(
+    `${window.location.origin}${relativePath}`,
+  );
+});
+
+test("copy link keeps absolute URLs unchanged", async () => {
+  const button = renderCopyLinkButton({
+    resolvedUrl: "https://example.test/file.docx",
+  });
+
+  await act(async () => {
+    fireEvent.click(button);
+  });
+
+  expect(writeText).toHaveBeenCalledWith("https://example.test/file.docx");
+});

--- a/frontend/src/components/documents/useDocumentPreviewState.ts
+++ b/frontend/src/components/documents/useDocumentPreviewState.ts
@@ -472,7 +472,9 @@ export function useDocumentPreviewState(props: DocumentPreviewProps) {
 
   const handleDownload = async () => {
     const downloadUrl =
-      getFullUrl(signedUrl) || resolvedUrl || getFullUrl(externalImageUrl);
+      getFullUrl(signedUrl) ||
+      getFullUrl(resolvedUrl) ||
+      getFullUrl(externalImageUrl);
     if (downloadUrl) {
       try {
         const response = await fetchUploadFile(


### PR DESCRIPTION
## 说明

develop 晋升 PR，增量内容：

- #288 refactor(frontend): 通知横幅、PWA 提示、落地页、画廊与 PDF 预览文字统一
- #289 fix(frontend): 文档预览复制链接补全为绝对地址

两者均为巡检线改动，CI 全绿。思考强度重做（#285/#286/#287）已随上一晋升进入 main，不在此增量内。