### PR TITLE
fix(frontend): 计价展示位置、Claude 渠道 API 格式选择器与分叉 loading 跟进

### DIFF
--- a/frontend/src/components/chat/ChatMessage/__tests__/forkButtonLoadingSource.test.ts
+++ b/frontend/src/components/chat/ChatMessage/__tests__/forkButtonLoadingSource.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+
+test("fork button shows a spinner and disables while forking", () => {
+  const source = readFileSync(resolve(currentDir, "../index.tsx"), "utf8");
+
+  // 分叉耗时长，点击后按钮进入 loading 态而不是无反馈
+  expect(source).toMatch(/const \[isForking, setIsForking\] = useState\(false\)/);
+  expect(source).toMatch(/setIsForking\(true\)/);
+  expect(source).toMatch(/finally\s*\{[\s\S]*?setIsForking\(false\)/);
+  expect(source).toMatch(/isForking \? \(\s*<Loader2[^>]*animate-spin/);
+  expect(source).toMatch(/: \(\s*<GitBranch size=\{16\} \/>/);
+  expect(source).toMatch(/disabled=\{isForking\}/);
+});
+
+test("fork click awaits the handler instead of fire-and-forget void", () => {
+  const source = readFileSync(resolve(currentDir, "../index.tsx"), "utf8");
+
+  expect(source).not.toMatch(/void onForkMessage\(message\.id\)/);
+  expect(source).toMatch(/await onForkMessage\(message\.id\)/);
+});

--- a/frontend/src/components/chat/ChatMessage/__tests__/tokenCostSource.test.ts
+++ b/frontend/src/components/chat/ChatMessage/__tests__/tokenCostSource.test.ts
@@ -9,11 +9,15 @@ function readJson(path: string) {
   return JSON.parse(readFileSync(path, "utf8"));
 }
 
-test("message action bar shows the total cost directly without opening the popover", () => {
+test("total cost is not shown directly in the action bar, only in the popover", () => {
   const source = readFileSync(resolve(currentDir, "../index.tsx"), "utf8");
 
-  expect(source).toMatch(/hasPricedCost\(message\.tokenUsage\)/);
-  expect(source).toMatch(/formatCostUsd\(message\.tokenUsage\?\.cost_usd/);
+  // 操作栏（点赞点踩一侧）不直接渲染金额，仅保留详情弹层
+  expect(source).not.toMatch(/formatCostUsd\(message\.tokenUsage/);
+  expect(source).not.toMatch(/hasPricedCost\(message\.tokenUsage\)/);
+  // 弹层内仍由 TokenDetailsButton 渲染费用明细
+  expect(source).toMatch(/fxRates=\{fxRates\}/);
+  expect(source).toMatch(/language=\{i18n\.language\}/);
 });
 
 test("token details popover renders a cost breakdown section", () => {

--- a/frontend/src/components/chat/ChatMessage/index.tsx
+++ b/frontend/src/components/chat/ChatMessage/index.tsx
@@ -565,6 +565,7 @@ export const ChatMessage = memo(function ChatMessage({
   const isUser = message.role === "user";
   const isStreaming = message.isStreaming && !message.content;
   const [copied, setCopied] = useState(false);
+  const [isForking, setIsForking] = useState(false);
   const modelDetails = resolveTokenUsageModelDetails({
     modelId: message.tokenUsage?.model_id,
     model: message.tokenUsage?.model,
@@ -784,40 +785,41 @@ export const ChatMessage = memo(function ChatMessage({
             </button>
             {sessionId && onForkMessage && (
               <button
-                onClick={() => void onForkMessage(message.id)}
+                onClick={async () => {
+                  if (isForking) return;
+                  setIsForking(true);
+                  try {
+                    await onForkMessage(message.id);
+                  } finally {
+                    setIsForking(false);
+                  }
+                }}
+                disabled={isForking}
                 className={clsx(
                   "p-1.5 rounded-md transition-colors",
                   "hover:bg-stone-200 dark:hover:bg-stone-700",
                   "text-stone-400 dark:text-stone-500 hover:text-stone-600 dark:hover:text-stone-300",
+                  isForking && "opacity-60 cursor-wait",
                 )}
                 title={t("chat.message.fork")}
               >
-                <GitBranch size={16} />
+                {isForking ? (
+                  <Loader2 size={16} className="animate-spin" />
+                ) : (
+                  <GitBranch size={16} />
+                )}
               </button>
             )}
             {/* Token usage statistics button */}
             {(message.tokenUsage || message.duration) && (
-              <>
-                {hasPricedCost(message.tokenUsage) && (
-                  <span
-                    className="px-1.5 py-0.5 rounded-md text-[11px] leading-none tabular-nums text-stone-400 dark:text-stone-500"
-                    title={t("chat.message.costTotal")}
-                  >
-                    {formatCostUsd(message.tokenUsage?.cost_usd ?? 0, {
-                      language: i18n.language,
-                      rates: fxRates,
-                    })}
-                  </span>
-                )}
-                <TokenDetailsButton
-                  tokenUsage={message.tokenUsage}
-                  duration={message.duration}
-                  timestamp={message.timestamp}
-                  modelDetails={modelDetails}
-                  fxRates={fxRates}
-                  language={i18n.language}
-                />
-              </>
+              <TokenDetailsButton
+                tokenUsage={message.tokenUsage}
+                duration={message.duration}
+                timestamp={message.timestamp}
+                modelDetails={modelDetails}
+                fxRates={fxRates}
+                language={i18n.language}
+              />
             )}
             {showFeedbackAndShareActions && (
               <>

--- a/frontend/src/components/panels/ModelPanel/tabs/ModelFormModal.tsx
+++ b/frontend/src/components/panels/ModelPanel/tabs/ModelFormModal.tsx
@@ -26,6 +26,11 @@ import type {
 } from "../../../../services/api/model";
 import { ModelIconSelect } from "./ModelIconSelect";
 import {
+  resolveModelProtocol,
+  showsApiFormat,
+  type ProviderInfo,
+} from "./modelProtocol";
+import {
   formatRequestHeaders,
   parseRequestHeadersInput,
 } from "./requestHeadersInput";
@@ -96,6 +101,26 @@ export const ModelFormModal = ({
   const [priceLookup, setPriceLookup] = useState<PricingLookupResponse | null>(
     null,
   );
+  const [providers, setProviders] = useState<ProviderInfo[]>([]);
+
+  // 供应商协议信息：决定「API 格式」是否显示（仅 OpenAI 协议有意义）
+  useEffect(() => {
+    let alive = true;
+    modelApi
+      .listProviders()
+      .then((list) => {
+        if (alive) setProviders(list);
+      })
+      .catch(() => null);
+    return () => {
+      alive = false;
+    };
+  }, []);
+  const modelProtocol = resolveModelProtocol({
+    value: formValue,
+    provider: formProvider,
+    providers,
+  });
 
   // 按模型标识查询 models.dev 匹配价格（防抖）
   useEffect(() => {
@@ -513,23 +538,25 @@ export const ModelFormModal = ({
                 className="es-input"
               />
             </div>
-            <div className="es-field">
-              <label className="es-label">
-                {t("agentConfig.modelApiFormat")}
-              </label>
-              <Select
-                value={formApiFormat}
-                onChange={(v) => setFormApiFormat(v as ApiFormat | "")}
-                options={[
-                  { value: "", label: t("agentConfig.apiFormatFollowDefault") },
-                  { value: "chat_completions", label: "Chat Completions" },
-                  { value: "responses", label: "Responses" },
-                ]}
-              />
-              <p className="es-hint">
-                {t("agentConfig.modelApiFormatHint")}
-              </p>
-            </div>
+            {showsApiFormat(modelProtocol) && (
+              <div className="es-field">
+                <label className="es-label">
+                  {t("agentConfig.modelApiFormat")}
+                </label>
+                <Select
+                  value={formApiFormat}
+                  onChange={(v) => setFormApiFormat(v as ApiFormat | "")}
+                  options={[
+                    { value: "", label: t("agentConfig.apiFormatFollowDefault") },
+                    { value: "chat_completions", label: "Chat Completions" },
+                    { value: "responses", label: "Responses" },
+                  ]}
+                />
+                <p className="es-hint">
+                  {t("agentConfig.modelApiFormatHint")}
+                </p>
+              </div>
+            )}
             <div className="es-field">
               <label className="es-label">
                 {t("agentConfig.modelRequestHeaders")}

--- a/frontend/src/components/panels/ModelPanel/tabs/__tests__/modelPricingSource.test.ts
+++ b/frontend/src/components/panels/ModelPanel/tabs/__tests__/modelPricingSource.test.ts
@@ -69,3 +69,13 @@ test("pricing form labels are available in every locale", () => {
     }
   }
 });
+
+test("api format selector is hidden for native anthropic/google protocols", () => {
+  const source = readFileSync(
+    resolve(currentDir, "../ModelFormModal.tsx"),
+    "utf8",
+  );
+
+  expect(source).toMatch(/showsApiFormat\(modelProtocol\) && \(/);
+  expect(source).toMatch(/resolveModelProtocol\(\{/);
+});

--- a/frontend/src/components/panels/ModelPanel/tabs/__tests__/modelProtocol.test.ts
+++ b/frontend/src/components/panels/ModelPanel/tabs/__tests__/modelProtocol.test.ts
@@ -1,0 +1,58 @@
+// 模型协议推断：决定「API 格式」选择器是否显示（仅 OpenAI 协议有意义）
+import { resolveModelProtocol, showsApiFormat } from "../modelProtocol";
+
+const providers = [
+  { value: "anthropic", protocol: "anthropic", prefixes: ["claude"] },
+  { value: "google", protocol: "google", prefixes: ["gemini", "gemma"] },
+  { value: "openai", protocol: "openai", prefixes: ["gpt", "o1"] },
+  { value: "deepseek", protocol: "openai", prefixes: ["deepseek"] },
+];
+
+describe("resolveModelProtocol", () => {
+  test("值自带 provider 前缀时按前缀解析", () => {
+    expect(
+      resolveModelProtocol({ value: "anthropic/claude-sonnet-4-5", providers }),
+    ).toBe("anthropic");
+    expect(
+      resolveModelProtocol({ value: "google/gemini-2.5-pro", providers }),
+    ).toBe("google");
+  });
+
+  test("显式 provider 字段优先于裸模型名", () => {
+    expect(
+      resolveModelProtocol({ value: "deepseek-chat", provider: "deepseek", providers }),
+    ).toBe("openai");
+  });
+
+  test("值前缀优先于 provider 提示（与后端 _parse_provider 一致）", () => {
+    expect(
+      resolveModelProtocol({ value: "anthropic/claude-x", provider: "openai", providers }),
+    ).toBe("anthropic");
+  });
+
+  test("裸模型名按前缀推断", () => {
+    expect(resolveModelProtocol({ value: "claude-opus-4", providers })).toBe("anthropic");
+    expect(resolveModelProtocol({ value: "gemini-2.5-flash", providers })).toBe("google");
+    expect(resolveModelProtocol({ value: "gpt-4o", providers })).toBe("openai");
+  });
+
+  test("未注册 provider 与未知模型名回退 openai 兼容", () => {
+    expect(
+      resolveModelProtocol({ value: "relay/custom-model", providers }),
+    ).toBe("openai");
+    expect(resolveModelProtocol({ value: "totally-unknown", providers })).toBe("openai");
+    expect(resolveModelProtocol({ value: "", providers })).toBe("openai");
+  });
+
+  test("空 provider 列表安全回退", () => {
+    expect(resolveModelProtocol({ value: "claude-x", providers: [] })).toBe("openai");
+  });
+});
+
+describe("showsApiFormat", () => {
+  test("仅 OpenAI 协议显示 API 格式选择器", () => {
+    expect(showsApiFormat("openai")).toBe(true);
+    expect(showsApiFormat("anthropic")).toBe(false);
+    expect(showsApiFormat("google")).toBe(false);
+  });
+});

--- a/frontend/src/components/panels/ModelPanel/tabs/modelProtocol.ts
+++ b/frontend/src/components/panels/ModelPanel/tabs/modelProtocol.ts
@@ -1,0 +1,46 @@
+// 模型协议推断（与后端 src/infra/llm/client.py 的 PROVIDER_REGISTRY/_parse_provider 语义对齐）：
+// 值前缀 > 显式 provider > 模型名前缀；未注册一律视为 OpenAI 兼容。
+// 「API 格式」（chat_completions / responses）仅对 OpenAI 协议有意义，
+// Claude/Gemini 原生协议应隐藏该选择器。
+
+export interface ProviderInfo {
+  value: string;
+  protocol: string;
+  prefixes: string[];
+}
+
+export function resolveModelProtocol(opts: {
+  value: string;
+  provider?: string;
+  providers: ProviderInfo[];
+}): string {
+  const raw = (opts.value || "").trim();
+  const providers = opts.providers || [];
+
+  let slug = "";
+  if (raw.includes("/")) {
+    slug = raw.split("/", 1)[0].trim().toLowerCase();
+  } else if (opts.provider) {
+    slug = opts.provider.trim().toLowerCase();
+  }
+
+  if (slug) {
+    const hit = providers.find((p) => p.value === slug);
+    return hit ? hit.protocol : "openai";
+  }
+
+  const lower = raw.toLowerCase();
+  for (const provider of providers) {
+    for (const prefix of provider.prefixes || []) {
+      if (prefix && lower.startsWith(prefix)) {
+        return provider.protocol;
+      }
+    }
+  }
+  return "openai";
+}
+
+/** API 格式选择器是否应该显示（仅 OpenAI 兼容协议） */
+export function showsApiFormat(protocol: string): boolean {
+  return protocol === "openai";
+}


### PR DESCRIPTION
## Summary

#306 合入后的三项体验跟进（本地部署实测反馈）。

## Changes

- **费用展示位置**：对话消息操作栏（点赞点踩一侧）不再直接显示 ¥/$ 金额，金额只保留在 ⓘ 详情弹层的费用区
- **API 格式选择器**：原生 Claude/Gemini 协议的模型隐藏「API 格式」（Chat Completions / Responses）选择器——该配置仅对 OpenAI 协议生效，对 Claude 渠道显示只会造成困惑。新增 `modelProtocol` 纯函数推断协议（值前缀 > 显式 provider > 模型名前缀，与后端 `PROVIDER_REGISTRY` / `_parse_provider` 语义对齐），接口失败时安全回退为显示
- **分叉按钮 loading**：分叉耗时长且原先零反馈，点击后按钮转圈 + 禁用 + cursor-wait，完成后恢复

## Testing

- [x] 新增 `modelProtocol` 纯函数测试（7 例）与两处 Source 测试
- [x] `pnpm test` 1910 passed（435 文件）
- [x] `pnpm run lint` / `pnpm run build` 通过
