### PR TITLE
fix(frontend): 角色广场弹窗搜索/换页不再跳回首页

### DIFF
--- a/frontend/src/components/chat/WelcomePage.tsx
+++ b/frontend/src/components/chat/WelcomePage.tsx
@@ -62,6 +62,8 @@ interface WelcomePageProps {
   starterPromptsLabel?: string;
   changePersonaLabel?: string;
   personaPresets: PersonaPreset[];
+  /** 首次列表请求是否已落地；后台刷新不回退骨架屏（issue #158） */
+  personaPresetsLoaded?: boolean;
   hasMorePersonaPresets?: boolean;
   isLoadingMorePersonaPresets?: boolean;
   onLoadMorePersonaPresets?: () => void;
@@ -109,6 +111,7 @@ export const WelcomePage = memo(function WelcomePage({
   starterPromptsLabel,
   changePersonaLabel,
   personaPresets,
+  personaPresetsLoaded = false,
   hasMorePersonaPresets,
   isLoadingMorePersonaPresets,
   onLoadMorePersonaPresets,
@@ -382,6 +385,7 @@ export const WelcomePage = memo(function WelcomePage({
     settingsLoading,
     currentAgent,
     personaPresetsLoading,
+    personaPresetsLoaded,
     teamRequestSettled: teamCardsLoaded,
   });
 

--- a/frontend/src/components/chat/__tests__/welcomePersonaRefetch.test.ts
+++ b/frontend/src/components/chat/__tests__/welcomePersonaRefetch.test.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * issue #158：角色广场（聊天内全屏弹窗）搜索/换页时，persona 列表重新加载
+ * 会把 WelcomePage 整体换成骨架屏，连带卸载 ChatInput 与已打开的弹窗，
+ * 用户视角即"直接跳转回首页"。本测试锁定整条接线：首次加载完成后，
+ * 后台刷新不再回退骨架屏；弹窗分页窗口与父级请求页大小一致。
+ */
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const hookSource = readFileSync(
+  resolve(currentDir, "../../../hooks/usePersonaPresets.ts"),
+  "utf8",
+);
+const chatAppContentSource = readFileSync(
+  resolve(
+    currentDir,
+    "../../layout/AppContent/ChatAppContent.tsx",
+  ),
+  "utf8",
+);
+const chatViewPropsSource = readFileSync(
+  resolve(currentDir, "../../layout/AppContent/ChatViewProps.tsx"),
+  "utf8",
+);
+const chatViewSource = readFileSync(
+  resolve(currentDir, "../../layout/AppContent/ChatView.tsx"),
+  "utf8",
+);
+const welcomePageSource = readFileSync(
+  resolve(currentDir, "../WelcomePage.tsx"),
+  "utf8",
+);
+
+test("persona presets hook exposes a settled-first-fetch flag", () => {
+  expect(hookSource).toMatch(/const \[hasLoaded, setHasLoaded\] = useState/);
+  expect(hookSource).toMatch(/setHasLoaded\(true\);/);
+  expect(hookSource).toMatch(/hasLoaded,/);
+});
+
+test("chat app content threads loaded flag and page size to chat view", () => {
+  expect(chatAppContentSource).toMatch(
+    /hasLoaded: personaPresetsLoaded,/,
+  );
+  expect(chatAppContentSource).toMatch(
+    /personaPresetsLoaded=\{personaPresetsLoaded\}/,
+  );
+});
+
+test("chat view passes the loaded flag into the welcome page", () => {
+  expect(chatViewPropsSource).toMatch(/personaPresetsLoaded: boolean;/);
+  expect(chatViewSource).toMatch(
+    /personaPresetsLoaded=\{personaPresetsLoaded\}/,
+  );
+  expect(welcomePageSource).toMatch(/personaPresetsLoaded\?: boolean;/);
+});
+
+test("welcome page readiness consults the loaded flag", () => {
+  expect(welcomePageSource).toMatch(
+    /personaPresetsLoaded,/,
+  );
+  expect(welcomePageSource).toMatch(/personaPresetsLoaded,/);
+  expect(welcomePageSource).toMatch(
+    /isWelcomeContentReady\(\{[\s\S]*personaPresetsLoaded,[\s\S]*\}\)/,
+  );
+});
+
+test("persona pagination window matches the selector page size", () => {
+  // 弹窗 PAGE_SIZE=20；父级若按 12 取数，翻页窗口与页码标注错位且会漏行。
+  expect(chatAppContentSource).toMatch(/const personaPresetPageSize = 20;/);
+});

--- a/frontend/src/components/chat/__tests__/welcomeReadyState.test.ts
+++ b/frontend/src/components/chat/__tests__/welcomeReadyState.test.ts
@@ -56,6 +56,32 @@ test("waits for persona presets only in persona mode", () => {
   ).toBe(true);
 });
 
+test("background persona refetch after initial load keeps content ready", () => {
+  // issue #158：搜索/换页触发的重新加载不应把欢迎页（含聊天输入与角色广场
+  // 弹窗）整体回退成骨架屏——首次加载完成后，后台刷新保持内容就绪。
+  expect(
+    isWelcomeContentReady({
+      settingsLoading: false,
+      currentAgent: "assistant",
+      personaPresetsLoading: true,
+      personaPresetsLoaded: true,
+      teamRequestSettled: false,
+    }),
+  ).toBe(true);
+});
+
+test("initial persona load without a settled first fetch still shows skeleton", () => {
+  expect(
+    isWelcomeContentReady({
+      settingsLoading: false,
+      currentAgent: "assistant",
+      personaPresetsLoading: true,
+      personaPresetsLoaded: false,
+      teamRequestSettled: false,
+    }),
+  ).toBe(false);
+});
+
 test("waits for the active team request and settles on success or failure", () => {
   expect(
     isWelcomeContentReady({

--- a/frontend/src/components/chat/welcomeReadyState.ts
+++ b/frontend/src/components/chat/welcomeReadyState.ts
@@ -2,6 +2,8 @@ export interface WelcomeReadinessState {
   settingsLoading: boolean;
   currentAgent?: string;
   personaPresetsLoading: boolean;
+  /** 首次列表请求是否已落地；后台刷新（搜索/换页）不应回退骨架屏（issue #158） */
+  personaPresetsLoaded?: boolean;
   teamRequestSettled: boolean;
 }
 
@@ -9,12 +11,14 @@ export function isWelcomeContentReady({
   settingsLoading,
   currentAgent,
   personaPresetsLoading,
+  personaPresetsLoaded = false,
   teamRequestSettled,
 }: WelcomeReadinessState) {
+  const personaReady = !personaPresetsLoading || personaPresetsLoaded;
   return (
     !settingsLoading &&
     !!currentAgent &&
-    (currentAgent === "team" ? teamRequestSettled : !personaPresetsLoading)
+    (currentAgent === "team" ? teamRequestSettled : personaReady)
   );
 }
 

--- a/frontend/src/components/layout/AppContent/ChatAppContent.tsx
+++ b/frontend/src/components/layout/AppContent/ChatAppContent.tsx
@@ -97,7 +97,9 @@ export function ChatAppContent({
   const [personaPresetPage, setPersonaPresetPage] = useState(1);
   const [personaPresetQuery, setPersonaPresetQuery] = useState("");
   const [personaPresetTag, setPersonaPresetTag] = useState<string | null>(null);
-  const personaPresetPageSize = 12;
+  // 与 PersonaPresetSelector 的 PAGE_SIZE 保持一致：弹窗页码窗口与取数窗口
+  // 错位会漏行并让页码标注失真（issue #158）
+  const personaPresetPageSize = 20;
   const personaPresetListParams = useMemo(
     () => ({
       skip: (personaPresetPage - 1) * personaPresetPageSize,
@@ -113,6 +115,7 @@ export function ChatAppContent({
     isLoading: personaPresetsLoading,
     isLoadingMore: personaPresetsLoadingMore,
     isMutating: personaPresetsMutating,
+    hasLoaded: personaPresetsLoaded,
     usePreset: activatePersonaPreset,
     updatePreference: updatePersonaPreference,
     copyPreset: copyPersonaPreset,
@@ -828,6 +831,7 @@ export function ChatAppContent({
           enableSkills={enableSkills}
           personaPresets={personaPresets}
           personaPresetsTotal={personaPresetsTotal}
+          personaPresetsLoaded={personaPresetsLoaded}
           hasMorePersonaPresets={hasMorePersonaPresets}
           isLoadingMorePersonaPresets={personaPresetsLoadingMore}
           onLoadMorePersonaPresets={handleLoadMorePersonaPresets}

--- a/frontend/src/components/layout/AppContent/ChatView.tsx
+++ b/frontend/src/components/layout/AppContent/ChatView.tsx
@@ -95,6 +95,7 @@ export function ChatView({
   enableSkills,
   personaPresets,
   personaPresetsTotal,
+  personaPresetsLoaded,
   hasMorePersonaPresets,
   isLoadingMorePersonaPresets,
   onLoadMorePersonaPresets,
@@ -741,6 +742,7 @@ export function ChatView({
                   "Change persona",
                 )}
                 personaPresets={personaPresets}
+                personaPresetsLoaded={personaPresetsLoaded}
                 hasMorePersonaPresets={hasMorePersonaPresets}
                 isLoadingMorePersonaPresets={isLoadingMorePersonaPresets}
                 onLoadMorePersonaPresets={onLoadMorePersonaPresets}

--- a/frontend/src/components/layout/AppContent/ChatViewProps.tsx
+++ b/frontend/src/components/layout/AppContent/ChatViewProps.tsx
@@ -143,6 +143,8 @@ export interface ChatViewProps {
   enableSkills: boolean;
   personaPresets: PersonaPreset[];
   personaPresetsTotal: number;
+  /** 首次列表请求是否已落地；后台刷新不回退骨架屏（issue #158） */
+  personaPresetsLoaded: boolean;
   hasMorePersonaPresets: boolean;
   isLoadingMorePersonaPresets: boolean;
   onLoadMorePersonaPresets: () => void;

--- a/frontend/src/hooks/usePersonaPresets.ts
+++ b/frontend/src/hooks/usePersonaPresets.ts
@@ -23,6 +23,7 @@ export function usePersonaPresets(options?: {
   const [isLoading, setIsLoading] = useState(false);
   const [isMutating, setIsMutating] = useState(false);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [hasLoaded, setHasLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const fetchPresets = useCallback(
@@ -49,6 +50,8 @@ export function usePersonaPresets(options?: {
         );
       } finally {
         setIsLoading(false);
+        // 首次请求落地后，后续搜索/翻页刷新不再把页面回退成骨架屏（issue #158）
+        setHasLoaded(true);
       }
     },
     [enabled, t],
@@ -264,6 +267,7 @@ export function usePersonaPresets(options?: {
     isLoading,
     isLoadingMore,
     isMutating,
+    hasLoaded,
     error,
     fetchPresets,
     loadMore,


### PR DESCRIPTION
## Summary

修复 #158 评论报障（2933613701）：聊天内"+" → 增强 → 角色 打开角色广场后，**搜索角色 / 换页会导致弹窗被销毁、直接回到首页**。

## 根因（浏览器实测复现）

搜索/换页触发 persona 列表重新加载 → `personaPresetsLoading` 置真 → `WelcomePage` 的就绪门控 `isWelcomeContentReady` 把整个欢迎页连同 `ChatInput` 回退成骨架屏 → 角色广场弹窗（portal 挂在 ChatInput 下）随之卸载。DOM 证据：portal div 被整卸载，全程无点击、无页面报错——是干净的卸载而非崩溃。刷新完成后新挂载的 ChatInput `activePanel` 归零，用户视角即"跳转回首页"。

## Changes

- `usePersonaPresets` 暴露 `hasLoaded`（首次请求落地后恒真），`ChatAppContent → ChatView → WelcomePage` 全链路透传
- `isWelcomeContentReady` 新增 `personaPresetsLoaded`：首次加载仍显示骨架屏；后台刷新（搜索/翻页/标签）保持内容就绪，弹窗与输入框不再被卸载
- `ChatAppContent` 的 `personaPresetPageSize` 12 → 20，与 `PersonaPresetSelector` 的 `PAGE_SIZE` 对齐——此前取数窗口与弹窗页码窗口错位，翻页会漏行且分页标注失真（如第 2 页实际取 13-24 却标注 21-40）

## Testing

- [x] TDD：`welcomeReadyState.test.ts` 新增后台刷新语义用例 + `welcomePersonaRefetch.test.ts` 全链路结构测试，先红后绿
- [x] 前端全量 1781 tests passed（414 files）；`pnpm run lint`、`pnpm run build` 通过
- [x] 浏览器 A/B 回归（本地双 vite 实例 + 25 个种子角色）：
  - 修复前：搜索输入"测试"/"11"后弹窗即销毁（截图与 DOM 日志佐证）
  - 修复后：搜索"05"正确过滤且弹窗存活；翻到第 2 页显示 21-25 共 5 张、分页标注"21-25 / 25"与数据窗口一致，弹窗全程存活

> `#158` 为缺陷收集型 issue，是否整体关闭由维护者判断；本 PR 解决其中已报告的唯一一条缺陷。
