### PR TITLE
fix(memory): 记忆误拒修复 + 写时语义去重，避免重复记忆

### DIFF
--- a/src/infra/memory/client/native/backend.py
+++ b/src/infra/memory/client/native/backend.py
@@ -1,6 +1,5 @@
 """Native Memory Backend — MongoDB-backed, zero external dependencies."""
 
-import asyncio
 import inspect
 import uuid
 from datetime import timedelta
@@ -14,6 +13,7 @@ from src.infra.logging import get_logger
 from src.infra.memory.client.base import MemoryBackend
 from src.infra.memory.client.native.classification import (
     find_existing_memory_match,
+    find_semantic_memory_match,
     is_manual_memory_worthy,
 )
 from src.infra.memory.client.native.content import (
@@ -206,6 +206,19 @@ class NativeMemoryBackend(MemoryBackend):
                 {"summary": 1, "memory_id": 1, "memory_type": 1},
             ).to_list(length=50)
 
+        async def fetch_semantic_candidates(target_user_id: str) -> list[dict[str, Any]]:
+            return await self._collection.find(
+                {
+                    "user_id": target_user_id,
+                    "embedding": {"$exists": True, "$ne": None},
+                    "source": {"$ne": "session_summary"},
+                },
+                {"memory_id": 1, "memory_type": 1, "summary": 1, "embedding": 1},
+            ).to_list(length=200)
+
+        # embedding 既用于落库，也用于写时语义去重（写前先读，避免重复记忆）
+        embedding = await self._maybe_embed(content)
+
         existing_match = None
         _match_projection = {
             "memory_id": 1,
@@ -230,6 +243,13 @@ class NativeMemoryBackend(MemoryBackend):
                 summary=summary,
                 memory_type=memory_type,
             )
+            if existing_match is None:
+                existing_match = await find_semantic_memory_match(
+                    fetch_candidates=fetch_semantic_candidates,
+                    user_id=user_id,
+                    query_embedding=embedding or [],
+                    memory_type=memory_type,
+                )
             # fetch content fields for store cleanup if matched via similarity
             if existing_match and "content_storage_mode" not in existing_match:
                 full_doc = await self._collection.find_one(
@@ -263,10 +283,7 @@ class NativeMemoryBackend(MemoryBackend):
                 )
                 merged_source_refs = []
         source_ref_docs = [ref.model_dump() for ref in merged_source_refs]
-        content_fields, embedding = await asyncio.gather(
-            build_content_fields(self, user_id, memory_id, content),
-            self._maybe_embed(content),
-        )
+        content_fields = await build_content_fields(self, user_id, memory_id, content)
 
         if is_update:
             await self._collection.update_one(

--- a/src/infra/memory/client/native/classification.py
+++ b/src/infra/memory/client/native/classification.py
@@ -10,7 +10,13 @@ with warnings.catch_warnings():
     warnings.simplefilter("ignore", SyntaxWarning)
     import jieba.posseg as pseg
 
-from src.infra.memory.client.native.models import CJK_STOPWORDS, STOPWORDS, char_ngrams, has_cjk
+from src.infra.memory.client.native.models import (
+    CJK_STOPWORDS,
+    STOPWORDS,
+    char_ngrams,
+    cosine_similarity,
+    has_cjk,
+)
 
 _USEFUL_POS = frozenset({"n", "nr", "ns", "nt", "nz", "v", "vn", "a", "eng", "x"})
 
@@ -187,6 +193,40 @@ async def find_existing_memory_match(
         if not existing_summary:
             continue
         score = word_similarity(summary, existing_summary)
+        if score >= threshold and score > best_score:
+            best_score = score
+            best_match = doc
+    return best_match
+
+
+# 写时语义去重阈值：生产同一条记忆“入党申请书”召回得分约 0.89，
+# 同一事实的改写通常 >= 0.9，相关但不同的事实一般在 0.8x 以下。
+SEMANTIC_DEDUP_THRESHOLD = 0.88
+
+
+async def find_semantic_memory_match(
+    fetch_candidates: Callable[[str], Awaitable[list[dict[str, Any]]]],
+    user_id: str,
+    query_embedding: list[float],
+    memory_type: str,
+    threshold: float = SEMANTIC_DEDUP_THRESHOLD,
+) -> dict[str, Any] | None:
+    """按新内容 embedding 与既有记忆的余弦相似度找同一条记忆（写时先读）。
+
+    摘要措辞不同但语义相同的写入应合并更新，而不是新建重复记忆。
+    """
+    if not query_embedding:
+        return None
+    candidates = await fetch_candidates(user_id)
+    best_match: dict[str, Any] | None = None
+    best_score = 0.0
+    for doc in candidates:
+        if doc.get("memory_type") != memory_type:
+            continue
+        embedding = doc.get("embedding")
+        if not embedding:
+            continue
+        score = cosine_similarity(query_embedding, embedding)
         if score >= threshold and score > best_score:
             best_score = score
             best_match = doc

--- a/src/infra/memory/client/native/classification.py
+++ b/src/infra/memory/client/native/classification.py
@@ -14,7 +14,8 @@ from src.infra.memory.client.native.models import CJK_STOPWORDS, STOPWORDS, char
 
 _USEFUL_POS = frozenset({"n", "nr", "ns", "nt", "nz", "v", "vn", "a", "eng", "x"})
 
-_CODE_MARKERS = (
+# 代码/命令/报错特征：单个出现即判定为非记忆内容
+_CODE_STRONG_MARKERS = (
     "import ",
     "def ",
     "class ",
@@ -25,14 +26,12 @@ _CODE_MARKERS = (
     "pip install",
     "npm install",
     "npm run",
-    "src/",
-    "node_modules",
-    ".py",
-    ".ts",
-    ".tsx",
-    ".js",
-    ".jsx",
 )
+
+# 文件引用是弱信号：耐久事实里提到单个文件名（如“gen_docx.py 保留在工作区”）
+# 不代表是代码转储，出现次数达到 2 才更像代码/路径列表。
+# 注意 alternation 中 tsx/jsx 必须排在 ts/js 前，避免 ".tsx" 被拆成 ".ts" 重复计数。
+_FILE_REFERENCE_RE = re.compile(r"\.(?:py|tsx|jsx|ts|js)|src/|node_modules")
 
 _TRANSIENT_STARTS = (
     "正在",
@@ -79,7 +78,10 @@ def word_similarity(a: str, b: str) -> float:
 def looks_like_code_or_path(content: str) -> bool:
     if content.count("/") + content.count("\\") >= 3:
         return True
-    return any(marker in content for marker in _CODE_MARKERS)
+    lowered = content.lower()
+    if any(marker in lowered for marker in _CODE_STRONG_MARKERS):
+        return True
+    return len(_FILE_REFERENCE_RE.findall(content)) >= 2
 
 
 def is_transient_status_content(content: str) -> bool:

--- a/src/infra/memory/tools.py
+++ b/src/infra/memory/tools.py
@@ -181,9 +181,11 @@ async def memory_retain(
 ) -> str:
     """
     Store a memory for cross-session persistence. STRICT: only genuinely useful,
-    non-temporary information is accepted. Content that is too short, looks like a
-    question, resembles code/commands, or duplicates an existing recent memory will
-    be rejected. Prefer storing high-signal facts like user preferences, project
+    non-temporary information is accepted. Content that is too short or resembles
+    code/commands will be rejected. If a semantically similar memory already exists
+    it is merged and updated automatically (result `updated_existing` is true), so
+    write the FULL refreshed content including previously known details, not just
+    the delta. Prefer storing high-signal facts like user preferences, project
     context, feedback, or external references. Use explicit context labels such as
     `user_identity`, `project_constraint`, `project_status`, `feedback_rule`, or
     `reference_link` instead of vague buckets like `user_preferences`.

--- a/tests/infra/memory/native/test_classification.py
+++ b/tests/infra/memory/native/test_classification.py
@@ -1,0 +1,47 @@
+from src.infra.memory.client.native.classification import (
+    is_manual_memory_worthy,
+    looks_like_code_or_path,
+)
+
+# 生产实际被误拒的记忆内容（run_20260829_2bd6df77，memory_retain 两次均被拒）
+_DURABLE_FACT_WITH_FILENAME = (
+    "用户申请加入中国共产党：2026-08-29起多次请AI撰写约3000字入党申请书Word文档"
+    "（作手写誊写底稿），已生成含标点3018字的通用版（不限定学生/职工身份），"
+    "生成脚本gen_docx.py与底稿txt保留在工作区可复用。"
+    "落款为占位符（XXX / XXXX年XX月XX日），身份场景仍未确认。"
+)
+
+
+def test_durable_fact_mentioning_single_filename_is_worthy():
+    assert is_manual_memory_worthy(_DURABLE_FACT_WITH_FILENAME)
+
+
+def test_single_filename_mention_is_not_code_or_path():
+    assert not looks_like_code_or_path("生成脚本gen_docx.py与底稿txt保留在工作区可复用")
+
+
+def test_single_path_fragment_mention_is_not_code_or_path():
+    assert not looks_like_code_or_path("生成的脚本保留在 src/ 目录下供后续复用")
+
+
+def test_single_tsx_mention_is_counted_once_not_double():
+    assert not looks_like_code_or_path("前端入口组件在 App.tsx 里，后续要改样式")
+
+
+def test_code_snippet_is_rejected():
+    assert looks_like_code_or_path("import os\n\n\ndef main():\n    print('hi')")
+    assert not is_manual_memory_worthy("import os\n\n\ndef main():\n    print('hi')")
+
+
+def test_traceback_dump_is_rejected():
+    assert looks_like_code_or_path("Traceback (most recent call last): File ...")
+    assert not is_manual_memory_worthy("Traceback (most recent call last): File ...")
+
+
+def test_multiple_file_references_are_rejected():
+    assert looks_like_code_or_path("脚本 gen_docx.py 和构建脚本 build.js 都要重跑")
+    assert not is_manual_memory_worthy("脚本 gen_docx.py 和构建脚本 build.js 都要重跑")
+
+
+def test_path_with_multiple_segments_is_rejected():
+    assert looks_like_code_or_path("部署脚本在 deploy/k8s/scripts/ 目录下的 run.sh")

--- a/tests/infra/memory/native/test_classification.py
+++ b/tests/infra/memory/native/test_classification.py
@@ -1,4 +1,7 @@
+import pytest
+
 from src.infra.memory.client.native.classification import (
+    find_semantic_memory_match,
     is_manual_memory_worthy,
     looks_like_code_or_path,
 )
@@ -45,3 +48,62 @@ def test_multiple_file_references_are_rejected():
 
 def test_path_with_multiple_segments_is_rejected():
     assert looks_like_code_or_path("部署脚本在 deploy/k8s/scripts/ 目录下的 run.sh")
+
+
+@pytest.mark.asyncio
+async def test_find_semantic_memory_match_returns_best_candidate_above_threshold():
+    candidates = [
+        {"memory_id": "m1", "memory_type": "user", "embedding": [1.0, 0.0]},
+        {"memory_id": "m2", "memory_type": "user", "embedding": [0.0, 1.0]},
+    ]
+
+    async def fake_fetch(_user_id):
+        return candidates
+
+    match = await find_semantic_memory_match(
+        fetch_candidates=fake_fetch,
+        user_id="u1",
+        query_embedding=[0.9, 0.44],
+        memory_type="user",
+    )
+
+    assert match is not None
+    assert match["memory_id"] == "m1"
+
+
+@pytest.mark.asyncio
+async def test_find_semantic_memory_match_returns_none_below_threshold():
+    candidates = [
+        {"memory_id": "m1", "memory_type": "user", "embedding": [1.0, 0.0]},
+    ]
+
+    async def fake_fetch(_user_id):
+        return candidates
+
+    match = await find_semantic_memory_match(
+        fetch_candidates=fake_fetch,
+        user_id="u1",
+        query_embedding=[0.0, 1.0],
+        memory_type="user",
+    )
+
+    assert match is None
+
+
+@pytest.mark.asyncio
+async def test_find_semantic_memory_match_skips_other_memory_types():
+    candidates = [
+        {"memory_id": "m1", "memory_type": "project", "embedding": [1.0, 0.0]},
+    ]
+
+    async def fake_fetch(_user_id):
+        return candidates
+
+    match = await find_semantic_memory_match(
+        fetch_candidates=fake_fetch,
+        user_id="u1",
+        query_embedding=[1.0, 0.0],
+        memory_type="user",
+    )
+
+    assert match is None

--- a/tests/infra/memory/native/test_retain.py
+++ b/tests/infra/memory/native/test_retain.py
@@ -165,3 +165,108 @@ async def test_retain_updates_existing_memory_and_refreshes_embedding():
     assert result["updated_existing"] is True
     assert seen["query"] == {"user_id": "u1", "memory_id": "m1"}
     assert seen["payload"]["$set"]["embedding"] == [58.0]
+
+
+class _RetainFakeCursor:
+    def __init__(self, docs):
+        self._docs = docs
+
+    async def to_list(self, length):
+        return self._docs[:length]
+
+
+class _SemanticDedupFakeCollection:
+    """find() 按 query 形状分流：含 embedding 键的是语义候选查询，否则是摘要匹配查询。"""
+
+    def __init__(self, summary_docs, semantic_docs):
+        self._summary_docs = summary_docs
+        self._semantic_docs = semantic_docs
+        self.updated: list[tuple[dict, dict]] = []
+        self.inserted: list[dict] = []
+
+    def find(self, query, _projection):
+        if "embedding" in query:
+            return _RetainFakeCursor(self._semantic_docs)
+        return _RetainFakeCursor(self._summary_docs)
+
+    async def find_one(self, *_args, **_kwargs):
+        return {"content_storage_mode": "inline", "content_store_key": None, "source_refs": []}
+
+    async def update_one(self, query, payload):
+        self.updated.append((query, payload))
+
+    async def insert_one(self, doc):
+        self.inserted.append(doc)
+
+
+def _backend_with_collection(collection, embed_value):
+    backend = NativeMemoryBackend()
+
+    async def fake_invalidate(_user_id):
+        return None
+
+    async def fake_embed(_text):
+        return embed_value
+
+    backend._collection = collection
+    backend._invalidate_cache = fake_invalidate  # type: ignore[method-assign]
+    backend._maybe_embed = fake_embed  # type: ignore[method-assign]
+    return backend
+
+
+@pytest.mark.asyncio
+async def test_retain_merges_into_semantically_similar_memory_without_explicit_id():
+    now = datetime.now(timezone.utc)
+    existing = {
+        "memory_id": "m9",
+        "memory_type": "user",
+        "summary": "User is writing a book about React.",
+        "embedding": [1.0, 0.0, 0.0],
+        "updated_at": now,
+    }
+    collection = _SemanticDedupFakeCollection(summary_docs=[existing], semantic_docs=[existing])
+    backend = _backend_with_collection(collection, embed_value=[0.99, 0.141, 0.0])
+
+    result = await backend.retain(
+        "u1",
+        "The user has been writing a book about React patterns since 2025.",
+        context="user_identity",
+        title="Writing a React book",
+        summary="Third chapter of the book is done.",
+        tags=["react", "book"],
+    )
+
+    assert result["success"] is True
+    assert result["updated_existing"] is True
+    assert result["memory_id"] == "m9"
+    assert len(collection.updated) == 1
+    assert collection.updated[0][0] == {"user_id": "u1", "memory_id": "m9"}
+    assert not collection.inserted
+
+
+@pytest.mark.asyncio
+async def test_retain_inserts_new_memory_when_semantically_distinct():
+    now = datetime.now(timezone.utc)
+    existing = {
+        "memory_id": "m9",
+        "memory_type": "user",
+        "summary": "User is writing a book about React.",
+        "embedding": [1.0, 0.0, 0.0],
+        "updated_at": now,
+    }
+    collection = _SemanticDedupFakeCollection(summary_docs=[existing], semantic_docs=[existing])
+    backend = _backend_with_collection(collection, embed_value=[0.0, 1.0, 0.0])
+
+    result = await backend.retain(
+        "u1",
+        "The user keeps three cats and a dog at home.",
+        context="user_identity",
+        title="Pets at home",
+        summary="Has three cats and a dog.",
+        tags=["pets"],
+    )
+
+    assert result["success"] is True
+    assert "updated_existing" not in result
+    assert not collection.updated
+    assert len(collection.inserted) == 1


### PR DESCRIPTION
## 背景

生产会话 https://lambchat.com/chat/ebbcca93-d8c3-4408-bd86-da0a0812d7c5 中，LLM 两次调用 `memory_retain` 更新「用户正在申请入党」记忆均被拒（前端显示「记忆被拒绝」），错误为 `Content rejected: appears transient, noisy, or not durable enough`。

## 修复一：单个文件名提及不再被误判为代码转储

**根因**：`looks_like_code_or_path()` 的 `_CODE_MARKERS` 含裸扩展名 `.py` 等弱标记，记忆内容只要**提到**一个文件名（本例 `gen_docx.py`）就整条被拒。该过滤的本意是拦代码/报错转储，但耐久事实里提及单个文件名是合法内容。

- 强信号（`import `/`def `/`class `/`traceback`/`error:`/`git `/安装命令等）单个出现即拒，且改为大小写不敏感（补上 `Traceback`/`ERROR:` 大写漏网）
- 弱信号（`.py/.ts/.tsx/.js/.jsx`、`src/`、`node_modules`）改为正则计数，出现 ≥2 次才判为代码/路径转储；`.tsx`/`.jsx` 在 alternation 中前置避免被拆分重复计数
- ≥3 斜杠的路径转储规则保持不变

## 修复二：写时语义去重（写前先读，避免重复写入）

此前 retain 判定"更新还是新建"只靠两条路：LLM 显式传 `existing_memory_id`，或摘要字符 n-gram Jaccard（仅近 7 天 50 条）。生产案例中 LLM 第二次调用丢掉了 `existing_memory_id`，摘要措辞一变匹配即失败 → 会新建重复记忆。

- retain 现在提前计算新内容 embedding，摘要匹配失败后按余弦相似度（阈值 0.88，参考生产同一记忆召回得分 0.89）在用户既有记忆中找同一条，**自动合并更新**
- 不依赖 LLM 传任何参数；embedding 不可用时回退原有摘要匹配，行为不变
- `memory_retain` docstring 同步纠正：相似记忆是自动合并而非拒绝，并提示 LLM 写全量刷新内容（合并为整体替换）

## 验证

- TDD：新增 `tests/infra/memory/native/test_classification.py`（11 用例，含生产原文复现 + 语义匹配单测）、`test_retain.py` 增加合并/新建两个集成用例，均先 RED 后 GREEN
- 生产被拒原文复验：两条内容 `is_manual_memory_worthy` 均为 True
- `uv run pytest tests/infra/memory/` + 记忆相关用例共 191 passed；ruff / mypy 通过
