### PR TITLE
fix(session): 消毒事件数据键并限制 chunk 写入重试上限，杜绝毒事件永久阻塞 flush

### DIFF
--- a/src/infra/session/dual_writer.py
+++ b/src/infra/session/dual_writer.py
@@ -24,6 +24,7 @@ from src.infra.async_utils import run_blocking_io
 from src.infra.logging import get_logger
 from src.infra.session.dual_writer_helpers import (
     MongoBufferItem,
+    _buffer_item_attempts,
     _buffer_item_base,
     _buffer_item_reserved_start_seq,
     _buffer_item_skip_chunk,  # noqa: F401 - compatibility re-export
@@ -33,6 +34,7 @@ from src.infra.session.dual_writer_helpers import (
     _group_mongo_buffer_events,  # noqa: F401 - compatibility re-export
     _iter_chunk_write_groups,
     _operation_trace_id,  # noqa: F401 - compatibility re-export
+    _sanitize_event_data_for_mongo,
     _with_chunk_retry_metadata,
 )
 from src.infra.session.trace_storage import (
@@ -53,6 +55,9 @@ _MONGO_BATCH_SIZE = 200  # 每 200 条立即刷新
 _MONGO_BUFFER_MAX = 10000  # buffer 上限，防止 MongoDB 慢/宕机时 OOM
 _TTL_SET_KEYS_MAX = 5000  # _ttl_set_keys 上限，防止内存泄漏
 _LIVE_STREAM_READ_TIMEOUT_SECONDS = 24 * 60 * 60
+# 单组 chunk 事件的最大重试次数：超过后判定为不可写事件（如含非法字段名），
+# 丢弃并告警，避免毒事件永久阻塞 flush 循环
+_CHUNK_WRITE_MAX_ATTEMPTS = 50
 _SSE_HEARTBEAT_INTERVAL_SECONDS = 15
 _REDIS_XREAD_BLOCK_MS = 5000
 _REDIS_REPLAY_BATCH_SIZE = 500
@@ -199,6 +204,9 @@ class DualEventWriter:
         """
         # 统一时间戳，确保 Redis 和 MongoDB 使用相同的时间
         timestamp = utc_now()
+        # 外部工具输出可能携带 MongoDB pipeline 写不进去的字段名（含 '.'、
+        # '$' 前缀、空键），先归一化避免事件永远写不进 traces/chunks
+        data = _sanitize_event_data_for_mongo(data)
 
         # ---- Redis 写入（立即，无锁） ----
         stream_key = self._stream_key(session_id, run_id)
@@ -406,17 +414,31 @@ class DualEventWriter:
                         raise RuntimeError("trace_chunk_write_fenced")
                 except Exception as e:
                     if start_seq is not None:
-                        failed_chunk_items.extend(
-                            _with_chunk_retry_metadata(
-                                item,
-                                # Keep the group base seq for every item so the
-                                # retry re-forms one group instead of one group
-                                # per event.
-                                reserved_start_seq=start_seq,
-                                skip_legacy=dual_write_legacy or _buffer_item_skip_legacy(item),
+                        attempts = max(_buffer_item_attempts(item) for item in items)
+                        if attempts >= _CHUNK_WRITE_MAX_ATTEMPTS:
+                            logger.error(
+                                "Dropping %s unwritable events for trace %s "
+                                "(seq %s..%s, event_type=%s, attempts=%s): %s",
+                                len(events),
+                                trace_id,
+                                start_seq,
+                                (start_seq or 0) + len(events) - 1,
+                                events[0].get("event_type"),
+                                attempts,
+                                e,
                             )
-                            for item in items
-                        )
+                        else:
+                            failed_chunk_items.extend(
+                                _with_chunk_retry_metadata(
+                                    item,
+                                    # Keep the group base seq for every item so the
+                                    # retry re-forms one group instead of one group
+                                    # per event.
+                                    reserved_start_seq=start_seq,
+                                    skip_legacy=dual_write_legacy or _buffer_item_skip_legacy(item),
+                                )
+                                for item in items
+                            )
                     else:
                         failed_chunk_items.extend(items)
                     logger.error(

--- a/src/infra/session/dual_writer_helpers.py
+++ b/src/infra/session/dual_writer_helpers.py
@@ -93,6 +93,12 @@ def _buffer_item_skip_chunk(item: MongoBufferItem) -> bool:
     return bool(len(item) >= 9 and item[8])
 
 
+def _buffer_item_attempts(item: MongoBufferItem) -> int:
+    if len(item) < 10 or item[9] is None:
+        return 0
+    return int(item[9])
+
+
 def _with_chunk_retry_metadata(
     item: MongoBufferItem,
     *,
@@ -101,9 +107,44 @@ def _with_chunk_retry_metadata(
     skip_chunk: bool = False,
 ) -> MongoBufferItem:
     base = (*_buffer_item_base(item), reserved_start_seq, skip_legacy)
-    if skip_chunk:
-        return (*base, True)
-    return base
+    attempts = _buffer_item_attempts(item) + 1
+    return (*base, skip_chunk, attempts)
+
+
+def _sanitize_event_data_for_mongo(obj: Any) -> Any:
+    """Rewrite dict keys that MongoDB update pipelines cannot store.
+
+    Chunked event writes build pipeline ``$set`` updates, which reject field
+    names containing '.', leading '$', or empty strings — patterns that occur
+    in external tool output (e.g. scraped structured content). Clean subtrees
+    are returned as-is (identity preserved) so normal events pay no copy cost.
+    """
+    if isinstance(obj, dict):
+        changed = False
+        new_dict: dict[Any, Any] = {}
+        for key, value in obj.items():
+            safe_key = _sanitize_mongo_key(key)
+            new_value = _sanitize_event_data_for_mongo(value)
+            changed = changed or safe_key != key or new_value is not value
+            new_dict[safe_key] = new_value
+        return new_dict if changed else obj
+    if isinstance(obj, list):
+        changed = False
+        items: list[Any] = []
+        for value in obj:
+            new_value = _sanitize_event_data_for_mongo(value)
+            changed = changed or new_value is not value
+            items.append(new_value)
+        return items if changed else obj
+    return obj
+
+
+def _sanitize_mongo_key(key: Any) -> Any:
+    key = key if isinstance(key, str) else str(key)
+    safe = key.replace(".", "_")
+    if safe.startswith("$"):
+        safe = f"_{safe[1:]}"
+    return safe or "_"
 
 
 def _group_mongo_buffer_events(

--- a/tests/infra/session/test_event_key_sanitization.py
+++ b/tests/infra/session/test_event_key_sanitization.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+"""Regression tests: unwritable event data keys must not poison the flush loop.
+
+Production symptom (k3s, single-node dual pods): a scheduled search-agent task
+emitted tool:result events whose ``data.result`` embedded external structured
+content containing a field name with a '.'. The chunked write path builds a
+pipeline ``$set`` update, and MongoDB rejects documents whose field paths
+contain '.' ("Invalid $set :: caused by :: FieldPath ... may not contain
+'.'", code 40353/16412). The buffered events could never be written and the
+flush loop retried them forever (~730 ERROR logs in 13h, event_revision
+churned to 950+, trace completion blocked with "Mongo event buffer still has
+N pending events").
+"""
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from src.infra.session import dual_writer as dual_writer_module
+from src.infra.session.dual_writer import DualEventWriter
+from src.infra.session.dual_writer_helpers import (
+    _buffer_item_attempts,
+    _sanitize_event_data_for_mongo,
+)
+
+# ---------------------------------------------------------------------------
+# Key sanitizer (pure function)
+# ---------------------------------------------------------------------------
+
+
+def test_sanitizer_rewrites_dotted_keys_recursively() -> None:
+    data = {
+        "content": "ok",
+        "structured_content": {"author.name": "x", "nested": {"a.b": 1, "c": 2}},
+    }
+    sanitized = _sanitize_event_data_for_mongo(data)
+    assert sanitized["structured_content"]["author_name"] == "x"
+    assert sanitized["structured_content"]["nested"]["a_b"] == 1
+    assert sanitized["structured_content"]["nested"]["c"] == 2
+
+
+def test_sanitizer_rewrites_dollar_prefixed_and_empty_keys() -> None:
+    data = {"$ref": 1, "": 2, "list": [{"$type": "a", ".t": "b"}]}
+    sanitized = _sanitize_event_data_for_mongo(data)
+    assert sanitized["_ref"] == 1
+    assert sanitized["_"] == 2
+    assert sanitized["list"][0] == {"_type": "a", "_t": "b"}
+
+
+def test_sanitizer_returns_clean_data_object_unchanged() -> None:
+    data = {"content": "hello", "result": {"text": "...", "blocks": [{"type": "text"}]}}
+    assert _sanitize_event_data_for_mongo(data) is data
+
+
+# ---------------------------------------------------------------------------
+# write_event buffers sanitized data
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_write_event_buffers_sanitized_data(monkeypatch: pytest.MonkeyPatch) -> None:
+    writer = object.__new__(DualEventWriter)
+    writer._mongo_lock = asyncio.Lock()
+    writer._mongo_buffer = []
+    writer._flush_event = asyncio.Event()
+    writer._ttl_set_keys = {}
+
+    async def fake_serialize(data: Any) -> Any:
+        return data
+
+    redis_payloads: list[dict] = []
+
+    async def fake_redis_write(stream_key: str, fields: dict) -> bool:
+        redis_payloads.append(fields)
+        return True
+
+    monkeypatch.setattr(dual_writer_module, "_serialize_event_data_for_redis", fake_serialize)
+    monkeypatch.setattr(writer, "_write_to_redis_direct", fake_redis_write)
+
+    original = {"tool": "search", "result": {"structured": {"author.name": "x"}}}
+    await writer.write_event(
+        session_id="session-1",
+        event_type="tool:result",
+        data=original,
+        trace_id="trace-1",
+        run_id="run-1",
+    )
+
+    buffered = writer._mongo_buffer[0]
+    assert buffered[2] == {"tool": "search", "result": {"structured": {"author_name": "x"}}}
+    # 原始入参对象不被就地修改
+    assert original["result"]["structured"] == {"author.name": "x"}
+
+
+# ---------------------------------------------------------------------------
+# Bounded retries for poisoned chunk groups
+# ---------------------------------------------------------------------------
+
+
+class _PoisonedTraceStorage:
+    """Fake TraceStorage whose chunk append always fails like production."""
+
+    def __init__(self) -> None:
+        self.append_calls = 0
+
+    async def acquire_session_trace_write(self, session_id: str) -> bool:
+        return True
+
+    async def release_session_trace_write(self, session_id: str) -> None:
+        return None
+
+    async def reserve_event_sequence_range(self, trace_id: str, count: int):
+        return {"trace_id": trace_id, "event_count": count, "session_id": "session-1"}
+
+    async def append_events_to_chunks(self, trace_doc, events, start_seq) -> bool:
+        self.append_calls += 1
+        raise RuntimeError("Invalid $set :: caused by :: FieldPath field names may not contain '.'")
+
+
+@pytest.mark.asyncio
+async def test_flush_drops_poisoned_group_after_attempt_cap(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setattr(dual_writer_module.settings, "SESSION_EVENT_CHUNK_STORAGE_ENABLED", True)
+    monkeypatch.setattr(dual_writer_module.settings, "SESSION_EVENT_CHUNK_DUAL_WRITE_LEGACY", False)
+    monkeypatch.setattr(dual_writer_module, "_CHUNK_WRITE_MAX_ATTEMPTS", 2)
+
+    writer = object.__new__(DualEventWriter)
+    writer._mongo_lock = asyncio.Lock()
+    writer._flush_event = asyncio.Event()
+    writer._mongo_buffer = []
+    fake_trace = _PoisonedTraceStorage()
+    monkeypatch.setattr(DualEventWriter, "trace", property(lambda self: fake_trace))
+
+    batch = [
+        ("trace-1", "tool:result", {"tool": "search"}, "session-1", "run-1", "t0"),
+    ]
+
+    # 第 1、2 次：重入缓冲区（带尝试计数）
+    await writer._flush_mongo_batch(list(batch))
+    first = writer._mongo_buffer
+    assert len(first) == 1
+    assert _buffer_item_attempts(first[0]) == 1
+
+    writer._mongo_buffer = []
+    await writer._flush_mongo_batch(list(first))
+    second = writer._mongo_buffer
+    assert len(second) == 1
+    assert _buffer_item_attempts(second[0]) == 2
+
+    # 第 3 次：达到上限，丢弃并打错误日志
+    writer._mongo_buffer = []
+    with caplog.at_level("ERROR", logger=dual_writer_module.logger.name):
+        await writer._flush_mongo_batch(list(second))
+    assert writer._mongo_buffer == []
+    drop_logs = [r for r in caplog.records if "unwritable" in r.getMessage()]
+    assert drop_logs, "expected a drop error log"
+    assert fake_trace.append_calls == 3

--- a/tests/infra/test_dual_writer_limits.py
+++ b/tests/infra/test_dual_writer_limits.py
@@ -1039,9 +1039,10 @@ async def test_flush_mongo_buffer_requeues_failed_chunk_write_with_reserved_sequ
 
     # Both events keep the group base seq so the retry re-forms a single
     # group (one claim/append round trip) instead of one group per event.
+    # Trailing fields: skip_chunk=False, attempts=1 (bounded-retry counter).
     assert writer._mongo_buffer == [
-        (*events[0], 6, False),
-        (*events[1], 6, False),
+        (*events[0], 6, False, False, 1),
+        (*events[1], 6, False, False, 1),
     ]
 
 
@@ -1255,6 +1256,8 @@ async def test_flush_mongo_buffer_dual_write_requeues_chunk_retry_without_rewrit
             datetime(2026, 1, 1),
             1,
             True,
+            False,
+            1,
         )
     ]
 


### PR DESCRIPTION
Fixes #295

## 问题

生产（k3s）某定时任务 run 的 tool:result 事件内嵌外部网页结构化内容，字段名含 `.`。chunked 写入走 pipeline ``，MongoDB 拒绝（`FieldPath may not contain '.'`，40353/16412，本地 Mongo 已复现同款报错）。失败分组无限重试：约 730 条 ERROR/13h、event_revision 推到 950+、buffer 永不清空（`Mongo event buffer still has 7 pending events`）、7 个 tool:result 事件丢失。

## 修复

1. **键归一化**（根因）：`DualEventWriter.write_event` 入口调用 `_sanitize_event_data_for_mongo`——含 `.` 的键、`$` 前缀键、空键替换为 `_`；干净数据 identity 直通零拷贝，Redis 流与 Mongo 落库保持同一份归一化数据。
2. **有界重试**（止损）：重试分组携带尝试计数（buffer 元组追加 attempts 字段），超过 `_CHUNK_WRITE_MAX_ATTEMPTS=50` 丢弃该组并打含 trace/seq/event_type 的错误日志。未来再出现任何不可写事件形态，代价仅为一组事件丢失+一条日志，不再无限循环。

## 测试

- 新增 `tests/infra/session/test_event_key_sanitization.py`（5 例：递归键改写/$与空键/干净直通/write_event 缓冲消毒/达到上限丢弃）——先红后绿
- 更新 `tests/infra/test_dual_writer_limits.py` 两处重入队列元组断言（新增 attempts 字段）
- 全量后端 3105 passed / 1 skipped；ruff check、ruff format、mypy 全绿（独立 worktree 干净环境验证）

## 部署提醒（合入 develop 后）

CI 出 develop-\<时间戳\> 镜像后：yang 上 `/data/lambchat-k8s/update-staging.sh` 滚 staging，`ssh -L 8021:127.0.0.1:8021 yang` 隧道验证；OK 后 PR develop→main 晋升，yang 上 `/data/lambchat-k8s/update.sh` 上生产 + `/root/disttest/run-all.sh` 回归。观察指标：涉事定时任务次日 08:00 run 的 tool:result 完整落库（25/25）、lambchat-a 不再刷 FieldPath ERROR。