### PR TITLE
fix(task): 定时任务 run 事件流挂死时由 stall watchdog 迁移 error 终态

### DIFF
--- a/src/infra/task/exceptions.py
+++ b/src/infra/task/exceptions.py
@@ -8,3 +8,9 @@ class TaskInterruptedError(Exception):
     """任务被中断异常"""
 
     pass
+
+
+class TaskStalledError(TimeoutError):
+    """任务事件流停滞异常（watchdog 超时，issue #293）"""
+
+    pass

--- a/src/infra/task/executor.py
+++ b/src/infra/task/executor.py
@@ -20,11 +20,22 @@ from src.kernel.schemas.session import SessionCreate, SessionUpdate
 
 from .exceptions import TaskInterruptedError
 from .heartbeat import TaskHeartbeat
+from .stall_watchdog import aiter_with_stall_timeout
 from .state_machine import TaskStateMachine
 from .status import TaskStatus
 
 logger = get_logger(__name__)
 _TERMINAL_STREAM_TTL_SECONDS = 60
+_DEFAULT_RUN_STALL_TIMEOUT_SECONDS = 3600
+
+
+def _run_stall_timeout_seconds() -> float:
+    """Watchdog deadline between executor events; 0/negative disables it."""
+    value = getattr(settings, "TASK_RUN_STALL_TIMEOUT", _DEFAULT_RUN_STALL_TIMEOUT_SECONDS)
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return _DEFAULT_RUN_STALL_TIMEOUT_SECONDS
 
 
 def should_schedule_recommend_questions() -> bool:
@@ -191,25 +202,28 @@ class TaskExecutor:
             # 2. 清除可能导致与 SSE 连接的竞争条件
             # 3. Redis Stream 有 TTL 自动过期
 
-            # 执行 agent，统一保存所有事件
-            async for event in executor(
-                session_id,
-                agent_id,
-                message,
-                user_id,
-                presenter=presenter,
-                disabled_tools=disabled_tools,
-                agent_options=agent_options,
-                attachments=attachments,
-                disabled_skills=disabled_skills,
-                enabled_skills=enabled_skills,
-                persona_system_prompt=persona_system_prompt,
-                disabled_mcp_tools=disabled_mcp_tools,
-                recommendation_input=recommendation_input,
-                team_id=team_id,
-                active_goal=active_goal,
-                auto_mode=auto_mode,
-                hitl_resume=hitl_resume,
+            # 执行 agent，统一保存所有事件；watchdog 保证事件流停滞时迁移 error 终态
+            async for event in aiter_with_stall_timeout(
+                executor(
+                    session_id,
+                    agent_id,
+                    message,
+                    user_id,
+                    presenter=presenter,
+                    disabled_tools=disabled_tools,
+                    agent_options=agent_options,
+                    attachments=attachments,
+                    disabled_skills=disabled_skills,
+                    enabled_skills=enabled_skills,
+                    persona_system_prompt=persona_system_prompt,
+                    disabled_mcp_tools=disabled_mcp_tools,
+                    recommendation_input=recommendation_input,
+                    team_id=team_id,
+                    active_goal=active_goal,
+                    auto_mode=auto_mode,
+                    hitl_resume=hitl_resume,
+                ),
+                timeout=_run_stall_timeout_seconds(),
             ):
                 await presenter.save_event(event)
 

--- a/src/infra/task/stall_watchdog.py
+++ b/src/infra/task/stall_watchdog.py
@@ -1,0 +1,55 @@
+"""Run-level stall watchdog for agent event streams (issue #293).
+
+worker 存活但 agent stream 挂死（LLM 首包永不到达、工具 await 挂起等）时，
+心跳持续刷新、孤儿接管判定永不触发，run/trace 停留在 running。本模块对
+executor 事件流施加"每两个事件之间"的停滞 deadline：超时即抛
+TaskStalledError，由 TaskExecutor 的通用错误路径迁移 error 终态。
+
+与 ``src/infra/llm/streaming.py`` 的首事件超时互补：那只覆盖模型适配层的
+首个流式事件，覆盖不了图内非流式调用与工具挂起。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterable, AsyncIterator
+from typing import TypeVar
+
+from src.infra.task.exceptions import TaskStalledError
+
+T = TypeVar("T")
+
+
+async def aiter_with_stall_timeout(
+    source: AsyncIterable[T],
+    *,
+    timeout: float | None,
+) -> AsyncIterator[T]:
+    """Require stream progress by a recurring deadline between events.
+
+    timeout 为 None 或 <=0 时直接透传（watchdog 关闭）。超时会取消对底层
+    迭代器的等待并尝试 aclose 释放其资源。
+    """
+    if timeout is None or timeout <= 0:
+        async for item in source:
+            yield item
+        return
+
+    iterator = source.__aiter__()
+    try:
+        while True:
+            try:
+                async with asyncio.timeout(timeout):
+                    item = await anext(iterator)
+            except StopAsyncIteration:
+                return
+            except TimeoutError as exc:
+                raise TaskStalledError(f"agent stream stalled: no event within {timeout}s") from exc
+            yield item
+    finally:
+        close = getattr(iterator, "aclose", None)
+        if close is not None:
+            try:
+                await close()
+            except Exception:
+                pass

--- a/src/kernel/config/_definitions_infra.py
+++ b/src/kernel/config/_definitions_infra.py
@@ -146,6 +146,14 @@ INFRA_SETTING_DEFINITIONS: dict[str, dict] = {
         "depends_on": {"key": "TASK_BACKEND", "value": "arq"},
         "frontend_visible": False,
     },
+    "TASK_RUN_STALL_TIMEOUT": {
+        "type": SettingType.NUMBER,
+        "category": SettingCategory.REDIS,
+        "subcategory": "task",
+        "description": "settingDesc.TASK_RUN_STALL_TIMEOUT",
+        "default": 3600,
+        "frontend_visible": False,
+    },
     # ============================================
     # LangSmith Tracing Settings
     # ============================================

--- a/src/kernel/config/base.py
+++ b/src/kernel/config/base.py
@@ -145,6 +145,10 @@ class Settings(BaseSettings):
     ARQ_JOB_TIMEOUT_SECONDS: int = 86400
     TASK_STARTUP_CLEANUP_CONCURRENCY: int = 16
     TASK_ORPHAN_RECOVERY_INTERVAL_SECONDS: int = 120
+    # run 级停滞 watchdog：executor 事件流超过该秒数无任何事件即判定挂死，
+    # 迁移 error 终态（worker 存活但 LLM/工具挂起时心跳不会失效，issue #293）。
+    # 默认须覆盖最长合法静默窗口（沙箱工具执行期无事件，E2B/CUBE 上限 3600s）
+    TASK_RUN_STALL_TIMEOUT: int = 3600
 
     # MongoDB Settings
     MONGODB_URL: str = "mongodb://localhost:27017"

--- a/tests/infra/task/test_executor_stall_watchdog.py
+++ b/tests/infra/task/test_executor_stall_watchdog.py
@@ -1,0 +1,211 @@
+"""Run-level stall watchdog for task executor (issue #293).
+
+Worker 存活但 agent stream 挂死（LLM 首包永不到达等）时，心跳持续刷新、
+孤儿接管永不触发，run/trace 停留在 running。watchdog 要求 executor 事件流
+按 deadline 持续推进，超时迁移 error 终态。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from src.infra.task.executor import TaskExecutor
+from src.infra.task.status import TaskStatus
+from src.kernel.config import settings
+
+
+class _FakeHeartbeat:
+    async def start(self, run_id: str, *, user_id: str | None = None) -> None:
+        return None
+
+    async def stop(self, run_id: str) -> None:
+        return None
+
+
+class _FakePresenter:
+    instances: list["_FakePresenter"] = []
+
+    def __init__(self, config) -> None:
+        self.trace_id = config.trace_id or "generated-trace"
+        self.run_id = config.run_id
+        self._trace_created = False
+        self.saved_events: list[dict] = []
+        self.completed: list[str] = []
+        self.__class__.instances.append(self)
+
+    async def _ensure_trace(self) -> None:
+        self._trace_created = True
+
+    async def emit_user_message(self, message: str, **_kwargs) -> None:
+        return None
+
+    async def save_event(self, event: dict) -> None:
+        self.saved_events.append(event)
+
+    async def complete(self, status: str) -> None:
+        self.completed.append(status)
+
+
+class _RecordingWriter:
+    def __init__(self) -> None:
+        self.written: list[dict] = []
+
+    async def _flush_redis_buffer(self, **_kwargs) -> None:
+        return None
+
+    async def flush_mongo_buffer(self, **_kwargs) -> None:
+        return None
+
+    async def write_event(self, **kwargs) -> None:
+        self.written.append(kwargs)
+
+    async def expire_stream(self, *_args, **_kwargs) -> None:
+        return None
+
+
+def _executor_fixture(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    stall_timeout: float,
+) -> tuple[TaskExecutor, _RecordingWriter, list[tuple[TaskStatus, str | None]]]:
+    from src.infra.task import cancellation
+
+    monkeypatch.setattr(settings, "TASK_RUN_STALL_TIMEOUT", stall_timeout)
+    _FakePresenter.instances.clear()
+    monkeypatch.setattr("src.infra.writer.present.Presenter", _FakePresenter)
+
+    writer = _RecordingWriter()
+    monkeypatch.setattr("src.infra.task.executor.get_dual_writer", lambda: writer)
+
+    async def _no_op(*_args, **_kwargs) -> None:
+        return None
+
+    monkeypatch.setattr(cancellation.TaskCancellation, "clear_interrupt", _no_op)
+
+    status_updates: list[tuple[TaskStatus, str | None]] = []
+
+    async def _record_status(session_id, status, error=None, run_id=None):
+        status_updates.append((status, error))
+
+    executor = TaskExecutor(
+        storage=SimpleNamespace(),  # type: ignore[arg-type]
+        run_info={},
+        heartbeat_manager=_FakeHeartbeat(),
+    )
+    monkeypatch.setattr(executor, "_update_session_status", _record_status)
+    monkeypatch.setattr(executor, "_send_task_notification", _no_op)
+    monkeypatch.setattr(executor, "_expire_terminal_stream", _no_op)
+    return executor, writer, status_updates
+
+
+@pytest.mark.asyncio
+async def test_stalled_stream_migrates_run_to_error_terminal_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor, writer, status_updates = _executor_fixture(monkeypatch, stall_timeout=0.05)
+
+    async def _hung_agent_stream(*_args, **_kwargs):
+        # 首事件永不到达：睡眠远超 stall 超时，模拟 LLM 首包挂起
+        await asyncio.sleep(5)
+        if False:
+            yield {}
+
+    result = await executor.run_task(
+        session_id="session-1",
+        run_id="run-1",
+        agent_id="search",
+        message="",
+        user_id="user-1",
+        executor=_hung_agent_stream,
+    )
+
+    presenter = _FakePresenter.instances[0]
+    assert result is None  # error path
+    assert presenter.completed == ["error"]
+    assert TaskStatus.FAILED in [s for s, _ in status_updates]
+    error_events = [w for w in writer.written if w.get("event_type") == "error"]
+    assert len(error_events) == 1
+    assert error_events[0]["data"]["type"] == "TaskStalledError"
+    assert error_events[0]["data"]["run_id"] == "run-1"
+
+
+@pytest.mark.asyncio
+async def test_stalled_mid_stream_times_out_between_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor, writer, _status_updates = _executor_fixture(monkeypatch, stall_timeout=0.05)
+
+    async def _stream_then_hang(*_args, **_kwargs):
+        yield {"event": "text", "data": {"content": "first"}}
+        await asyncio.sleep(5)  # 第二个事件挂起
+        yield {"event": "text", "data": {"content": "never"}}
+
+    await executor.run_task(
+        session_id="session-1",
+        run_id="run-2",
+        agent_id="search",
+        message="",
+        user_id="user-1",
+        executor=_stream_then_hang,
+    )
+
+    presenter = _FakePresenter.instances[0]
+    assert presenter.completed == ["error"]
+    saved = [e["event"] for e in presenter.saved_events]
+    assert "text" in saved
+    error_events = [w for w in writer.written if w.get("event_type") == "error"]
+    assert len(error_events) == 1
+    assert error_events[0]["data"]["type"] == "TaskStalledError"
+
+
+@pytest.mark.asyncio
+async def test_progressing_stream_completes_without_watchdog_interference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor, writer, _status_updates = _executor_fixture(monkeypatch, stall_timeout=1.0)
+
+    async def _steady_agent_stream(*_args, **_kwargs):
+        for i in range(3):
+            await asyncio.sleep(0.01)
+            yield {"event": "text", "data": {"content": f"chunk-{i}"}}
+
+    result = await executor.run_task(
+        session_id="session-1",
+        run_id="run-3",
+        agent_id="search",
+        message="",
+        user_id="user-1",
+        executor=_steady_agent_stream,
+    )
+
+    presenter = _FakePresenter.instances[0]
+    assert result is False  # completed path
+    assert presenter.completed == ["completed"]
+    assert len(presenter.saved_events) == 3
+    assert not [w for w in writer.written if w.get("event_type") == "error"]
+
+
+@pytest.mark.asyncio
+async def test_watchdog_disabled_when_timeout_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor, _writer, _status_updates = _executor_fixture(monkeypatch, stall_timeout=0)
+
+    async def _slow_then_done(*_args, **_kwargs):
+        await asyncio.sleep(0.1)
+        yield {"event": "text", "data": {"content": "slow"}}
+
+    result = await executor.run_task(
+        session_id="session-1",
+        run_id="run-4",
+        agent_id="search",
+        message="",
+        user_id="user-1",
+        executor=_slow_then_done,
+    )
+
+    assert result is False
+    assert _FakePresenter.instances[0].completed == ["completed"]

--- a/tests/infra/task/test_stall_watchdog.py
+++ b/tests/infra/task/test_stall_watchdog.py
@@ -1,0 +1,98 @@
+"""Unit tests for the stall-watchdog async iterator wrapper (issue #293)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from src.infra.task.stall_watchdog import TaskStalledError, aiter_with_stall_timeout
+
+
+async def _gen(items: list, delay_before: float = 0.0, delay_each: float = 0.0):
+    await asyncio.sleep(delay_before)
+    for item in items:
+        yield item
+        await asyncio.sleep(delay_each)
+
+
+@pytest.mark.asyncio
+async def test_yields_all_items_when_stream_progresses() -> None:
+    async def source():
+        for i in range(3):
+            await asyncio.sleep(0.01)
+            yield i
+
+    result = []
+    async for item in aiter_with_stall_timeout(source(), timeout=1.0):
+        result.append(item)
+    assert result == [0, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_first_event_deadline_raises_task_stalled_error() -> None:
+    with pytest.raises(TaskStalledError) as exc_info:
+        async for _item in aiter_with_stall_timeout(_gen([1], delay_before=5), timeout=0.05):
+            pass
+    assert "0.05" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_idle_deadline_between_events_raises_task_stalled_error() -> None:
+    async def source():
+        yield "first"
+        await asyncio.sleep(5)
+        yield "second"
+
+    seen: list = []
+    with pytest.raises(TaskStalledError):
+        async for item in aiter_with_stall_timeout(source(), timeout=0.05):
+            seen.append(item)
+    assert seen == ["first"]
+
+
+@pytest.mark.asyncio
+async def test_timeout_zero_or_none_disables_watchdog() -> None:
+    for disabled in (0, None):
+        result = []
+        async for item in aiter_with_stall_timeout(_gen([1, 2], delay_each=0.05), timeout=disabled):
+            result.append(item)
+        assert result == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_timeout_closes_underlying_generator() -> None:
+    closed = asyncio.Event()
+
+    async def source():
+        try:
+            yield "first"
+            await asyncio.sleep(5)
+            yield "second"
+        finally:
+            closed.set()
+
+    with pytest.raises(TaskStalledError):
+        async for _item in aiter_with_stall_timeout(source(), timeout=0.05):
+            pass
+
+    assert closed.is_set()
+
+
+@pytest.mark.asyncio
+async def test_early_consumer_exit_closes_underlying_generator() -> None:
+    closed = asyncio.Event()
+
+    async def source():
+        try:
+            for i in range(10):
+                yield i
+        finally:
+            closed.set()
+
+    async for _item in aiter_with_stall_timeout(source(), timeout=1.0):
+        break
+
+    # 消费者提前退出后，generator 最终被 aclose 释放
+    _, pending = await asyncio.wait([asyncio.create_task(closed.wait())], timeout=1)
+    assert not pending


### PR DESCRIPTION
## Summary

Closes #293

worker 存活但 agent stream 挂死（LLM 首包永不到达、图内非流式调用或工具 await 挂起）时，心跳持续刷新、孤儿接管判定永不触发，run/trace 永久停留 running（回归 R7b 实录：`Starting astream_events` 后再无任何日志）。本 PR 给 `TaskExecutor.run_task` 消费的 executor 事件流加 run 级停滞 watchdog：任意相邻事件间隔超过 deadline 即抛 `TaskStalledError`，走既有通用错误路径迁移 FAILED / trace error / 通知 / 终态流过期。

## Changes

- 新增 `src/infra/task/stall_watchdog.py`：`aiter_with_stall_timeout` 包装器，超时取消底层等待并 `aclose` 释放生成器
- 新增 `TaskStalledError`（`TimeoutError` 子类）
- `TaskExecutor.run_task` 接线 watchdog；新配置 `TASK_RUN_STALL_TIMEOUT`（默认 **3600s**，须覆盖沙箱工具执行期最长合法静默窗口 E2B/CUBE_TIMEOUT=3600；0 关闭），local 与 arq 两条执行路径共用 run_task，均被覆盖
- 与 LLM 适配层首事件超时（#239 拆分，流式调用已双向生效）互补，覆盖其管不到的非流式调用与工具挂起

## Testing

- [x] TDD：`tests/infra/task/test_stall_watchdog.py`（10 用例：首事件 deadline / 相邻事件 deadline / 关闭开关 / aclose 释放）先红后绿
- [x] `tests/infra/task/` 全量 208 passed、`tests/kernel` 54 passed
- [x] `make lint` / `ruff format --check` / `mypy src/infra/task/` 全绿

## 说明

- issue 建议的回归侧 R7b 判定宽限属于 disttest 脚本（服务器仓库外），不随本 PR 变更
- 部署后如需更快收敛僵尸 run，可将 `TASK_RUN_STALL_TIMEOUT` 下调（如 600），前提是该环境没有长于窗口的静默工具调用
