### PR TITLE
fix(frontend): 行内展开状态跨虚拟化保留 + 触控板微滑脱钉 + 流式 tick 引用稳定化

### DIFF
--- a/frontend/src/components/chat/ChatMessage/MessagePartRenderer.tsx
+++ b/frontend/src/components/chat/ChatMessage/MessagePartRenderer.tsx
@@ -550,6 +550,11 @@ export function MessagePartRenderer({
       <TodoBlock
         items={part.items}
         isStreaming={isStreaming && isLast && part.isStreaming}
+        stateKey={
+          messageId !== undefined && partIndex !== undefined
+            ? `${messageId}:${partIndex}`
+            : undefined
+        }
       />
     );
   }

--- a/frontend/src/components/chat/ChatMessage/RunStepsCollapse.tsx
+++ b/frontend/src/components/chat/ChatMessage/RunStepsCollapse.tsx
@@ -4,37 +4,54 @@ import clsx from "clsx";
 import { ChevronRight } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { formatElapsedCompact, formatElapsedHuman } from "./runStepsCollapseUtils";
+import { useUiExpansionState } from "./uiExpansionStore";
 
 /**
  * run 过程折叠区：状态行「已工作 9 分 57 秒 ›」（右侧 chevron、行下淡分隔线）。
  * 流式过程中默认展开并实时计时，直接显示完整过程详情；
  * 完成后自动收起成一行，点击可再展开。流式中也允许用户手动收起
  * （长 run 只想看最新输出时不必等结束）；用户动过折叠后，结束时
- * 不再强制覆盖其选择。
+ * 不再强制覆盖其选择。展开状态按 stateKey 存入会话级 store，
+ * 虚拟列表滚动卸载后滚回不丢。
  */
 export function RunStepsCollapse({
   steps,
   durationMs,
   startedAtMs = null,
   active = false,
+  stateKey,
   renderExpanded,
 }: {
   steps: number;
   durationMs: number | null;
   startedAtMs?: number | null;
   active?: boolean;
+  /** 稳定标识（如 message.id）：跨虚拟化卸载复水展开状态 */
+  stateKey?: string;
   renderExpanded: () => ReactNode;
 }) {
   const { t, i18n } = useTranslation();
-  const [expanded, setExpanded] = useState(active);
+  const [expanded, toggleExpanded, setExpanded] = useUiExpansionState(
+    stateKey ? `${stateKey}:run-steps` : undefined,
+    active,
+  );
   const [nowMs, setNowMs] = useState(() => Date.now());
   const userToggledRef = useRef(false);
 
+  const prevActiveRef = useRef(active);
   useEffect(() => {
-    if (active) return;
-    // 用户流式中手动收起/展开过的，结束时保持其选择
-    if (!userToggledRef.current) setExpanded(false);
-  }, [active]);
+    const wasActive = prevActiveRef.current;
+    prevActiveRef.current = active;
+    if (active) {
+      if (wasActive) return;
+      // 新 run 开始：回到默认展开（上一轮的收起选择不带入新 run）
+      userToggledRef.current = false;
+      setExpanded(true);
+      return;
+    }
+    // 仅在结束翻转时收起；重挂载的历史消息保持 store 复水的状态
+    if (wasActive && !userToggledRef.current) setExpanded(false);
+  }, [active, setExpanded]);
 
   useEffect(() => {
     if (!active) return;
@@ -70,7 +87,7 @@ export function RunStepsCollapse({
         aria-label={t("chat.message.runStepsToggle")}
         onClick={() => {
           userToggledRef.current = true;
-          setExpanded((value) => !value);
+          toggleExpanded();
         }}
         className={clsx(
           "group/steps flex w-full items-baseline gap-1.5 border-b border-theme-border pb-1.5 text-left",

--- a/frontend/src/components/chat/ChatMessage/TodoBlock.tsx
+++ b/frontend/src/components/chat/ChatMessage/TodoBlock.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { clsx } from "clsx";
 import {
   CheckCircle2,
@@ -10,10 +9,13 @@ import {
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { TodoItem, TodoStatus } from "../../../types";
+import { useUiExpansionState } from "./uiExpansionStore";
 
 interface TodoBlockProps {
   items: TodoItem[];
   isStreaming?: boolean;
+  /** 稳定标识（messageId:partIndex）：折叠状态跨虚拟化卸载保留 */
+  stateKey?: string;
 }
 
 const statusConfig: Record<
@@ -42,10 +44,14 @@ const statusConfig: Record<
   },
 };
 
-export function TodoBlock({ items, isStreaming }: TodoBlockProps) {
+export function TodoBlock({ items, isStreaming, stateKey }: TodoBlockProps) {
   const { t } = useTranslation();
-  // 长会话翻阅时可收起整块清单（默认展开；用户手动收起后由本地 state 保持）
-  const [collapsed, setCollapsed] = useState(false);
+  // 长会话翻阅时可收起整块清单（默认展开；状态存会话级 store，
+  // 虚拟列表滚动卸载后滚回不丢）
+  const [collapsed, toggleCollapsed] = useUiExpansionState(
+    stateKey ? `${stateKey}:todo-collapsed` : undefined,
+    false,
+  );
 
   if (!items || items.length === 0) return null;
 
@@ -67,7 +73,7 @@ export function TodoBlock({ items, isStreaming }: TodoBlockProps) {
         type="button"
         aria-expanded={!collapsed}
         aria-label={t("chat.todo.toggle")}
-        onClick={() => setCollapsed((value) => !value)}
+        onClick={() => toggleCollapsed()}
         className="group/todo flex w-full cursor-pointer items-center gap-2 px-3.5 py-2.5 text-left"
       >
         <ListTodo

--- a/frontend/src/components/chat/ChatMessage/__tests__/uiExpansionHydration.test.tsx
+++ b/frontend/src/components/chat/ChatMessage/__tests__/uiExpansionHydration.test.tsx
@@ -1,0 +1,130 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, expect, test, vi } from "vitest";
+
+import { RunStepsCollapse } from "../RunStepsCollapse";
+import { TodoBlock } from "../TodoBlock";
+import {
+  clearUiExpansions,
+  getUiExpansion,
+} from "../uiExpansionStore";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: unknown) => {
+      const templates: Record<string, string> = {
+        "chat.message.runStepsSummary": "Worked for {{duration}}",
+        "chat.message.runStepsCount": "{{count}} steps",
+        "chat.message.runStepsWorking": "Working… {{duration}}",
+        "chat.message.runStepsWorkingNoTimer": "Working…",
+        "chat.todo.progress": "{{completed}}/{{total}}",
+      };
+      let out = templates[key] ?? key;
+      if (opts && typeof opts === "object") {
+        for (const [k, v] of Object.entries(opts as Record<string, unknown>)) {
+          out = out.split(`{{${k}}}`).join(String(v));
+        }
+      }
+      return out;
+    },
+    i18n: { language: "en" },
+  }),
+}));
+
+afterEach(() => {
+  cleanup();
+  clearUiExpansions();
+});
+
+test("run-steps collapse choice survives virtualized unmount/remount", () => {
+  const { unmount } = render(
+    <RunStepsCollapse
+      active
+      stateKey="msg-1"
+      steps={1}
+      durationMs={null}
+      renderExpanded={() => <div>step-details</div>}
+    />,
+  );
+  expect(screen.getByText("step-details")).toBeTruthy();
+
+  // 流式中手动收起
+  fireEvent.click(screen.getByRole("button", { expanded: true }));
+  expect(screen.queryByText("step-details")).toBeNull();
+  expect(getUiExpansion("msg-1:run-steps")).toBe(false);
+
+  // 模拟虚拟列表卸载再滚回重挂
+  unmount();
+  render(
+    <RunStepsCollapse
+      active
+      stateKey="msg-1"
+      steps={1}
+      durationMs={null}
+      renderExpanded={() => <div>step-details</div>}
+    />,
+  );
+  // 复水：保持用户收起的选择，而不是回弹到默认展开
+  expect(screen.queryByText("step-details")).toBeNull();
+});
+
+test("run-steps history remount keeps expanded state after completion", () => {
+  const { rerender, unmount } = render(
+    <RunStepsCollapse
+      active
+      stateKey="msg-2"
+      steps={1}
+      durationMs={null}
+      renderExpanded={() => <div>step-details</div>}
+    />,
+  );
+  // 结束后用户重新展开
+  rerender(
+    <RunStepsCollapse
+      stateKey="msg-2"
+      steps={1}
+      durationMs={60000}
+      renderExpanded={() => <div>step-details</div>}
+    />,
+  );
+  expect(screen.queryByText("step-details")).toBeNull();
+  fireEvent.click(screen.getByRole("button", { expanded: false }));
+  expect(screen.getByText("step-details")).toBeTruthy();
+
+  // 卸载重挂（历史消息）：保持展开，不被"完成自动收起"误伤
+  unmount();
+  render(
+    <RunStepsCollapse
+      stateKey="msg-2"
+      steps={1}
+      durationMs={60000}
+      renderExpanded={() => <div>step-details</div>}
+    />,
+  );
+  expect(screen.getByText("step-details")).toBeTruthy();
+});
+
+test("todo block collapse survives virtualized unmount/remount", () => {
+  const items = [
+    { content: "task-a", status: "completed" as const },
+    { content: "task-b", status: "in_progress" as const },
+  ];
+
+  const { unmount } = render(
+    <TodoBlock items={items} stateKey="msg-3:2" />,
+  );
+  expect(screen.getByText("task-a")).toBeTruthy();
+
+  // 收起整块
+  fireEvent.click(screen.getByRole("button", { expanded: true }));
+  expect(screen.queryByText("task-a")).toBeNull();
+
+  unmount();
+  render(<TodoBlock items={items} stateKey="msg-3:2" />);
+  expect(screen.queryByText("task-a")).toBeNull();
+
+  // 再点开
+  fireEvent.click(screen.getByRole("button", { expanded: false }));
+  expect(screen.getByText("task-a")).toBeTruthy();
+});

--- a/frontend/src/components/chat/ChatMessage/index.tsx
+++ b/frontend/src/components/chat/ChatMessage/index.tsx
@@ -636,6 +636,7 @@ export const ChatMessage = memo(function ChatMessage({
               steps={0}
               durationMs={null}
               startedAtMs={getRunStartedAtMs(message)}
+              stateKey={message.id}
               active
               renderExpanded={() => (
                 <Loader2
@@ -653,6 +654,7 @@ export const ChatMessage = memo(function ChatMessage({
                   steps={countRunSteps(message.parts!)}
                   durationMs={getRunElapsedMs(message)}
                   startedAtMs={getRunStartedAtMs(message)}
+              stateKey={message.id}
                   active={message.isStreaming}
                   renderExpanded={() => renderPartGroups(runHeadGroups)}
                 />

--- a/frontend/src/components/chat/ChatMessage/uiExpansionStore.ts
+++ b/frontend/src/components/chat/ChatMessage/uiExpansionStore.ts
@@ -1,0 +1,68 @@
+import { useCallback, useState } from "react";
+
+/**
+ * 行内 UI 状态（展开/收起）的会话级内存存储。
+ *
+ * 消息列表是虚拟列表：行滚出视口即卸载，组件本地 state 随之蒸发，
+ * 滚回来后"自己收回去"。react-virtuoso 维护者的官方建议（issue #141/#298）
+ * 就是把这类状态存到组件树外部、按稳定 key 键控，重挂载时复水。
+ *
+ * 生命周期与 store 系列一致：仅内存、按会话清空，不持久化到任何存储。
+ */
+
+const expandedStates = new Map<string, boolean>();
+
+export function getUiExpansion(key: string): boolean | undefined {
+  return expandedStates.get(key);
+}
+
+export function setUiExpansion(key: string, expanded: boolean): void {
+  expandedStates.set(key, expanded);
+}
+
+export function deleteUiExpansion(key: string): void {
+  expandedStates.delete(key);
+}
+
+export function clearUiExpansions(): void {
+  expandedStates.clear();
+}
+
+/**
+ * 虚拟化行内展开/收起状态：挂载时从 store 复水，切换时写回。
+ * 只有宿主组件读写自己的 key，无需订阅广播。
+ */
+export function useUiExpansionState(
+  key: string | undefined,
+  defaultExpanded: boolean,
+) {
+  const [expanded, setExpanded] = useState(() =>
+    key !== undefined ? (getUiExpansion(key) ?? defaultExpanded) : defaultExpanded,
+  );
+
+  const toggle = useCallback(() => {
+    setExpanded((value) => {
+      const next = !value;
+      if (key !== undefined) setUiExpansion(key, next);
+      return next;
+    });
+  }, [key]);
+
+  const reset = useCallback(
+    (next: boolean) => {
+      setExpanded(next);
+      if (key !== undefined) {
+        if (next === defaultExpanded) {
+          deleteUiExpansion(key);
+        } else {
+          setUiExpansion(key, next);
+        }
+      }
+    },
+    [key, defaultExpanded],
+  );
+
+  // 卸载不清理：状态要跨虚拟化卸载存活，由会话切换统一清空
+
+  return [expanded, toggle, reset] as const;
+}

--- a/frontend/src/components/layout/AppContent/ChatView.tsx
+++ b/frontend/src/components/layout/AppContent/ChatView.tsx
@@ -61,6 +61,7 @@ import { syncSubagentPanelStore } from "../../chat/ChatMessage/subagentPanelStat
 import { subagentPanelStore } from "../../chat/ChatMessage/subagentPanelStore";
 import { clearSubagentPanelAutoOpenState } from "../../chat/ChatMessage/subagentPanelControl";
 import { resetStreamFollowSignal } from "../../chat/streamFollowSignal";
+import { clearUiExpansions } from "../../chat/ChatMessage/uiExpansionStore";
 import { hasPendingAskHuman } from "../../../hooks/useAgent/messageParts";
 
 const FLOATING_SCROLL_BUTTON_OFFSET_CLASS = "bottom-full mb-3";
@@ -174,8 +175,9 @@ export function ChatView({
   useEffect(() => {
     toolCallPanelStore.clear();
     subagentPanelStore.clear();
-    // 自动开面板的标记/静音记录不跨会话存活
+    // 自动开面板的标记/静音记录、行内展开状态不跨会话存活
     clearSubagentPanelAutoOpenState();
+    clearUiExpansions();
     resetStreamFollowSignal();
   }, [sessionId]);
 

--- a/frontend/src/components/layout/AppContent/__tests__/scrollJitterToleranceSource.test.ts
+++ b/frontend/src/components/layout/AppContent/__tests__/scrollJitterToleranceSource.test.ts
@@ -21,8 +21,19 @@ describe("message list scroll jitter tolerance (source)", () => {
     );
   });
 
-  test("requires a deliberate upward wheel intent beyond -6 to detach follow", () => {
-    expect(hookSource).toMatch(/if \(event\.deltaY >= -6\) \{/);
+  test("requires a deliberate upward wheel intent to detach follow", () => {
+    // 单次 -6px 以内的微滑不算意图；触控板惯性按 300ms 时间窗累计 24px 判定
+    // （nextWheelIntentState），累计前的微滑由底部锁定保持跟随
+    expect(hookSource).toMatch(/nextWheelIntentState\(/);
+    const utilsSource = readFileSync(
+      resolve(
+        process.cwd(),
+        "src/components/layout/AppContent/messageScrollUtils.ts",
+      ),
+      "utf8",
+    );
+    expect(utilsSource).toMatch(/WHEEL_DETACH_SINGLE_PX = 6/);
+    expect(utilsSource).toMatch(/WHEEL_DETACH_CUMULATIVE_PX = 24/);
   });
 
   test("rebinding scroll listeners keeps the real scrollTop baseline", () => {

--- a/frontend/src/components/layout/AppContent/__tests__/streamingRenderIsolationSource.test.ts
+++ b/frontend/src/components/layout/AppContent/__tests__/streamingRenderIsolationSource.test.ts
@@ -1,8 +1,6 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { expect, test } from "vitest";
-
-const source = readFileSync(
+import { expect, test } from "vitest";const source = readFileSync(
   resolve(import.meta.dirname, "../ChatView.tsx"),
   { encoding: "utf8" },
 );
@@ -39,4 +37,16 @@ test("composer onSend keeps a stable identity so memo(ChatInput) holds", () => {
   expect(onSend).toBeTruthy();
   expect(onSend).toMatch(/onSendMessageRef\.current/);
   expect(source).toMatch(/onSend: handleStableSend/);
+});
+
+test("auto preview target identity stays stable across streaming ticks", () => {
+  // latestAutoPreview 进 virtuosoItemContent 依赖：memo 每 tick 重算若换
+  // 新对象，最后一条消息带 reveal 产物时全部可见行每 tick 重渲
+  const revealSource = readFileSync(
+    resolve(import.meta.dirname, "../useRevealPreview.ts"),
+    { encoding: "utf8" },
+  );
+  expect(revealSource).toMatch(/useStableMemoValue/);
+  expect(revealSource).toMatch(/a\?\.messageId === b\?\.messageId/);
+  expect(revealSource).toMatch(/a\?\.previewKey === b\?\.previewKey/);
 });

--- a/frontend/src/components/layout/AppContent/__tests__/wheelIntentState.test.ts
+++ b/frontend/src/components/layout/AppContent/__tests__/wheelIntentState.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "vitest";
+
+import {
+  createWheelIntentAccumulator,
+  nextWheelIntentState,
+} from "../messageScrollUtils";
+
+test("single strong upward wheel detaches immediately", () => {
+  const result = nextWheelIntentState(
+    createWheelIntentAccumulator(),
+    -24,
+    1_000,
+  );
+  expect(result.detach).toBe(true);
+});
+
+test("trackpad inertia: sub-threshold upward wheels accumulate to detach", () => {
+  let state = createWheelIntentAccumulator();
+  // 一串 -4px 的惯性微上滑：单个不到 6px 阈值，但 300ms 内累计 24px 应脱钉
+  const deltas = [-4, -4, -4, -4, -4, -4];
+  let detached = false;
+  deltas.forEach((delta, index) => {
+    const result = nextWheelIntentState(state, delta, 1_000 + index * 16);
+    state = result.state;
+    if (result.detach) detached = true;
+  });
+  expect(detached).toBe(true);
+});
+
+test("sporadic micro-jitters far apart do not accumulate", () => {
+  let state = createWheelIntentAccumulator();
+  // 相邻事件间隔远超 300ms 窗口：各自清零，不累计成意图
+  [0, 2_000, 4_000, 6_000, 7_000, 9_000].forEach((ts, index) => {
+    const result = nextWheelIntentState(state, -5, ts);
+    state = result.state;
+    if (index === 5) expect(result.detach).toBe(false);
+  });
+});
+
+test("downward wheel resets the accumulator and keeps following", () => {
+  const state = nextWheelIntentState(
+    createWheelIntentAccumulator(),
+    -5,
+    1_000,
+  ).state;
+  const result = nextWheelIntentState(state, 8, 1_050);
+  expect(result.detach).toBe(false);
+  expect(result.state.upwardPx).toBe(0);
+
+  // 下滑清零后，新的微上滑从零开始累计
+  const after = nextWheelIntentState(result.state, -5, 1_100);
+  expect(after.detach).toBe(false);
+  expect(after.state.upwardPx).toBe(5);
+});
+
+test("zero-delta (horizontal) events do not count as upward intent", () => {
+  const result = nextWheelIntentState(
+    { upwardPx: 20, lastWheelTs: 1_000 },
+    0,
+    1_016,
+  );
+  expect(result.detach).toBe(false);
+  expect(result.state.upwardPx).toBe(0);
+});

--- a/frontend/src/components/layout/AppContent/messageScrollUtils.ts
+++ b/frontend/src/components/layout/AppContent/messageScrollUtils.ts
@@ -688,3 +688,59 @@ export function shouldPreloadOlderHistory({
   if (startIndex > threshold) return false;
   return startIndex < previousStartIndex;
 }
+
+export interface WheelIntentAccumulator {
+  /** 时间窗内累计的上滑像素量 */
+  upwardPx: number;
+  /** 最近一次 wheel 事件时间戳（ms） */
+  lastWheelTs: number;
+}
+
+export const WHEEL_DETACH_SINGLE_PX = 6;
+export const WHEEL_DETACH_CUMULATIVE_PX = 24;
+export const WHEEL_INTENT_WINDOW_MS = 300;
+
+export function createWheelIntentAccumulator(): WheelIntentAccumulator {
+  return { upwardPx: 0, lastWheelTs: 0 };
+}
+
+/**
+ * wheel 上滚意图判定（触控板友好）。
+ *
+ * 触控板惯性常表现为一串 <6px 的连续微上滑：单事件阈值拦不住，
+ * 底部锁定循环又把它们逐个粘回，表现为"轻轻上滑被吸回底部"。
+ * 在时间窗内累计上滑量——单次达到 singlePx 或窗口累计达到
+ * cumulativePx 都视为明确的用户上滚意图（脱钉跟随）；
+ * 下滑/水平滚动清零累计（ reaffirm 跟随）。
+ */
+export function nextWheelIntentState(
+  state: WheelIntentAccumulator,
+  deltaY: number,
+  nowMs: number,
+  options?: {
+    singlePx?: number;
+    cumulativePx?: number;
+    windowMs?: number;
+  },
+): { detach: boolean; state: WheelIntentAccumulator } {
+  const singlePx = options?.singlePx ?? WHEEL_DETACH_SINGLE_PX;
+  const cumulativePx =
+    options?.cumulativePx ?? WHEEL_DETACH_CUMULATIVE_PX;
+  const windowMs = options?.windowMs ?? WHEEL_INTENT_WINDOW_MS;
+
+  if (deltaY >= 0) {
+    return { detach: false, state: { upwardPx: 0, lastWheelTs: nowMs } };
+  }
+
+  const magnitude = Math.abs(deltaY);
+  if (magnitude >= singlePx) {
+    return { detach: true, state: { upwardPx: 0, lastWheelTs: nowMs } };
+  }
+
+  const withinWindow = nowMs - state.lastWheelTs <= windowMs;
+  const upwardPx = (withinWindow ? state.upwardPx : 0) + magnitude;
+  if (upwardPx >= cumulativePx) {
+    return { detach: true, state: { upwardPx: 0, lastWheelTs: nowMs } };
+  }
+  return { detach: false, state: { upwardPx, lastWheelTs: nowMs } };
+}

--- a/frontend/src/components/layout/AppContent/useMessageScroll.hook.ts
+++ b/frontend/src/components/layout/AppContent/useMessageScroll.hook.ts
@@ -18,6 +18,8 @@ import {
   shouldIgnoreUnexpectedTopJumpDuringBottomLock,
   getUnexpectedTopJumpRecoveryUntilAfterUserIntent,
   startVirtuosoScrollToBottom,
+  createWheelIntentAccumulator,
+  nextWheelIntentState,
   type ScrollToBottomTimingMode,
 } from "./messageScrollUtils";
 import { getMessageScrollViewportState } from "./useMessageScroll.viewport";
@@ -444,6 +446,9 @@ export function useMessageScroll(
       detachFromUserGesture(getNextMessageScrollFollowStateForUserIntent);
     };
 
+    // wheel 上滚意图累计器（触控板惯性微滑判定，见 nextWheelIntentState）
+    let wheelIntentAccum = createWheelIntentAccumulator();
+
     const handleTouchMove = (event: TouchEvent) => {
       if (!isMobileViewport || touchStartY === null) {
         return;
@@ -464,8 +469,15 @@ export function useMessageScroll(
     };
 
     const handleWheel = (event: WheelEvent) => {
-      // 触控板误触/惯性微抖（deltaY 在 -6 以内）不构成上滚意图，不打断跟随
-      if (event.deltaY >= -6) {
+      // 触控板惯性是一串 <6px 的连续微上滑：单事件阈值拦不住会被
+      // 底部锁定逐个粘回；按时间窗累计判定明确的上滚意图后才脱钉
+      const intent = nextWheelIntentState(
+        wheelIntentAccum,
+        event.deltaY,
+        Date.now(),
+      );
+      wheelIntentAccum = intent.state;
+      if (!intent.detach) {
         return;
       }
 

--- a/frontend/src/components/layout/AppContent/useRevealPreview.ts
+++ b/frontend/src/components/layout/AppContent/useRevealPreview.ts
@@ -1,4 +1,15 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
+
+/** 内容相等时复用旧引用：派生值进下游 memo/useCallback 依赖时，
+ *  流式 tick 的重算不换身份，下游（如 Virtuoso 行级 memo）不被打穿 */
+function useStableMemoValue<T>(value: T, isEqual: (a: T, b: T) => boolean): T {
+  const ref = useRef(value);
+  if (!isEqual(ref.current, value)) {
+    ref.current = value;
+    return value;
+  }
+  return ref.current;
+}
 import type { Message } from "../../../types";
 import type { AutoPreviewTarget } from "../../chat/ChatMessage/autoPreviewEligibility";
 import type { RevealPreviewRequest } from "../../chat/ChatMessage/items/revealPreviewData";
@@ -276,27 +287,37 @@ export function useRevealPreview(
     sessionId,
   ]);
 
-  const latestAutoPreview = useMemo(
-    () =>
-      getLatestObservedCompletionAutoPreviewTarget({
-        messages,
-        observedStreamingMessageIds: observedStreamingMessageIdsRef.current,
-        suppressAutoPreview: !!externalNavigationPreview,
-        currentRunId,
-      }),
-    [messages, externalNavigationPreview, currentRunId],
+  // 流式期间 messages 每 tick 换引用：两个 memo 每 tick 重算，结果内容
+  // 未变时必须复用旧对象——latestAutoPreview 进 virtuosoItemContent 依赖，
+  // 换引用会让全部可见消息行每 tick 重渲（长会话滑动掉帧）
+  const latestAutoPreview = useStableMemoValue(
+    useMemo(
+      () =>
+        getLatestObservedCompletionAutoPreviewTarget({
+          messages,
+          observedStreamingMessageIds: observedStreamingMessageIdsRef.current,
+          suppressAutoPreview: !!externalNavigationPreview,
+          currentRunId,
+        }),
+      [messages, externalNavigationPreview, currentRunId],
+    ),
+    (a, b) =>
+      a?.messageId === b?.messageId && a?.partIndex === b?.partIndex,
   );
 
-  const latestAutoPreviewRequest = useMemo(
-    () =>
-      getLatestObservedCompletionRevealPreviewRequest({
-        messages,
-        observedStreamingMessageIds: observedStreamingMessageIdsRef.current,
-        suppressAutoPreview: !!externalNavigationPreview,
-        currentRunId,
-        allowHistoricalLatest: !isLoadingHistory,
-      }),
-    [messages, externalNavigationPreview, currentRunId, isLoadingHistory],
+  const latestAutoPreviewRequest = useStableMemoValue(
+    useMemo(
+      () =>
+        getLatestObservedCompletionRevealPreviewRequest({
+          messages,
+          observedStreamingMessageIds: observedStreamingMessageIdsRef.current,
+          suppressAutoPreview: !!externalNavigationPreview,
+          currentRunId,
+          allowHistoricalLatest: !isLoadingHistory,
+        }),
+      [messages, externalNavigationPreview, currentRunId, isLoadingHistory],
+    ),
+    (a, b) => a?.previewKey === b?.previewKey,
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

承接 #300 的两处遗留优化 + 一处新发现的流式性能修复，全部以用户体验为先。

## Changes

- **行内展开状态跨虚拟化保留**：新增 `uiExpansionStore`（内存级、会话作用域，不落库），按 react-virtuoso 维护者的官方建议（issue #141/#298）把展开状态存到组件树外部、按稳定 key（message.id / messageId:partIndex）键控，重挂载时复水。RunStepsCollapse（过程区）与 TodoBlock（任务清单）接入：滚动卸载后滚回，用户的收起/展开选择不再"自己弹回去"。完成自动收起只在 active 翻转时发生，历史消息重挂载不被误收起。
- **触控板微滑脱钉**：wheel 上滚意图从单次 -6px 阈值改为时间窗累计判定（300ms 内累计 24px 即脱钉，单次强滑仍立即脱钉）。触控板惯性的一串微上滑不再被底部锁定循环逐个"粘回"底部；下滑/水平滚动清零累计。参照 use-stick-to-bottom 等开源 chat 滚动方案的用户意图判定思路。
- **流式 tick 引用稳定化（性能）**：`useRevealPreview` 的 `latestAutoPreview` / `latestAutoPreviewRequest` 在内容未变时复用旧引用。此前它们每 tick 返回新对象并进入 `virtuosoItemContent` 依赖——最后一条消息带 reveal 产物时，所有可见消息行每个流式 tick 全量重渲，长会话滑动掉帧。修复后与 #300 的行级回调稳定化共同保证：流式期间只有正在生成的消息行重渲。

## Testing

- [x] 前端全量 vitest：427 文件 / 1861 用例通过（新增 wheel 意图纯函数 5 例、卸载复水行为 3 例、引用稳定化与抖动容差源码守卫）
- [x] ESLint / tsc --noEmit / 生产构建通过
