### PR TITLE
feat(chat): 思考中标签流式显示最新思考片段

### DIFF
--- a/frontend/src/components/chat/ChatMessage/ThinkingBlock.tsx
+++ b/frontend/src/components/chat/ChatMessage/ThinkingBlock.tsx
@@ -9,6 +9,7 @@ import {
   isPersistentToolPanelOpen,
 } from "./items/persistentToolPanelState";
 import { SidebarMarkdownContent } from "./SidebarMarkdownContent";
+import { buildStreamingThinkingPreview } from "./thinkingPreview";
 
 export function ThinkingBlock({
   content,
@@ -44,13 +45,16 @@ export function ThinkingBlock({
 
   // Show a brief preview of the reasoning content in the pill label
   const preview = useMemo(() => {
-    if (isStreaming || !content) return "";
+    if (!content) return "";
+    if (isStreaming) return buildStreamingThinkingPreview(content);
     const text = content.replace(/\n+/g, " ").trim();
     return text.length > 80 ? text.slice(0, 80) + "…" : text;
   }, [content, isStreaming]);
 
   const label = isStreaming
-    ? t("chat.message.thinking")
+    ? preview
+      ? `${t("chat.message.thinking")} ${preview}`
+      : t("chat.message.thinking")
     : preview || t("chat.message.thought");
 
   return (

--- a/frontend/src/components/chat/ChatMessage/__tests__/thinkingPreview.test.ts
+++ b/frontend/src/components/chat/ChatMessage/__tests__/thinkingPreview.test.ts
@@ -1,0 +1,41 @@
+import { buildStreamingThinkingPreview } from "../thinkingPreview.ts";
+
+test("returns empty string for empty content", () => {
+  expect(buildStreamingThinkingPreview("")).toBe("");
+  expect(buildStreamingThinkingPreview("   \n  ")).toBe("");
+});
+
+test("returns short content flattened as-is without truncation marker", () => {
+  expect(buildStreamingThinkingPreview("分析需求")).toBe("分析需求");
+});
+
+test("collapses newlines and whitespace runs into single spaces", () => {
+  expect(buildStreamingThinkingPreview("第一段\n\n\n   第二段")).toBe(
+    "第一段 第二段",
+  );
+});
+
+test("long content keeps only the last few characters with a leading ellipsis", () => {
+  const head = "前情提要".repeat(40); // 160 chars
+  const tail = "最新进展";
+  const preview = buildStreamingThinkingPreview(head + tail);
+  expect(preview.startsWith("…")).toBe(true);
+  expect(preview.endsWith(tail)).toBe(true);
+  // … + at most 12 chars
+  expect(preview.length).toBeLessThanOrEqual(13);
+});
+
+test("tail window survives content much longer than the preview cap", () => {
+  const content = "句子。".repeat(500) + "结尾必须出现";
+  const preview = buildStreamingThinkingPreview(content);
+  expect(preview.endsWith("结尾必须出现")).toBe(true);
+});
+
+test("does not start with a dangling high surrogate from the tail slice", () => {
+  const emoji = "🤔"; // surrogate pair
+  const content = "a".repeat(300) + emoji + "思考中";
+  const preview = buildStreamingThinkingPreview(content);
+  // must not begin with a lone high surrogate (would render as replacement char)
+  const first = preview.charCodeAt(preview.startsWith("…") ? 1 : 0);
+  expect(first < 0xd800 || first > 0xdbff).toBe(true);
+});

--- a/frontend/src/components/chat/ChatMessage/__tests__/thinkingPreviewSource.test.ts
+++ b/frontend/src/components/chat/ChatMessage/__tests__/thinkingPreviewSource.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from "node:fs";
+
+test("ThinkingBlock appends the live tail preview to the streaming label", () => {
+  const source = readFileSync(
+    new URL("../ThinkingBlock.tsx", import.meta.url),
+    "utf8",
+  );
+
+  // 流式分支用尾部预览而非空串，保证标签随 delta 动态更新
+  expect(source).toMatch(/if \(isStreaming\) return buildStreamingThinkingPreview\(content\);/);
+  // 标签拼上「思考中」前缀
+  expect(source).toMatch(/`\$\{t\("chat\.message\.thinking"\)\} \$\{preview\}`/);
+});

--- a/frontend/src/components/chat/ChatMessage/thinkingPreview.ts
+++ b/frontend/src/components/chat/ChatMessage/thinkingPreview.ts
@@ -1,0 +1,24 @@
+// Streaming preview for the thinking pill label — shows the latest few
+// characters of the reasoning so the user can see it updating live.
+
+// Slice a bounded tail window before flattening so per-delta cost stays
+// constant regardless of how long the reasoning grows.
+const TAIL_WINDOW = 60;
+
+export const STREAMING_PREVIEW_MAX_LEN = 12;
+
+function isHighSurrogate(code: number): boolean {
+  return code >= 0xd800 && code <= 0xdbff;
+}
+
+export function buildStreamingThinkingPreview(content: string): string {
+  if (!content) return "";
+  let window = content.slice(-TAIL_WINDOW);
+  if (isHighSurrogate(window.charCodeAt(0))) window = window.slice(1);
+  const text = window.replace(/\s+/g, " ").trim();
+  if (!text) return "";
+  if (text.length <= STREAMING_PREVIEW_MAX_LEN) return text;
+  let tail = text.slice(-STREAMING_PREVIEW_MAX_LEN);
+  if (isHighSurrogate(tail.charCodeAt(0))) tail = tail.slice(1);
+  return `…${tail.trimStart()}`;
+}


### PR DESCRIPTION
## 变更

思考中的 pill 标签不再只显示「思考中」：流式期间实时追加**最新 12 个字**的思考片段（类似 DeepSeek 的滚动感），随 SSE delta 持续更新；思考尚未产出时仍显示「思考中」+动画点。

- 新增 `thinkingPreview.ts`：`buildStreamingThinkingPreview()` 从尾部 60 字符窗口拍平空白后取最新 12 字，超长前缀 `…`，处理 emoji 代理对截断；窗口固定大小，长思考内容下每帧计算 O(1)
- `ThinkingBlock.tsx` 流式分支 label 改为 `思考中 {最新片段}`；**完成后行为不变**（前 80 字 preview / 空则「已思考」）
- 子代理思考块 re-export 同一组件，自动生效
- 无新增 i18n 文案

## 测试

- TDD：6 条纯函数测试 + 1 条 Source 接线测试
- 全量 `pnpm test` 1770/1770、`pnpm run lint` 干净、`pnpm run build` 成功