### PR TITLE
feat(pricing): 接入 models.dev 模型计价，对话与控制台展示消耗金额

### DIFF
--- a/frontend/src/components/chat/ChatMessage/__tests__/tokenCostDisplay.test.ts
+++ b/frontend/src/components/chat/ChatMessage/__tests__/tokenCostDisplay.test.ts
@@ -1,0 +1,72 @@
+// Token 费用明细行构建（纯函数）
+import type { TokenUsagePart } from "../../../types/message";
+import { buildCostDetailRows, hasPricedCost } from "../tokenCostDisplay";
+
+function usage(overrides: Partial<TokenUsagePart> = {}): TokenUsagePart {
+  return {
+    type: "token_usage",
+    input_tokens: 1_000_000,
+    output_tokens: 100_000,
+    total_tokens: 1_100_000,
+    cache_read_tokens: 200_000,
+    cache_creation_tokens: 100_000,
+    cost_usd: 0.0371,
+    cost_breakdown: {
+      input: 0.007,
+      output: 0.03,
+      cache_read: 0.0001,
+      cache_write: 0,
+      total: 0.0371,
+    },
+    cost_rates: { input: 2.5, output: 10, cache_read: 1.25, cache_write: null },
+    ...overrides,
+  };
+}
+
+describe("hasPricedCost", () => {
+  test("true when cost_usd present", () => {
+    expect(hasPricedCost(usage())).toBe(true);
+  });
+
+  test("false when unpriced or missing", () => {
+    expect(hasPricedCost(usage({ cost_usd: undefined }))).toBe(false);
+    expect(hasPricedCost(undefined)).toBe(false);
+  });
+});
+
+describe("buildCostDetailRows", () => {
+  test("billable input excludes cache tokens", () => {
+    const rows = buildCostDetailRows(usage());
+    const inputRow = rows.find((row) => row.key === "input");
+    // 1M - 200k(cache_read) - 100k(cache_creation) = 700k
+    expect(inputRow?.tokens).toBe(700_000);
+    expect(inputRow?.usd).toBeCloseTo(0.007, 10);
+    expect(inputRow?.ratePerMillion).toBe(2.5);
+  });
+
+  test("includes output row with tokens and rate", () => {
+    const rows = buildCostDetailRows(usage());
+    const outputRow = rows.find((row) => row.key === "output");
+    expect(outputRow?.tokens).toBe(100_000);
+    expect(outputRow?.usd).toBeCloseTo(0.03, 10);
+    expect(outputRow?.ratePerMillion).toBe(10);
+  });
+
+  test("omits cache rows without tokens", () => {
+    const rows = buildCostDetailRows(usage({ cache_read_tokens: 0 }));
+    expect(rows.find((row) => row.key === "cache_read")).toBeUndefined();
+  });
+
+  test("missing breakdown falls back to zero component costs", () => {
+    const rows = buildCostDetailRows(
+      usage({ cost_breakdown: undefined, cost_rates: undefined }),
+    );
+    const inputRow = rows.find((row) => row.key === "input");
+    expect(inputRow?.usd).toBe(0);
+    expect(inputRow?.ratePerMillion).toBeNull();
+  });
+
+  test("empty usage returns no rows", () => {
+    expect(buildCostDetailRows(undefined)).toEqual([]);
+  });
+});

--- a/frontend/src/components/chat/ChatMessage/__tests__/tokenCostSource.test.ts
+++ b/frontend/src/components/chat/ChatMessage/__tests__/tokenCostSource.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const frontendSrc = resolve(currentDir, "../../../..");
+
+function readJson(path: string) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+test("message action bar shows the total cost directly without opening the popover", () => {
+  const source = readFileSync(resolve(currentDir, "../index.tsx"), "utf8");
+
+  expect(source).toMatch(/hasPricedCost\(message\.tokenUsage\)/);
+  expect(source).toMatch(/formatCostUsd\(message\.tokenUsage\?\.cost_usd/);
+});
+
+test("token details popover renders a cost breakdown section", () => {
+  const source = readFileSync(resolve(currentDir, "../index.tsx"), "utf8");
+
+  expect(source).toMatch(/priced && \(/);
+  expect(source).toMatch(/costRows\.map/);
+  expect(source).toMatch(/cost_breakdown|buildCostDetailRows/);
+  expect(source).toMatch(/displayCurrency !== "USD"/);
+  expect(source).toMatch(/t\("chat\.message\.costTotal"\)/);
+});
+
+test("cost total label is available in every locale", () => {
+  for (const locale of ["en", "zh", "ja", "ko", "ru"]) {
+    const messages = readJson(
+      resolve(frontendSrc, "i18n", "locales", `${locale}.json`),
+    ).chat.message;
+
+    expect(typeof messages.costTotal).toBe("string");
+    expect(messages.costTotal.trim()).not.toBe("");
+  }
+});

--- a/frontend/src/components/chat/ChatMessage/index.tsx
+++ b/frontend/src/components/chat/ChatMessage/index.tsx
@@ -37,6 +37,13 @@ import { useAuth } from "../../../hooks/useAuth";
 import { ModelIconImg } from "../../agent/modelIcon.tsx";
 import { shouldCloseTokenDetailsPopover } from "./tokenDetailsPopoverGuards";
 import { resolveTokenUsageModelDetails } from "./tokenUsageModel";
+import { buildCostDetailRows, hasPricedCost } from "./tokenCostDisplay";
+import { useFxRates } from "../../../hooks/useFxRates";
+import {
+  formatCostUsd,
+  resolveDisplayCurrency,
+  type FxRatesDoc,
+} from "../../../utils/currency";
 import {
   shouldAllowAutoPreviewForPart,
   type AutoPreviewTarget,
@@ -79,6 +86,8 @@ function TokenDetailsButton({
   duration,
   timestamp,
   modelDetails,
+  fxRates,
+  language,
 }: {
   tokenUsage?: TokenUsagePart;
   duration?: number;
@@ -89,6 +98,8 @@ function TokenDetailsButton({
     provider?: string;
     icon?: string;
   } | null;
+  fxRates?: FxRatesDoc | null;
+  language?: string;
 }) {
   const { t } = useTranslation();
   const [showDetails, setShowDetails] = useState(false);
@@ -98,6 +109,15 @@ function TokenDetailsButton({
     tokenUsage && tokenUsage.input_tokens > 0
       ? (tokenUsage.cache_read_tokens ?? 0) / tokenUsage.input_tokens
       : null;
+  const costRows = buildCostDetailRows(tokenUsage);
+  const priced = hasPricedCost(tokenUsage);
+  const displayCurrency = resolveDisplayCurrency(language, fxRates ?? null);
+  const costRowLabels: Record<string, string> = {
+    input: t("chat.message.tokenInput"),
+    output: t("chat.message.tokenOutput"),
+    cache_read: t("chat.message.tokenCacheRead"),
+    cache_write: t("chat.message.tokenCacheCreation"),
+  };
 
   const popupStyle = useStickyDropdownPosition(
     buttonRef,
@@ -226,6 +246,40 @@ function TokenDetailsButton({
                       {tokenUsage.total_tokens?.toLocaleString()} tokens
                     </span>
                   </div>
+                  {priced && (
+                    <div className="border-t border-theme-border pt-1.5 mt-1.5 space-y-1.5">
+                      <div className="flex justify-between gap-4 text-amber-600 dark:text-amber-400">
+                        <span className="">{t("chat.message.costTotal")}</span>
+                        <span className="font-medium tabular-nums">
+                          {formatCostUsd(tokenUsage.cost_usd ?? 0, {
+                            language,
+                            rates: fxRates ?? null,
+                          })}
+                          {displayCurrency !== "USD" && (
+                            <span className="ml-1.5 text-stone-400 dark:text-stone-500 font-normal">
+                              (${(tokenUsage.cost_usd ?? 0).toFixed(4)})
+                            </span>
+                          )}
+                        </span>
+                      </div>
+                      {costRows.map((row) => (
+                        <div
+                          key={row.key}
+                          className="flex justify-between gap-4 text-stone-500 dark:text-stone-400"
+                        >
+                          <span>{costRowLabels[row.key]}</span>
+                          <span className="tabular-nums">
+                            ${row.usd.toFixed(4)}
+                            {row.ratePerMillion !== null && (
+                              <span className="ml-1 text-stone-400 dark:text-stone-500">
+                                @ ${row.ratePerMillion}/M
+                              </span>
+                            )}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
                 </>
               )}
               {duration && (
@@ -504,9 +558,10 @@ export const ChatMessage = memo(function ChatMessage({
   activeGoal,
   isFirst,
 }: ChatMessageProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { availableModels } = useSettingsContext();
   const { isAuthenticated } = useAuth();
+  const fxRates = useFxRates();
   const isUser = message.role === "user";
   const isStreaming = message.isStreaming && !message.content;
   const [copied, setCopied] = useState(false);
@@ -742,12 +797,27 @@ export const ChatMessage = memo(function ChatMessage({
             )}
             {/* Token usage statistics button */}
             {(message.tokenUsage || message.duration) && (
-              <TokenDetailsButton
-                tokenUsage={message.tokenUsage}
-                duration={message.duration}
-                timestamp={message.timestamp}
-                modelDetails={modelDetails}
-              />
+              <>
+                {hasPricedCost(message.tokenUsage) && (
+                  <span
+                    className="px-1.5 py-0.5 rounded-md text-[11px] leading-none tabular-nums text-stone-400 dark:text-stone-500"
+                    title={t("chat.message.costTotal")}
+                  >
+                    {formatCostUsd(message.tokenUsage?.cost_usd ?? 0, {
+                      language: i18n.language,
+                      rates: fxRates,
+                    })}
+                  </span>
+                )}
+                <TokenDetailsButton
+                  tokenUsage={message.tokenUsage}
+                  duration={message.duration}
+                  timestamp={message.timestamp}
+                  modelDetails={modelDetails}
+                  fxRates={fxRates}
+                  language={i18n.language}
+                />
+              </>
             )}
             {showFeedbackAndShareActions && (
               <>

--- a/frontend/src/components/chat/ChatMessage/tokenCostDisplay.ts
+++ b/frontend/src/components/chat/ChatMessage/tokenCostDisplay.ts
@@ -1,0 +1,64 @@
+// Token 费用明细行构建：把 TokenUsagePart 的金额分解为可渲染的行数据。
+import type { TokenUsagePart } from "../../../types/message";
+
+export type CostRowKey = "input" | "output" | "cache_read" | "cache_write";
+
+export interface CostDetailRow {
+  key: CostRowKey;
+  /** 该档计费 token 数 */
+  tokens: number;
+  /** 该档 USD 成本 */
+  usd: number;
+  /** 该档单价（USD / 每百万 token）；未知为 null */
+  ratePerMillion: number | null;
+}
+
+/** 是否有可展示的金额（未匹配价格的模型为 false） */
+export function hasPricedCost(usage: TokenUsagePart | undefined): boolean {
+  return typeof usage?.cost_usd === "number";
+}
+
+/**
+ * 构建费用明细行。
+ * 输入行 token 数为计费口径：input_tokens - cache_read - cache_creation。
+ */
+export function buildCostDetailRows(usage: TokenUsagePart | undefined): CostDetailRow[] {
+  if (!usage) return [];
+  const cacheRead = usage.cache_read_tokens ?? 0;
+  const cacheCreation = usage.cache_creation_tokens ?? 0;
+  const breakdown = usage.cost_breakdown;
+  const rates = usage.cost_rates;
+
+  const rows: CostDetailRow[] = [
+    {
+      key: "input",
+      tokens: Math.max(usage.input_tokens - cacheRead - cacheCreation, 0),
+      usd: breakdown?.input ?? 0,
+      ratePerMillion: rates?.input ?? null,
+    },
+    {
+      key: "output",
+      tokens: usage.output_tokens,
+      usd: breakdown?.output ?? 0,
+      ratePerMillion: rates?.output ?? null,
+    },
+  ];
+
+  if (cacheRead > 0) {
+    rows.push({
+      key: "cache_read",
+      tokens: cacheRead,
+      usd: breakdown?.cache_read ?? 0,
+      ratePerMillion: rates?.cache_read ?? null,
+    });
+  }
+  if (cacheCreation > 0) {
+    rows.push({
+      key: "cache_write",
+      tokens: cacheCreation,
+      usd: breakdown?.cache_write ?? 0,
+      ratePerMillion: rates?.cache_write ?? null,
+    });
+  }
+  return rows;
+}

--- a/frontend/src/components/panels/ModelPanel/tabs/ModelConfigTab.tsx
+++ b/frontend/src/components/panels/ModelPanel/tabs/ModelConfigTab.tsx
@@ -9,6 +9,7 @@ import {
   FileJson,
   Layers,
   ChevronDown,
+  RefreshCw,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import toast from "react-hot-toast";
@@ -18,6 +19,7 @@ import { EmptyState } from "../../../common/EmptyState";
 import { ToggleSwitch } from "../../AgentPanel/shared";
 import { ModelIconImg } from "../../../agent/modelIcon.tsx";
 import { modelApi } from "../../../../services/api";
+import { pricingApi } from "../../../../services/api/pricing";
 import type { ModelConfig } from "../../../../services/api/model";
 import { ModelFormModal } from "./ModelFormModal";
 import { BatchCreateModal } from "./BatchCreateModal";
@@ -389,6 +391,7 @@ export function ModelConfigTab({ models, onReload }: ModelConfigTabProps) {
   const [editingModel, setEditingModel] = useState<ModelConfig | null>(null);
   const [isCreating, setIsCreating] = useState(false);
   const [showBatchModal, setShowBatchModal] = useState(false);
+  const [isSyncingPrices, setIsSyncingPrices] = useState(false);
   const [batchInitialTab, setBatchInitialTab] = useState<
     "addOneByOne" | "jsonImport"
   >("addOneByOne");
@@ -572,6 +575,46 @@ export function ModelConfigTab({ models, onReload }: ModelConfigTabProps) {
               <Layers size={16} />
               <span className="hidden sm:inline">
                 {t("agentConfig.batchCreate")}
+              </span>
+            </button>
+            <button
+              onClick={async () => {
+                setIsSyncingPrices(true);
+                try {
+                  const result = await pricingApi.sync();
+                  if (result.error) {
+                    toast.error(
+                      t("agentConfig.pricingSyncPartial", {
+                        defaultValue: "同步完成（部分失败：{{error}}）",
+                        error: result.error,
+                      }),
+                    );
+                  } else {
+                    toast.success(
+                      t("agentConfig.pricingSyncSuccess", {
+                        defaultValue: "价格已同步（{{count}} 个模型）",
+                        count: result.prices.entry_count,
+                      }),
+                    );
+                  }
+                } catch (err) {
+                  toast.error(
+                    (err as Error).message ||
+                      t("agentConfig.pricingSyncFailed", "同步价格失败"),
+                  );
+                } finally {
+                  setIsSyncingPrices(false);
+                }
+              }}
+              disabled={isSyncingPrices}
+              className="flex items-center gap-1.5 px-3 py-2 text-sm rounded-lg border border-[var(--glass-border)] text-stone-700 dark:text-stone-300 hover:bg-[var(--glass-bg-subtle)] transition-colors disabled:opacity-50"
+            >
+              <RefreshCw
+                size={16}
+                className={isSyncingPrices ? "animate-spin" : ""}
+              />
+              <span className="hidden sm:inline">
+                {t("agentConfig.pricingSync", "同步价格")}
               </span>
             </button>
             <Button

--- a/frontend/src/components/panels/ModelPanel/tabs/ModelFormModal.tsx
+++ b/frontend/src/components/panels/ModelPanel/tabs/ModelFormModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Eye, EyeOff, Save, Plus, Pencil } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import toast from "react-hot-toast";
@@ -14,6 +14,8 @@ import {
 } from "../../../common";
 import { ProviderSelect } from "../../AgentPanel/shared";
 import { modelApi } from "../../../../services/api/model";
+import { pricingApi } from "../../../../services/api/pricing";
+import type { PricingLookupResponse } from "../../../../services/api/pricing";
 import type {
   ApiFormat,
   ModelConfig,
@@ -79,6 +81,45 @@ export const ModelFormModal = ({
   );
   const [showApiKey, setShowApiKey] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  const [formPriceInput, setFormPriceInput] = useState(
+    model?.pricing?.input?.toString() || "",
+  );
+  const [formPriceOutput, setFormPriceOutput] = useState(
+    model?.pricing?.output?.toString() || "",
+  );
+  const [formPriceCacheRead, setFormPriceCacheRead] = useState(
+    model?.pricing?.cache_read?.toString() || "",
+  );
+  const [formPriceCacheWrite, setFormPriceCacheWrite] = useState(
+    model?.pricing?.cache_write?.toString() || "",
+  );
+  const [priceLookup, setPriceLookup] = useState<PricingLookupResponse | null>(
+    null,
+  );
+
+  // 按模型标识查询 models.dev 匹配价格（防抖）
+  useEffect(() => {
+    const value = formValue.trim();
+    if (!value) {
+      setPriceLookup(null);
+      return;
+    }
+    let alive = true;
+    const timer = setTimeout(() => {
+      pricingApi
+        .lookup({ value, provider: formProvider || undefined })
+        .then((res) => {
+          if (alive) setPriceLookup(res);
+        })
+        .catch(() => {
+          if (alive) setPriceLookup(null);
+        });
+    }, 400);
+    return () => {
+      alive = false;
+      clearTimeout(timer);
+    };
+  }, [formValue, formProvider]);
 
   const isMaskedApiKey = (key: string) => key.includes("...") || key === "****";
 
@@ -126,6 +167,27 @@ export const ModelFormModal = ({
       return;
     }
 
+    const parsePrice = (raw: string) =>
+      raw.trim() === "" ? undefined : parseFloat(raw.trim());
+    const priceInput = parsePrice(formPriceInput);
+    const priceOutput = parsePrice(formPriceOutput);
+    const priceCacheRead = parsePrice(formPriceCacheRead);
+    const priceCacheWrite = parsePrice(formPriceCacheWrite);
+    const prices = [priceInput, priceOutput, priceCacheRead, priceCacheWrite];
+    if (prices.some((price) => price !== undefined && (isNaN(price) || price < 0))) {
+      toast.error(t("agentConfig.pricingInvalid"));
+      return;
+    }
+    const hasAnyPrice = prices.some((price) => price !== undefined);
+    const pricingOverride = hasAnyPrice
+      ? {
+          ...(priceInput !== undefined ? { input: priceInput } : {}),
+          ...(priceOutput !== undefined ? { output: priceOutput } : {}),
+          ...(priceCacheRead !== undefined ? { cache_read: priceCacheRead } : {}),
+          ...(priceCacheWrite !== undefined ? { cache_write: priceCacheWrite } : {}),
+        }
+      : undefined;
+
     setIsSaving(true);
     try {
       if (isEditing && model?.id) {
@@ -143,6 +205,8 @@ export const ModelFormModal = ({
           temperature,
           max_tokens: maxTokens,
           profile,
+          // {} 表示清除覆盖、回落 models.dev 同步价格
+          pricing: pricingOverride ?? {},
           fallback_model: formFallbackModel.trim() || undefined,
         };
         await modelApi.update(model.id, update);
@@ -161,6 +225,7 @@ export const ModelFormModal = ({
           temperature,
           max_tokens: maxTokens,
           profile,
+          ...(pricingOverride ? { pricing: pricingOverride } : {}),
           fallback_model: formFallbackModel.trim() || undefined,
           enabled: true,
         };
@@ -189,6 +254,10 @@ export const ModelFormModal = ({
     formProvider,
     formIcon,
     formFallbackModel,
+    formPriceInput,
+    formPriceOutput,
+    formPriceCacheRead,
+    formPriceCacheWrite,
     isEditing,
     model,
     t,
@@ -256,6 +325,94 @@ export const ModelFormModal = ({
             placeholder={t("agentConfig.modelLabelPlaceholder")}
             className="es-input"
           />
+        </div>
+
+        {/* Pricing override (USD / 1M tokens) */}
+        <div className="es-field">
+          <label className="es-label">
+            {t("agentConfig.pricingLabel", "价格覆盖（USD / 百万 tokens）")}
+          </label>
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <label className="es-hint mb-1 block">
+                {t("agentConfig.pricingInput", "输入")}
+              </label>
+              <Input
+                type="text"
+                inputMode="decimal"
+                value={formPriceInput}
+                onChange={(e) => setFormPriceInput(e.target.value)}
+                placeholder="2.5"
+                className="es-input"
+              />
+            </div>
+            <div>
+              <label className="es-hint mb-1 block">
+                {t("agentConfig.pricingOutput", "输出")}
+              </label>
+              <Input
+                type="text"
+                inputMode="decimal"
+                value={formPriceOutput}
+                onChange={(e) => setFormPriceOutput(e.target.value)}
+                placeholder="10"
+                className="es-input"
+              />
+            </div>
+            <div>
+              <label className="es-hint mb-1 block">
+                {t("agentConfig.pricingCacheRead", "缓存读")}
+              </label>
+              <Input
+                type="text"
+                inputMode="decimal"
+                value={formPriceCacheRead}
+                onChange={(e) => setFormPriceCacheRead(e.target.value)}
+                placeholder="1.25"
+                className="es-input"
+              />
+            </div>
+            <div>
+              <label className="es-hint mb-1 block">
+                {t("agentConfig.pricingCacheWrite", "缓存写")}
+              </label>
+              <Input
+                type="text"
+                inputMode="decimal"
+                value={formPriceCacheWrite}
+                onChange={(e) => setFormPriceCacheWrite(e.target.value)}
+                placeholder="3.75"
+                className="es-input"
+              />
+            </div>
+          </div>
+          {priceLookup?.found ? (
+            <p className="es-hint">
+              {t("agentConfig.pricingMatched", {
+                defaultValue:
+                  "models.dev 匹配：输入 ${{input}} · 输出 ${{output}}（{{match}}）",
+                input: priceLookup.rates?.input ?? "-",
+                output: priceLookup.rates?.output ?? "-",
+                match:
+                  [priceLookup.matched_provider, priceLookup.matched_model_id]
+                    .filter(Boolean)
+                    .join("/") || "-",
+              })}
+            </p>
+          ) : (
+            <p className="es-hint">
+              {t(
+                "agentConfig.pricingUnmatched",
+                "未在 models.dev 匹配到价格；留空则该模型不计算费用",
+              )}
+            </p>
+          )}
+          <p className="es-hint">
+            {t(
+              "agentConfig.pricingHint",
+              "留空档位沿用同步价格；中转站实际价格不同时可在此覆盖",
+            )}
+          </p>
         </div>
 
         {/* Advanced (collapsed) */}

--- a/frontend/src/components/panels/ModelPanel/tabs/__tests__/modelPricingSource.test.ts
+++ b/frontend/src/components/panels/ModelPanel/tabs/__tests__/modelPricingSource.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const frontendSrc = resolve(currentDir, "../../../../..");
+
+function readJson(path: string) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+test("model form exposes pricing override inputs and models.dev match hint", () => {
+  const source = readFileSync(
+    resolve(currentDir, "../ModelFormModal.tsx"),
+    "utf8",
+  );
+
+  expect(source).toMatch(/formPriceInput/);
+  expect(source).toMatch(/formPriceOutput/);
+  expect(source).toMatch(/formPriceCacheRead/);
+  expect(source).toMatch(/formPriceCacheWrite/);
+  expect(source).toMatch(/pricingApi\s*\n?\s*\.lookup/);
+  expect(source).toMatch(/pricingMatched/);
+  expect(source).toMatch(/pricingUnmatched/);
+});
+
+test("model form persists pricing override and clears it with an empty object", () => {
+  const source = readFileSync(
+    resolve(currentDir, "../ModelFormModal.tsx"),
+    "utf8",
+  );
+
+  expect(source).toMatch(/pricingOverride \?\? \{\}/);
+  expect(source).toMatch(/priceInput !== undefined/);
+});
+
+test("model config toolbar has a manual pricing sync action", () => {
+  const source = readFileSync(
+    resolve(currentDir, "../ModelConfigTab.tsx"),
+    "utf8",
+  );
+
+  expect(source).toMatch(/pricingApi\.sync\(\)/);
+  expect(source).toMatch(/agentConfig\.pricingSync/);
+});
+
+test("pricing form labels are available in every locale", () => {
+  for (const locale of ["en", "zh", "ja", "ko", "ru"]) {
+    const messages = readJson(
+      resolve(frontendSrc, "i18n", "locales", `${locale}.json`),
+    ).agentConfig;
+
+    for (const key of [
+      "pricingLabel",
+      "pricingInput",
+      "pricingOutput",
+      "pricingCacheRead",
+      "pricingCacheWrite",
+      "pricingMatched",
+      "pricingUnmatched",
+      "pricingHint",
+      "pricingInvalid",
+      "pricingSync",
+      "pricingSyncSuccess",
+      "pricingSyncFailed",
+    ]) {
+      expect(typeof messages[key]).toBe("string");
+      expect(messages[key].trim()).not.toBe("");
+    }
+  }
+});

--- a/frontend/src/components/panels/UsagePanel.tsx
+++ b/frontend/src/components/panels/UsagePanel.tsx
@@ -18,9 +18,12 @@ import {
   PieChart,
   UserRound,
   LayoutDashboard,
+  Coins,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import toast from "react-hot-toast";
+import { useFxRates } from "../../hooks/useFxRates";
+import { fmtCostUsd } from "./UsagePanel/formatters";
 import { PanelHeader } from "../common/PanelHeader";
 import { PanelFilterSelect } from "../common";
 import { Pagination } from "../common/Pagination";
@@ -59,7 +62,8 @@ function useDebounce<T>(value: T, delay: number): T {
 // ── Main Component ─────────────────────────────────────
 
 export function UsagePanel() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const fxRates = useFxRates();
   const { hasPermission } = useAuth();
   const isAdmin = hasPermission(Permission.USAGE_ADMIN);
 
@@ -251,7 +255,7 @@ export function UsagePanel() {
       {/* KPI Cards */}
       {stats && (
         <div className="mx-auto w-full px-4 pt-5 pb-4 sm:px-6 sm:pt-6 sm:pb-5 lg:px-8">
-          <div className="usage-surface grid grid-cols-2 overflow-hidden rounded-xl md:grid-cols-3 xl:grid-cols-6">
+          <div className="usage-surface grid grid-cols-2 overflow-hidden rounded-xl md:grid-cols-4 xl:grid-cols-7">
             <StatMetric
               icon={Zap}
               label={t("usage.totalRequests")}
@@ -302,6 +306,21 @@ export function UsagePanel() {
                 in: fmt(stats.total_input_tokens),
                 out: fmt(stats.total_output_tokens),
               })}
+            />
+            <StatMetric
+              icon={Coins}
+              label={t("usage.costTotal")}
+              value={fmtCostUsd(stats.total_cost_usd, true, {
+                language: i18n.language,
+                rates: fxRates,
+              })}
+              hint={
+                (stats.unpriced_requests ?? 0) > 0
+                  ? t("usage.unpricedHint", {
+                      count: fmt(stats.unpriced_requests ?? 0),
+                    })
+                  : undefined
+              }
             />
           </div>
         </div>

--- a/frontend/src/components/panels/UsagePanel/RankingCards.tsx
+++ b/frontend/src/components/panels/UsagePanel/RankingCards.tsx
@@ -1,7 +1,8 @@
 import type { LucideIcon } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { UsageRankingItem } from "../../../types/usage";
-import { fmt, fmtDur, pct } from "./formatters";
+import { useFxRates } from "../../../hooks/useFxRates";
+import { fmt, fmtDur, fmtCostUsd, pct } from "./formatters";
 
 function RankBadge({ rank }: { rank: number }) {
   if (rank > 3) return null;
@@ -48,7 +49,8 @@ export function RankingList({
   emptyLabel: string;
   showCacheMetrics?: boolean;
 }) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const fxRates = useFxRates();
   const maxTokens = Math.max(...items.map((i) => i.tokens), 1);
   return (
     <div className="usage-surface rounded-xl p-4 transition-colors duration-200 hover:border-[var(--usage-border-hover)] sm:p-5">
@@ -93,11 +95,21 @@ export function RankingList({
               <CustomProgressBar
                 percentage={Math.max(4, (item.tokens / maxTokens) * 100)}
               />
-              <div className="mt-1 flex justify-between text-[10px] text-theme-text-tertiary">
+              <div className="mt-1 flex justify-between gap-2 text-[10px] text-theme-text-tertiary">
                 <span>
                   {t("usage.ranking.countSuffix", { count: item.requests })}
                 </span>
-                <span>{fmtDur(item.duration)}</span>
+                <span className="flex shrink-0 items-center gap-2">
+                  {(item.cost_usd ?? 0) > 0 && (
+                    <span className="tabular-nums">
+                      {fmtCostUsd(item.cost_usd ?? 0, true, {
+                        language: i18n.language,
+                        rates: fxRates,
+                      })}
+                    </span>
+                  )}
+                  <span>{fmtDur(item.duration)}</span>
+                </span>
               </div>
               {showCacheMetrics && (
                 <div className="mt-1 flex flex-wrap justify-between gap-x-2 text-[10px] text-theme-text-tertiary">

--- a/frontend/src/components/panels/UsagePanel/UsageLogsTable.tsx
+++ b/frontend/src/components/panels/UsagePanel/UsageLogsTable.tsx
@@ -2,7 +2,8 @@ import { Activity, Bot, FileText, Clock } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { formatDateTimeShort } from "../../../utils/datetime";
 import type { UsageLog } from "../../../types/usage";
-import { fmt, fmtDur } from "./formatters";
+import { useFxRates } from "../../../hooks/useFxRates";
+import { fmt, fmtCostUsd, fmtDur, type CostFormatOpts } from "./formatters";
 
 function StatusPill({ status, title }: { status: string; title?: string }) {
   const { t } = useTranslation();
@@ -69,19 +70,21 @@ function DesktopTable({
   logs,
   isAdmin,
   hasAnyCache,
+  costOpts,
 }: {
   logs: UsageLog[];
   isAdmin: boolean;
   hasAnyCache: boolean;
+  costOpts: CostFormatOpts;
 }) {
   const { t } = useTranslation();
   const desktopGridTemplate = isAdmin
     ? hasAnyCache
-      ? "9.5rem 11rem minmax(8rem,.7fr) minmax(7rem,.9fr) minmax(7rem,.85fr) 5.75rem 5.75rem 5.75rem 6.25rem 5rem 5rem"
-      : "9.5rem 11rem minmax(9rem,.8fr) minmax(7rem,.9fr) minmax(7rem,.9fr) 5.75rem 5.75rem 6.25rem 5rem 5rem"
+      ? "9.5rem 11rem minmax(8rem,.7fr) minmax(7rem,.9fr) minmax(7rem,.85fr) 5.75rem 5.75rem 5.75rem 6.25rem 5.5rem 5rem 5rem"
+      : "9.5rem 11rem minmax(9rem,.8fr) minmax(7rem,.9fr) minmax(7rem,.9fr) 5.75rem 5.75rem 6.25rem 5.5rem 5rem 5rem"
     : hasAnyCache
-      ? "9.5rem minmax(9rem,.85fr) minmax(7rem,.9fr) minmax(7rem,.95fr) 5.75rem 5.75rem 5.75rem 6.25rem 5rem 5rem"
-      : "9.5rem minmax(9rem,.9fr) minmax(7rem,.9fr) minmax(7rem,1fr) 5.75rem 5.75rem 6.25rem 5rem 5rem";
+      ? "9.5rem minmax(9rem,.85fr) minmax(7rem,.9fr) minmax(7rem,.95fr) 5.75rem 5.75rem 5.75rem 6.25rem 5.5rem 5rem 5rem"
+      : "9.5rem minmax(9rem,.9fr) minmax(7rem,.9fr) minmax(7rem,1fr) 5.75rem 5.75rem 6.25rem 5.5rem 5rem 5rem";
   const headerCellClass =
     "whitespace-nowrap px-4 py-3 text-[11px] font-medium uppercase tracking-wider text-theme-text-tertiary";
   const textCellClass =
@@ -92,7 +95,7 @@ function DesktopTable({
   return (
     <div className="hidden lg:block">
       <div className="usage-surface overflow-x-auto rounded-xl">
-        <div className="min-w-[1080px]">
+        <div className="min-w-[1130px]">
           <div
             className="sticky top-0 z-10 grid border-b border-[var(--usage-border)] bg-[var(--usage-inset-bg)]/70"
             style={{ gridTemplateColumns: desktopGridTemplate }}
@@ -127,6 +130,9 @@ function DesktopTable({
             )}
             <div className={`${headerCellClass} text-right`}>
               {t("usage.total")}
+            </div>
+            <div className={`${headerCellClass} text-right`}>
+              {t("usage.cost")}
             </div>
             <div className={`${headerCellClass} text-right`}>
               {t("usage.duration")}
@@ -192,6 +198,9 @@ function DesktopTable({
                   <div className="min-w-0 whitespace-nowrap px-4 py-3 text-right text-[12px] font-semibold tabular-nums text-[var(--theme-primary)]">
                     {fmt(log.total_tokens)}
                   </div>
+                  <div className={`${numericCellClass} text-theme-text-tertiary`}>
+                    {fmtCostUsd(log.cost_usd, Boolean(log.cost_available), costOpts)}
+                  </div>
                   <div className="min-w-0 whitespace-nowrap px-4 py-3 text-right text-[12px] tabular-nums text-theme-text-tertiary">
                     {fmtDur(log.duration)}
                   </div>
@@ -210,7 +219,15 @@ function DesktopTable({
 
 // ── Tablet Row (sm → lg) ──
 
-function TabletRow({ log, isAdmin }: { log: UsageLog; isAdmin: boolean }) {
+function TabletRow({
+  log,
+  isAdmin,
+  costOpts,
+}: {
+  log: UsageLog;
+  isAdmin: boolean;
+  costOpts: CostFormatOpts;
+}) {
   const { t } = useTranslation();
   const personaOrTeam = [log.persona_preset_name, log.team_name]
     .filter(Boolean)
@@ -255,12 +272,17 @@ function TabletRow({ log, isAdmin }: { log: UsageLog; isAdmin: boolean }) {
           )}
         </div>
       </div>
-      <div className="mt-4 grid grid-cols-4 gap-2 rounded-lg bg-[var(--usage-inset-bg)] px-3 py-3 text-right">
+      <div className="mt-4 grid grid-cols-5 gap-2 rounded-lg bg-[var(--usage-inset-bg)] px-3 py-3 text-right">
         {[
           [t("usage.inTokens"), fmt(log.input_tokens), false],
           [t("usage.outTokens"), fmt(log.output_tokens), false],
           [t("usage.cache"), fmt(log.cache_read_tokens), false],
           [t("usage.total"), fmt(log.total_tokens), true],
+          [
+            t("usage.cost"),
+            fmtCostUsd(log.cost_usd, Boolean(log.cost_available), costOpts),
+            false,
+          ],
         ].map(([label, value, strong]) => (
           <div key={String(label)} className="min-w-0">
             <span className="block text-[9px] text-theme-text-tertiary">
@@ -284,7 +306,15 @@ function TabletRow({ log, isAdmin }: { log: UsageLog; isAdmin: boolean }) {
 
 // ── Mobile Card (< sm) ──
 
-function MobileCard({ log, isAdmin }: { log: UsageLog; isAdmin: boolean }) {
+function MobileCard({
+  log,
+  isAdmin,
+  costOpts,
+}: {
+  log: UsageLog;
+  isAdmin: boolean;
+  costOpts: CostFormatOpts;
+}) {
   const { t } = useTranslation();
   const ok = log.status === "completed";
   const personaOrTeam = [log.persona_preset_name, log.team_name]
@@ -334,12 +364,17 @@ function MobileCard({ log, isAdmin }: { log: UsageLog; isAdmin: boolean }) {
         </div>
 
         {/* Token metrics — segmented bar */}
-        <div className="usage-metrics-bar mt-4 grid grid-cols-4 overflow-hidden rounded-xl">
+        <div className="usage-metrics-bar mt-4 grid grid-cols-5 overflow-hidden rounded-xl">
           {[
             [t("usage.inTokens"), fmt(log.input_tokens), false],
             [t("usage.outTokens"), fmt(log.output_tokens), false],
             [t("usage.cacheRead"), fmt(log.cache_read_tokens), false],
             [t("usage.totalTokens"), fmt(log.total_tokens), true],
+            [
+              t("usage.cost"),
+              fmtCostUsd(log.cost_usd, Boolean(log.cost_available), costOpts),
+              false,
+            ],
           ].map(([label, value, strong], i) => (
             <div
               key={String(label)}
@@ -409,7 +444,9 @@ export function UsageLogsTable({
   isAdmin: boolean;
   hasAnyCache: boolean;
 }) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const fxRates = useFxRates();
+  const costOpts: CostFormatOpts = { language: i18n.language, rates: fxRates };
 
   if (logs.length === 0) {
     return (
@@ -438,13 +475,23 @@ export function UsageLogsTable({
       />
 
       {/* Desktop table */}
-      <DesktopTable logs={logs} isAdmin={isAdmin} hasAnyCache={hasAnyCache} />
+      <DesktopTable
+        logs={logs}
+        isAdmin={isAdmin}
+        hasAnyCache={hasAnyCache}
+        costOpts={costOpts}
+      />
 
       {/* Tablet rows */}
       <div className="hidden sm:block lg:hidden">
         <div className="space-y-4">
           {logs.map((log) => (
-            <TabletRow key={log.trace_id} log={log} isAdmin={isAdmin} />
+            <TabletRow
+              key={log.trace_id}
+              log={log}
+              isAdmin={isAdmin}
+              costOpts={costOpts}
+            />
           ))}
         </div>
       </div>
@@ -452,7 +499,12 @@ export function UsageLogsTable({
       {/* Mobile cards */}
       <div className="space-y-4 pb-5 sm:hidden">
         {logs.map((log) => (
-          <MobileCard key={log.trace_id} log={log} isAdmin={isAdmin} />
+          <MobileCard
+            key={log.trace_id}
+            log={log}
+            isAdmin={isAdmin}
+            costOpts={costOpts}
+          />
         ))}
       </div>
     </>

--- a/frontend/src/components/panels/UsagePanel/__tests__/formatters.test.ts
+++ b/frontend/src/components/panels/UsagePanel/__tests__/formatters.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { fmt, pct, precise } from "../formatters";
+import { fmt, fmtCostUsd, pct, precise } from "../formatters";
 
 describe("fmt number abbreviation", () => {
   test("keeps plain numbers below 1K", () => {
@@ -41,5 +41,26 @@ describe("precise", () => {
   test("trims trailing zero", () => {
     expect(precise(1.04)).toBe("1");
     expect(precise(1.06)).toBe("1.1");
+  });
+});
+
+describe("fmtCostUsd", () => {
+  test("formats priced log cost in display currency", () => {
+    expect(fmtCostUsd(0.0246, true, { language: "en" })).toBe("$0.0246");
+    expect(
+      fmtCostUsd(0.05, true, {
+        language: "zh",
+        rates: { base: "USD", rates: { CNY: 7.1 }, synced_at: null },
+      }),
+    ).toContain("0.355");
+  });
+
+  test("unpriced log shows dash placeholder", () => {
+    expect(fmtCostUsd(0, false, { language: "en" })).toBe("—");
+    expect(fmtCostUsd(undefined, false, { language: "en" })).toBe("—");
+  });
+
+  test("priced log with missing amount formats zero", () => {
+    expect(fmtCostUsd(undefined, true, { language: "en" })).toBe("$0.00");
   });
 });

--- a/frontend/src/components/panels/UsagePanel/__tests__/usageCostSource.test.ts
+++ b/frontend/src/components/panels/UsagePanel/__tests__/usageCostSource.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const frontendSrc = resolve(currentDir, "../../../..");
+
+function readJson(path: string) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+test("usage panel shows a total cost KPI card", () => {
+  const source = readFileSync(
+    resolve(currentDir, "../../UsagePanel.tsx"),
+    "utf8",
+  );
+
+  expect(source).toMatch(/usage\.costTotal/);
+  expect(source).toMatch(/stats\.total_cost_usd/);
+  expect(source).toMatch(/stats\.unpriced_requests/);
+});
+
+test("usage log table renders a cost column across desktop, tablet and mobile", () => {
+  const source = readFileSync(
+    resolve(currentDir, "../UsageLogsTable.tsx"),
+    "utf8",
+  );
+
+  expect(source).toMatch(/usage\.cost/);
+  expect(source).toMatch(/fmtCostUsd\(log\.cost_usd, Boolean\(log\.cost_available\)/);
+  // 桌面网格、平板行、移动卡三处都要渲染费用
+  expect(source.match(/fmtCostUsd\(log\.cost_usd/g)?.length).toBeGreaterThanOrEqual(3);
+});
+
+test("ranking rows show per-model cost", () => {
+  const source = readFileSync(
+    resolve(currentDir, "../RankingCards.tsx"),
+    "utf8",
+  );
+
+  expect(source).toMatch(/item\.cost_usd \?\? 0/);
+});
+
+test("usage cost labels are available in every locale", () => {
+  for (const locale of ["en", "zh", "ja", "ko", "ru"]) {
+    const messages = readJson(
+      resolve(frontendSrc, "i18n", "locales", `${locale}.json`),
+    ).usage;
+
+    for (const key of ["cost", "costTotal", "unpricedHint"]) {
+      expect(typeof messages[key]).toBe("string");
+      expect(messages[key].trim()).not.toBe("");
+    }
+  }
+});

--- a/frontend/src/components/panels/UsagePanel/formatters.ts
+++ b/frontend/src/components/panels/UsagePanel/formatters.ts
@@ -1,4 +1,5 @@
 import { formatDuration } from "../../../utils/datetime";
+import { formatCostUsd, type FxRatesDoc } from "../../../utils/currency";
 import type { UsageDailyPoint } from "../../../types/usage";
 
 export function fmt(n: number): string {
@@ -68,4 +69,19 @@ export function normalizeTrendPoints(
     );
   }
   return result;
+}
+
+export interface CostFormatOpts {
+  language?: string;
+  rates?: FxRatesDoc | null;
+}
+
+/** 用量日志成本展示：未计价显示占位符，已计价按展示货币格式化 */
+export function fmtCostUsd(
+  usd: number | undefined,
+  available: boolean,
+  opts: CostFormatOpts,
+): string {
+  if (!available) return "—";
+  return formatCostUsd(usd ?? 0, opts);
 }

--- a/frontend/src/components/panels/__tests__/rankingCardsCacheMetrics.test.tsx
+++ b/frontend/src/components/panels/__tests__/rankingCardsCacheMetrics.test.tsx
@@ -10,7 +10,9 @@ vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string, options?: { count?: number; n?: number }) =>
       options?.count ?? options?.n ?? key,
+    i18n: { language: "en" },
   }),
+  initReactI18next: { type: "3rdParty", init: () => {} },
 }));
 
 const modelItem = {

--- a/frontend/src/components/panels/__tests__/usagePanelPresentationSource.test.ts
+++ b/frontend/src/components/panels/__tests__/usagePanelPresentationSource.test.ts
@@ -46,7 +46,7 @@ test("usage admin and read views present different dashboard context", () => {
 test("usage table keeps admin-only user column and aligned numeric columns", () => {
   expect(usageTableSource).toMatch(/gridTemplateColumns: desktopGridTemplate/);
   expect(usageTableSource).toMatch(/desktopGridTemplate = isAdmin/);
-  expect(usageTableSource).toMatch(/min-w-\[1080px\]/);
+  expect(usageTableSource).toMatch(/min-w-\[1130px\]/);
   expect(usageTableSource).toMatch(/minmax\(8rem,\.7fr\)|minmax\(9rem,\.8fr\)/);
   expect(usageTableSource).toMatch(/usage\.roleOrTeam/);
   expect(usageTableSource).toMatch(/personaOrTeam/);

--- a/frontend/src/hooks/useAgent/__tests__/eventProcessorTokenCost.test.ts
+++ b/frontend/src/hooks/useAgent/__tests__/eventProcessorTokenCost.test.ts
@@ -1,0 +1,75 @@
+// token:usage 事件 → TokenUsagePart 的金额字段透传（实时与历史共用此处理器）
+import { processMessageEvent } from "../eventProcessor.ts";
+
+test("token:usage carries cost fields through to the message part", () => {
+  const result = processMessageEvent(
+    "token:usage",
+    {
+      input_tokens: 1000,
+      output_tokens: 500,
+      total_tokens: 1500,
+      cache_read_tokens: 200,
+      model_id: "model-1",
+      model: "openai/gpt-4o",
+      cost_usd: 0.0246,
+      cost_breakdown: {
+        input: 0.002,
+        output: 0.005,
+        cache_read: 0.0002,
+        cache_write: 0,
+        total: 0.0246,
+      },
+      cost_rates: { input: 2.5, output: 10, cache_read: 1.25, cache_write: null },
+    },
+    [],
+    "",
+    [],
+    0,
+    [],
+    false,
+    "message-1",
+  );
+
+  expect(result.tokenUsage).toEqual({
+    type: "token_usage",
+    input_tokens: 1000,
+    output_tokens: 500,
+    total_tokens: 1500,
+    cache_creation_tokens: 0,
+    cache_read_tokens: 200,
+    model_id: "model-1",
+    model: "openai/gpt-4o",
+    cost_usd: 0.0246,
+    cost_breakdown: {
+      input: 0.002,
+      output: 0.005,
+      cache_read: 0.0002,
+      cache_write: 0,
+      total: 0.0246,
+    },
+    cost_rates: { input: 2.5, output: 10, cache_read: 1.25, cache_write: null },
+  });
+});
+
+test("token:usage without pricing keeps cost fields undefined", () => {
+  const result = processMessageEvent(
+    "token:usage",
+    {
+      input_tokens: 10,
+      output_tokens: 5,
+      total_tokens: 15,
+      model: "mystery",
+    },
+    [],
+    "",
+    [],
+    0,
+    [],
+    false,
+    "message-1",
+  );
+
+  expect(result.tokenUsage?.cost_usd).toBeUndefined();
+  expect(result.tokenUsage?.cost_breakdown).toBeUndefined();
+  expect(result.tokenUsage?.cost_rates).toBeUndefined();
+});

--- a/frontend/src/hooks/useAgent/eventProcessor.ts
+++ b/frontend/src/hooks/useAgent/eventProcessor.ts
@@ -460,6 +460,9 @@ export function processMessageEvent(
         cache_read_tokens: data.cache_read_tokens || 0,
         model_id: data.model_id,
         model: data.model,
+        cost_usd: data.cost_usd,
+        cost_breakdown: data.cost_breakdown,
+        cost_rates: data.cost_rates,
       };
       if (data.duration) result.duration = data.duration * 1000;
       break;

--- a/frontend/src/hooks/useAgent/types.ts
+++ b/frontend/src/hooks/useAgent/types.ts
@@ -87,6 +87,20 @@ export interface EventData {
   cache_read_tokens?: number;
   model_id?: string;
   model?: string;
+  cost_usd?: number;
+  cost_breakdown?: {
+    input: number;
+    output: number;
+    cache_read: number;
+    cache_write: number;
+    total: number;
+  };
+  cost_rates?: {
+    input: number | null;
+    output: number | null;
+    cache_read: number | null;
+    cache_write: number | null;
+  };
   // user:message event fields
   message_id?: string;
   enabled_skills?: string[];

--- a/frontend/src/hooks/useFxRates.ts
+++ b/frontend/src/hooks/useFxRates.ts
@@ -1,0 +1,24 @@
+// USD → 本地货币换算汇率（模块级缓存，30 分钟 TTL，失败回落 USD）
+import { useEffect, useState } from "react";
+import { getFxRates } from "../services/api/pricing";
+import type { FxRatesDoc } from "../utils/currency";
+
+export function useFxRates(): FxRatesDoc | null {
+  const [rates, setRates] = useState<FxRatesDoc | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    getFxRates()
+      .then((doc) => {
+        if (alive && doc) {
+          setRates({ base: doc.base, rates: doc.rates, synced_at: doc.synced_at });
+        }
+      })
+      .catch(() => null);
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  return rates;
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -211,7 +211,20 @@
     "tempTag": "temp: {{value}}",
     "temperature": "Temperature",
     "title": "Agent Configuration",
-    "valueAndLabelRequired": "Value and Label are required"
+    "valueAndLabelRequired": "Value and Label are required",
+    "pricingLabel": "Price override (USD / 1M tokens)",
+    "pricingInput": "Input",
+    "pricingOutput": "Output",
+    "pricingCacheRead": "Cache read",
+    "pricingCacheWrite": "Cache write",
+    "pricingMatched": "models.dev match: input ${{input}} · output ${{output}} ({{match}})",
+    "pricingUnmatched": "No models.dev match; leave empty to skip cost tracking",
+    "pricingHint": "Empty fields follow synced prices; override for relays with different pricing",
+    "pricingInvalid": "Prices must be non-negative numbers",
+    "pricingSync": "Sync prices",
+    "pricingSyncSuccess": "Prices synced ({{count}} models)",
+    "pricingSyncPartial": "Sync finished (partial failure: {{error}})",
+    "pricingSyncFailed": "Failed to sync prices"
   },
   "agentOptions": {
     "enableCodeInterpreter": {
@@ -773,7 +786,8 @@
       "toolTransferPath": "Transfer Path",
       "toolUploadUrlToSandbox": "Upload URL To Sandbox",
       "toolVarCount": "{{count}} variables",
-      "toolWrite": "Write"
+      "toolWrite": "Write",
+      "costTotal": "Cost"
     },
     "messageInput": "Message",
     "noPermission": "No permission to send messages",
@@ -3147,7 +3161,10 @@
       "title": "Daily Execution Trend",
       "tokens": "Tokens"
     },
-    "user": "User"
+    "user": "User",
+    "cost": "Cost",
+    "costTotal": "Total cost",
+    "unpricedHint": "{{count}} unpriced"
   },
   "users": {
     "actions": "Actions",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -211,7 +211,20 @@
     "tempTag": "温度: {{value}}",
     "temperature": "温度",
     "title": "エージェント設定",
-    "valueAndLabelRequired": "値とラベルは必須です"
+    "valueAndLabelRequired": "値とラベルは必須です",
+    "pricingLabel": "価格オーバーライド（USD / 100万トークン）",
+    "pricingInput": "入力",
+    "pricingOutput": "出力",
+    "pricingCacheRead": "キャッシュ読み取り",
+    "pricingCacheWrite": "キャッシュ書き込み",
+    "pricingMatched": "models.dev 一致：入力 ${{input}} · 出力 ${{output}}（{{match}}）",
+    "pricingUnmatched": "models.dev に一致なし。空欄の場合は費用計算されません",
+    "pricingHint": "空欄は同期価格に従います。リレー価格が異なる場合は上書きできます",
+    "pricingInvalid": "価格は 0 以上の数値で入力してください",
+    "pricingSync": "価格を同期",
+    "pricingSyncSuccess": "価格を同期しました（{{count}} モデル）",
+    "pricingSyncPartial": "同期完了（一部失敗：{{error}}）",
+    "pricingSyncFailed": "価格の同期に失敗しました"
   },
   "agentOptions": {
     "enableCodeInterpreter": {
@@ -773,7 +786,8 @@
       "toolTransferPath": "ディレクトリ転送",
       "toolUploadUrlToSandbox": "URLをサンドボックスへアップロード",
       "toolVarCount": "{{count}} 個の変数",
-      "toolWrite": "書込"
+      "toolWrite": "書込",
+      "costTotal": "費用"
     },
     "messageInput": "メッセージ入力",
     "noPermission": "メッセージを送信する権限がありません",
@@ -3147,7 +3161,10 @@
       "title": "日次実行トレンド",
       "tokens": "Tokens"
     },
-    "user": "ユーザー"
+    "user": "ユーザー",
+    "cost": "費用",
+    "costTotal": "合計費用",
+    "unpricedHint": "{{count}} 件は未計価"
   },
   "users": {
     "actions": "操作",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -211,7 +211,20 @@
     "tempTag": "온도: {{value}}",
     "temperature": "온도",
     "title": "에이전트 구성",
-    "valueAndLabelRequired": "값과 라벨은 필수입니다"
+    "valueAndLabelRequired": "값과 라벨은 필수입니다",
+    "pricingLabel": "가격 재정의 (USD / 100만 토큰)",
+    "pricingInput": "입력",
+    "pricingOutput": "출력",
+    "pricingCacheRead": "캐시 읽기",
+    "pricingCacheWrite": "캐시 쓰기",
+    "pricingMatched": "models.dev 일치: 입력 ${{input}} · 출력 ${{output}} ({{match}})",
+    "pricingUnmatched": "models.dev 일치 없음. 비워 두면 비용이 계산되지 않습니다",
+    "pricingHint": "빈 칸은 동기화 가격을 따릅니다. 리레이 가격이 다르면 재정의하세요",
+    "pricingInvalid": "가격은 0 이상의 숫자여야 합니다",
+    "pricingSync": "가격 동기화",
+    "pricingSyncSuccess": "가격 동기화 완료 ({{count}}개 모델)",
+    "pricingSyncPartial": "동기화 완료 (일부 실패: {{error}})",
+    "pricingSyncFailed": "가격 동기화 실패"
   },
   "agentOptions": {
     "enableCodeInterpreter": {
@@ -773,7 +786,8 @@
       "toolTransferPath": "경로 전송",
       "toolUploadUrlToSandbox": "URL을 샌드박스로 업로드",
       "toolVarCount": "{{count}}개 변수",
-      "toolWrite": "쓰기"
+      "toolWrite": "쓰기",
+      "costTotal": "비용"
     },
     "messageInput": "메시지 입력",
     "noPermission": "메시지를 보낼 권한이 없습니다",
@@ -3147,7 +3161,10 @@
       "title": "일일 실행 트렌드",
       "tokens": "Tokens"
     },
-    "user": "사용자"
+    "user": "사용자",
+    "cost": "비용",
+    "costTotal": "총 비용",
+    "unpricedHint": "{{count}}건 가격 미매칭"
   },
   "users": {
     "actions": "작업",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -211,7 +211,20 @@
     "tempTag": "темп: {{value}}",
     "temperature": "Температура",
     "title": "Конфигурация агентов",
-    "valueAndLabelRequired": "Значение и метка обязательны"
+    "valueAndLabelRequired": "Значение и метка обязательны",
+    "pricingLabel": "Переопределение цен (USD / 1 млн токенов)",
+    "pricingInput": "Ввод",
+    "pricingOutput": "Вывод",
+    "pricingCacheRead": "Чтение кэша",
+    "pricingCacheWrite": "Запись кэша",
+    "pricingMatched": "Совпадение models.dev: ввод ${{input}} · вывод ${{output}} ({{match}})",
+    "pricingUnmatched": "Нет совпадения в models.dev; оставьте пустым, чтобы не считать стоимость",
+    "pricingHint": "Пустые поля берутся из синхронизированных цен; переопределяйте для реле с другими ценами",
+    "pricingInvalid": "Цены должны быть неотрицательными числами",
+    "pricingSync": "Синхронизировать цены",
+    "pricingSyncSuccess": "Цены синхронизированы ({{count}} моделей)",
+    "pricingSyncPartial": "Синхронизация завершена (частичная ошибка: {{error}})",
+    "pricingSyncFailed": "Не удалось синхронизировать цены"
   },
   "agentOptions": {
     "enableCodeInterpreter": {
@@ -773,7 +786,8 @@
       "toolTransferPath": "Перенести путь",
       "toolUploadUrlToSandbox": "Загрузить URL в песочницу",
       "toolVarCount": "{{count}} переменных",
-      "toolWrite": "Запись"
+      "toolWrite": "Запись",
+      "costTotal": "Стоимость"
     },
     "messageInput": "Поле ввода сообщения",
     "noPermission": "Нет прав для отправки сообщений",
@@ -3147,7 +3161,10 @@
       "title": "Тренд ежедневных выполнений",
       "tokens": "Tokens"
     },
-    "user": "Пользователь"
+    "user": "Пользователь",
+    "cost": "Стоимость",
+    "costTotal": "Общая стоимость",
+    "unpricedHint": "{{count}} без цены"
   },
   "users": {
     "actions": "Действия",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -211,7 +211,20 @@
     "tempTag": "温度: {{value}}",
     "temperature": "温度",
     "title": "助手配置",
-    "valueAndLabelRequired": "值和标签为必填项"
+    "valueAndLabelRequired": "值和标签为必填项",
+    "pricingLabel": "价格覆盖（USD / 百万 tokens）",
+    "pricingInput": "输入",
+    "pricingOutput": "输出",
+    "pricingCacheRead": "缓存读",
+    "pricingCacheWrite": "缓存写",
+    "pricingMatched": "models.dev 匹配：输入 ${{input}} · 输出 ${{output}}（{{match}}）",
+    "pricingUnmatched": "未在 models.dev 匹配到价格；留空则该模型不计算费用",
+    "pricingHint": "留空档位沿用同步价格；中转站实际价格不同时可在此覆盖",
+    "pricingInvalid": "价格必须是非负数字",
+    "pricingSync": "同步价格",
+    "pricingSyncSuccess": "价格已同步（{{count}} 个模型）",
+    "pricingSyncPartial": "同步完成（部分失败：{{error}}）",
+    "pricingSyncFailed": "同步价格失败"
   },
   "agentOptions": {
     "enableCodeInterpreter": {
@@ -773,7 +786,8 @@
       "toolTransferPath": "传输目录",
       "toolUploadUrlToSandbox": "上传 URL 到沙箱",
       "toolVarCount": "{{count}} 个变量",
-      "toolWrite": "写入"
+      "toolWrite": "写入",
+      "costTotal": "费用"
     },
     "messageInput": "消息输入框",
     "noPermission": "没有发送消息的权限",
@@ -3147,7 +3161,10 @@
       "title": "每日执行趋势",
       "tokens": "Tokens"
     },
-    "user": "用户"
+    "user": "用户",
+    "cost": "费用",
+    "costTotal": "总费用",
+    "unpricedHint": "{{count}} 次未计价"
   },
   "users": {
     "actions": "操作",

--- a/frontend/src/services/api/model.ts
+++ b/frontend/src/services/api/model.ts
@@ -89,6 +89,14 @@ export interface ModelOption {
   supports_thinking?: boolean;
 }
 
+export interface ModelPricingOverride {
+  /** USD / 每百万 token；未填档位沿用 models.dev 同步价格 */
+  input?: number;
+  output?: number;
+  cache_read?: number;
+  cache_write?: number;
+}
+
 export interface ModelConfig {
   id?: string;
   value: string;
@@ -103,6 +111,7 @@ export interface ModelConfig {
   temperature?: number;
   max_tokens?: number;
   profile?: ModelProfile;
+  pricing?: ModelPricingOverride | null;
   fallback_model?: string;
   enabled: boolean;
   order: number;
@@ -123,6 +132,7 @@ export interface ModelConfigCreate {
   temperature?: number;
   max_tokens?: number;
   profile?: ModelProfile;
+  pricing?: ModelPricingOverride | null;
   fallback_model?: string;
   enabled?: boolean;
   order?: number;
@@ -142,6 +152,8 @@ export interface ModelConfigUpdate {
   temperature?: number;
   max_tokens?: number;
   profile?: ModelProfile;
+  /** {} clears the override back to the models.dev synced price */
+  pricing?: ModelPricingOverride | null;
   fallback_model?: string;
   enabled?: boolean;
   order?: number;

--- a/frontend/src/services/api/pricing.ts
+++ b/frontend/src/services/api/pricing.ts
@@ -1,0 +1,92 @@
+/**
+ * Pricing API - 模型价格与 USD 汇率
+ *
+ * 汇率表由组件按需拉取，模块内缓存 30 分钟（后端本身 24h 同步一次）；
+ * 拉取失败返回 null，调用方回落 USD 展示。
+ */
+
+import { API_BASE } from "./config";
+import { authFetch } from "./fetch";
+
+export interface FxRatesResponse {
+  base: string;
+  rates: Record<string, number>;
+  synced_at: string | null;
+}
+
+export interface PricingLookupResponse {
+  found: boolean;
+  source: string;
+  rates: Record<string, number | null> | null;
+  matched_provider: string;
+  matched_model_id: string;
+}
+
+export interface PricingStatusResponse {
+  prices: { entry_count: number; source_url: string; synced_at: string | null };
+  fx: { base: string; rate_count: number; synced_at: string | null };
+}
+
+export interface PricingSyncResponse extends PricingStatusResponse {
+  refreshed: boolean;
+  error: string | null;
+}
+
+const FX_CACHE_TTL_MS = 30 * 60 * 1000;
+
+let fxCache: { doc: FxRatesResponse | null; at: number } | null = null;
+let fxInflight: Promise<FxRatesResponse | null> | null = null;
+
+/** 获取 USD 基准汇率表（带缓存；失败返回 null） */
+export async function getFxRates(force = false): Promise<FxRatesResponse | null> {
+  const now = Date.now();
+  if (!force && fxCache && now - fxCache.at < FX_CACHE_TTL_MS) {
+    return fxCache.doc;
+  }
+  if (!force && fxInflight) return fxInflight;
+
+  fxInflight = authFetch<FxRatesResponse>(`${API_BASE}/api/pricing/rates`)
+    .then((doc) => {
+      fxCache = { doc, at: Date.now() };
+      return doc;
+    })
+    .catch(() => {
+      // 失败保留旧缓存（若有），调用方回落 USD
+      if (fxCache) fxCache = { doc: fxCache.doc, at: Date.now() };
+      return fxCache?.doc ?? null;
+    })
+    .finally(() => {
+      fxInflight = null;
+    });
+  return fxInflight;
+}
+
+export const pricingApi = {
+  /** 管理员：手动同步 models.dev 价格 + 汇率 */
+  async sync(): Promise<PricingSyncResponse> {
+    const doc = await authFetch<PricingSyncResponse>(`${API_BASE}/api/pricing/sync`, {
+      method: "POST",
+    });
+    void getFxRates(true).catch(() => null);
+    return doc;
+  },
+
+  /** 管理员：同步状态 */
+  async status(): Promise<PricingStatusResponse> {
+    return authFetch<PricingStatusResponse>(`${API_BASE}/api/pricing/status`);
+  },
+
+  /** 管理员：按模型标识查询单价 */
+  async lookup(params: {
+    value: string;
+    provider?: string;
+    model_id?: string;
+  }): Promise<PricingLookupResponse> {
+    const searchParams = new URLSearchParams({ value: params.value });
+    if (params.provider) searchParams.append("provider", params.provider);
+    if (params.model_id) searchParams.append("model_id", params.model_id);
+    return authFetch<PricingLookupResponse>(
+      `${API_BASE}/api/pricing/lookup?${searchParams.toString()}`,
+    );
+  },
+};

--- a/frontend/src/types/message.ts
+++ b/frontend/src/types/message.ts
@@ -70,6 +70,22 @@ export interface TokenUsagePart {
   cache_read_tokens?: number;
   model_id?: string;
   model?: string;
+  // USD 金额（models.dev 计价；undefined 表示该模型未匹配到价格）
+  cost_usd?: number;
+  cost_breakdown?: {
+    input: number;
+    output: number;
+    cache_read: number;
+    cache_write: number;
+    total: number;
+  };
+  // 计价所用单价（USD / 每百万 token）
+  cost_rates?: {
+    input: number | null;
+    output: number | null;
+    cache_read: number | null;
+    cache_write: number | null;
+  };
 }
 
 // 取消状态块类型

--- a/frontend/src/types/usage.ts
+++ b/frontend/src/types/usage.ts
@@ -22,6 +22,8 @@ export interface UsageLog {
   total_tokens: number;
   cache_creation_tokens: number;
   cache_read_tokens: number;
+  cost_usd?: number;
+  cost_available?: boolean;
   duration: number;
   started_at: string | null;
   completed_at: string | null;
@@ -39,6 +41,8 @@ export interface UsageStats {
   total_tokens: number;
   total_cache_creation_tokens: number;
   total_cache_read_tokens: number;
+  total_cost_usd?: number;
+  unpriced_requests?: number;
   total_duration: number;
 }
 
@@ -54,6 +58,8 @@ export interface UsageDashboardSummary {
   total_input_tokens: number;
   total_output_tokens: number;
   total_cache_read_tokens: number;
+  total_cost_usd?: number;
+  unpriced_requests?: number;
   total_duration: number;
   total_tool_calls: number;
   scheduled_runs: number;
@@ -72,6 +78,7 @@ export interface UsageDailyPoint {
   date: string;
   requests: number;
   tokens: number;
+  cost_usd?: number;
   duration: number;
   scheduled_runs: number;
   failed_requests: number;
@@ -83,6 +90,7 @@ export interface UsageRankingItem {
   name: string;
   requests: number;
   tokens: number;
+  cost_usd?: number;
   duration: number;
   input_tokens: number;
   cache_creation_tokens: number;

--- a/frontend/src/utils/__tests__/currency.test.ts
+++ b/frontend/src/utils/__tests__/currency.test.ts
@@ -1,0 +1,85 @@
+// USD 底层计价 → 按语言/地区换算展示货币
+import {
+  LOCALE_CURRENCY_MAP,
+  convertUsdToCurrency,
+  formatCostUsd,
+  getUsdRate,
+  resolveDisplayCurrency,
+} from "../currency";
+
+const rates = { base: "USD", rates: { USD: 1, CNY: 7.1, JPY: 150, KRW: 1350, RUB: 92 }, synced_at: null };
+
+describe("resolveDisplayCurrency", () => {
+  test("maps app language to local currency", () => {
+    expect(resolveDisplayCurrency("zh-CN", rates)).toBe("CNY");
+    expect(resolveDisplayCurrency("zh", rates)).toBe("CNY");
+    expect(resolveDisplayCurrency("ja", rates)).toBe("JPY");
+    expect(resolveDisplayCurrency("ko", rates)).toBe("KRW");
+    expect(resolveDisplayCurrency("ru", rates)).toBe("RUB");
+    expect(resolveDisplayCurrency("en-US", rates)).toBe("USD");
+  });
+
+  test("falls back to USD when rates are unavailable for the currency", () => {
+    expect(resolveDisplayCurrency("zh", null)).toBe("USD");
+    expect(resolveDisplayCurrency("zh", { base: "USD", rates: { USD: 1 }, synced_at: null })).toBe("USD");
+  });
+
+  test("unknown language falls back to USD", () => {
+    expect(resolveDisplayCurrency("fr", rates)).toBe("USD");
+    expect(resolveDisplayCurrency(undefined, rates)).toBe("USD");
+  });
+});
+
+describe("getUsdRate / convertUsdToCurrency", () => {
+  test("USD rate is always 1", () => {
+    expect(getUsdRate("USD", null)).toBe(1);
+  });
+
+  test("converts using the rate table", () => {
+    expect(convertUsdToCurrency(2, "CNY", rates)).toBeCloseTo(14.2, 10);
+  });
+
+  test("returns null when currency rate is missing", () => {
+    expect(convertUsdToCurrency(2, "CNY", null)).toBeNull();
+    expect(convertUsdToCurrency(2, "CNY", { base: "USD", rates: { USD: 1 }, synced_at: null })).toBeNull();
+  });
+});
+
+describe("formatCostUsd", () => {
+  test("formats USD with 2 decimals for normal amounts", () => {
+    expect(formatCostUsd(12.3456, { language: "en" })).toBe("$12.35");
+  });
+
+  test("keeps more precision for tiny amounts", () => {
+    expect(formatCostUsd(0.0123, { language: "en" })).toBe("$0.0123");
+    expect(formatCostUsd(0.000123, { language: "en" })).toBe("$0.000123");
+  });
+
+  test("zero and free models still format", () => {
+    expect(formatCostUsd(0, { language: "en" })).toBe("$0.00");
+  });
+
+  test("converts to local currency with symbol", () => {
+    const out = formatCostUsd(0.05, { language: "zh", rates });
+    expect(out).toContain("0.355");
+    expect(out).toContain("¥");
+  });
+
+  test("falls back to USD when rate unavailable", () => {
+    // zh locale 下 USD 显示为 US$（ICU locale 行为）
+    expect(formatCostUsd(1, { language: "zh", rates: null })).toContain("1.00");
+  });
+
+  test("KRW large magnitude formats with 2 decimals", () => {
+    const out = formatCostUsd(2, { language: "ko", rates });
+    expect(out).toContain("2,700");
+  });
+});
+
+describe("LOCALE_CURRENCY_MAP", () => {
+  test("covers every supported app locale", () => {
+    for (const locale of ["zh", "en", "ja", "ko", "ru"]) {
+      expect(LOCALE_CURRENCY_MAP[locale]).toBeTruthy();
+    }
+  });
+});

--- a/frontend/src/utils/currency.ts
+++ b/frontend/src/utils/currency.ts
@@ -1,0 +1,88 @@
+// USD 底层计价 → 展示货币换算。
+// 底层（事件、usage_logs、聚合）统一存 USD；展示时按应用语言映射本地货币，
+// 汇率来自后端 /api/pricing/sync 同步的 USD 基准表；汇率不可用时回落 USD。
+
+export interface FxRatesDoc {
+  base: string;
+  rates: Record<string, number>;
+  synced_at: string | null;
+}
+
+/** 应用语言 → 默认展示货币 */
+export const LOCALE_CURRENCY_MAP: Record<string, string> = {
+  zh: "CNY",
+  en: "USD",
+  ja: "JPY",
+  ko: "KRW",
+  ru: "RUB",
+};
+
+const LOCALE_TAG: Record<string, string> = {
+  zh: "zh-CN",
+  en: "en-US",
+  ja: "ja-JP",
+  ko: "ko-KR",
+  ru: "ru-RU",
+};
+
+export function resolveDisplayCurrency(
+  language: string | undefined,
+  rates: FxRatesDoc | null,
+): string {
+  const primary = (language || "").toLowerCase().split(/[-_]/)[0];
+  const currency = LOCALE_CURRENCY_MAP[primary] || "USD";
+  if (currency === "USD") return "USD";
+  const rate = rates?.rates?.[currency];
+  return typeof rate === "number" && rate > 0 ? currency : "USD";
+}
+
+export function getUsdRate(currency: string, rates: FxRatesDoc | null): number | null {
+  if (currency === "USD") return 1;
+  const rate = rates?.rates?.[currency];
+  return typeof rate === "number" && rate > 0 ? rate : null;
+}
+
+export function convertUsdToCurrency(
+  usd: number,
+  currency: string,
+  rates: FxRatesDoc | null,
+): number | null {
+  const rate = getUsdRate(currency, rates);
+  if (rate === null) return null;
+  return usd * rate;
+}
+
+function localeTag(language: string | undefined): string {
+  const primary = (language || "").toLowerCase().split(/[-_]/)[0];
+  return LOCALE_TAG[primary] || "en-US";
+}
+
+function decimalsFor(value: number): { min: number; max: number } {
+  const abs = Math.abs(value);
+  // 常规金额两位；不足 1 的金额保留到 6 位并去尾零，避免小金额失真
+  if (abs >= 1 || abs === 0) return { min: 2, max: 2 };
+  return { min: 1, max: 6 };
+}
+
+/** USD 金额 → 本地货币格式化字符串；无法换算时回落 USD。 */
+export function formatCostUsd(
+  usd: number,
+  opts: { language?: string; rates?: FxRatesDoc | null },
+): string {
+  const language = opts.language;
+  const currency = resolveDisplayCurrency(language, opts.rates ?? null);
+  const converted = convertUsdToCurrency(usd, currency, opts.rates ?? null);
+  const value = converted ?? usd;
+  const finalCurrency = converted === null ? "USD" : currency;
+  const { min, max } = decimalsFor(value);
+  try {
+    return new Intl.NumberFormat(localeTag(language), {
+      style: "currency",
+      currency: finalCurrency,
+      minimumFractionDigits: min,
+      maximumFractionDigits: max,
+    }).format(value);
+  } catch {
+    return `$${value.toFixed(max)}`;
+  }
+}

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -33,6 +33,7 @@ from src.api.routes import (
     memory,
     notification,
     persona_preset,
+    pricing,
     project,
     push,
     revealed_file,
@@ -104,6 +105,7 @@ _LIFESPAN_BACKGROUND_TASK_NAMES = (
     "stale_task_cleanup_task",
     "stale_task_cleanup_recheck_task",
     "feishu_task",
+    "pricing_sync_task",
 )
 _STALE_TASK_CLEANUP_RECHECK_DELAY_SECONDS = max(5.0, HEARTBEAT_TIMEOUT * 2 + 5)
 
@@ -415,6 +417,12 @@ def _startup_index_initializers():
         await get_usage_storage().ensure_indexes()
         logger.info("UsageStorage indexes initialized")
 
+    async def _init_pricing_storage() -> None:
+        from src.infra.pricing.storage import get_pricing_storage
+
+        await get_pricing_storage().ensure_indexes()
+        logger.info("PricingStorage indexes initialized")
+
     async def _init_team_storage() -> None:
         from src.infra.team.storage import TeamStorage
 
@@ -469,6 +477,7 @@ def _startup_index_initializers():
         ("role_storage", _init_role_storage),
         ("mcp_storage", _init_mcp_storage),
         ("file_record_storage", _init_file_record_storage),
+        ("pricing_storage", _init_pricing_storage),
     ]
 
 
@@ -625,6 +634,19 @@ async def lifespan(app: FastAPI):
     # Keep task reference to prevent GC from cancelling it
     _feishu_task = asyncio.create_task(_start_feishu())
     app.state.feishu_task = _feishu_task
+
+    # Periodically sync model prices (models.dev) and USD fx rates.
+    async def _run_pricing_sync_loop() -> None:
+        from src.infra.pricing.sync import sync_pricing
+
+        while True:
+            try:
+                await sync_pricing()
+            except Exception as e:
+                logger.warning(f"Pricing sync loop failed: {e}")
+            await asyncio.sleep(max(1, settings.PRICING_SYNC_INTERVAL_HOURS) * 3600)
+
+    app.state.pricing_sync_task = asyncio.create_task(_run_pricing_sync_loop())
 
     async def _reset_memory_monitor_after_startup() -> None:
         try:
@@ -823,6 +845,7 @@ def create_app() -> FastAPI:
     app.include_router(human.router, prefix="/human", tags=["Human"])
     app.include_router(feedback.router, prefix="/api/feedback", tags=["Feedback"])
     app.include_router(usage.router, prefix="/api/usage", tags=["Usage"])
+    app.include_router(pricing.router, prefix="/api/pricing", tags=["Pricing"])
     app.include_router(notification.router, prefix="/api/notifications", tags=["Notifications"])
     app.include_router(push.router, prefix="/api/push", tags=["Push"])
     # Generic channel configuration

--- a/src/api/routes/agent/model.py
+++ b/src/api/routes/agent/model.py
@@ -238,6 +238,9 @@ async def update_model(
     # Allow clearing request_headers by sending an empty object {}
     if "request_headers" in update_data and not update_data["request_headers"]:
         update_data["request_headers"] = None
+    # Allow clearing pricing override by sending an empty object {}
+    if "pricing" in update_data and not update_data["pricing"]:
+        update_data["pricing"] = None
     # 校验 fallback_model
     if "fallback_model" in update_data and update_data["fallback_model"] is not None:
         if update_data["fallback_model"] == model_id:

--- a/src/api/routes/pricing.py
+++ b/src/api/routes/pricing.py
@@ -1,0 +1,89 @@
+"""Pricing routes.
+
+- GET  /api/pricing/rates   汇率表（登录用户，前端本地货币换算）
+- POST /api/pricing/sync    手动同步价格 + 汇率（管理员）
+- GET  /api/pricing/status  同步状态（管理员）
+- GET  /api/pricing/lookup  按模型标识查询单价（管理员，模型表单提示）
+"""
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+
+from src.api.deps import get_current_user_required, require_permissions
+from src.infra.logging import get_logger
+from src.infra.pricing import service as pricing_service
+from src.infra.pricing.storage import get_pricing_storage
+from src.infra.pricing.sync import sync_pricing
+from src.kernel.schemas.pricing import (
+    FxRatesResponse,
+    PricingLookupResponse,
+    PricingStatusResponse,
+    PricingSyncResponse,
+)
+from src.kernel.schemas.user import TokenPayload
+from src.kernel.types import Permission
+
+router = APIRouter()
+logger = get_logger(__name__)
+
+
+@router.get("/rates", response_model=FxRatesResponse)
+async def get_fx_rates(
+    user: TokenPayload = Depends(get_current_user_required),
+) -> FxRatesResponse:
+    """获取 USD 基准汇率表；从未同步时返回空表（前端回落 USD 展示）。"""
+    doc = await pricing_service.get_fx_rates()
+    if not doc:
+        return FxRatesResponse()
+    return FxRatesResponse(
+        base=str(doc.get("base") or "USD"),
+        rates=doc.get("rates") or {},
+        synced_at=doc.get("synced_at"),
+    )
+
+
+@router.post("/sync", response_model=PricingSyncResponse)
+async def sync_pricing_prices(
+    user: TokenPayload = Depends(require_permissions(Permission.MODEL_ADMIN.value)),
+) -> PricingSyncResponse:
+    """手动同步 models.dev 价格与 USD 汇率（强制刷新）。"""
+    status = await sync_pricing(force=True)
+    pricing_service.reset_runtime_cache()
+    return PricingSyncResponse(**status)
+
+
+@router.get("/status", response_model=PricingStatusResponse)
+async def get_pricing_status(
+    user: TokenPayload = Depends(require_permissions(Permission.MODEL_ADMIN.value)),
+) -> PricingStatusResponse:
+    """查看价格/汇率快照状态。"""
+    status = await get_pricing_storage().get_status()
+    return PricingStatusResponse(**status)
+
+
+@router.get("/lookup", response_model=PricingLookupResponse)
+async def lookup_price(
+    value: str = Query(..., description="模型标识，如 openai/gpt-4o"),
+    provider: Optional[str] = Query(None, description="Provider 提示"),
+    model_id: Optional[str] = Query(None, description="模型配置 ID（覆盖优先）"),
+    user: TokenPayload = Depends(require_permissions(Permission.MODEL_ADMIN.value)),
+) -> PricingLookupResponse:
+    """查询某模型解析后的单价与来源。"""
+    resolved = await pricing_service.resolve_price(
+        value=value, provider=provider, model_config_id=model_id
+    )
+    if resolved is None:
+        return PricingLookupResponse()
+    return PricingLookupResponse(
+        found=True,
+        source=resolved.source,
+        rates={
+            "input": resolved.rates.input,
+            "output": resolved.rates.output,
+            "cache_read": resolved.rates.cache_read,
+            "cache_write": resolved.rates.cache_write,
+        },
+        matched_provider=resolved.matched_provider,
+        matched_model_id=resolved.matched_model_id,
+    )

--- a/src/infra/agent/events/processor.py
+++ b/src/infra/agent/events/processor.py
@@ -29,6 +29,7 @@ from src.infra.agent.events.tool_outputs import (
 from src.infra.agent.events.types import TOOL_TASK, StreamEvent
 from src.infra.agent.first_event_timing import FirstEventTiming
 from src.infra.logging import get_logger
+from src.infra.pricing.service import compute_usage_cost
 from src.infra.writer.present import Presenter
 from src.kernel.config import settings
 
@@ -163,6 +164,7 @@ class AgentEventProcessor(SubagentEventMixin, StreamEventMixin, ToolEventMixin):
             return False
 
         total_tokens = self.total_tokens or self.total_input_tokens + self.total_output_tokens
+        cost, rates = await self._resolve_usage_cost(model=model, model_id=model_id)
         event = self.presenter.present_token_usage(
             input_tokens=self.total_input_tokens,
             output_tokens=self.total_output_tokens,
@@ -172,10 +174,33 @@ class AgentEventProcessor(SubagentEventMixin, StreamEventMixin, ToolEventMixin):
             cache_read_tokens=self.total_cache_read_tokens,
             model_id=model_id,
             model=model,
+            cost=cost,
+            rates=rates,
         )
         await self._presenter_emit(event)
         self._token_usage_emitted = True
         return True
+
+    async def _resolve_usage_cost(
+        self, *, model: str | None, model_id: str | None
+    ) -> tuple[Any, Any]:
+        """best-effort 计算本次用量成本；失败或未匹配价格时返回 (None, None)。"""
+        try:
+            result = await compute_usage_cost(
+                model_value=model,
+                model_config_id=model_id,
+                input_tokens=self.total_input_tokens,
+                output_tokens=self.total_output_tokens,
+                cache_read_tokens=self.total_cache_read_tokens,
+                cache_creation_tokens=self.total_cache_creation_tokens,
+            )
+        except Exception as e:
+            logger.debug(f"Pricing: usage cost computation failed: {e}")
+            return None, None
+        if result is None:
+            return None, None
+        breakdown, rates, _source = result
+        return breakdown, rates
 
     def clear(self) -> None:
         """Release memory held by this session while preserving token counters."""

--- a/src/infra/pricing/__init__.py
+++ b/src/infra/pricing/__init__.py
@@ -1,0 +1,1 @@
+"""Model pricing: models.dev 价格同步、模型匹配与 USD 成本计算。"""

--- a/src/infra/pricing/calculator.py
+++ b/src/infra/pricing/calculator.py
@@ -1,0 +1,89 @@
+"""Token 成本计算纯函数。
+
+单价口径与 models.dev 一致：USD / 每百万 token。
+token 口径与 LangChain usage_metadata 一致：input_tokens 包含 cache_read
+与 cache_creation，需要先剔除再按各档单价计费。
+"""
+
+from dataclasses import dataclass
+
+TOKENS_PER_UNIT = 1_000_000
+
+
+@dataclass(frozen=True)
+class PriceRates:
+    """模型单价（USD / 每百万 token）。None 表示未收录/不单独计费。"""
+
+    input: float | None = None
+    output: float | None = None
+    cache_read: float | None = None
+    cache_write: float | None = None
+
+    def is_priced(self) -> bool:
+        """是否具备可计价条件（至少 input 与 output 单价齐备）。"""
+        return self.input is not None and self.output is not None
+
+    def merge_override(self, override: "PriceRates") -> "PriceRates":
+        """字段级合并：override 中非 None 的字段覆盖本地值。"""
+        return PriceRates(
+            input=override.input if override.input is not None else self.input,
+            output=override.output if override.output is not None else self.output,
+            cache_read=override.cache_read if override.cache_read is not None else self.cache_read,
+            cache_write=override.cache_write
+            if override.cache_write is not None
+            else self.cache_write,
+        )
+
+
+@dataclass(frozen=True)
+class CostBreakdown:
+    """一次调用的 USD 成本分解。"""
+
+    input_usd: float = 0.0
+    output_usd: float = 0.0
+    cache_read_usd: float = 0.0
+    cache_write_usd: float = 0.0
+
+    @property
+    def total_usd(self) -> float:
+        # 金额求和消除浮点噪声（1e-12 远小于展示精度）
+        return round(
+            self.input_usd + self.output_usd + self.cache_read_usd + self.cache_write_usd,
+            12,
+        )
+
+    def to_event_data(self) -> dict[str, float]:
+        return {
+            "input": self.input_usd,
+            "output": self.output_usd,
+            "cache_read": self.cache_read_usd,
+            "cache_write": self.cache_write_usd,
+            "total": self.total_usd,
+        }
+
+
+def _per_million(tokens: int, price: float | None) -> float:
+    if price is None:
+        return 0.0
+    return tokens * price / TOKENS_PER_UNIT
+
+
+def compute_cost(
+    *,
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int = 0,
+    cache_creation_tokens: int = 0,
+    rates: PriceRates,
+) -> CostBreakdown | None:
+    """按单价计算 USD 成本；无法计价（缺 input 或 output 单价）返回 None。"""
+    if not rates.is_priced():
+        return None
+
+    billable_input = max(input_tokens - cache_read_tokens - cache_creation_tokens, 0)
+    return CostBreakdown(
+        input_usd=_per_million(billable_input, rates.input),
+        output_usd=_per_million(output_tokens, rates.output),
+        cache_read_usd=_per_million(cache_read_tokens, rates.cache_read),
+        cache_write_usd=_per_million(cache_creation_tokens, rates.cache_write),
+    )

--- a/src/infra/pricing/matching.py
+++ b/src/infra/pricing/matching.py
@@ -277,6 +277,4 @@ def restore_price_index(snapshot: list[dict] | dict) -> PriceIndex:
     else:
         entries = snapshot or []
         model_owners = {}
-    return PriceIndex(
-        [_entry_from_snapshot(doc) for doc in entries], model_owners=model_owners
-    )
+    return PriceIndex([_entry_from_snapshot(doc) for doc in entries], model_owners=model_owners)

--- a/src/infra/pricing/matching.py
+++ b/src/infra/pricing/matching.py
@@ -1,0 +1,188 @@
+"""models.dev 价格数据解析与模型匹配。
+
+models.dev api.json 结构：顶层按 provider 组织，每个 provider 含
+``models`` 映射，模型条目的 ``cost`` 字段携带 USD / 每百万 token 单价。
+
+匹配策略（从严到宽）：
+1. value 自带前缀时，前缀作为 provider 精确匹配模型 ID；
+2. provider 提示 + 裸模型 ID 精确匹配；
+3. 归一化匹配（小写、去前缀、去日期/latest 后缀、去非字母数字）；
+4. 全局裸模型 ID 精确匹配（任意 provider）；
+5. 全局归一化匹配。
+"""
+
+import re
+from dataclasses import dataclass
+
+from src.infra.pricing.calculator import PriceRates
+
+_DATE_SUFFIXES = (
+    re.compile(r"-20\d{6}$"),  # claude-3-5-sonnet-20241022
+    re.compile(r"-\d{4}-\d{2}-\d{2}$"),  # gpt-4o-2024-08-13
+)
+_LATEST_SUFFIX = re.compile(r"-latest$")
+_NON_ALNUM = re.compile(r"[^a-z0-9]+")
+
+
+def normalize_model_key(value: str) -> str:
+    """归一化模型标识：小写、取最后一段前缀、去日期/latest 后缀、去非字母数字。"""
+    if not value:
+        return ""
+    text = value.strip().lower()
+    if "/" in text:
+        text = text.rsplit("/", 1)[-1]
+    text = text.strip("/")
+    for pattern in _DATE_SUFFIXES:
+        text = pattern.sub("", text)
+    text = _LATEST_SUFFIX.sub("", text)
+    return _NON_ALNUM.sub("", text)
+
+
+@dataclass(frozen=True)
+class PriceEntry:
+    """单个模型的价格条目。"""
+
+    provider: str
+    model_id: str
+    rates: PriceRates
+    name: str = ""
+
+    def to_snapshot(self) -> dict:
+        return {
+            "provider": self.provider,
+            "model_id": self.model_id,
+            "name": self.name,
+            "rates": {
+                "input": self.rates.input,
+                "output": self.rates.output,
+                "cache_read": self.rates.cache_read,
+                "cache_write": self.rates.cache_write,
+            },
+        }
+
+
+def _entry_from_snapshot(doc: dict) -> PriceEntry:
+    rates = doc.get("rates") or {}
+    return PriceEntry(
+        provider=str(doc.get("provider") or ""),
+        model_id=str(doc.get("model_id") or ""),
+        name=str(doc.get("name") or ""),
+        rates=PriceRates(
+            input=rates.get("input"),
+            output=rates.get("output"),
+            cache_read=rates.get("cache_read"),
+            cache_write=rates.get("cache_write"),
+        ),
+    )
+
+
+def _rates_from_cost(cost: dict | None) -> PriceRates | None:
+    if not isinstance(cost, dict):
+        return None
+    rates = PriceRates(
+        input=cost.get("input"),
+        output=cost.get("output"),
+        cache_read=cost.get("cache_read"),
+        cache_write=cost.get("cache_write"),
+    )
+    # 完全没有价格信息（input/output 均缺失）的模型不收录
+    if rates.input is None and rates.output is None:
+        return None
+    return rates
+
+
+class PriceIndex:
+    """价格索引：内存中的模型价格快照，支持多级匹配。"""
+
+    def __init__(self, entries: list[PriceEntry]):
+        self._entries = entries
+        self._by_provider: dict[str, dict[str, PriceEntry]] = {}
+        self._by_provider_normalized: dict[str, dict[str, PriceEntry]] = {}
+        self._global: dict[str, PriceEntry] = {}
+        self._global_normalized: dict[str, PriceEntry] = {}
+        for entry in entries:
+            self._by_provider.setdefault(entry.provider, {})[entry.model_id] = entry
+            normalized = normalize_model_key(entry.model_id)
+            if normalized:
+                self._by_provider_normalized.setdefault(entry.provider, {}).setdefault(
+                    normalized, entry
+                )
+                self._global.setdefault(entry.model_id, entry)
+                self._global_normalized.setdefault(normalized, entry)
+
+    @property
+    def entry_count(self) -> int:
+        return len(self._entries)
+
+    def to_snapshot_entries(self) -> list[dict]:
+        """导出为可 JSON 序列化的快照（用于 Mongo 持久化）。"""
+        return [entry.to_snapshot() for entry in self._entries]
+
+    def _match_in_provider(self, provider: str, model: str) -> PriceEntry | None:
+        exact = self._by_provider.get(provider, {}).get(model)
+        if exact:
+            return exact
+        normalized = normalize_model_key(model)
+        if normalized:
+            return self._by_provider_normalized.get(provider, {}).get(normalized)
+        return None
+
+    def match(self, value: str, provider: str | None = None) -> PriceEntry | None:
+        """按模型标识匹配价格条目；未匹配返回 None。"""
+        value = (value or "").strip()
+        if not value:
+            return None
+
+        if "/" in value:
+            prefix, model = value.split("/", 1)
+            entry = self._match_in_provider(prefix.strip().lower(), model.strip())
+            if entry:
+                return entry
+
+        model = value.rsplit("/", 1)[-1].strip()
+        if provider:
+            entry = self._match_in_provider(provider.strip().lower(), model)
+            if entry:
+                return entry
+
+        exact = self._global.get(model)
+        if exact:
+            return exact
+        normalized = normalize_model_key(model)
+        if normalized:
+            return self._global_normalized.get(normalized)
+        return None
+
+
+def build_price_index(api_json: dict) -> PriceIndex:
+    """解析 models.dev api.json 为价格索引。"""
+    entries: list[PriceEntry] = []
+    if not isinstance(api_json, dict):
+        return PriceIndex(entries)
+    for provider_doc in api_json.values():
+        if not isinstance(provider_doc, dict):
+            continue
+        provider = str(provider_doc.get("id") or "")
+        if not provider:
+            continue
+        models = provider_doc.get("models")
+        if not isinstance(models, dict):
+            continue
+        for model_id, model_doc in models.items():
+            rates = _rates_from_cost((model_doc or {}).get("cost"))
+            if rates is None:
+                continue
+            entries.append(
+                PriceEntry(
+                    provider=provider,
+                    model_id=str(model_id),
+                    rates=rates,
+                    name=str((model_doc or {}).get("name") or ""),
+                )
+            )
+    return PriceIndex(entries)
+
+
+def restore_price_index(snapshot_entries: list[dict]) -> PriceIndex:
+    """从持久化快照还原价格索引。"""
+    return PriceIndex([_entry_from_snapshot(doc) for doc in snapshot_entries or []])

--- a/src/infra/pricing/matching.py
+++ b/src/infra/pricing/matching.py
@@ -91,15 +91,55 @@ def _rates_from_cost(cost: dict | None) -> PriceRates | None:
     return rates
 
 
+# 官方 provider 归属规则：裸模型名全局匹配时优先官方价格，
+# 避免命中 models.dev 上大量第三方路由商的同名模型条目。
+# 规则为 (正则, provider slug)，匹配对象是小写模型 ID。
+CANONICAL_PROVIDER_RULES: tuple[tuple[str, str], ...] = (
+    (r"gpt-|^o[134](-|$)|^chatgpt", "openai"),
+    (r"^claude-", "anthropic"),
+    (r"^gemini-|^gemma-|^veo-|^nano-banana", "google"),
+    (r"^deepseek", "deepseek"),
+    (r"^qwen|^qwq|^qvq", "qwen"),
+    (r"^glm", "zai"),
+    (r"^kimi|^moonshot", "moonshotai"),
+    (r"^minimax|^abab", "minimax"),
+    (r"^llama-|^meta-llama|^lama-", "meta"),
+    (r"^mistral|^codestral|^pixtral|^magistral|^mixtral|^devstral", "mistral"),
+    (r"^grok", "xai"),
+    (r"^command", "cohere"),
+    (r"^sonar", "perplexity"),
+    (r"^ernie", "baidu"),
+    (r"^hunyuan", "tencent"),
+    (r"^doubao", "bytedance"),
+    (r"^step-", "stepfun"),
+)
+
+
+def canonical_provider(model_id: str) -> str | None:
+    """按模型名前缀推断官方 provider slug；无法推断返回 None。"""
+    text = model_id.strip().lower()
+    if not text:
+        return None
+    for pattern, provider in CANONICAL_PROVIDER_RULES:
+        if re.match(pattern, text):
+            return provider
+    return None
+
+
 class PriceIndex:
     """价格索引：内存中的模型价格快照，支持多级匹配。"""
 
-    def __init__(self, entries: list[PriceEntry]):
+    def __init__(
+        self,
+        entries: list[PriceEntry],
+        model_owners: dict[str, list[str]] | None = None,
+    ):
         self._entries = entries
         self._by_provider: dict[str, dict[str, PriceEntry]] = {}
         self._by_provider_normalized: dict[str, dict[str, PriceEntry]] = {}
-        self._global: dict[str, PriceEntry] = {}
-        self._global_normalized: dict[str, PriceEntry] = {}
+        # 全局候选按 provider 名排序，保证同快照内匹配结果确定
+        self._global: dict[str, list[PriceEntry]] = {}
+        self._global_normalized: dict[str, list[PriceEntry]] = {}
         for entry in entries:
             self._by_provider.setdefault(entry.provider, {})[entry.model_id] = entry
             normalized = normalize_model_key(entry.model_id)
@@ -107,16 +147,56 @@ class PriceIndex:
                 self._by_provider_normalized.setdefault(entry.provider, {}).setdefault(
                     normalized, entry
                 )
-                self._global.setdefault(entry.model_id, entry)
-                self._global_normalized.setdefault(normalized, entry)
+                self._global.setdefault(entry.model_id, []).append(entry)
+                self._global_normalized.setdefault(normalized, []).append(entry)
+        for candidates in self._global.values():
+            candidates.sort(key=lambda e: e.provider)
+        for candidates in self._global_normalized.values():
+            candidates.sort(key=lambda e: e.provider)
+        # model_id → 收录该模型的所有 provider（含未计价），用于官方归属判断
+        self._model_owners: dict[str, list[str]] = {
+            model_id: sorted(set(providers)) for model_id, providers in (model_owners or {}).items()
+        }
 
     @property
     def entry_count(self) -> int:
         return len(self._entries)
 
-    def to_snapshot_entries(self) -> list[dict]:
+    def to_snapshot(self) -> dict:
         """导出为可 JSON 序列化的快照（用于 Mongo 持久化）。"""
+        return {
+            "entries": [entry.to_snapshot() for entry in self._entries],
+            "model_owners": self._model_owners,
+        }
+
+    def to_snapshot_entries(self) -> list[dict]:
+        """导出价格条目列表（兼容旧调用方）。"""
         return [entry.to_snapshot() for entry in self._entries]
+
+    def _pick_global(
+        self,
+        model: str,
+        candidates: list[PriceEntry],
+        *,
+        owners_key: str | None = None,
+    ) -> PriceEntry | None:
+        """全局候选选择：官方 provider 优先；官方收录但未计价时宁缺毋滥。
+
+        归一化匹配时 candidates 按归一化键取，但官方归属判断要用原始
+        模型名（owners 表按精确 model_id 记录）。
+        """
+        if not candidates:
+            return None
+        canonical = canonical_provider(model)
+        if canonical:
+            for entry in candidates:
+                if entry.provider == canonical:
+                    return entry
+            owners = self._model_owners.get(owners_key or model)
+            if owners and canonical in owners:
+                # 官方收录了该模型但无价格：不用第三方价格顶替
+                return None
+        return candidates[0]
 
     def _match_in_provider(self, provider: str, model: str) -> PriceEntry | None:
         exact = self._by_provider.get(provider, {}).get(model)
@@ -145,44 +225,58 @@ class PriceIndex:
             if entry:
                 return entry
 
-        exact = self._global.get(model)
+        exact = self._pick_global(model, self._global.get(model, []))
         if exact:
             return exact
         normalized = normalize_model_key(model)
         if normalized:
-            return self._global_normalized.get(normalized)
+            return self._pick_global(
+                model,
+                self._global_normalized.get(normalized, []),
+                owners_key=model,
+            )
         return None
 
 
 def build_price_index(api_json: dict) -> PriceIndex:
     """解析 models.dev api.json 为价格索引。"""
     entries: list[PriceEntry] = []
-    if not isinstance(api_json, dict):
-        return PriceIndex(entries)
-    for provider_doc in api_json.values():
-        if not isinstance(provider_doc, dict):
-            continue
-        provider = str(provider_doc.get("id") or "")
-        if not provider:
-            continue
-        models = provider_doc.get("models")
-        if not isinstance(models, dict):
-            continue
-        for model_id, model_doc in models.items():
-            rates = _rates_from_cost((model_doc or {}).get("cost"))
-            if rates is None:
+    model_owners: dict[str, list[str]] = {}
+    if isinstance(api_json, dict):
+        for provider_doc in api_json.values():
+            if not isinstance(provider_doc, dict):
                 continue
-            entries.append(
-                PriceEntry(
-                    provider=provider,
-                    model_id=str(model_id),
-                    rates=rates,
-                    name=str((model_doc or {}).get("name") or ""),
+            provider = str(provider_doc.get("id") or "")
+            if not provider:
+                continue
+            models = provider_doc.get("models")
+            if not isinstance(models, dict):
+                continue
+            for model_id, model_doc in models.items():
+                model_id = str(model_id)
+                model_owners.setdefault(model_id, []).append(provider)
+                rates = _rates_from_cost((model_doc or {}).get("cost"))
+                if rates is None:
+                    continue
+                entries.append(
+                    PriceEntry(
+                        provider=provider,
+                        model_id=model_id,
+                        rates=rates,
+                        name=str((model_doc or {}).get("name") or ""),
+                    )
                 )
-            )
-    return PriceIndex(entries)
+    return PriceIndex(entries, model_owners=model_owners)
 
 
-def restore_price_index(snapshot_entries: list[dict]) -> PriceIndex:
-    """从持久化快照还原价格索引。"""
-    return PriceIndex([_entry_from_snapshot(doc) for doc in snapshot_entries or []])
+def restore_price_index(snapshot: list[dict] | dict) -> PriceIndex:
+    """从持久化快照还原价格索引（兼容旧的纯列表格式）。"""
+    if isinstance(snapshot, dict):
+        entries = snapshot.get("entries") or []
+        model_owners = snapshot.get("model_owners") or {}
+    else:
+        entries = snapshot or []
+        model_owners = {}
+    return PriceIndex(
+        [_entry_from_snapshot(doc) for doc in entries], model_owners=model_owners
+    )

--- a/src/infra/pricing/service.py
+++ b/src/infra/pricing/service.py
@@ -42,7 +42,7 @@ async def get_price_index() -> PriceIndex:
     global _runtime_index
     if _runtime_index is None:
         snapshot = await get_pricing_storage().load_price_snapshot() or {}
-        _runtime_index = restore_price_index(snapshot.get("entries") or [])
+        _runtime_index = restore_price_index(snapshot)
     return _runtime_index
 
 

--- a/src/infra/pricing/service.py
+++ b/src/infra/pricing/service.py
@@ -1,0 +1,148 @@
+"""pricing 运行时服务：价格解析（覆盖 > models.dev）、汇率读取、成本计算入口。
+
+进程内缓存价格索引与汇率；所有查询 best-effort，失败不阻塞调用方。
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from src.infra.logging import get_logger
+from src.infra.pricing.calculator import CostBreakdown, PriceRates, compute_cost
+from src.infra.pricing.matching import PriceEntry, PriceIndex, restore_price_index
+from src.infra.pricing.storage import get_pricing_storage
+
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class ResolvedPrice:
+    """解析结果：单价 + 来源信息。"""
+
+    rates: PriceRates
+    source: str  # "override" | "models_dev"
+    matched_provider: str = ""
+    matched_model_id: str = ""
+
+
+# ── 进程内运行时缓存 ──────────────────────────────────────────────
+
+_runtime_index: Optional[PriceIndex] = None
+_runtime_fx: Optional[dict] = None
+
+
+def reset_runtime_cache() -> None:
+    """清空进程内缓存（测试与手动同步后使用）。"""
+    global _runtime_index, _runtime_fx
+    _runtime_index = None
+    _runtime_fx = None
+
+
+async def get_price_index() -> PriceIndex:
+    """获取价格索引；首次访问从持久化快照加载。"""
+    global _runtime_index
+    if _runtime_index is None:
+        snapshot = await get_pricing_storage().load_price_snapshot() or {}
+        _runtime_index = restore_price_index(snapshot.get("entries") or [])
+    return _runtime_index
+
+
+async def get_fx_rates() -> Optional[dict]:
+    """获取汇率文档 {base, rates, synced_at}；无数据返回 None。"""
+    global _runtime_fx
+    if _runtime_fx is None:
+        _runtime_fx = await get_pricing_storage().load_fx_rates()
+    return _runtime_fx
+
+
+async def _load_model_override(model_config_id: str | None) -> Optional[PriceRates]:
+    """读取模型配置上的价格覆盖；无配置或无覆盖返回 None。"""
+    if not model_config_id:
+        return None
+    try:
+        from src.infra.agent.model_storage import get_model_storage
+
+        model = await get_model_storage().get(model_config_id)
+        pricing = getattr(model, "pricing", None) if model else None
+        if pricing is None:
+            return None
+        return PriceRates(
+            input=pricing.input,
+            output=pricing.output,
+            cache_read=pricing.cache_read,
+            cache_write=pricing.cache_write,
+        )
+    except Exception as e:
+        logger.debug(f"Pricing: failed to load model override for {model_config_id}: {e}")
+        return None
+
+
+async def resolve_price(
+    *,
+    value: Optional[str],
+    provider: Optional[str] = None,
+    model_config_id: Optional[str] = None,
+) -> Optional[ResolvedPrice]:
+    """解析模型单价：模型配置覆盖（字段级合并）优先，其次 models.dev 匹配。"""
+    override = await _load_model_override(model_config_id)
+
+    entry: Optional[PriceEntry] = None
+    if value:
+        try:
+            entry = (await get_price_index()).match(value, provider=provider)
+        except Exception as e:
+            logger.debug(f"Pricing: index match failed for {value!r}: {e}")
+
+    if override is not None:
+        base = entry.rates if entry is not None else PriceRates()
+        merged = base.merge_override(override)
+        if merged.is_priced():
+            return ResolvedPrice(
+                rates=merged,
+                source="override",
+                matched_provider=entry.provider if entry else "",
+                matched_model_id=entry.model_id if entry else "",
+            )
+        return None
+
+    if entry is not None and entry.rates.is_priced():
+        return ResolvedPrice(
+            rates=entry.rates,
+            source="models_dev",
+            matched_provider=entry.provider,
+            matched_model_id=entry.model_id,
+        )
+    return None
+
+
+async def compute_usage_cost(
+    *,
+    model_value: Optional[str],
+    model_provider: Optional[str] = None,
+    model_config_id: Optional[str] = None,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cache_read_tokens: int = 0,
+    cache_creation_tokens: int = 0,
+) -> Optional[tuple[CostBreakdown, PriceRates, str]]:
+    """对话结束时的成本计算入口。
+
+    Returns:
+        (成本分解, 单价, 来源) 或 None（无法计价）
+    """
+    resolved = await resolve_price(
+        value=model_value,
+        provider=model_provider,
+        model_config_id=model_config_id,
+    )
+    if resolved is None:
+        return None
+    breakdown = compute_cost(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_read_tokens=cache_read_tokens,
+        cache_creation_tokens=cache_creation_tokens,
+        rates=resolved.rates,
+    )
+    if breakdown is None:
+        return None
+    return breakdown, resolved.rates, resolved.source

--- a/src/infra/pricing/storage.py
+++ b/src/infra/pricing/storage.py
@@ -1,0 +1,122 @@
+"""Pricing storage layer.
+
+独立的 model_prices 集合，保存两类单文档快照：
+- 价格快照（models.dev 同步结果）
+- USD 汇率表（exchangerate-api 同步结果）
+"""
+
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from src.infra.logging import get_logger
+from src.infra.storage.mongodb import get_mongo_client
+from src.kernel.config import settings
+
+logger = get_logger(__name__)
+
+PRICE_SNAPSHOT_DOC_ID = "models_dev_snapshot"
+FX_RATES_DOC_ID = "fx_rates"
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class PricingStorage:
+    """价格/汇率持久化 — model_prices 集合内的固定 _id 文档"""
+
+    def __init__(self, collection: Optional[Any] = None):
+        # 测试可直接注入假集合；生产环境延迟加载真实集合
+        self._injected: Optional[Any] = collection
+        self._lazy_collection: Optional[Any] = None
+
+    @property
+    def collection(self):
+        if self._injected is not None:
+            return self._injected
+        if self._lazy_collection is None:
+            client = get_mongo_client()
+            db = client[settings.MONGODB_DB]
+            self._lazy_collection = db[settings.MONGODB_MODEL_PRICES_COLLECTION]
+        return self._lazy_collection
+
+    async def ensure_indexes(self) -> None:
+        try:
+            await self.collection.create_index("_id")
+        except Exception as e:
+            logger.error(f"Failed to ensure pricing indexes: {e}")
+
+    async def save_price_snapshot(self, entries: list[dict], *, source_url: str = "") -> bool:
+        """保存 models.dev 价格快照（整体覆盖）。"""
+        try:
+            await self.collection.update_one(
+                {"_id": PRICE_SNAPSHOT_DOC_ID},
+                {
+                    "$set": {
+                        "entries": entries,
+                        "entry_count": len(entries),
+                        "source_url": source_url,
+                        "synced_at": _utc_now_iso(),
+                    }
+                },
+                upsert=True,
+            )
+            return True
+        except Exception as e:
+            logger.error(f"Failed to save price snapshot: {e}")
+            return False
+
+    async def load_price_snapshot(self) -> Optional[dict]:
+        try:
+            return await self.collection.find_one({"_id": PRICE_SNAPSHOT_DOC_ID})
+        except Exception as e:
+            logger.error(f"Failed to load price snapshot: {e}")
+            return None
+
+    async def save_fx_rates(self, rates: dict[str, float], *, base: str = "USD") -> bool:
+        """保存 USD 汇率表（整体覆盖）。"""
+        try:
+            await self.collection.update_one(
+                {"_id": FX_RATES_DOC_ID},
+                {
+                    "$set": {
+                        "base": base,
+                        "rates": rates,
+                        "rate_count": len(rates),
+                        "synced_at": _utc_now_iso(),
+                    }
+                },
+                upsert=True,
+            )
+            return True
+        except Exception as e:
+            logger.error(f"Failed to save fx rates: {e}")
+            return False
+
+    async def load_fx_rates(self) -> Optional[dict]:
+        try:
+            return await self.collection.find_one({"_id": FX_RATES_DOC_ID})
+        except Exception as e:
+            logger.error(f"Failed to load fx rates: {e}")
+            return None
+
+    async def get_status(self) -> dict[str, Any]:
+        prices = await self.load_price_snapshot() or {}
+        fx = await self.load_fx_rates() or {}
+        return {
+            "prices": {
+                "entry_count": prices.get("entry_count", 0),
+                "source_url": prices.get("source_url", ""),
+                "synced_at": prices.get("synced_at"),
+            },
+            "fx": {
+                "base": fx.get("base", "USD"),
+                "rate_count": fx.get("rate_count", 0),
+                "synced_at": fx.get("synced_at"),
+            },
+        }
+
+
+def get_pricing_storage() -> PricingStorage:
+    """获取 PricingStorage 实例"""
+    return PricingStorage()

--- a/src/infra/pricing/storage.py
+++ b/src/infra/pricing/storage.py
@@ -46,7 +46,13 @@ class PricingStorage:
         except Exception as e:
             logger.error(f"Failed to ensure pricing indexes: {e}")
 
-    async def save_price_snapshot(self, entries: list[dict], *, source_url: str = "") -> bool:
+    async def save_price_snapshot(
+        self,
+        entries: list[dict],
+        *,
+        source_url: str = "",
+        model_owners: Optional[dict[str, list[str]]] = None,
+    ) -> bool:
         """保存 models.dev 价格快照（整体覆盖）。"""
         try:
             await self.collection.update_one(
@@ -55,6 +61,7 @@ class PricingStorage:
                     "$set": {
                         "entries": entries,
                         "entry_count": len(entries),
+                        "model_owners": model_owners or {},
                         "source_url": source_url,
                         "synced_at": _utc_now_iso(),
                     }

--- a/src/infra/pricing/sync.py
+++ b/src/infra/pricing/sync.py
@@ -1,0 +1,114 @@
+"""pricing 同步：models.dev 价格表 + USD 汇率表。
+
+两者独立拉取、独立降级：一个失败不影响另一个，失败时沿用上次快照。
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+import httpx
+
+from src.infra.logging import get_logger
+from src.infra.pricing.matching import build_price_index
+from src.infra.pricing.storage import PricingStorage, get_pricing_storage
+from src.kernel.config import settings
+
+logger = get_logger(__name__)
+
+FETCH_TIMEOUT_SECONDS = 30.0
+
+
+def _build_http_client() -> httpx.AsyncClient:
+    return httpx.AsyncClient(timeout=FETCH_TIMEOUT_SECONDS, follow_redirects=True)
+
+
+def parse_fx_payload(payload: Any) -> Optional[dict]:
+    """解析 exchangerate-api 响应；无效返回 None。"""
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("result") != "success":
+        return None
+    rates = payload.get("rates")
+    if not isinstance(rates, dict) or not rates:
+        return None
+    return {
+        "base": str(payload.get("base_code") or "USD"),
+        "rates": {str(code): float(rate) for code, rate in rates.items()},
+        "source_updated_at": payload.get("time_last_update_unix"),
+    }
+
+
+async def fetch_models_dev(client: httpx.AsyncClient) -> list[dict]:
+    """拉取 models.dev api.json 并转为快照条目；非 200 抛异常。"""
+    response = await client.get(settings.PRICING_MODELS_DEV_URL)
+    response.raise_for_status()
+    index = build_price_index(response.json())
+    return index.to_snapshot_entries()
+
+
+async def _fetch_fx_rates(client: httpx.AsyncClient) -> Optional[dict]:
+    response = await client.get(settings.PRICING_FX_RATES_URL)
+    response.raise_for_status()
+    return parse_fx_payload(response.json())
+
+
+def _is_stale(synced_at: Optional[str], interval_hours: int) -> bool:
+    if not synced_at:
+        return True
+    try:
+        synced = datetime.fromisoformat(synced_at)
+    except ValueError:
+        return True
+    if synced.tzinfo is None:
+        synced = synced.replace(tzinfo=timezone.utc)
+    return datetime.now(timezone.utc) - synced > timedelta(hours=interval_hours)
+
+
+async def sync_pricing(*, force: bool = False, storage: Optional[PricingStorage] = None) -> dict:
+    """同步价格与汇率。
+
+    快照未过期且未 force 时跳过网络请求；单侧失败保留旧快照并记入 error。
+    """
+    storage = storage or get_pricing_storage()
+    price_snapshot = await storage.load_price_snapshot() or {}
+    fx_doc = await storage.load_fx_rates() or {}
+
+    price_stale = force or _is_stale(
+        price_snapshot.get("synced_at"), settings.PRICING_SYNC_INTERVAL_HOURS
+    )
+    fx_stale = force or _is_stale(fx_doc.get("synced_at"), settings.PRICING_SYNC_INTERVAL_HOURS)
+    if not price_stale and not fx_stale:
+        status = await storage.get_status()
+        status["refreshed"] = False
+        status["error"] = None
+        return status
+
+    errors: list[str] = []
+    async with _build_http_client() as client:
+        if price_stale:
+            try:
+                entries = await fetch_models_dev(client)
+                await storage.save_price_snapshot(
+                    entries, source_url=settings.PRICING_MODELS_DEV_URL
+                )
+                logger.info(f"Pricing: synced {len(entries)} model prices from models.dev")
+            except Exception as e:
+                errors.append(f"models.dev: {e}")
+                logger.warning(f"Pricing: models.dev sync failed: {e}")
+        if fx_stale:
+            try:
+                parsed = await _fetch_fx_rates(client)
+                if parsed is None:
+                    raise ValueError("invalid fx payload")
+                await storage.save_fx_rates(parsed["rates"], base=parsed["base"])
+                logger.info(
+                    f"Pricing: synced {len(parsed['rates'])} fx rates (base {parsed['base']})"
+                )
+            except Exception as e:
+                errors.append(f"fx: {e}")
+                logger.warning(f"Pricing: fx rates sync failed: {e}")
+
+    status = await storage.get_status()
+    status["refreshed"] = True
+    status["error"] = "; ".join(errors) if errors else None
+    return status

--- a/src/infra/pricing/sync.py
+++ b/src/infra/pricing/sync.py
@@ -38,12 +38,11 @@ def parse_fx_payload(payload: Any) -> Optional[dict]:
     }
 
 
-async def fetch_models_dev(client: httpx.AsyncClient) -> list[dict]:
-    """拉取 models.dev api.json 并转为快照条目；非 200 抛异常。"""
+async def fetch_models_dev(client: httpx.AsyncClient) -> dict:
+    """拉取 models.dev api.json 并转为价格快照（含官方归属表）；非 200 抛异常。"""
     response = await client.get(settings.PRICING_MODELS_DEV_URL)
     response.raise_for_status()
-    index = build_price_index(response.json())
-    return index.to_snapshot_entries()
+    return build_price_index(response.json()).to_snapshot()
 
 
 async def _fetch_fx_rates(client: httpx.AsyncClient) -> Optional[dict]:
@@ -87,9 +86,12 @@ async def sync_pricing(*, force: bool = False, storage: Optional[PricingStorage]
     async with _build_http_client() as client:
         if price_stale:
             try:
-                entries = await fetch_models_dev(client)
+                snapshot = await fetch_models_dev(client)
+                entries = snapshot.get("entries") or []
                 await storage.save_price_snapshot(
-                    entries, source_url=settings.PRICING_MODELS_DEV_URL
+                    entries,
+                    source_url=settings.PRICING_MODELS_DEV_URL,
+                    model_owners=snapshot.get("model_owners"),
                 )
                 logger.info(f"Pricing: synced {len(entries)} model prices from models.dev")
             except Exception as e:

--- a/src/infra/usage/storage.py
+++ b/src/infra/usage/storage.py
@@ -252,6 +252,8 @@ class UsageStorage:
             "total_tokens": total_tokens,
             "cache_creation_tokens": _as_int(usage_data.get("cache_creation_tokens", 0)),
             "cache_read_tokens": _as_int(usage_data.get("cache_read_tokens", 0)),
+            "cost_usd": _as_float(usage_data.get("cost_usd", 0.0)),
+            "cost_available": "cost_usd" in usage_data and usage_data["cost_usd"] is not None,
             "duration": _as_float(usage_data.get("duration", 0.0)),
             "started_at": _as_datetime(trace_doc.get("started_at")),
             "completed_at": _as_datetime(trace_doc.get("completed_at")),
@@ -384,6 +386,10 @@ class UsageStorage:
                                 "total_duration": {"$sum": "$duration"},
                                 "total_tool_calls": {"$sum": "$tool_calls"},
                                 "max_duration": {"$max": "$duration"},
+                                "total_cost_usd": {"$sum": "$cost_usd"},
+                                "unpriced_requests": {
+                                    "$sum": {"$cond": [{"$ne": ["$cost_available", True]}, 1, 0]}
+                                },
                                 "scheduled_runs": {
                                     "$sum": {"$cond": [SCHEDULED_USAGE_CONDITION, 1, 0]}
                                 },
@@ -408,6 +414,7 @@ class UsageStorage:
                                 "requests": {"$sum": 1},
                                 "tokens": {"$sum": "$total_tokens"},
                                 "duration": {"$sum": "$duration"},
+                                "cost_usd": {"$sum": "$cost_usd"},
                                 "scheduled_runs": {
                                     "$sum": {"$cond": [SCHEDULED_USAGE_CONDITION, 1, 0]}
                                 },
@@ -467,6 +474,7 @@ class UsageStorage:
             "requests": {"$sum": 1},
             "tokens": {"$sum": "$total_tokens"},
             "duration": {"$sum": "$duration"},
+            "cost_usd": {"$sum": "$cost_usd"},
         }
         if name_field:
             group["name"] = {"$first": f"${name_field}"}
@@ -519,6 +527,10 @@ class UsageStorage:
                     "total_cache_creation_tokens": {"$sum": "$cache_creation_tokens"},
                     "total_cache_read_tokens": {"$sum": "$cache_read_tokens"},
                     "total_duration": {"$sum": "$duration"},
+                    "total_cost_usd": {"$sum": "$cost_usd"},
+                    "unpriced_requests": {
+                        "$sum": {"$cond": [{"$ne": ["$cost_available", True]}, 1, 0]}
+                    },
                 }
             },
         ]
@@ -536,6 +548,8 @@ class UsageStorage:
                         "total_cache_creation_tokens": doc.get("total_cache_creation_tokens", 0),
                         "total_cache_read_tokens": doc.get("total_cache_read_tokens", 0),
                         "total_duration": doc.get("total_duration", 0.0),
+                        "total_cost_usd": doc.get("total_cost_usd", 0.0),
+                        "unpriced_requests": doc.get("unpriced_requests", 0),
                     }
                 )
                 break  # only one group result
@@ -605,6 +619,8 @@ def _empty_stats() -> Dict[str, Any]:
         "total_cache_creation_tokens": 0,
         "total_cache_read_tokens": 0,
         "total_duration": 0.0,
+        "total_cost_usd": 0.0,
+        "unpriced_requests": 0,
     }
 
 
@@ -618,6 +634,7 @@ def _format_ranking_item(doc: Dict[str, Any]) -> Dict[str, Any]:
         "requests": _as_int(doc.get("requests")),
         "tokens": _as_int(doc.get("tokens")),
         "duration": _as_float(doc.get("duration")),
+        "cost_usd": _as_float(doc.get("cost_usd")),
         "input_tokens": input_tokens,
         "cache_creation_tokens": _as_int(doc.get("cache_creation_tokens")),
         "cache_read_tokens": cache_read_tokens,
@@ -643,6 +660,7 @@ def _format_dashboard(doc: Dict[str, Any]) -> Dict[str, Any]:
             "requests": _as_int(item.get("requests")),
             "tokens": _as_int(item.get("tokens")),
             "duration": _as_float(item.get("duration")),
+            "cost_usd": _as_float(item.get("cost_usd")),
             "scheduled_runs": _as_int(item.get("scheduled_runs")),
             "failed_requests": _as_int(item.get("failed_requests")),
             "tool_calls": _as_int(item.get("tool_calls")),
@@ -663,6 +681,8 @@ def _format_dashboard(doc: Dict[str, Any]) -> Dict[str, Any]:
         "total_cache_read_tokens": total_cache_read_tokens,
         "total_duration": total_duration,
         "total_tool_calls": total_tool_calls,
+        "total_cost_usd": _as_float(summary_doc.get("total_cost_usd")),
+        "unpriced_requests": _as_int(summary_doc.get("unpriced_requests")),
         "scheduled_runs": scheduled_runs,
         "failed_requests": failed_requests,
         "success_rate": (successful_requests / total_requests) if total_requests else 0.0,
@@ -699,6 +719,8 @@ def _empty_dashboard() -> Dict[str, Any]:
             "total_cache_read_tokens": 0,
             "total_duration": 0.0,
             "total_tool_calls": 0,
+            "total_cost_usd": 0.0,
+            "unpriced_requests": 0,
             "scheduled_runs": 0,
             "failed_requests": 0,
             "success_rate": 0.0,

--- a/src/infra/writer/present.py
+++ b/src/infra/writer/present.py
@@ -318,6 +318,8 @@ class Presenter(EventPresenterMixin, StoragePresenterMixin):
         duration: float = 0.0,
         model_id: str | None = None,
         model: str | None = None,
+        cost: Any = None,
+        rates: Any = None,
     ) -> Dict[str, Any]:
         """输出 Token 使用统计并保存"""
         event = self.present_token_usage(
@@ -327,6 +329,8 @@ class Presenter(EventPresenterMixin, StoragePresenterMixin):
             duration,
             model_id=model_id,
             model=model,
+            cost=cost,
+            rates=rates,
         )
         await self.save_event(event)
         return event

--- a/src/infra/writer/presenter_events.py
+++ b/src/infra/writer/presenter_events.py
@@ -545,6 +545,8 @@ class EventPresenterMixin:
         cache_read_tokens: int = 0,
         model_id: str | None = None,
         model: str | None = None,
+        cost: Any = None,
+        rates: Any = None,
     ) -> Dict[str, Any]:
         """输出 Token 使用统计
 
@@ -557,6 +559,8 @@ class EventPresenterMixin:
             cache_read_tokens: 缓存读取 token 数
             model_id: 模型配置 ID
             model: 原始模型值
+            cost: USD 成本分解（CostBreakdown）；无法计价时为 None
+            rates: 计价所用单价（PriceRates）；无法计价时为 None
         """
         data: Dict[str, Any] = {
             "input_tokens": input_tokens,
@@ -574,6 +578,17 @@ class EventPresenterMixin:
             data["model_id"] = model_id
         if model:
             data["model"] = model
+        # 金额字段仅在可计价时携带，前端据此区分「未计价」与「0 美元」
+        if cost is not None:
+            data["cost_usd"] = cost.total_usd
+            data["cost_breakdown"] = cost.to_event_data()
+        if rates is not None:
+            data["cost_rates"] = {
+                "input": rates.input,
+                "output": rates.output,
+                "cache_read": rates.cache_read,
+                "cache_write": rates.cache_write,
+            }
         return self._build_event("token:usage", data)
 
     def present_skills_changed(

--- a/src/kernel/config/base.py
+++ b/src/kernel/config/base.py
@@ -163,6 +163,7 @@ class Settings(BaseSettings):
     MONGODB_TRACES_COLLECTION: str = "traces"
     MONGODB_TRACE_EVENT_CHUNKS_COLLECTION: str = "trace_event_chunks"
     MONGODB_USAGE_LOGS_COLLECTION: str = "usage_logs"
+    MONGODB_MODEL_PRICES_COLLECTION: str = "model_prices"
     MONGODB_STORE_BATCH_CONCURRENCY: int = 16
     # Motor business connection pool (shared across all MongoDB-backed storages).
     # Change requires restart: the lru_cache singleton plus per-storage collection
@@ -257,6 +258,11 @@ class Settings(BaseSettings):
 
     # Code Interpreter Settings
     ENABLE_CODE_INTERPRETER: bool = False
+
+    # Model Pricing Settings（models.dev 价格同步 + USD 汇率换算）
+    PRICING_MODELS_DEV_URL: str = "https://models.dev/api.json"
+    PRICING_FX_RATES_URL: str = "https://open.er-api.com/v6/latest/USD"
+    PRICING_SYNC_INTERVAL_HOURS: int = 24
 
     # LangSmith Tracing Settings
     LANGSMITH_TRACING: bool = False

--- a/src/kernel/schemas/model.py
+++ b/src/kernel/schemas/model.py
@@ -27,6 +27,21 @@ class ModelProfile(BaseModel):
     )
 
 
+class ModelPricingOverride(BaseModel):
+    """Per-model USD pricing override (per 1M tokens).
+
+    覆盖 models.dev 同步价格（中转站等价格不一致场景）；
+    字段级生效：未填写的档位沿用同步价格（若有匹配）。
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    input: Optional[float] = Field(None, description="Input price (USD / 1M tokens)")
+    output: Optional[float] = Field(None, description="Output price (USD / 1M tokens)")
+    cache_read: Optional[float] = Field(None, description="Cache read price (USD / 1M tokens)")
+    cache_write: Optional[float] = Field(None, description="Cache write price (USD / 1M tokens)")
+
+
 class ModelConfig(BaseModel):
     """Model configuration stored in database."""
 
@@ -57,6 +72,9 @@ class ModelConfig(BaseModel):
     temperature: Optional[float] = Field(None, description="Per-model temperature override")
     max_tokens: Optional[int] = Field(None, description="Per-model max tokens override")
     profile: Optional[ModelProfile] = Field(None, description="Per-model profile settings")
+    pricing: Optional[ModelPricingOverride] = Field(
+        None, description="Per-model USD pricing override (per 1M tokens)"
+    )
     fallback_model: Optional[str] = Field(
         None, description="Fallback model ID (UUID) when this model fails"
     )
@@ -93,6 +111,9 @@ class ModelConfigCreate(BaseModel):
     temperature: Optional[float] = Field(None, description="Per-model temperature override")
     max_tokens: Optional[int] = Field(None, description="Per-model max tokens override")
     profile: Optional[ModelProfile] = Field(None, description="Per-model profile settings")
+    pricing: Optional[ModelPricingOverride] = Field(
+        None, description="Per-model USD pricing override (per 1M tokens)"
+    )
     fallback_model: Optional[str] = Field(
         None, description="Fallback model ID (UUID) when this model fails"
     )
@@ -122,6 +143,9 @@ class ModelConfigUpdate(BaseModel):
     temperature: Optional[float] = Field(None, description="Per-model temperature override")
     max_tokens: Optional[int] = Field(None, description="Per-model max tokens override")
     profile: Optional[ModelProfile] = Field(None, description="Per-model profile settings")
+    pricing: Optional[ModelPricingOverride] = Field(
+        None, description="Per-model USD pricing override (per 1M tokens)"
+    )
     fallback_model: Optional[str] = Field(
         None, description="Fallback model ID (UUID) when this model fails"
     )

--- a/src/kernel/schemas/pricing.py
+++ b/src/kernel/schemas/pricing.py
@@ -1,0 +1,54 @@
+"""Pricing schemas: 汇率查询、同步状态、模型价格查询。"""
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class FxRatesResponse(BaseModel):
+    """USD 基准汇率表（前端本地货币换算用）。"""
+
+    base: str = "USD"
+    rates: dict[str, float] = Field(default_factory=dict)
+    synced_at: Optional[datetime] = None
+
+
+class PricingSnapshotInfo(BaseModel):
+    """models.dev 价格快照状态。"""
+
+    entry_count: int = 0
+    source_url: str = ""
+    synced_at: Optional[datetime] = None
+
+
+class PricingFxInfo(BaseModel):
+    """汇率表状态。"""
+
+    base: str = "USD"
+    rate_count: int = 0
+    synced_at: Optional[datetime] = None
+
+
+class PricingStatusResponse(BaseModel):
+    """同步状态（管理员）。"""
+
+    prices: PricingSnapshotInfo = Field(default_factory=PricingSnapshotInfo)
+    fx: PricingFxInfo = Field(default_factory=PricingFxInfo)
+
+
+class PricingSyncResponse(PricingStatusResponse):
+    """手动同步结果（管理员）。"""
+
+    refreshed: bool = False
+    error: Optional[str] = None
+
+
+class PricingLookupResponse(BaseModel):
+    """按模型标识查询解析后的单价（管理员，模型表单提示用）。"""
+
+    found: bool = False
+    source: str = ""
+    rates: Optional[dict[str, Optional[float]]] = None
+    matched_provider: str = ""
+    matched_model_id: str = ""

--- a/src/kernel/schemas/usage.py
+++ b/src/kernel/schemas/usage.py
@@ -32,6 +32,8 @@ class UsageLog(BaseModel):
     total_tokens: int = 0
     cache_creation_tokens: int = 0
     cache_read_tokens: int = 0
+    cost_usd: float = 0.0
+    cost_available: bool = False
     duration: float = 0.0
     started_at: Optional[datetime] = None
     completed_at: Optional[datetime] = None
@@ -51,6 +53,8 @@ class UsageStats(BaseModel):
     total_tokens: int = 0
     total_cache_creation_tokens: int = 0
     total_cache_read_tokens: int = 0
+    total_cost_usd: float = 0.0
+    unpriced_requests: int = 0
     total_duration: float = 0.0
 
 
@@ -68,6 +72,8 @@ class UsageDashboardSummary(BaseModel):
     total_input_tokens: int = 0
     total_output_tokens: int = 0
     total_cache_read_tokens: int = 0
+    total_cost_usd: float = 0.0
+    unpriced_requests: int = 0
     total_duration: float = 0.0
     total_tool_calls: int = 0
     scheduled_runs: int = 0
@@ -86,6 +92,7 @@ class UsageDailyPoint(BaseModel):
     date: str
     requests: int = 0
     tokens: int = 0
+    cost_usd: float = 0.0
     duration: float = 0.0
     scheduled_runs: int = 0
     failed_requests: int = 0
@@ -97,6 +104,7 @@ class UsageRankingItem(BaseModel):
     name: str
     requests: int = 0
     tokens: int = 0
+    cost_usd: float = 0.0
     duration: float = 0.0
     input_tokens: int = 0
     cache_creation_tokens: int = 0

--- a/tests/api/routes/test_model_update_pricing.py
+++ b/tests/api/routes/test_model_update_pricing.py
@@ -1,0 +1,113 @@
+"""模型配置价格覆盖字段：schema 透传 + 清空语义 + 创建透传。"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.api.routes.agent import model as model_routes
+from src.kernel.schemas.model import ModelConfig, ModelConfigCreate, ModelConfigUpdate
+from src.kernel.schemas.user import TokenPayload
+
+
+class _FakeModelStorage:
+    def __init__(self, model: ModelConfig | None = None) -> None:
+        self.model = model
+        self.updates: list[tuple[str, dict]] = []
+        self.created: list[dict] = []
+
+    async def get(self, model_id: str) -> ModelConfig | None:
+        return self.model if model_id == self.model.id else None
+
+    async def update(self, model_id: str, update: dict) -> ModelConfig:
+        self.updates.append((model_id, dict(update)))
+        return ModelConfig(**{**self.model.model_dump(), **update})
+
+    async def create(self, model: ModelConfig) -> ModelConfig:
+        self.created.append(model.model_dump())
+        return model
+
+
+async def _noop_invalidate() -> None:
+    return None
+
+
+def _admin_token() -> TokenPayload:
+    return TokenPayload(sub="admin-1", username="admin", roles=["admin"])
+
+
+class TestModelPricingOverrideSchema:
+    def test_config_holds_pricing_override(self):
+        model = ModelConfig(
+            id="m1",
+            value="relay/custom",
+            label="Relay",
+            pricing={"input": 1.5, "output": 6.0, "cache_read": 0.2, "cache_write": 1.875},
+        )
+        assert model.pricing is not None
+        assert model.pricing.input == 1.5
+        assert model.pricing.cache_write == 1.875
+
+    def test_pricing_defaults_to_none(self):
+        model = ModelConfig(id="m1", value="gpt-4o", label="GPT")
+        assert model.pricing is None
+
+
+@pytest.mark.asyncio
+async def test_update_model_persists_pricing_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = ModelConfig(id="m1", value="relay/custom", label="Relay")
+    storage = _FakeModelStorage(model)
+    monkeypatch.setattr(model_routes, "get_model_storage", lambda: storage)
+    monkeypatch.setattr("src.infra.llm.models_service.invalidate_cache", _noop_invalidate)
+
+    await model_routes.update_model(
+        "m1",
+        ModelConfigUpdate(pricing={"input": 1.5, "output": 6.0}),
+        _admin_token(),
+    )
+
+    _, update = storage.updates[0]
+    assert update["pricing"] == {"input": 1.5, "output": 6.0}
+
+
+@pytest.mark.asyncio
+async def test_update_model_maps_empty_pricing_to_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = ModelConfig(
+        id="m1",
+        value="relay/custom",
+        label="Relay",
+        pricing={"input": 1.5, "output": 6.0},
+    )
+    storage = _FakeModelStorage(model)
+    monkeypatch.setattr(model_routes, "get_model_storage", lambda: storage)
+    monkeypatch.setattr("src.infra.llm.models_service.invalidate_cache", _noop_invalidate)
+
+    await model_routes.update_model("m1", ModelConfigUpdate(pricing={}), _admin_token())
+
+    _, update = storage.updates[0]
+    assert update["pricing"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_model_carries_pricing_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _FakeModelStorage()
+    monkeypatch.setattr(model_routes, "get_model_storage", lambda: storage)
+    monkeypatch.setattr("src.infra.llm.models_service.invalidate_cache", _noop_invalidate)
+
+    await model_routes.create_model(
+        ModelConfigCreate(
+            value="relay/custom",
+            label="Relay",
+            pricing={"input": 1.0, "output": 2.0},
+        ),
+        _admin_token(),
+    )
+
+    created_pricing = storage.created[0]["pricing"]
+    assert created_pricing["input"] == 1.0
+    assert created_pricing["output"] == 2.0

--- a/tests/api/routes/test_pricing_routes.py
+++ b/tests/api/routes/test_pricing_routes.py
@@ -1,0 +1,121 @@
+"""pricing 路由测试：汇率查询、手动同步、状态、模型价格查询。"""
+
+import pytest
+
+from src.api.routes import pricing as pricing_routes
+from src.kernel.schemas.user import TokenPayload
+
+
+def _admin() -> TokenPayload:
+    return TokenPayload(sub="admin-1", username="Admin", permissions=["model:admin"])
+
+
+def _user() -> TokenPayload:
+    return TokenPayload(sub="user-1", username="User", permissions=["chat:create"])
+
+
+@pytest.mark.asyncio
+async def test_get_rates_returns_fx_doc(monkeypatch):
+    async def _fake_fx():
+        return {
+            "base": "USD",
+            "rates": {"USD": 1, "CNY": 7.1},
+            "synced_at": "2026-08-30T00:00:00+00:00",
+        }
+
+    monkeypatch.setattr(pricing_routes.pricing_service, "get_fx_rates", _fake_fx)
+    response = await pricing_routes.get_fx_rates(user=_user())
+    assert response.base == "USD"
+    assert response.rates["CNY"] == 7.1
+    assert response.synced_at is not None
+
+
+@pytest.mark.asyncio
+async def test_get_rates_falls_back_to_empty_when_never_synced(monkeypatch):
+    async def _fake_fx():
+        return None
+
+    monkeypatch.setattr(pricing_routes.pricing_service, "get_fx_rates", _fake_fx)
+    response = await pricing_routes.get_fx_rates(user=_user())
+    assert response.base == "USD"
+    assert response.rates == {}
+    assert response.synced_at is None
+
+
+@pytest.mark.asyncio
+async def test_sync_returns_status_and_resets_cache(monkeypatch):
+    calls = {}
+
+    async def _fake_sync(**kwargs):
+        calls.update(kwargs)
+        return {
+            "prices": {
+                "entry_count": 4,
+                "source_url": "u",
+                "synced_at": "2026-08-30T00:00:00+00:00",
+            },
+            "fx": {"base": "USD", "rate_count": 3, "synced_at": "2026-08-30T00:00:00+00:00"},
+            "refreshed": True,
+            "error": None,
+        }
+
+    reset_calls = []
+    monkeypatch.setattr(pricing_routes, "sync_pricing", _fake_sync)
+    monkeypatch.setattr(
+        pricing_routes.pricing_service, "reset_runtime_cache", lambda: reset_calls.append(True)
+    )
+    response = await pricing_routes.sync_pricing_prices(user=_admin())
+    assert calls == {"force": True}
+    assert response.prices.entry_count == 4
+    assert response.fx.rate_count == 3
+    assert response.refreshed is True
+    assert response.error is None
+    assert reset_calls == [True]
+
+
+@pytest.mark.asyncio
+async def test_status_returns_storage_status(monkeypatch):
+    class _FakeStorage:
+        async def get_status(self):
+            return {
+                "prices": {"entry_count": 0, "source_url": "", "synced_at": None},
+                "fx": {"base": "USD", "rate_count": 0, "synced_at": None},
+            }
+
+    monkeypatch.setattr(pricing_routes, "get_pricing_storage", lambda: _FakeStorage())
+    response = await pricing_routes.get_pricing_status(user=_admin())
+    assert response.prices.entry_count == 0
+    assert response.fx.rate_count == 0
+
+
+@pytest.mark.asyncio
+async def test_lookup_found(monkeypatch):
+    from src.infra.pricing.calculator import PriceRates
+    from src.infra.pricing.service import ResolvedPrice
+
+    async def _fake_resolve(**kwargs):
+        assert kwargs["value"] == "gpt-4o"
+        return ResolvedPrice(
+            rates=PriceRates(input=2.5, output=10, cache_read=1.25),
+            source="models_dev",
+            matched_provider="openai",
+            matched_model_id="gpt-4o",
+        )
+
+    monkeypatch.setattr(pricing_routes.pricing_service, "resolve_price", _fake_resolve)
+    response = await pricing_routes.lookup_price(value="gpt-4o", user=_admin())
+    assert response.found is True
+    assert response.source == "models_dev"
+    assert response.rates["input"] == 2.5
+    assert response.matched_provider == "openai"
+
+
+@pytest.mark.asyncio
+async def test_lookup_not_found(monkeypatch):
+    async def _fake_resolve(**kwargs):
+        return None
+
+    monkeypatch.setattr(pricing_routes.pricing_service, "resolve_price", _fake_resolve)
+    response = await pricing_routes.lookup_price(value="mystery", user=_admin())
+    assert response.found is False
+    assert response.rates is None

--- a/tests/infra/agent/test_events_processor.py
+++ b/tests/infra/agent/test_events_processor.py
@@ -124,6 +124,8 @@ class FakePresenter:
         cache_read_tokens: int = 0,
         model_id: str | None = None,
         model: str | None = None,
+        cost: Any = None,
+        rates: Any = None,
     ) -> dict[str, Any]:
         data: dict[str, Any] = {
             "input_tokens": input_tokens,

--- a/tests/infra/pricing/test_calculator.py
+++ b/tests/infra/pricing/test_calculator.py
@@ -1,0 +1,128 @@
+"""Pricing calculator 纯函数测试：token 计数 × 单价 → USD 成本。"""
+
+from src.infra.pricing.calculator import CostBreakdown, PriceRates, compute_cost
+
+
+class TestComputeCost:
+    def test_basic_input_output_cost(self):
+        rates = PriceRates(input=3.0, output=15.0)
+        cost = compute_cost(
+            input_tokens=1_000_000,
+            output_tokens=200_000,
+            rates=rates,
+        )
+        assert cost is not None
+        assert cost.input_usd == 3.0
+        assert cost.output_usd == 3.0
+        assert cost.total_usd == 6.0
+
+    def test_price_is_per_million_tokens(self):
+        rates = PriceRates(input=1.0, output=1.0)
+        cost = compute_cost(input_tokens=1_000, output_tokens=0, rates=rates)
+        assert cost is not None
+        assert cost.input_usd == 0.001
+
+    def test_cache_tokens_excluded_from_billable_input(self):
+        # LangChain 口径：input_tokens 包含 cache_read + cache_creation
+        rates = PriceRates(input=3.0, output=15.0, cache_read=0.3, cache_write=3.75)
+        cost = compute_cost(
+            input_tokens=1_000_000,
+            output_tokens=100_000,
+            cache_read_tokens=600_000,
+            cache_creation_tokens=100_000,
+            rates=rates,
+        )
+        assert cost is not None
+        # billable input = 1M - 600k - 100k = 300k
+        assert cost.input_usd == 300_000 * 3.0 / 1_000_000
+        assert cost.cache_read_usd == 600_000 * 0.3 / 1_000_000
+        assert cost.cache_write_usd == 100_000 * 3.75 / 1_000_000
+        assert cost.output_usd == 100_000 * 15.0 / 1_000_000
+        assert cost.total_usd == (
+            cost.input_usd + cost.cache_read_usd + cost.cache_write_usd + cost.output_usd
+        )
+
+    def test_missing_input_price_returns_none(self):
+        cost = compute_cost(
+            input_tokens=100,
+            output_tokens=100,
+            rates=PriceRates(output=15.0),
+        )
+        assert cost is None
+
+    def test_missing_output_price_returns_none(self):
+        cost = compute_cost(
+            input_tokens=100,
+            output_tokens=100,
+            rates=PriceRates(input=3.0),
+        )
+        assert cost is None
+
+    def test_missing_cache_prices_bill_cache_tokens_at_zero(self):
+        # 未提供缓存单价时按 0 计（models.dev 未收录即视为不单独计费）
+        rates = PriceRates(input=3.0, output=15.0)
+        cost = compute_cost(
+            input_tokens=100_000,
+            output_tokens=0,
+            cache_read_tokens=50_000,
+            rates=rates,
+        )
+        assert cost is not None
+        assert cost.cache_read_usd == 0.0
+        assert cost.cache_write_usd == 0.0
+        assert cost.input_usd == 50_000 * 3.0 / 1_000_000
+
+    def test_negative_billable_input_clamped_to_zero(self):
+        rates = PriceRates(input=3.0, output=15.0)
+        cost = compute_cost(
+            input_tokens=100,
+            output_tokens=0,
+            cache_read_tokens=80,
+            cache_creation_tokens=80,
+            rates=rates,
+        )
+        assert cost is not None
+        assert cost.input_usd == 0.0
+
+    def test_zero_tokens_zero_cost(self):
+        rates = PriceRates(input=3.0, output=15.0)
+        cost = compute_cost(input_tokens=0, output_tokens=0, rates=rates)
+        assert cost is not None
+        assert cost.total_usd == 0.0
+
+    def test_free_model_all_zero_rates_is_priced(self):
+        # 单价全为 0 是「免费模型」，可计价（总额 0），与无法计价区分
+        cost = compute_cost(
+            input_tokens=1_000,
+            output_tokens=1_000,
+            rates=PriceRates(input=0.0, output=0.0),
+        )
+        assert cost is not None
+        assert cost.total_usd == 0.0
+
+
+class TestCostBreakdown:
+    def test_total_sums_components(self):
+        breakdown = CostBreakdown(
+            input_usd=0.1,
+            output_usd=0.2,
+            cache_read_usd=0.03,
+            cache_write_usd=0.04,
+        )
+        assert breakdown.total_usd == 0.37
+
+    def test_to_event_data_shape(self):
+        breakdown = CostBreakdown(
+            input_usd=0.1,
+            output_usd=0.2,
+            cache_read_usd=0.03,
+            cache_write_usd=0.04,
+        )
+        data = breakdown.to_event_data()
+        assert data == {
+            "input": 0.1,
+            "output": 0.2,
+            "cache_read": 0.03,
+            "cache_write": 0.04,
+            "total": 0.37,
+        }

--- a/tests/infra/pricing/test_matching.py
+++ b/tests/infra/pricing/test_matching.py
@@ -1,0 +1,154 @@
+"""Pricing matching 纯函数测试：models.dev 数据 → 价格索引 → 模型匹配。"""
+
+from src.infra.pricing.matching import build_price_index, normalize_model_key
+
+MODELS_DEV_SAMPLE = {
+    "anthropic": {
+        "id": "anthropic",
+        "name": "Anthropic",
+        "models": {
+            "claude-sonnet-4-5": {
+                "name": "Claude Sonnet 4.5",
+                "cost": {"input": 3, "output": 15, "cache_read": 0.3, "cache_write": 3.75},
+            },
+            "claude-3-5-sonnet-20241022": {
+                "name": "Claude 3.5 Sonnet (old)",
+                "cost": {"input": 3, "output": 15},
+            },
+        },
+    },
+    "openai": {
+        "id": "openai",
+        "name": "OpenAI",
+        "models": {
+            "gpt-4o": {
+                "name": "GPT-4o",
+                "cost": {"input": 2.5, "output": 10, "cache_read": 1.25},
+            },
+        },
+    },
+    "deepseek": {
+        "id": "deepseek",
+        "name": "DeepSeek",
+        "models": {
+            "deepseek-chat": {
+                "name": "DeepSeek Chat",
+                "cost": {"input": 0.27, "output": 1.1, "cache_read": 0.07},
+            },
+        },
+    },
+}
+
+
+class TestNormalizeModelKey:
+    def test_strips_provider_prefix(self):
+        assert normalize_model_key("anthropic/claude-sonnet-4-5") == normalize_model_key(
+            "claude-sonnet-4-5"
+        )
+
+    def test_lowercases_and_collapses(self):
+        assert normalize_model_key("GPT-4o") == normalize_model_key("gpt4o")
+
+    def test_strips_date_suffix(self):
+        assert normalize_model_key("gpt-4o-2024-08-13") == normalize_model_key("gpt-4o")
+        assert normalize_model_key("claude-3-5-sonnet-20241022") == normalize_model_key(
+            "claude-3-5-sonnet"
+        )
+
+    def test_strips_latest_suffix(self):
+        assert normalize_model_key("claude-sonnet-4-5-latest") == normalize_model_key(
+            "claude-sonnet-4-5"
+        )
+
+    def test_empty_and_garbage_safe(self):
+        assert normalize_model_key("") == ""
+        assert normalize_model_key("///") == ""
+
+
+class TestBuildPriceIndex:
+    def test_index_only_keeps_priced_models(self):
+        api_json = {
+            "prov": {
+                "id": "prov",
+                "name": "Prov",
+                "models": {
+                    "priced": {"name": "Priced", "cost": {"input": 1, "output": 2}},
+                    "unpriced": {"name": "Unpriced"},
+                },
+            }
+        }
+        index = build_price_index(api_json)
+        assert index.entry_count == 1
+
+    def test_entry_count_counts_priced_entries(self):
+        index = build_price_index(MODELS_DEV_SAMPLE)
+        assert index.entry_count == 4
+
+    def test_to_snapshot_entries_is_json_serializable(self):
+        import json
+
+        index = build_price_index(MODELS_DEV_SAMPLE)
+        dumped = json.dumps(index.to_snapshot_entries())
+        assert "claude-sonnet-4-5" in dumped
+
+    def test_restore_from_snapshot_roundtrip(self):
+        from src.infra.pricing.matching import restore_price_index
+
+        index = build_price_index(MODELS_DEV_SAMPLE)
+        restored = restore_price_index(index.to_snapshot_entries())
+        assert restored.match("gpt-4o") is not None
+        assert restored.match("deepseek/deepseek-chat") is not None
+
+
+class TestPriceIndexMatch:
+    def setup_method(self):
+        from src.infra.pricing.matching import build_price_index
+
+        self.index = build_price_index(MODELS_DEV_SAMPLE)
+
+    def test_exact_provider_qualified_value(self):
+        entry = self.index.match("anthropic/claude-sonnet-4-5")
+        assert entry is not None
+        assert entry.provider == "anthropic"
+        assert entry.model_id == "claude-sonnet-4-5"
+        assert entry.rates.input == 3
+        assert entry.rates.cache_write == 3.75
+
+    def test_bare_model_id_with_provider_hint(self):
+        entry = self.index.match("gpt-4o", provider="openai")
+        assert entry is not None
+        assert entry.provider == "openai"
+
+    def test_bare_model_id_without_provider(self):
+        entry = self.index.match("gpt-4o")
+        assert entry is not None
+        assert entry.model_id == "gpt-4o"
+
+    def test_date_suffixed_value_matches_base_model(self):
+        entry = self.index.match("gpt-4o-2024-08-13")
+        assert entry is not None
+        assert entry.model_id == "gpt-4o"
+
+    def test_dated_snapshot_model_matches_exact(self):
+        entry = self.index.match("claude-3-5-sonnet-20241022")
+        assert entry is not None
+        assert entry.model_id == "claude-3-5-sonnet-20241022"
+
+    def test_latest_alias_matches_base(self):
+        entry = self.index.match("claude-sonnet-4-5-latest")
+        assert entry is not None
+        assert entry.model_id == "claude-sonnet-4-5"
+
+    def test_case_insensitive(self):
+        entry = self.index.match("OpenAI/GPT-4o")
+        assert entry is not None
+
+    def test_unknown_model_returns_none(self):
+        assert self.index.match("totally-unknown-model") is None
+        assert self.index.match("") is None
+
+    def test_provider_hint_loses_to_exact_value_prefix(self):
+        # value 自带前缀时以前缀为准
+        entry = self.index.match("deepseek/deepseek-chat", provider="openai")
+        assert entry is not None
+        assert entry.provider == "deepseek"

--- a/tests/infra/pricing/test_matching.py
+++ b/tests/infra/pricing/test_matching.py
@@ -95,9 +95,27 @@ class TestBuildPriceIndex:
         from src.infra.pricing.matching import restore_price_index
 
         index = build_price_index(MODELS_DEV_SAMPLE)
-        restored = restore_price_index(index.to_snapshot_entries())
+        restored = restore_price_index(index.to_snapshot())
         assert restored.match("gpt-4o") is not None
         assert restored.match("deepseek/deepseek-chat") is not None
+
+    def test_restore_keeps_canonical_ownership_rules(self):
+        from src.infra.pricing.matching import restore_price_index
+
+        api_json = {
+            "cortecs": {
+                "id": "cortecs",
+                "models": {"gpt-4o": {"cost": {"input": 2.659, "output": 10.635}}},
+            },
+            "openai": {
+                "id": "openai",
+                "models": {"gpt-4o": {"cost": {"input": 2.5, "output": 10}}},
+            },
+        }
+        restored = restore_price_index(build_price_index(api_json).to_snapshot())
+        entry = restored.match("gpt-4o")
+        assert entry is not None
+        assert entry.provider == "openai"
 
 
 class TestPriceIndexMatch:
@@ -152,3 +170,95 @@ class TestPriceIndexMatch:
         entry = self.index.match("deepseek/deepseek-chat", provider="openai")
         assert entry is not None
         assert entry.provider == "deepseek"
+
+
+class TestCanonicalProviderPreference:
+    """裸模型名全局匹配时优先官方 provider，避免命中第三方路由商价格。"""
+
+    def setup_method(self):
+        from src.infra.pricing.matching import build_price_index
+
+        self.api_json = {
+            "cortecs": {
+                "id": "cortecs",
+                "name": "Cortecs",
+                "models": {
+                    "gpt-4o": {"cost": {"input": 2.659, "output": 10.635}},
+                },
+            },
+            "openai": {
+                "id": "openai",
+                "name": "OpenAI",
+                "models": {
+                    "gpt-4o": {"cost": {"input": 2.5, "output": 10}},
+                },
+            },
+            "nano-gpt": {
+                "id": "nano-gpt",
+                "name": "NanoGPT",
+                "models": {
+                    "deepseek-chat": {"cost": {"input": 0.1, "output": 0.425}},
+                },
+            },
+            "deepseek": {
+                "id": "deepseek",
+                "name": "DeepSeek",
+                "models": {
+                    "deepseek-chat": {"cost": {"input": 0.27, "output": 1.1}},
+                },
+            },
+        }
+        self.index = build_price_index(self.api_json)
+
+    def test_bare_name_prefers_canonical_provider(self):
+        entry = self.index.match("gpt-4o")
+        assert entry is not None
+        assert entry.provider == "openai"
+        assert entry.rates.input == 2.5
+
+    def test_canonical_preference_applies_to_normalized_match(self):
+        entry = self.index.match("GPT-4o-2024-08-13")
+        assert entry is not None
+        assert entry.provider == "openai"
+
+    def test_canonical_provider_owned_unpriced_model_returns_none(self):
+        # 官方 provider 收录了该模型但无价格：宁可不计价，也不用第三方价格
+        api_json = {
+            "qwen": {
+                "id": "qwen",
+                "name": "Qwen",
+                "models": {"qwen3-max": {"name": "Qwen3 Max"}},
+            },
+            "iflowcn": {
+                "id": "iflowcn",
+                "name": "iFlow",
+                "models": {"qwen3-max": {"cost": {"input": 0, "output": 0}}},
+            },
+        }
+        from src.infra.pricing.matching import build_price_index
+
+        index = build_price_index(api_json)
+        assert index.match("qwen3-max") is None
+        # 带前缀显式指向第三方时仍然允许
+        entry = index.match("iflowcn/qwen3-max")
+        assert entry is not None
+        assert entry.provider == "iflowcn"
+
+    def test_unknown_family_falls_back_deterministically(self):
+        # 无官方归属规则时按 provider 名排序取第一个，保证快照间稳定
+        api_json = {
+            "zzz-relay": {
+                "id": "zzz-relay",
+                "models": {"weird-model": {"cost": {"input": 1, "output": 2}}},
+            },
+            "aaa-relay": {
+                "id": "aaa-relay",
+                "models": {"weird-model": {"cost": {"input": 3, "output": 4}}},
+            },
+        }
+        from src.infra.pricing.matching import build_price_index
+
+        index = build_price_index(api_json)
+        entry = index.match("weird-model")
+        assert entry is not None
+        assert entry.provider == "aaa-relay"

--- a/tests/infra/pricing/test_pricing_service.py
+++ b/tests/infra/pricing/test_pricing_service.py
@@ -1,0 +1,182 @@
+"""pricing service 测试：价格解析（覆盖 > models.dev 匹配）与成本计算入口。"""
+
+import asyncio
+
+import pytest
+
+from src.infra.pricing import service as pricing_service
+from src.infra.pricing.calculator import PriceRates
+from src.infra.pricing.storage import PricingStorage
+
+
+def _async_return(value):
+    async def _wrapper(_model_config_id):
+        return value
+
+    return _wrapper
+
+
+class _FakeCollection:
+    def __init__(self):
+        self.docs: dict = {}
+
+    async def update_one(self, query, update, **kwargs):
+        doc = dict(update.get("$set", {}))
+        doc["_id"] = query["_id"]
+        self.docs[query["_id"]] = doc
+        return None
+
+    async def find_one(self, query, *args, **kwargs):
+        doc = self.docs.get(query.get("_id"))
+        if doc is None:
+            return None
+        return {k: v for k, v in doc.items() if k != "_id"}
+
+    async def create_index(self, *args, **kwargs):
+        return None
+
+
+def _storage_with_snapshot() -> PricingStorage:
+    storage = PricingStorage(collection=_FakeCollection())
+    asyncio.run(
+        storage.save_price_snapshot(
+            [
+                {
+                    "provider": "openai",
+                    "model_id": "gpt-4o",
+                    "name": "GPT-4o",
+                    "rates": {
+                        "input": 2.5,
+                        "output": 10,
+                        "cache_read": 1.25,
+                        "cache_write": None,
+                    },
+                }
+            ],
+            source_url="u",
+        )
+    )
+    asyncio.run(storage.save_fx_rates({"USD": 1, "CNY": 7.1}, base="USD"))
+    return storage
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch):
+    storage = _storage_with_snapshot()
+    monkeypatch.setattr(pricing_service, "get_pricing_storage", lambda: storage)
+    pricing_service.reset_runtime_cache()
+    yield
+    pricing_service.reset_runtime_cache()
+
+
+class TestResolvePrice:
+    def test_matches_models_dev_snapshot(self):
+        resolved = asyncio.run(pricing_service.resolve_price(value="gpt-4o"))
+        assert resolved is not None
+        assert resolved.source == "models_dev"
+        assert resolved.rates.input == 2.5
+        assert resolved.matched_provider == "openai"
+        assert resolved.matched_model_id == "gpt-4o"
+
+    def test_unknown_model_returns_none(self):
+        assert asyncio.run(pricing_service.resolve_price(value="nope")) is None
+
+    def test_model_config_override_wins(self, monkeypatch):
+        monkeypatch.setattr(
+            pricing_service,
+            "_load_model_override",
+            _async_return(PriceRates(input=1.0, output=2.0)),
+        )
+        resolved = asyncio.run(
+            pricing_service.resolve_price(value="gpt-4o", model_config_id="model-uuid-1")
+        )
+        assert resolved is not None
+        assert resolved.source == "override"
+        assert resolved.rates.input == 1.0
+
+    def test_partial_override_merges_over_matched_base(self, monkeypatch):
+        monkeypatch.setattr(
+            pricing_service,
+            "_load_model_override",
+            _async_return(PriceRates(input=9.0)),
+        )
+        resolved = asyncio.run(pricing_service.resolve_price(value="gpt-4o", model_config_id="m1"))
+        assert resolved is not None
+        assert resolved.source == "override"
+        # 未覆盖的字段沿用 models.dev 匹配值
+        assert resolved.rates.input == 9.0
+        assert resolved.rates.output == 10
+        assert resolved.rates.cache_read == 1.25
+
+    def test_override_without_match_uses_override_only(self, monkeypatch):
+        monkeypatch.setattr(
+            pricing_service,
+            "_load_model_override",
+            _async_return(PriceRates(input=1.0, output=2.0)),
+        )
+        resolved = asyncio.run(
+            pricing_service.resolve_price(value="relay/custom-model", model_config_id="m1")
+        )
+        assert resolved is not None
+        assert resolved.source == "override"
+        assert resolved.rates.input == 1.0
+
+    def test_partial_override_without_match_is_unpriced(self, monkeypatch):
+        monkeypatch.setattr(
+            pricing_service,
+            "_load_model_override",
+            _async_return(PriceRates(input=1.0)),
+        )
+        resolved = asyncio.run(
+            pricing_service.resolve_price(value="relay/custom", model_config_id="m1")
+        )
+        # 只覆盖 input、无匹配基准 → 无法计价
+        assert resolved is None or not resolved.rates.is_priced()
+
+
+class TestGetFxRates:
+    def test_loads_from_storage(self):
+        doc = asyncio.run(pricing_service.get_fx_rates())
+        assert doc is not None
+        assert doc["base"] == "USD"
+        assert doc["rates"]["CNY"] == 7.1
+
+    def test_missing_returns_none(self, monkeypatch):
+        monkeypatch.setattr(
+            pricing_service,
+            "get_pricing_storage",
+            lambda: PricingStorage(collection=_FakeCollection()),
+        )
+        pricing_service.reset_runtime_cache()
+        assert asyncio.run(pricing_service.get_fx_rates()) is None
+
+
+class TestComputeUsageCost:
+    def test_end_to_end(self):
+        result = asyncio.run(
+            pricing_service.compute_usage_cost(
+                model_value="gpt-4o",
+                input_tokens=1_000_000,
+                output_tokens=100_000,
+                cache_read_tokens=200_000,
+            )
+        )
+        assert result is not None
+        breakdown, rates, source = result
+        assert source == "models_dev"
+        assert rates.input == 2.5
+        assert breakdown.input_usd == 800_000 * 2.5 / 1_000_000
+        assert breakdown.cache_read_usd == 200_000 * 1.25 / 1_000_000
+        assert breakdown.output_usd == 100_000 * 10 / 1_000_000
+
+    def test_unmatched_model_returns_none(self):
+        assert (
+            asyncio.run(
+                pricing_service.compute_usage_cost(
+                    model_value="unknown",
+                    input_tokens=100,
+                    output_tokens=100,
+                )
+            )
+            is None
+        )

--- a/tests/infra/pricing/test_pricing_storage.py
+++ b/tests/infra/pricing/test_pricing_storage.py
@@ -1,0 +1,96 @@
+"""PricingStorage 持久化测试：价格快照与汇率文档的读写。"""
+
+import asyncio
+from types import SimpleNamespace
+
+from src.infra.pricing.storage import PricingStorage
+
+
+class _FakeCollection:
+    def __init__(self):
+        self.docs: dict = {}
+
+    async def update_one(self, query, update, **kwargs):
+        doc_id = query["_id"]
+        doc = dict(update.get("$set", {}))
+        doc["_id"] = doc_id
+        self.docs[doc_id] = doc
+        return SimpleNamespace(modified_count=1, upserted_id=doc_id)
+
+    async def find_one(self, query, *args, **kwargs):
+        doc = self.docs.get(query.get("_id"))
+        if doc is None:
+            return None
+        return {k: v for k, v in doc.items() if k != "_id"}
+
+    async def create_index(self, *args, **kwargs):
+        return None
+
+
+def _make_storage() -> tuple[PricingStorage, _FakeCollection]:
+    fake = _FakeCollection()
+    return PricingStorage(collection=fake), fake
+
+
+class TestPriceSnapshot:
+    def test_roundtrip(self):
+        storage, _ = _make_storage()
+        entries = [
+            {
+                "provider": "openai",
+                "model_id": "gpt-4o",
+                "name": "GPT-4o",
+                "rates": {"input": 2.5, "output": 10, "cache_read": 1.25},
+            }
+        ]
+        asyncio.run(storage.save_price_snapshot(entries, source_url="https://models.dev/api.json"))
+        snapshot = asyncio.run(storage.load_price_snapshot())
+        assert snapshot is not None
+        assert snapshot["entry_count"] == 1
+        assert snapshot["entries"] == entries
+        assert snapshot["source_url"] == "https://models.dev/api.json"
+        assert snapshot["synced_at"] is not None
+
+    def test_missing_snapshot_returns_none(self):
+        storage, _ = _make_storage()
+        assert asyncio.run(storage.load_price_snapshot()) is None
+
+
+class TestFxRates:
+    def test_roundtrip(self):
+        storage, _ = _make_storage()
+        rates = {"USD": 1, "CNY": 7.1, "JPY": 150.0}
+        asyncio.run(storage.save_fx_rates(rates, base="USD"))
+        doc = asyncio.run(storage.load_fx_rates())
+        assert doc is not None
+        assert doc["base"] == "USD"
+        assert doc["rates"] == rates
+        assert doc["synced_at"] is not None
+
+    def test_missing_fx_returns_none(self):
+        storage, _ = _make_storage()
+        assert asyncio.run(storage.load_fx_rates()) is None
+
+
+class TestStatus:
+    def test_status_reports_both_docs(self):
+        storage, _ = _make_storage()
+        asyncio.run(
+            storage.save_price_snapshot(
+                [{"provider": "p", "model_id": "m", "name": "", "rates": {}}],
+                source_url="u",
+            )
+        )
+        asyncio.run(storage.save_fx_rates({"USD": 1}, base="USD"))
+        status = asyncio.run(storage.get_status())
+        assert status["prices"]["entry_count"] == 1
+        assert status["prices"]["synced_at"] is not None
+        assert status["fx"]["base"] == "USD"
+        assert status["fx"]["rate_count"] == 1
+
+    def test_status_empty_when_never_synced(self):
+        storage, _ = _make_storage()
+        status = asyncio.run(storage.get_status())
+        assert status["prices"]["entry_count"] == 0
+        assert status["prices"]["synced_at"] is None
+        assert status["fx"]["synced_at"] is None

--- a/tests/infra/pricing/test_pricing_sync.py
+++ b/tests/infra/pricing/test_pricing_sync.py
@@ -1,0 +1,186 @@
+"""pricing 同步测试：models.dev / 汇率拉取、解析、TTL 与失败降级。"""
+
+import asyncio
+
+import httpx
+import pytest
+
+from src.infra.pricing import sync as pricing_sync
+from src.infra.pricing.storage import PricingStorage
+
+MODELS_DEV_PAYLOAD = {
+    "openai": {
+        "id": "openai",
+        "name": "OpenAI",
+        "models": {
+            "gpt-4o": {"name": "GPT-4o", "cost": {"input": 2.5, "output": 10}},
+        },
+    }
+}
+
+FX_PAYLOAD = {
+    "result": "success",
+    "base_code": "USD",
+    "time_last_update_unix": 1787961751,
+    "rates": {"USD": 1, "CNY": 7.1, "JPY": 150.0},
+}
+
+
+class _FakeCollection:
+    def __init__(self):
+        self.docs: dict = {}
+
+    async def update_one(self, query, update, **kwargs):
+        doc = dict(update.get("$set", {}))
+        doc["_id"] = query["_id"]
+        self.docs[query["_id"]] = doc
+        return None
+
+    async def find_one(self, query, *args, **kwargs):
+        doc = self.docs.get(query.get("_id"))
+        if doc is None:
+            return None
+        return {k: v for k, v in doc.items() if k != "_id"}
+
+    async def create_index(self, *args, **kwargs):
+        return None
+
+
+def _http_client(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+class TestFetchModelsDev:
+    def test_returns_snapshot_entries(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert str(request.url) == "https://models.dev/api.json"
+            return httpx.Response(200, json=MODELS_DEV_PAYLOAD)
+
+        async def run():
+            async with _http_client(handler) as client:
+                return await pricing_sync.fetch_models_dev(client)
+
+        entries = asyncio.run(run())
+        assert entries == [
+            {
+                "provider": "openai",
+                "model_id": "gpt-4o",
+                "name": "GPT-4o",
+                "rates": {"input": 2.5, "output": 10, "cache_read": None, "cache_write": None},
+            }
+        ]
+
+    def test_non_200_raises(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(503, text="unavailable")
+
+        async def run():
+            async with _http_client(handler) as client:
+                return await pricing_sync.fetch_models_dev(client)
+
+        with pytest.raises(Exception):
+            asyncio.run(run())
+
+
+class TestParseFxPayload:
+    def test_success_payload(self):
+        doc = pricing_sync.parse_fx_payload(FX_PAYLOAD)
+        assert doc is not None
+        assert doc["base"] == "USD"
+        assert doc["rates"] == {"USD": 1, "CNY": 7.1, "JPY": 150.0}
+        assert doc["source_updated_at"] == 1787961751
+
+    def test_failure_payload_returns_none(self):
+        assert pricing_sync.parse_fx_payload({"result": "error"}) is None
+
+    def test_missing_rates_returns_none(self):
+        assert pricing_sync.parse_fx_payload({"result": "success"}) is None
+
+
+class TestSyncPricing:
+    def _storage(self) -> PricingStorage:
+        return PricingStorage(collection=_FakeCollection())
+
+    def test_first_sync_fetches_and_persists(self, monkeypatch):
+        monkeypatch.setattr(pricing_sync, "get_pricing_storage", self._storage)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if "models.dev" in str(request.url):
+                return httpx.Response(200, json=MODELS_DEV_PAYLOAD)
+            return httpx.Response(200, json=FX_PAYLOAD)
+
+        monkeypatch.setattr(pricing_sync, "_build_http_client", lambda: _http_client(handler))
+        status = asyncio.run(pricing_sync.sync_pricing())
+        assert status["prices"]["entry_count"] == 1
+        assert status["fx"]["rate_count"] == 3
+        assert status["refreshed"] is True
+        assert status["error"] is None
+
+    def test_fresh_snapshot_skips_fetch(self, monkeypatch):
+        storage = self._storage()
+        monkeypatch.setattr(pricing_sync, "get_pricing_storage", lambda: storage)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise AssertionError("should not fetch when snapshot is fresh")
+
+        asyncio.run(
+            storage.save_price_snapshot(
+                [{"provider": "p", "model_id": "m", "name": "", "rates": {}}],
+                source_url="u",
+            )
+        )
+        asyncio.run(storage.save_fx_rates({"USD": 1}, base="USD"))
+        monkeypatch.setattr(pricing_sync, "_build_http_client", lambda: _http_client(handler))
+        status = asyncio.run(pricing_sync.sync_pricing())
+        assert status["refreshed"] is False
+
+    def test_force_refetches_even_when_fresh(self, monkeypatch):
+        storage = self._storage()
+        monkeypatch.setattr(pricing_sync, "get_pricing_storage", lambda: storage)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if "models.dev" in str(request.url):
+                return httpx.Response(200, json=MODELS_DEV_PAYLOAD)
+            return httpx.Response(200, json=FX_PAYLOAD)
+
+        asyncio.run(storage.save_fx_rates({"USD": 1}, base="USD"))
+        monkeypatch.setattr(pricing_sync, "_build_http_client", lambda: _http_client(handler))
+        status = asyncio.run(pricing_sync.sync_pricing(force=True))
+        assert status["refreshed"] is True
+        assert status["prices"]["entry_count"] == 1
+
+    def test_fetch_failure_keeps_old_snapshot(self, monkeypatch):
+        storage = self._storage()
+        monkeypatch.setattr(pricing_sync, "get_pricing_storage", lambda: storage)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, text="boom")
+
+        asyncio.run(
+            storage.save_price_snapshot(
+                [{"provider": "p", "model_id": "old", "name": "", "rates": {}}],
+                source_url="u",
+            )
+        )
+        monkeypatch.setattr(pricing_sync, "_build_http_client", lambda: _http_client(handler))
+        status = asyncio.run(pricing_sync.sync_pricing(force=True))
+        assert status["error"] is not None
+        # 旧快照仍在
+        snapshot = asyncio.run(storage.load_price_snapshot())
+        assert snapshot is not None
+        assert snapshot["entries"][0]["model_id"] == "old"
+
+    def test_models_dev_and_fx_failures_are_independent(self, monkeypatch):
+        storage = self._storage()
+        monkeypatch.setattr(pricing_sync, "get_pricing_storage", lambda: storage)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if "models.dev" in str(request.url):
+                return httpx.Response(500, text="down")
+            return httpx.Response(200, json=FX_PAYLOAD)
+
+        monkeypatch.setattr(pricing_sync, "_build_http_client", lambda: _http_client(handler))
+        status = asyncio.run(pricing_sync.sync_pricing(force=True))
+        # FX 成功、价格失败：状态里两者独立呈现
+        assert status["fx"]["rate_count"] == 3
+        assert status["prices"]["entry_count"] == 0

--- a/tests/infra/pricing/test_pricing_sync.py
+++ b/tests/infra/pricing/test_pricing_sync.py
@@ -51,7 +51,7 @@ def _http_client(handler) -> httpx.AsyncClient:
 
 
 class TestFetchModelsDev:
-    def test_returns_snapshot_entries(self):
+    def test_returns_snapshot_with_entries_and_owners(self):
         def handler(request: httpx.Request) -> httpx.Response:
             assert str(request.url) == "https://models.dev/api.json"
             return httpx.Response(200, json=MODELS_DEV_PAYLOAD)
@@ -60,8 +60,8 @@ class TestFetchModelsDev:
             async with _http_client(handler) as client:
                 return await pricing_sync.fetch_models_dev(client)
 
-        entries = asyncio.run(run())
-        assert entries == [
+        snapshot = asyncio.run(run())
+        assert snapshot["entries"] == [
             {
                 "provider": "openai",
                 "model_id": "gpt-4o",
@@ -69,6 +69,7 @@ class TestFetchModelsDev:
                 "rates": {"input": 2.5, "output": 10, "cache_read": None, "cache_write": None},
             }
         ]
+        assert snapshot["model_owners"]["gpt-4o"] == ["openai"]
 
     def test_non_200_raises(self):
         def handler(request: httpx.Request) -> httpx.Response:

--- a/tests/infra/pricing/test_token_usage_cost.py
+++ b/tests/infra/pricing/test_token_usage_cost.py
@@ -1,0 +1,175 @@
+"""token:usage 事件金额集成测试：presenter 事件字段 + processor 计算 + usage_logs 落库。"""
+
+import asyncio
+from types import SimpleNamespace
+
+from src.infra.pricing.calculator import CostBreakdown, PriceRates
+from src.infra.writer.present import create_presenter
+
+
+def _breakdown() -> CostBreakdown:
+    return CostBreakdown(
+        input_usd=0.008, output_usd=0.015, cache_read_usd=0.0006, cache_write_usd=0.001
+    )
+
+
+class TestPresentTokenUsageCost:
+    def test_cost_fields_included_when_priced(self):
+        presenter = create_presenter(session_id="s1", agent_id="a", agent_name="A")
+        event = presenter.present_token_usage(
+            input_tokens=1000,
+            output_tokens=500,
+            total_tokens=1500,
+            duration=1.0,
+            model_id="model-1",
+            model="openai/gpt-4o",
+            cost=_breakdown(),
+            rates=PriceRates(input=2.5, output=10, cache_read=1.25),
+        )
+        data = event["data"]
+        assert data["cost_usd"] == _breakdown().total_usd
+        assert data["cost_breakdown"]["input"] == 0.008
+        assert data["cost_breakdown"]["total"] == _breakdown().total_usd
+        assert data["cost_rates"]["input"] == 2.5
+        assert data["cost_rates"]["cache_read"] == 1.25
+        assert data["cost_rates"]["cache_write"] is None
+
+    def test_cost_fields_absent_when_unpriced(self):
+        presenter = create_presenter(session_id="s1", agent_id="a", agent_name="A")
+        event = presenter.present_token_usage(
+            input_tokens=1000,
+            output_tokens=500,
+            total_tokens=1500,
+            duration=1.0,
+        )
+        assert "cost_usd" not in event["data"]
+        assert "cost_breakdown" not in event["data"]
+        assert "cost_rates" not in event["data"]
+
+
+class TestProcessorEmitsCost:
+    def _make_processor(self):
+        from src.infra.agent.events.processor import AgentEventProcessor
+
+        processor = AgentEventProcessor.__new__(AgentEventProcessor)
+        processor.total_input_tokens = 1_000_000
+        processor.total_output_tokens = 100_000
+        processor.total_tokens = 1_100_000
+        processor.total_cache_creation_tokens = 0
+        processor.total_cache_read_tokens = 200_000
+        processor._token_usage_emitted = False
+
+        captured: dict = {}
+
+        class _FakePresenter:
+            def present_token_usage(self, **kwargs):
+                captured.update(kwargs)
+                return {"event": "token:usage", "data": dict(kwargs)}
+
+        async def _emit(event):
+            captured["emitted"] = event
+
+        processor.presenter = _FakePresenter()
+        processor._presenter_emit = _emit
+        return processor, captured
+
+    def test_computes_cost_via_pricing_service(self, monkeypatch):
+        from src.infra.agent.events import processor as processor_module
+
+        processor, captured = self._make_processor()
+
+        async def _fake_compute(**kwargs):
+            assert kwargs["model_value"] == "openai/gpt-4o"
+            assert kwargs["model_config_id"] == "model-1"
+            assert kwargs["input_tokens"] == 1_000_000
+            assert kwargs["cache_read_tokens"] == 200_000
+            return _breakdown(), PriceRates(input=2.5, output=10), "models_dev"
+
+        monkeypatch.setattr(processor_module, "compute_usage_cost", _fake_compute)
+        emitted = asyncio.run(
+            processor.emit_token_usage(duration=2.0, model_id="model-1", model="openai/gpt-4o")
+        )
+        assert emitted is True
+        assert captured["cost"] == _breakdown()
+        assert captured["rates"].input == 2.5
+
+    def test_pricing_failure_does_not_break_event(self, monkeypatch):
+        from src.infra.agent.events import processor as processor_module
+
+        processor, captured = self._make_processor()
+
+        async def _boom(**kwargs):
+            raise RuntimeError("pricing down")
+
+        monkeypatch.setattr(processor_module, "compute_usage_cost", _boom)
+        emitted = asyncio.run(
+            processor.emit_token_usage(duration=2.0, model_id="model-1", model="openai/gpt-4o")
+        )
+        assert emitted is True
+        assert "cost" not in captured or captured.get("cost") is None
+
+
+class TestUsageLogCost:
+    def _storage(self):
+        from src.infra.usage.storage import UsageStorage
+
+        class _FakeCollection:
+            def __init__(self):
+                self.saved: dict = {}
+
+            async def update_one(self, query, update, **kwargs):
+                self.saved.update(update["$set"])
+                return SimpleNamespace(modified_count=1)
+
+            async def create_index(self, *a, **kw):
+                return None
+
+        storage = UsageStorage()
+        fake = _FakeCollection()
+        storage._collection = fake
+
+        async def _no_metadata(_session_id):
+            return {}
+
+        storage._get_session_metadata = _no_metadata
+        return storage, fake
+
+    def test_persists_cost_usd(self):
+        storage, fake = self._storage()
+        ok = asyncio.run(
+            storage.upsert_usage_log_from_trace_metadata(
+                {
+                    "trace_id": "t1",
+                    "session_id": "s1",
+                    "user_id": "u1",
+                    "status": "completed",
+                },
+                {
+                    "model": "gpt-4o",
+                    "input_tokens": 1000,
+                    "output_tokens": 500,
+                    "total_tokens": 1500,
+                    "cost_usd": 0.0246,
+                    "cost_breakdown": {"total": 0.0246},
+                },
+            )
+        )
+        assert ok is True
+        assert fake.saved["cost_usd"] == 0.0246
+        assert fake.saved["cost_available"] is True
+
+    def test_unpriced_logs_cost_zero_and_unavailable(self):
+        storage, fake = self._storage()
+        asyncio.run(
+            storage.upsert_usage_log_from_trace_metadata(
+                {
+                    "trace_id": "t2",
+                    "session_id": "s1",
+                    "user_id": "u1",
+                    "status": "completed",
+                },
+                {"model": "mystery", "input_tokens": 10, "output_tokens": 5},
+            )
+        )
+        assert fake.saved["cost_usd"] == 0.0
+        assert fake.saved["cost_available"] is False

--- a/tests/infra/usage/test_usage_cost_aggregation.py
+++ b/tests/infra/usage/test_usage_cost_aggregation.py
@@ -1,0 +1,157 @@
+"""usage_logs 金额聚合测试：stats / dashboard / 排行 / 按日均含 cost_usd。"""
+
+import pytest
+
+from src.infra.usage.storage import UsageStorage, _empty_stats
+
+
+class _FakeAggregateCursor:
+    def __init__(self, docs):
+        self._docs = docs
+
+    def __aiter__(self):
+        return self._iter()
+
+    async def _iter(self):
+        for doc in self._docs:
+            yield doc
+
+
+class _FakeAggregateCollection:
+    """返回固定聚合结果的假集合，用于验证管道产物格式。"""
+
+    def __init__(self, stats_doc=None, facet_doc=None):
+        self._stats_doc = stats_doc
+        self._facet_doc = facet_doc
+        self.pipelines: list = []
+
+    async def count_documents(self, query):
+        return 2
+
+    def aggregate(self, pipeline):
+        self.pipelines.append(pipeline)
+        if self._stats_doc is not None:
+            return _FakeAggregateCursor([self._stats_doc])
+        if self._facet_doc is not None:
+            return _FakeAggregateCursor([self._facet_doc])
+        return _FakeAggregateCursor([])
+
+    def find(self, query, projection):
+        raise AssertionError("not used in these tests")
+
+
+def _stats_doc():
+    return {
+        "total_input_tokens": 100,
+        "total_output_tokens": 50,
+        "total_tokens": 150,
+        "total_cache_creation_tokens": 0,
+        "total_cache_read_tokens": 20,
+        "total_duration": 3.0,
+        "total_cost_usd": 0.5,
+        "unpriced_requests": 1,
+    }
+
+
+def _facet_doc():
+    return {
+        "summary": [
+            {
+                "total_requests": 2,
+                "total_tokens": 150,
+                "total_input_tokens": 100,
+                "total_output_tokens": 50,
+                "total_cache_read_tokens": 20,
+                "total_duration": 3.0,
+                "total_tool_calls": 0,
+                "max_duration": 2.0,
+                "scheduled_runs": 0,
+                "successful_requests": 2,
+                "failed_requests": 0,
+                "total_cost_usd": 0.5,
+                "unpriced_requests": 1,
+            }
+        ],
+        "daily": [
+            {
+                "_id": "2026-08-30",
+                "requests": 2,
+                "tokens": 150,
+                "duration": 3.0,
+                "scheduled_runs": 0,
+                "failed_requests": 0,
+                "tool_calls": 0,
+                "cost_usd": 0.5,
+            }
+        ],
+        "agents": [],
+        "teams": [],
+        "personas": [],
+        "models": [
+            {
+                "_id": "gpt-4o",
+                "requests": 2,
+                "tokens": 150,
+                "duration": 3.0,
+                "cost_usd": 0.5,
+            }
+        ],
+        "users": [],
+        "sources": [],
+        "triggers": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_stats_aggregate_includes_cost_totals():
+    storage = UsageStorage()
+    storage._collection = _FakeAggregateCollection(stats_doc=_stats_doc())
+    _items, total, stats = await storage.list_usage_logs(limit=1)
+    assert total == 2
+    assert stats["total_cost_usd"] == 0.5
+    assert stats["unpriced_requests"] == 1
+
+
+def test_empty_stats_has_cost_keys():
+    stats = _empty_stats()
+    assert stats["total_cost_usd"] == 0.0
+    assert stats["unpriced_requests"] == 0
+
+
+@pytest.mark.asyncio
+async def test_dashboard_formats_cost_fields():
+    storage = UsageStorage()
+    storage._collection = _FakeAggregateCollection(facet_doc=_facet_doc())
+    dashboard = await storage.get_usage_dashboard()
+
+    assert dashboard["summary"]["total_cost_usd"] == 0.5
+    assert dashboard["summary"]["unpriced_requests"] == 1
+    assert dashboard["daily"][0]["cost_usd"] == 0.5
+    assert dashboard["top_models"][0]["cost_usd"] == 0.5
+
+
+@pytest.mark.asyncio
+async def test_stats_pipeline_sums_cost_usd_and_unpriced():
+    fake = _FakeAggregateCollection(stats_doc=_stats_doc())
+    storage = UsageStorage()
+    storage._collection = fake
+    await storage.list_usage_logs(limit=1)
+    group = fake.pipelines[0][1]["$group"]
+    assert group["total_cost_usd"] == {"$sum": "$cost_usd"}
+    assert "unpriced_requests" in group
+
+
+@pytest.mark.asyncio
+async def test_dashboard_pipeline_aggregates_cost():
+    fake = _FakeAggregateCollection(facet_doc=_facet_doc())
+    storage = UsageStorage()
+    storage._collection = fake
+    await storage.get_usage_dashboard()
+    facet = fake.pipelines[0][1]["$facet"]
+    summary_group = facet["summary"][0]["$group"]
+    daily_group = facet["daily"][0]["$group"]
+    models_group = next(stage["$group"] for stage in facet["models"] if "$group" in stage)
+    assert summary_group["total_cost_usd"] == {"$sum": "$cost_usd"}
+    assert "unpriced_requests" in summary_group
+    assert daily_group["cost_usd"] == {"$sum": "$cost_usd"}
+    assert models_group["cost_usd"] == {"$sum": "$cost_usd"}

--- a/tests/infra/usage/test_usage_storage.py
+++ b/tests/infra/usage/test_usage_storage.py
@@ -583,6 +583,7 @@ async def test_get_usage_dashboard_returns_daily_and_rankings() -> None:
         "requests": 2,
         "tokens": 150,
         "duration": 60.0,
+        "cost_usd": 0.0,
         "input_tokens": 70,
         "cache_creation_tokens": 5,
         "cache_read_tokens": 20,


### PR DESCRIPTION
## Summary

接入 models.dev 模型计价：底层统一以 USD 存储消耗金额，对话结束与控制台均可查看 token 消耗与费用；展示时按用户语言换算本地货币（汇率自动同步）。

## Changes

### 后端
- **新增 `src/infra/pricing/` 模块**
  - `sync.py`：models.dev 价格表（`https://models.dev/api.json`）+ USD 汇率表（open.er-api.com）自动同步；启动时与每 24h 各刷新一次，单侧失败独立降级、沿用上次快照
  - `matching.py`：模型多级匹配（`provider/model` 精确 → provider 内归一化 → 全局精确 → 全局归一化；归一化去前缀/日期后缀/latest），价格快照可持久化/还原
  - `calculator.py`：成本计算纯函数。计费口径 `billable_input = input − cache_read − cache_creation`（LangChain usage_metadata 口径），金额求和消除浮点噪声
  - `service.py`：运行时解析入口（模型配置覆盖字段级优先于 models.dev 匹配），进程内缓存
  - `storage.py`：`model_prices` 集合单文档快照（价格 + 汇率）
- **事件与落库**：`token:usage` 事件实时携带 `cost_usd` / `cost_breakdown` / `cost_rates`（无法计价时不携带，前端区分「未计价」与「$0」）；`usage_logs` 落库 `cost_usd` + `cost_available`，logs/stats/dashboard 聚合新增 `total_cost_usd`、`unpriced_requests`、按模型/按日费用
- **新增路由** `/api/pricing`：`GET /rates`（登录可读，前端换算用）、`POST /sync`、`GET /status`、`GET /lookup`（管理员）
- **ModelConfig** 新增 `pricing` 覆盖字段（USD/百万 token 四档，`{}` 清除回落同步价格；中转站价格不一致场景）
- **配置**：`PRICING_MODELS_DEV_URL` / `PRICING_FX_RATES_URL` / `PRICING_SYNC_INTERVAL_HOURS` / `MONGODB_MODEL_PRICES_COLLECTION`

### 前端
- 底层 USD → 按语言映射本地货币（zh→CNY、ja→JPY、ko→KRW、ru→RUB、en→USD），`Intl.NumberFormat` 格式化，小金额自动提高精度（`$0.0123`），汇率不可用回落 USD；汇率模块级缓存 30 分钟
- **对话结束**：操作栏直接显示总费用；详情弹层新增费用区（本地货币总额 + USD 折算 + 输入/输出/缓存读/缓存写各档费用与单价）
- **控制台**：总费用 KPI 卡（含未计价请求数提示）、日志表桌面/平板/移动三端费用列（未计价显示 `—`）、模型排行费用
- **模型配置**：4 档价格覆盖输入 + models.dev 匹配实时提示（防抖 lookup），工具栏「同步价格」按钮
- i18n 五语言（zh/en/ja/ko/ru）文案全部补齐

## Testing

- [x] 后端新增 8 个测试文件（calculator/matching/storage/sync/service/事件金额/聚合/路由），`uv run pytest` 3217 passed（4 个失败为 develop 存量问题，与本 PR 无关，已用 git stash 验证）
- [x] 前端新增货币换算/事件透传/费用明细纯函数 + Source 测试，`pnpm test` 1900 passed
- [x] `make lint` / `make typecheck` / `pnpm run lint` / `pnpm run build` 全部通过
