### PR TITLE
chore(release): 晋升 #303（工具流式升级错配修复）

### DIFF
--- a/frontend/src/hooks/useAgent/__tests__/toolArgsChunk.test.ts
+++ b/frontend/src/hooks/useAgent/__tests__/toolArgsChunk.test.ts
@@ -588,3 +588,150 @@ test("tool:start upgrade keeps existing alias when the generating part has none"
 
   expect((started.parts[0] as ToolPart).alias_id).toBeUndefined();
 });
+
+test("tool:start upgrades the LATEST generating part, not a stale leftover", () => {
+  // 上一轮流式中断残留的 stale 生成中 part 排在前面；新一轮工具的
+  // 生成中 part 在最后。tool:start 必须升级后者，否则新 pill 永远
+  // 停在"参数生成中"不被替换（用户实测的卡死现象）
+  const stale = processMessageEvent(
+    "tool:args:chunk",
+    toolArgsChunk('{"q":"old"', { tool: "grep" }),
+    [],
+    "",
+    [],
+    0,
+    [],
+    true,
+    "message-1",
+  );
+  const fresh = processMessageEvent(
+    "tool:args:chunk",
+    toolArgsChunk('{"q":"new"', { tool: "grep", tool_call_id: "call_new" }),
+    stale.parts,
+    "",
+    [],
+    0,
+    [],
+    true,
+    "message-1",
+  );
+  expect(fresh.parts).toHaveLength(2);
+
+  const started = processMessageEvent(
+    "tool:start",
+    { tool: "grep", tool_call_id: "run-9", args: { q: "new" } },
+    fresh.parts,
+    "",
+    [],
+    0,
+    [],
+    true,
+    "message-1",
+  );
+
+  const parts = started.parts as ToolPart[];
+  expect(parts).toHaveLength(2);
+  // 升级命中的是最后一个（本轮正在流式的）part
+  expect(parts[1]).toMatchObject({ id: "run-9", args: { q: "new" } });
+  expect(parts[1].argsPartial).toBeUndefined();
+  // stale part 保持原样（由中断清理流程标记 cancelled，不被误吃）
+  expect(parts[0]).toMatchObject({ argsPartial: true, args: { partial: '{"q":"old"' } });
+});
+
+test("parallel tools upgrade by tool name even in reverse execution order", () => {
+  let parts: MessagePart[] = [];
+  parts = processMessageEvent(
+    "tool:args:chunk",
+    { tool: "grep", tool_call_id: "call_a", content: '{"q' },
+    parts,
+    "",
+    [],
+    0,
+    [],
+    true,
+    "message-1",
+  ).parts;
+  parts = processMessageEvent(
+    "tool:args:chunk",
+    { tool: "read_file", tool_call_id: "call_b", content: '{"file_path' },
+    parts,
+    "",
+    [],
+    0,
+    [],
+    true,
+    "message-1",
+  ).parts;
+
+  // 执行顺序与生成顺序相反：read_file 先执行
+  const startedB = processMessageEvent(
+    "tool:start",
+    { tool: "read_file", tool_call_id: "run-b", args: { file_path: "/a" } },
+    parts,
+    "",
+    [],
+    0,
+    [],
+    true,
+    "message-1",
+  ).parts as ToolPart[];
+  expect(startedB[0]).toMatchObject({ name: "grep", argsPartial: true });
+  expect(startedB[1]).toMatchObject({ id: "run-b", args: { file_path: "/a" } });
+  expect(startedB[1].argsPartial).toBeUndefined();
+
+  const startedA = processMessageEvent(
+    "tool:start",
+    { tool: "grep", tool_call_id: "run-a", args: { q: "x" } },
+    startedB,
+    "",
+    [],
+    0,
+    [],
+    true,
+    "message-1",
+  ).parts as ToolPart[];
+  expect(startedA[0]).toMatchObject({ id: "run-a", args: { q: "x" } });
+  expect(startedA[0].argsPartial).toBeUndefined();
+});
+
+test("late args chunk after upgrade does not create a ghost generating part", () => {
+  const generating = processMessageEvent(
+    "tool:args:chunk",
+    toolArgsChunk('{"q":"x"'),
+    [],
+    "",
+    [],
+    0,
+    [],
+    true,
+    "message-1",
+  );
+  const started = processMessageEvent(
+    "tool:start",
+    { tool: "grep", tool_call_id: "run-1", args: { q: "x" } },
+    generating.parts,
+    "",
+    [],
+    0,
+    [],
+    true,
+    "message-1",
+  );
+
+  // 迟到的参数增量（极端时序下可能残留）：不得再生成新的 argsPartial part
+  const late = processMessageEvent(
+    "tool:args:chunk",
+    toolArgsChunk('y"}', { tool_call_id: "call_1" }),
+    started.parts,
+    "",
+    [],
+    0,
+    [],
+    true,
+    "message-1",
+  );
+
+  expect(late.parts).toHaveLength(1);
+  expect((late.parts[0] as ToolPart).argsPartial).toBeUndefined();
+  expect((late.parts[0] as ToolPart).args).toEqual({ q: "x" });
+});

--- a/frontend/src/hooks/useAgent/eventProcessor.ts
+++ b/frontend/src/hooks/useAgent/eventProcessor.ts
@@ -265,7 +265,8 @@ export function processMessageEvent(
       );
 
       // 流式参数已先建生成中 part：原位升级而不是再追加一个
-      const upgraded = upgradeGeneratingToolPart(parts, toolPart);
+      // depth 决定升级范围：嵌套 subagent 工具只在自己子树内找目标
+      const upgraded = upgradeGeneratingToolPart(parts, toolPart, depth);
       if (upgraded) {
         result.parts = upgraded;
         if (depth === 0) {

--- a/frontend/src/hooks/useAgent/messageParts.ts
+++ b/frontend/src/hooks/useAgent/messageParts.ts
@@ -131,6 +131,13 @@ export function appendToolArgsDelta(
   const merged = mergeToolArgsDeltaInParts(parts, toolCallId, delta);
   if (merged) return merged;
 
+  // 防御：对应的工具已转正（tool:start 已升级，id 或 alias 命中）时，
+  // 迟到的增量直接丢弃——最终 args 已权威，再建 part 会留下一个永远
+  // 停留在「参数生成中」的幽灵卡片
+  if (toolCallId && hasUpgradedToolCallId(parts, toolCallId)) {
+    return parts;
+  }
+
   const part = createGeneratingToolPart(toolName, toolCallId, delta, depth, agentId);
   if (depth > 0) {
     return addPartToDepth(parts, part, depth, activeSubagentStack, agentId, messageId);
@@ -138,42 +145,86 @@ export function appendToolArgsDelta(
   return [...parts, part];
 }
 
+function hasUpgradedToolCallId(parts: MessagePart[], toolCallId: string): boolean {
+  return parts.some((p) => {
+    if (p.type === "tool") {
+      return (
+        !p.argsPartial && (p.id === toolCallId || p.alias_id === toolCallId)
+      );
+    }
+    return p.type === "subagent" && p.parts
+      ? hasUpgradedToolCallId(p.parts, toolCallId)
+      : false;
+  });
+}
+
 /**
- * Replace the first (generation-order) args-partial tool part with the final
- * tool:start part, keeping the earlier startedAt for honest elapsed timing.
+ * 定位 tool:start 应升级的生成中 part。
+ *
+ * 优先级：id 精确命中 > 按工具名取「最后一个」> 最后一个 argsPartial。
+ * 必须与 findGeneratingToolIndex 的合并目标（反扫取最后一个）一致：
+ * 若按位置取第一个，早前轮次残留的 stale 生成中 part（流式中断遗留）
+ * 或并行工具执行顺序与生成顺序不一致时会错配——正在流式的新 part
+ * 永远等不到升级，UI 卡在「参数生成中」不被替换。
+ */
+function findUpgradeTargetIndex(
+  parts: MessagePart[],
+  replacement: ToolPart,
+): number {
+  let nameMatch = -1;
+  let anyMatch = -1;
+  for (let i = 0; i < parts.length; i++) {
+    const p = parts[i];
+    if (p.type !== "tool" || !p.argsPartial) continue;
+    if (replacement.id && p.id === replacement.id) return i;
+    if (replacement.name && p.name === replacement.name) nameMatch = i;
+    anyMatch = i;
+  }
+  return nameMatch !== -1 ? nameMatch : anyMatch;
+}
+
+/**
+ * Replace the matching args-partial tool part with the final tool:start part,
+ * keeping the earlier startedAt for honest elapsed timing.
+ * depth 0 only upgrades top-level generating parts; nested subagent tools
+ * (depth > 0) upgrade within their own subtree, matching where the args
+ * chunks were routed.
  * The streaming-era id (if any) is preserved as alias_id so panels opened
  * during args streaming keep receiving live updates under the new id.
- * Returns null when no generating part exists (plain append path).
+ * Returns null when no matching generating part exists (plain append path).
  */
 export function upgradeGeneratingToolPart(
   parts: MessagePart[],
   replacement: ToolPart,
+  targetDepth = 0,
 ): MessagePart[] | null {
-  for (let i = 0; i < parts.length; i++) {
-    const p = parts[i];
-    if (p.type === "tool" && (p as ToolPart).argsPartial) {
-      const generating = p as ToolPart;
-      const newParts = [...parts];
-      newParts[i] = {
-        ...replacement,
-        startedAt: generating.startedAt ?? replacement.startedAt,
-        alias_id:
-          generating.id && generating.id !== replacement.id
-            ? generating.id
-            : replacement.alias_id,
-      };
-      return newParts;
-    }
-    if (p.type === "subagent" && p.parts) {
-      const updated = upgradeGeneratingToolPart(p.parts, replacement);
+  if (targetDepth > 0) {
+    for (let i = 0; i < parts.length; i++) {
+      const p = parts[i];
+      if (p.type !== "subagent" || !p.parts) continue;
+      const updated = upgradeGeneratingToolPart(p.parts, replacement, targetDepth - 1);
       if (updated) {
         const newParts = [...parts];
         newParts[i] = { ...p, parts: updated };
         return newParts;
       }
     }
+    return null;
   }
-  return null;
+
+  const idx = findUpgradeTargetIndex(parts, replacement);
+  if (idx === -1) return null;
+  const generating = parts[idx] as ToolPart;
+  const newParts = [...parts];
+  newParts[idx] = {
+    ...replacement,
+    startedAt: generating.startedAt ?? replacement.startedAt,
+    alias_id:
+      generating.id && generating.id !== replacement.id
+        ? generating.id
+        : replacement.alias_id,
+  };
+  return newParts;
 }
 
 /**


### PR DESCRIPTION
## Summary

晋升 develop 已验证的工具参数流式修复到 main。

## 包含内容

**#303 fix(chat): tool:start 升级目标与参数合并目标对齐，流式 pill 不再卡死**
- 修复参数流式中的工具卡片在流式完成后不被 tool:start 替换、一直停留在「参数生成中」的问题
- 升级目标定位与参数合并目标对齐（id > 工具名反扫 > 最后 argsPartial），stale 残留 / 并行乱序不再错配
- depth 分层升级 + 迟到增量幽灵 part 防御

## 验证

- [x] develop CI 八项全过（#303）
- [x] staging（develop-20260829-182143）部署验证：健康检查、前端资源正常
- [ ] 生产部署后回归（/root/disttest/run-all.sh）
