### PR TITLE
feat(pricing): 存量费用回填与多副本分布式加固

### DIFF
--- a/frontend/src/components/panels/ModelPanel/tabs/ModelConfigTab.tsx
+++ b/frontend/src/components/panels/ModelPanel/tabs/ModelConfigTab.tsx
@@ -10,6 +10,7 @@ import {
   Layers,
   ChevronDown,
   RefreshCw,
+  History,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import toast from "react-hot-toast";
@@ -392,6 +393,7 @@ export function ModelConfigTab({ models, onReload }: ModelConfigTabProps) {
   const [isCreating, setIsCreating] = useState(false);
   const [showBatchModal, setShowBatchModal] = useState(false);
   const [isSyncingPrices, setIsSyncingPrices] = useState(false);
+  const [isBackfillingCosts, setIsBackfillingCosts] = useState(false);
   const [batchInitialTab, setBatchInitialTab] = useState<
     "addOneByOne" | "jsonImport"
   >("addOneByOne");
@@ -615,6 +617,41 @@ export function ModelConfigTab({ models, onReload }: ModelConfigTabProps) {
               />
               <span className="hidden sm:inline">
                 {t("agentConfig.pricingSync", "同步价格")}
+              </span>
+            </button>
+            <button
+              onClick={async () => {
+                setIsBackfillingCosts(true);
+                try {
+                  const result = await pricingApi.backfillUsage();
+                  const base = t("agentConfig.pricingBackfillSuccess", {
+                    defaultValue: "补算完成：{{priced}}/{{scanned}} 条",
+                    priced: result.priced,
+                    scanned: result.scanned,
+                  });
+                  toast.success(
+                    result.still_unpriced > 0
+                      ? `${base} · ${t("agentConfig.pricingBackfillUnpriced", {
+                          defaultValue: "{{count}} 条未计价",
+                          count: result.still_unpriced,
+                        })}`
+                      : base,
+                  );
+                } catch (err) {
+                  toast.error(
+                    (err as Error).message ||
+                      t("agentConfig.pricingBackfillFailed", "补算历史费用失败"),
+                  );
+                } finally {
+                  setIsBackfillingCosts(false);
+                }
+              }}
+              disabled={isBackfillingCosts}
+              className="flex items-center gap-1.5 px-3 py-2 text-sm rounded-lg border border-[var(--glass-border)] text-stone-700 dark:text-stone-300 hover:bg-[var(--glass-bg-subtle)] transition-colors disabled:opacity-50"
+            >
+              <History size={16} className={isBackfillingCosts ? "animate-spin" : ""} />
+              <span className="hidden sm:inline">
+                {t("agentConfig.pricingBackfill", "补算历史费用")}
               </span>
             </button>
             <Button

--- a/frontend/src/components/panels/ModelPanel/tabs/__tests__/modelPricingSource.test.ts
+++ b/frontend/src/components/panels/ModelPanel/tabs/__tests__/modelPricingSource.test.ts
@@ -79,3 +79,32 @@ test("api format selector is hidden for native anthropic/google protocols", () =
   expect(source).toMatch(/showsApiFormat\(modelProtocol\) && \(/);
   expect(source).toMatch(/resolveModelProtocol\(\{/);
 });
+
+test("model config toolbar has a usage cost backfill action", () => {
+  const source = readFileSync(
+    resolve(currentDir, "../ModelConfigTab.tsx"),
+    "utf8",
+  );
+
+  expect(source).toMatch(/pricingApi\.backfillUsage\(/);
+  expect(source).toMatch(/agentConfig\.pricingBackfillSuccess/);
+  expect(source).toMatch(/agentConfig\.pricingBackfillUnpriced/);
+});
+
+test("backfill labels are available in every locale", () => {
+  for (const locale of ["en", "zh", "ja", "ko", "ru"]) {
+    const messages = readJson(
+      resolve(frontendSrc, "i18n", "locales", `${locale}.json`),
+    ).agentConfig;
+
+    for (const key of [
+      "pricingBackfill",
+      "pricingBackfillSuccess",
+      "pricingBackfillUnpriced",
+      "pricingBackfillFailed",
+    ]) {
+      expect(typeof messages[key]).toBe("string");
+      expect(messages[key].trim()).not.toBe("");
+    }
+  }
+});

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -224,7 +224,11 @@
     "pricingSync": "Sync prices",
     "pricingSyncSuccess": "Prices synced ({{count}} models)",
     "pricingSyncPartial": "Sync finished (partial failure: {{error}})",
-    "pricingSyncFailed": "Failed to sync prices"
+    "pricingSyncFailed": "Failed to sync prices",
+    "pricingBackfill": "Backfill costs",
+    "pricingBackfillSuccess": "Backfilled {{priced}}/{{scanned}} records",
+    "pricingBackfillUnpriced": "{{count}} unpriced",
+    "pricingBackfillFailed": "Failed to backfill costs"
   },
   "agentOptions": {
     "enableCodeInterpreter": {

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -224,7 +224,11 @@
     "pricingSync": "価格を同期",
     "pricingSyncSuccess": "価格を同期しました（{{count}} モデル）",
     "pricingSyncPartial": "同期完了（一部失敗：{{error}}）",
-    "pricingSyncFailed": "価格の同期に失敗しました"
+    "pricingSyncFailed": "価格の同期に失敗しました",
+    "pricingBackfill": "履歴費用を再計算",
+    "pricingBackfillSuccess": "再計算完了：{{priced}}/{{scanned}} 件",
+    "pricingBackfillUnpriced": "{{count}} 件は未計価",
+    "pricingBackfillFailed": "履歴費用の再計算に失敗しました"
   },
   "agentOptions": {
     "enableCodeInterpreter": {

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -224,7 +224,11 @@
     "pricingSync": "가격 동기화",
     "pricingSyncSuccess": "가격 동기화 완료 ({{count}}개 모델)",
     "pricingSyncPartial": "동기화 완료 (일부 실패: {{error}})",
-    "pricingSyncFailed": "가격 동기화 실패"
+    "pricingSyncFailed": "가격 동기화 실패",
+    "pricingBackfill": "과거 비용 재계산",
+    "pricingBackfillSuccess": "재계산 완료: {{priced}}/{{scanned}}건",
+    "pricingBackfillUnpriced": "{{count}}건 가격 미매칭",
+    "pricingBackfillFailed": "과거 비용 재계산 실패"
   },
   "agentOptions": {
     "enableCodeInterpreter": {

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -224,7 +224,11 @@
     "pricingSync": "Синхронизировать цены",
     "pricingSyncSuccess": "Цены синхронизированы ({{count}} моделей)",
     "pricingSyncPartial": "Синхронизация завершена (частичная ошибка: {{error}})",
-    "pricingSyncFailed": "Не удалось синхронизировать цены"
+    "pricingSyncFailed": "Не удалось синхронизировать цены",
+    "pricingBackfill": "Пересчитать расходы",
+    "pricingBackfillSuccess": "Пересчитано: {{priced}}/{{scanned}} записей",
+    "pricingBackfillUnpriced": "{{count}} без цены",
+    "pricingBackfillFailed": "Не удалось пересчитать расходы"
   },
   "agentOptions": {
     "enableCodeInterpreter": {

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -224,7 +224,11 @@
     "pricingSync": "同步价格",
     "pricingSyncSuccess": "价格已同步（{{count}} 个模型）",
     "pricingSyncPartial": "同步完成（部分失败：{{error}}）",
-    "pricingSyncFailed": "同步价格失败"
+    "pricingSyncFailed": "同步价格失败",
+    "pricingBackfill": "补算历史费用",
+    "pricingBackfillSuccess": "补算完成：{{priced}}/{{scanned}} 条",
+    "pricingBackfillUnpriced": "{{count}} 条未计价",
+    "pricingBackfillFailed": "补算历史费用失败"
   },
   "agentOptions": {
     "enableCodeInterpreter": {

--- a/frontend/src/services/api/pricing.ts
+++ b/frontend/src/services/api/pricing.ts
@@ -32,6 +32,14 @@ export interface PricingSyncResponse extends PricingStatusResponse {
   error: string | null;
 }
 
+export interface PricingBackfillResponse {
+  scanned: number;
+  priced: number;
+  still_unpriced: number;
+  unpriced_models: Record<string, number>;
+  dry_run: boolean;
+}
+
 const FX_CACHE_TTL_MS = 30 * 60 * 1000;
 
 let fxCache: { doc: FxRatesResponse | null; at: number } | null = null;
@@ -69,6 +77,14 @@ export const pricingApi = {
     });
     void getFxRates(true).catch(() => null);
     return doc;
+  },
+
+  /** 管理员：补算存量 usage_logs 费用（幂等） */
+  async backfillUsage(dryRun = false): Promise<PricingBackfillResponse> {
+    return authFetch<PricingBackfillResponse>(
+      `${API_BASE}/api/pricing/backfill-usage?dry_run=${dryRun}`,
+      { method: "POST" },
+    );
   },
 
   /** 管理员：同步状态 */

--- a/src/api/routes/pricing.py
+++ b/src/api/routes/pricing.py
@@ -17,6 +17,7 @@ from src.infra.pricing.storage import get_pricing_storage
 from src.infra.pricing.sync import sync_pricing
 from src.kernel.schemas.pricing import (
     FxRatesResponse,
+    PricingBackfillResponse,
     PricingLookupResponse,
     PricingStatusResponse,
     PricingSyncResponse,
@@ -87,3 +88,19 @@ async def lookup_price(
         matched_provider=resolved.matched_provider,
         matched_model_id=resolved.matched_model_id,
     )
+
+
+@router.post("/backfill-usage", response_model=PricingBackfillResponse)
+async def backfill_usage_costs(
+    dry_run: bool = Query(False, description="只统计不写入"),
+    user: TokenPayload = Depends(require_permissions(Permission.MODEL_ADMIN.value)),
+) -> PricingBackfillResponse:
+    """用当前价格快照补算存量 usage_logs 的费用（幂等，可重复执行）。"""
+    from fastapi import HTTPException
+
+    from src.infra.pricing.backfill import backfill_usage_costs as run_backfill
+
+    summary = await run_backfill(dry_run=dry_run)
+    if summary.get("lock_contended"):
+        raise HTTPException(status_code=409, detail="Another replica is running the backfill")
+    return PricingBackfillResponse(**summary)

--- a/src/infra/pricing/backfill.py
+++ b/src/infra/pricing/backfill.py
@@ -1,0 +1,128 @@
+"""usage_logs 历史费用回填。
+
+用当前价格快照（models.dev 同步 + 模型配置覆盖）补算未计价的存量记录：
+- 只处理 ``cost_available != True`` 的文档，可重复执行（幂等）
+- 逐条解析价格并写入 cost_usd 快照；无法计价的按模型名汇总返回
+- 注意：历史记录按「当前」价格估算，模型若曾调价会有出入
+"""
+
+from typing import Optional
+
+from src.infra.logging import get_logger
+from src.infra.pricing.calculator import compute_cost
+from src.infra.pricing.locks import acquire_pricing_lock, release_pricing_lock
+from src.infra.pricing.service import resolve_price
+from src.infra.usage.storage import get_usage_storage
+
+logger = get_logger(__name__)
+
+BATCH_SIZE = 500
+MAX_BATCHES = 100_000  # 安全阀：防止异常数据导致死循环
+BACKFILL_LOCK_KEY = "pricing:backfill:lock"
+BACKFILL_LOCK_TTL_SECONDS = 10 * 60
+
+
+async def _resolve_config_id_by_value(model_value: str) -> Optional[str]:
+    """按模型值查 ModelConfig ID，使价格覆盖在回填时同样生效。"""
+    try:
+        from src.infra.agent.model_storage import get_model_storage
+
+        model = await get_model_storage().get_by_value(model_value)
+        return model.id if model and model.id else None
+    except Exception as e:
+        logger.debug(f"Pricing backfill: model config lookup failed for {model_value!r}: {e}")
+        return None
+
+
+async def backfill_usage_costs(
+    *,
+    dry_run: bool = False,
+    batch_size: int = BATCH_SIZE,
+    usage_storage=None,
+) -> dict:
+    """补算存量 usage_logs 的费用。
+
+    Returns:
+        {scanned, priced, still_unpriced, unpriced_models, dry_run}
+    """
+    usage = usage_storage or get_usage_storage()
+
+    # 多副本互斥：其他实例正在回填时直接返回，不重复扫描；
+    # Redis 故障时退化为本地执行（写入幂等）。
+    lock_token = None
+    lock_ok = True
+    try:
+        lock_token = await acquire_pricing_lock(BACKFILL_LOCK_KEY, BACKFILL_LOCK_TTL_SECONDS)
+    except Exception as e:
+        logger.warning(f"Pricing backfill: lock unavailable, proceeding locally: {e}")
+        lock_ok = False
+    if lock_ok and lock_token is None:
+        logger.info("Pricing backfill: lock held by another replica, skipping")
+        return _empty_summary(dry_run=dry_run, lock_contended=True)
+
+    try:
+        return await _backfill_locked(usage=usage, dry_run=dry_run, batch_size=batch_size)
+    finally:
+        if lock_token is not None:
+            await release_pricing_lock(BACKFILL_LOCK_KEY, lock_token)
+
+
+def _empty_summary(*, dry_run: bool, lock_contended: bool) -> dict:
+    return {
+        "scanned": 0,
+        "priced": 0,
+        "still_unpriced": 0,
+        "unpriced_models": {},
+        "dry_run": dry_run,
+        "lock_contended": lock_contended,
+    }
+
+
+async def _backfill_locked(*, usage, dry_run: bool, batch_size: int) -> dict:
+    scanned = 0
+    priced = 0
+    unpriced_models: dict[str, int] = {}
+    seen: set[str] = set()
+
+    for _ in range(MAX_BATCHES):
+        docs = await usage.list_unpriced_usage_logs(limit=batch_size)
+        fresh = [doc for doc in docs if doc.get("trace_id") not in seen]
+        if not fresh:
+            break
+        for doc in fresh:
+            seen.add(doc["trace_id"])
+            scanned += 1
+            model_value = str(doc.get("model") or "")
+            model_config_id = None
+            if model_value:
+                model_config_id = await _resolve_config_id_by_value(model_value)
+
+            resolved = await resolve_price(
+                value=model_value or None, model_config_id=model_config_id
+            )
+            cost = None
+            if resolved is not None:
+                cost = compute_cost(
+                    input_tokens=int(doc.get("input_tokens") or 0),
+                    output_tokens=int(doc.get("output_tokens") or 0),
+                    cache_read_tokens=int(doc.get("cache_read_tokens") or 0),
+                    cache_creation_tokens=int(doc.get("cache_creation_tokens") or 0),
+                    rates=resolved.rates,
+                )
+            if cost is None:
+                unpriced_models[model_value] = unpriced_models.get(model_value, 0) + 1
+                continue
+            priced += 1
+            if not dry_run:
+                await usage.update_usage_cost(doc["trace_id"], cost.total_usd)
+
+    summary = {
+        "scanned": scanned,
+        "priced": priced,
+        "still_unpriced": scanned - priced,
+        "unpriced_models": unpriced_models,
+        "dry_run": dry_run,
+        "lock_contended": False,
+    }
+    logger.info(f"Pricing backfill: {summary}")
+    return summary

--- a/src/infra/pricing/locks.py
+++ b/src/infra/pricing/locks.py
@@ -1,0 +1,49 @@
+"""Pricing 分布式锁：同步与回填的多副本互斥。
+
+Redis SET NX EX 获取 + Lua 比较删除释放（同 scheduler/locks 模式）。
+Redis 不可用时由调用方决定退化行为（单机场景不应中断主流程）。
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Awaitable
+from typing import Any, Optional, cast
+
+from src.infra.logging import get_logger
+from src.infra.storage.redis import get_redis_client
+
+logger = get_logger(__name__)
+
+# Lua: 只释放自己持有的锁
+_RELEASE_LOCK_LUA = """
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+    return redis.call("DEL", KEYS[1])
+else
+    return 0
+end
+"""
+
+
+async def acquire_pricing_lock(lock_key: str, ttl: int) -> Optional[str]:
+    """尝试获取锁；成功返回 token，被其他副本持有时返回 None。
+
+    Redis 异常向上抛出，由调用方决定是否退化为本地执行。
+    """
+    redis = get_redis_client()
+    token = f"{uuid.uuid4().hex[:16]}"
+    acquired = await redis.set(lock_key, token, nx=True, ex=ttl)
+    if acquired:
+        logger.debug("[PricingLock] acquired %s", lock_key)
+        return token
+    logger.debug("[PricingLock] contended %s", lock_key)
+    return None
+
+
+async def release_pricing_lock(lock_key: str, token: str) -> None:
+    """释放锁（best-effort，持锁过期也能自动释放）。"""
+    try:
+        redis = get_redis_client()
+        await cast(Awaitable[Any], redis.eval(_RELEASE_LOCK_LUA, 1, lock_key, token))
+    except Exception as e:
+        logger.warning(f"[PricingLock] 释放 {lock_key} 失败: {e}")

--- a/src/infra/pricing/pubsub.py
+++ b/src/infra/pricing/pubsub.py
@@ -1,0 +1,92 @@
+"""Pricing Pub/Sub — 价格/汇率快照变更的跨副本缓存失效广播。
+
+任一副本完成价格同步后向 Redis 发布失效消息，其他副本收到后清空本地
+运行时缓存（下一次访问重新从 Mongo 加载）。广播是 best-effort：丢了
+也由 service 层的缓存 TTL 兜底自愈。
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any, Optional
+
+from src.infra.async_utils import run_blocking_io
+from src.infra.logging import get_logger
+from src.infra.pricing.service import reset_runtime_cache
+from src.infra.pubsub_hub import get_pubsub_hub
+from src.infra.storage.redis import get_redis_client
+from src.infra.task.constants import PRICING_CACHE_CHANNEL
+
+logger = get_logger(__name__)
+
+
+class PricingPubSub:
+    """Redis Pub/Sub listener for pricing snapshot changes."""
+
+    def __init__(self):
+        self._subscription_token: Optional[str] = None
+        self._running = False
+        # 唯一实例 ID —— 用于跳过自己发布的消息
+        self._instance_id = uuid.uuid4().hex[:8]
+
+    @property
+    def instance_id(self) -> str:
+        return self._instance_id
+
+    async def start_listener(self) -> None:
+        """应用启动时开始监听价格失效广播。"""
+        if self._running:
+            return
+
+        hub = get_pubsub_hub()
+        self._subscription_token = hub.subscribe(
+            PRICING_CACHE_CHANNEL,
+            self._handle_message,
+        )
+        await hub.start()
+        self._running = True
+        logger.info(
+            f"Pricing pub/sub listening on channel: {PRICING_CACHE_CHANNEL} "
+            f"(instance={self._instance_id})"
+        )
+
+    async def stop_listener(self) -> None:
+        if not self._running:
+            return
+        hub = get_pubsub_hub()
+        if self._subscription_token:
+            hub.unsubscribe(self._subscription_token)
+        self._running = False
+
+    async def _handle_message(self, message: dict[str, Any]) -> None:
+        try:
+            data = await run_blocking_io(json.loads, message["data"])
+            if data.get("instance_id") == self._instance_id:
+                return
+            logger.info("[PricingPubSub] 收到价格快照变更，清空本地缓存")
+            reset_runtime_cache()
+        except Exception as e:
+            logger.warning(f"[PricingPubSub] 处理消息失败: {e}")
+
+
+_pricing_pubsub: Optional[PricingPubSub] = None
+
+
+def get_pricing_pubsub() -> PricingPubSub:
+    global _pricing_pubsub
+    if _pricing_pubsub is None:
+        _pricing_pubsub = PricingPubSub()
+    return _pricing_pubsub
+
+
+async def publish_pricing_cache_invalidate() -> None:
+    """价格/汇率快照写入成功后调用，通知其他副本失效缓存（best-effort）。"""
+    try:
+        redis_client = get_redis_client()
+        pubsub = get_pricing_pubsub()
+        message = await run_blocking_io(json.dumps, {"instance_id": pubsub.instance_id})
+        await redis_client.publish(PRICING_CACHE_CHANNEL, message)
+        logger.debug(f"[PricingPubSub] published cache invalidate: {message}")
+    except Exception as e:
+        logger.warning(f"[PricingPubSub] 发布失效广播失败: {e}")

--- a/src/infra/pricing/service.py
+++ b/src/infra/pricing/service.py
@@ -24,33 +24,54 @@ class ResolvedPrice:
     matched_model_id: str = ""
 
 
-# ── 进程内运行时缓存 ──────────────────────────────────────────────
+# ── 进程内运行时缓存（带 TTL，多副本下兜底自愈） ──────────────────
+# 正常失效路径是 PricingPubSub 广播；TTL 保证广播丢失时副本最终也能
+# 读到最后一次快照。
+
+CACHE_TTL_SECONDS = 600
 
 _runtime_index: Optional[PriceIndex] = None
+_runtime_index_loaded_at: float = 0.0
 _runtime_fx: Optional[dict] = None
+_runtime_fx_loaded_at: float = 0.0
+_cache_clock: float = 0.0  # 单调时钟（秒），测试可用 _advance_cache_clock 快进
+
+
+def _advance_cache_clock(seconds: float) -> None:
+    """测试专用：快进缓存时钟。"""
+    global _cache_clock
+    _cache_clock += seconds
 
 
 def reset_runtime_cache() -> None:
-    """清空进程内缓存（测试与手动同步后使用）。"""
-    global _runtime_index, _runtime_fx
+    """清空进程内缓存（本实例同步后 / 收到广播后 / 测试使用）。"""
+    global _runtime_index, _runtime_fx, _runtime_index_loaded_at, _runtime_fx_loaded_at
     _runtime_index = None
     _runtime_fx = None
+    _runtime_index_loaded_at = 0.0
+    _runtime_fx_loaded_at = 0.0
+
+
+def _cache_fresh(loaded_at: float) -> bool:
+    return (_cache_clock - loaded_at) < CACHE_TTL_SECONDS
 
 
 async def get_price_index() -> PriceIndex:
-    """获取价格索引；首次访问从持久化快照加载。"""
-    global _runtime_index
-    if _runtime_index is None:
+    """获取价格索引；首次访问或缓存过期时从持久化快照加载。"""
+    global _runtime_index, _runtime_index_loaded_at
+    if _runtime_index is None or not _cache_fresh(_runtime_index_loaded_at):
         snapshot = await get_pricing_storage().load_price_snapshot() or {}
         _runtime_index = restore_price_index(snapshot)
+        _runtime_index_loaded_at = _cache_clock
     return _runtime_index
 
 
 async def get_fx_rates() -> Optional[dict]:
     """获取汇率文档 {base, rates, synced_at}；无数据返回 None。"""
-    global _runtime_fx
-    if _runtime_fx is None:
+    global _runtime_fx, _runtime_fx_loaded_at
+    if _runtime_fx is None or not _cache_fresh(_runtime_fx_loaded_at):
         _runtime_fx = await get_pricing_storage().load_fx_rates()
+        _runtime_fx_loaded_at = _cache_clock
     return _runtime_fx
 
 

--- a/src/infra/pricing/sync.py
+++ b/src/infra/pricing/sync.py
@@ -1,6 +1,8 @@
 """pricing 同步：models.dev 价格表 + USD 汇率表。
 
 两者独立拉取、独立降级：一个失败不影响另一个，失败时沿用上次快照。
+多副本部署下用 Redis 锁互斥，同一时刻只有一个实例真正发起网络同步；
+写入成功后广播缓存失效（PricingPubSub），广播失败由各副本缓存 TTL 兜底。
 """
 
 from datetime import datetime, timedelta, timezone
@@ -9,6 +11,7 @@ from typing import Any, Optional
 import httpx
 
 from src.infra.logging import get_logger
+from src.infra.pricing.locks import acquire_pricing_lock, release_pricing_lock
 from src.infra.pricing.matching import build_price_index
 from src.infra.pricing.storage import PricingStorage, get_pricing_storage
 from src.kernel.config import settings
@@ -16,6 +19,8 @@ from src.kernel.config import settings
 logger = get_logger(__name__)
 
 FETCH_TIMEOUT_SECONDS = 30.0
+SYNC_LOCK_KEY = "pricing:sync:lock"
+SYNC_LOCK_TTL_SECONDS = 15 * 60
 
 
 def _build_http_client() -> httpx.AsyncClient:
@@ -66,7 +71,8 @@ def _is_stale(synced_at: Optional[str], interval_hours: int) -> bool:
 async def sync_pricing(*, force: bool = False, storage: Optional[PricingStorage] = None) -> dict:
     """同步价格与汇率。
 
-    快照未过期且未 force 时跳过网络请求；单侧失败保留旧快照并记入 error。
+    快照未过期且未 force 时跳过网络请求；被其他副本持锁时本副本跳过；
+    单侧失败保留旧快照并记入 error；写入成功后清本副本缓存并广播失效。
     """
     storage = storage or get_pricing_storage()
     price_snapshot = await storage.load_price_snapshot() or {}
@@ -80,37 +86,70 @@ async def sync_pricing(*, force: bool = False, storage: Optional[PricingStorage]
         status = await storage.get_status()
         status["refreshed"] = False
         status["error"] = None
+        status["lock_contended"] = False
+        return status
+
+    # 多副本互斥：锁竞争 → 本副本跳过；Redis 故障 → 退化本地执行（写入幂等）
+    lock_token: Optional[str] = None
+    lock_ok = True
+    try:
+        lock_token = await acquire_pricing_lock(SYNC_LOCK_KEY, SYNC_LOCK_TTL_SECONDS)
+    except Exception as e:
+        logger.warning(f"Pricing: sync lock unavailable, proceeding locally: {e}")
+        lock_ok = False
+
+    if lock_ok and lock_token is None:
+        logger.info("Pricing: sync lock held by another replica, skipping")
+        status = await storage.get_status()
+        status["refreshed"] = False
+        status["error"] = None
+        status["lock_contended"] = True
         return status
 
     errors: list[str] = []
-    async with _build_http_client() as client:
-        if price_stale:
-            try:
-                snapshot = await fetch_models_dev(client)
-                entries = snapshot.get("entries") or []
-                await storage.save_price_snapshot(
-                    entries,
-                    source_url=settings.PRICING_MODELS_DEV_URL,
-                    model_owners=snapshot.get("model_owners"),
-                )
-                logger.info(f"Pricing: synced {len(entries)} model prices from models.dev")
-            except Exception as e:
-                errors.append(f"models.dev: {e}")
-                logger.warning(f"Pricing: models.dev sync failed: {e}")
-        if fx_stale:
-            try:
-                parsed = await _fetch_fx_rates(client)
-                if parsed is None:
-                    raise ValueError("invalid fx payload")
-                await storage.save_fx_rates(parsed["rates"], base=parsed["base"])
-                logger.info(
-                    f"Pricing: synced {len(parsed['rates'])} fx rates (base {parsed['base']})"
-                )
-            except Exception as e:
-                errors.append(f"fx: {e}")
-                logger.warning(f"Pricing: fx rates sync failed: {e}")
+    changed = False
+    try:
+        async with _build_http_client() as client:
+            if price_stale:
+                try:
+                    snapshot = await fetch_models_dev(client)
+                    entries = snapshot.get("entries") or []
+                    await storage.save_price_snapshot(
+                        entries,
+                        source_url=settings.PRICING_MODELS_DEV_URL,
+                        model_owners=snapshot.get("model_owners"),
+                    )
+                    changed = True
+                    logger.info(f"Pricing: synced {len(entries)} model prices from models.dev")
+                except Exception as e:
+                    errors.append(f"models.dev: {e}")
+                    logger.warning(f"Pricing: models.dev sync failed: {e}")
+            if fx_stale:
+                try:
+                    parsed = await _fetch_fx_rates(client)
+                    if parsed is None:
+                        raise ValueError("invalid fx payload")
+                    await storage.save_fx_rates(parsed["rates"], base=parsed["base"])
+                    changed = True
+                    logger.info(
+                        f"Pricing: synced {len(parsed['rates'])} fx rates (base {parsed['base']})"
+                    )
+                except Exception as e:
+                    errors.append(f"fx: {e}")
+                    logger.warning(f"Pricing: fx rates sync failed: {e}")
+    finally:
+        if lock_token is not None:
+            await release_pricing_lock(SYNC_LOCK_KEY, lock_token)
+
+    if changed:
+        from src.infra.pricing.pubsub import publish_pricing_cache_invalidate
+        from src.infra.pricing.service import reset_runtime_cache
+
+        reset_runtime_cache()
+        await publish_pricing_cache_invalidate()
 
     status = await storage.get_status()
     status["refreshed"] = True
     status["error"] = "; ".join(errors) if errors else None
+    status["lock_contended"] = False
     return status

--- a/src/infra/runtime_services.py
+++ b/src/infra/runtime_services.py
@@ -15,6 +15,7 @@ from src.infra.monitoring.event_loop import (
     start_event_loop_lag_monitor,
     stop_event_loop_lag_monitor,
 )
+from src.infra.pricing.pubsub import get_pricing_pubsub
 from src.infra.scheduler import ScheduledJob, get_runtime_scheduler
 from src.infra.scheduler.service import ScheduledTaskService
 from src.infra.scheduler.storage import get_scheduled_task_storage
@@ -223,6 +224,7 @@ async def start_runtime_services() -> None:
     channel_pubsub = get_channel_config_pubsub()
     tool_cache_pubsub = get_tool_cache_pubsub()
     mcp_cache_pubsub = get_mcp_cache_pubsub()
+    pricing_pubsub = get_pricing_pubsub()
     websocket_manager = get_connection_manager()
 
     listeners = [
@@ -231,6 +233,7 @@ async def start_runtime_services() -> None:
         channel_pubsub.start_listener(),
         tool_cache_pubsub.start_listener(),
         mcp_cache_pubsub.start_listener(),
+        pricing_pubsub.start_listener(),
         websocket_manager.start_pubsub_listener(),
     ]
     if settings.ENABLE_MEMORY:

--- a/src/infra/task/constants.py
+++ b/src/infra/task/constants.py
@@ -15,3 +15,6 @@ SETTINGS_CHANNEL = "settings:changed"
 
 # Model config sync channel (distributed instances)
 MODEL_CONFIG_CHANNEL = "model_config:changed"
+
+# Pricing snapshot/cache invalidation across replicas
+PRICING_CACHE_CHANNEL = "pricing:cache_invalidate"

--- a/src/infra/usage/storage.py
+++ b/src/infra/usage/storage.py
@@ -574,6 +574,34 @@ class UsageStorage:
             logger.error(f"Failed to fetch usage items: {e}")
             return []
 
+    async def list_unpriced_usage_logs(self, *, limit: int = 500) -> List[Dict[str, Any]]:
+        """读取未计价（cost_available != True）的记录，按时间升序分批。
+
+        回填用：已回填的记录不再命中查询，重复执行天然幂等。
+        """
+        try:
+            cursor = (
+                self.collection.find({"cost_available": {"$ne": True}}, {"_id": 0})
+                .sort("started_at", 1)
+                .limit(limit)
+            )
+            return await cursor.to_list(length=limit)
+        except Exception as e:
+            logger.error(f"Failed to list unpriced usage logs: {e}")
+            return []
+
+    async def update_usage_cost(self, trace_id: str, cost_usd: float) -> bool:
+        """回填单条记录的 USD 费用快照。"""
+        try:
+            await self.collection.update_one(
+                {"trace_id": trace_id},
+                {"$set": {"cost_usd": cost_usd, "cost_available": True}},
+            )
+            return True
+        except Exception as e:
+            logger.error(f"Failed to update usage cost for trace {trace_id}: {e}")
+            return False
+
     async def get_user_usage_summary(self, user_id: str) -> Dict[str, Any]:
         """获取单个用户的用量汇总"""
         query = {"user_id": user_id}

--- a/src/kernel/schemas/pricing.py
+++ b/src/kernel/schemas/pricing.py
@@ -52,3 +52,14 @@ class PricingLookupResponse(BaseModel):
     rates: Optional[dict[str, Optional[float]]] = None
     matched_provider: str = ""
     matched_model_id: str = ""
+
+
+class PricingBackfillResponse(BaseModel):
+    """存量 usage_logs 费用回填结果。"""
+
+    scanned: int = 0
+    priced: int = 0
+    still_unpriced: int = 0
+    unpriced_models: dict[str, int] = Field(default_factory=dict)
+    dry_run: bool = False
+    lock_contended: bool = False

--- a/tests/api/routes/test_pricing_routes.py
+++ b/tests/api/routes/test_pricing_routes.py
@@ -119,3 +119,50 @@ async def test_lookup_not_found(monkeypatch):
     response = await pricing_routes.lookup_price(value="mystery", user=_admin())
     assert response.found is False
     assert response.rates is None
+
+
+@pytest.mark.asyncio
+async def test_backfill_usage_calls_backfill_module(monkeypatch):
+    from src.infra.pricing import backfill as backfill_module
+
+    calls = {}
+
+    async def _fake_backfill(**kwargs):
+        calls.update(kwargs)
+        return {
+            "scanned": 10,
+            "priced": 8,
+            "still_unpriced": 2,
+            "unpriced_models": {"mystery": 2},
+            "dry_run": kwargs.get("dry_run", False),
+        }
+
+    monkeypatch.setattr(backfill_module, "backfill_usage_costs", _fake_backfill)
+    response = await pricing_routes.backfill_usage_costs(dry_run=True, user=_admin())
+    assert calls == {"dry_run": True}
+    assert response.scanned == 10
+    assert response.priced == 8
+    assert response.unpriced_models == {"mystery": 2}
+    assert response.dry_run is True
+
+
+@pytest.mark.asyncio
+async def test_backfill_usage_returns_409_when_lock_contended(monkeypatch):
+    from src.infra.pricing import backfill as backfill_module
+
+    async def _fake_backfill(**kwargs):
+        return {
+            "scanned": 0,
+            "priced": 0,
+            "still_unpriced": 0,
+            "unpriced_models": {},
+            "dry_run": False,
+            "lock_contended": True,
+        }
+
+    monkeypatch.setattr(backfill_module, "backfill_usage_costs", _fake_backfill)
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc_info:
+        await pricing_routes.backfill_usage_costs(dry_run=False, user=_admin())
+    assert exc_info.value.status_code == 409

--- a/tests/infra/pricing/test_backfill.py
+++ b/tests/infra/pricing/test_backfill.py
@@ -1,0 +1,252 @@
+"""usage_logs 历史费用回填测试。"""
+
+import asyncio
+
+import pytest
+
+from src.infra.pricing import backfill as pricing_backfill
+from src.infra.pricing import service as pricing_service
+from src.infra.pricing.storage import PricingStorage
+
+
+class _FakeUsageCollection:
+    def __init__(self, docs):
+        self.docs = {doc["trace_id"]: dict(doc) for doc in docs}
+        self.queries = []
+
+    def find(self, query, projection=None, *args, **kwargs):
+        self.queries.append(query)
+        matched = [d for d in self.docs.values() if self._match(d, query)]
+        matched.sort(key=lambda d: d.get("started_at") or "")
+
+        class _Cursor:
+            def __init__(self, items):
+                self._items = items
+                self._skip = 0
+                self._limit = None
+
+            def sort(self, *a, **kw):
+                return self
+
+            def skip(self, v):
+                self._skip = v
+                return self
+
+            def limit(self, v):
+                self._limit = v
+                return self
+
+            async def to_list(self, length=None):
+                items = self._items[self._skip : self._limit]
+                return [dict(i) for i in items]
+
+        return _Cursor(matched)
+
+    def _match(self, doc, query):
+        for key, expected in query.items():
+            if key == "cost_available" and isinstance(expected, dict) and "$ne" in expected:
+                if doc.get(key) == expected["$ne"]:
+                    return False
+            elif doc.get(key) != expected:
+                return False
+        return True
+
+    async def update_one(self, query, update, **kwargs):
+        trace_id = query.get("trace_id")
+        if trace_id in self.docs:
+            self.docs[trace_id].update(update.get("$set", {}))
+        import types
+
+        return types.SimpleNamespace(modified_count=1)
+
+    async def count_documents(self, query):
+        return sum(1 for d in self.docs.values() if self._match(d, query))
+
+
+class _FakeUsageStorage:
+    def __init__(self, docs):
+        self.collection = _FakeUsageCollection(docs)
+
+    async def list_unpriced_usage_logs(self, *, limit=500):
+        cursor = self.collection.find({"cost_available": {"$ne": True}})
+        return await cursor.to_list(length=limit)
+
+    async def update_usage_cost(self, trace_id, cost_usd):
+        await self.collection.update_one(
+            {"trace_id": trace_id},
+            {"$set": {"cost_usd": cost_usd, "cost_available": True}},
+        )
+        return True
+
+
+class _PricingFakeCollection:
+    def __init__(self):
+        self.docs = {
+            "models_dev_snapshot": {
+                "entries": [
+                    {
+                        "provider": "zai",
+                        "model_id": "glm-5.3",
+                        "name": "GLM 5.3",
+                        "rates": {
+                            "input": 1.4,
+                            "output": 4.4,
+                            "cache_read": None,
+                            "cache_write": None,
+                        },
+                    }
+                ],
+                "entry_count": 1,
+                "model_owners": {"glm-5.3": ["zai"]},
+                "source_url": "u",
+                "synced_at": "2026-08-30T00:00:00",
+            }
+        }
+
+    async def update_one(self, query, update, **kwargs):
+        doc = dict(update.get("$set", {}))
+        doc["_id"] = query["_id"]
+        self.docs[query["_id"]] = doc
+        return None
+
+    async def find_one(self, query, *args, **kwargs):
+        doc = self.docs.get(query.get("_id"))
+        return None if doc is None else {k: v for k, v in doc.items() if k != "_id"}
+
+    async def create_index(self, *a, **kw):
+        return None
+
+
+def _pricing_storage():
+    return PricingStorage(collection=_PricingFakeCollection())
+
+
+def _logs():
+    return [
+        {
+            "trace_id": "t-priced",
+            "model": "glm-5.3",
+            "input_tokens": 1000,
+            "output_tokens": 500,
+            "total_tokens": 1500,
+            "cache_creation_tokens": 0,
+            "cache_read_tokens": 0,
+            "cost_usd": 0.001,
+            "cost_available": True,
+            "started_at": "2026-08-01T00:00:00",
+        },
+        {
+            "trace_id": "t-open",
+            "model": "glm-5.3",
+            "input_tokens": 1_000_000,
+            "output_tokens": 100_000,
+            "total_tokens": 1_100_000,
+            "cache_creation_tokens": 0,
+            "cache_read_tokens": 200_000,
+            "started_at": "2026-08-02T00:00:00",
+        },
+        {
+            "trace_id": "t-unknown",
+            "model": "relay/custom-x",
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "total_tokens": 150,
+            "cache_creation_tokens": 0,
+            "cache_read_tokens": 0,
+            "started_at": "2026-08-03T00:00:00",
+        },
+        {
+            "trace_id": "t-nomodel",
+            "model": "",
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "total_tokens": 15,
+            "cache_creation_tokens": 0,
+            "cache_read_tokens": 0,
+            "started_at": "2026-08-04T00:00:00",
+        },
+    ]
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch):
+    monkeypatch.setattr(pricing_service, "get_pricing_storage", _pricing_storage)
+    pricing_service.reset_runtime_cache()
+
+    async def _acquire(lock_key, ttl):
+        return "test-token"
+
+    async def _release(lock_key, token):
+        return None
+
+    monkeypatch.setattr(pricing_backfill, "acquire_pricing_lock", _acquire)
+    monkeypatch.setattr(pricing_backfill, "release_pricing_lock", _release)
+    yield
+    pricing_service.reset_runtime_cache()
+
+
+class TestBackfillUsageCosts:
+    def test_prices_unpriced_and_skips_priced(self):
+        usage = _FakeUsageStorage(_logs())
+        summary = asyncio.run(pricing_backfill.backfill_usage_costs(usage_storage=usage))
+        assert summary["scanned"] == 3  # 跳过已计价的 t-priced
+        assert summary["priced"] == 1
+        assert summary["still_unpriced"] == 2
+        doc = usage.collection.docs["t-open"]
+        assert doc["cost_available"] is True
+        # billable input = 1M - 200k cache_read = 800k
+        expected = 800_000 * 1.4 / 1e6 + 100_000 * 4.4 / 1e6
+        assert doc["cost_usd"] == pytest.approx(expected)
+        # 已计价的不动
+        assert usage.collection.docs["t-priced"]["cost_usd"] == 0.001
+
+    def test_unpriced_models_reported_by_model(self):
+        usage = _FakeUsageStorage(_logs())
+        summary = asyncio.run(pricing_backfill.backfill_usage_costs(usage_storage=usage))
+        assert summary["unpriced_models"] == {"relay/custom-x": 1, "": 1}
+
+    def test_dry_run_does_not_write(self):
+        usage = _FakeUsageStorage(_logs())
+        summary = asyncio.run(
+            pricing_backfill.backfill_usage_costs(usage_storage=usage, dry_run=True)
+        )
+        assert summary["priced"] == 1
+        assert "cost_usd" not in usage.collection.docs["t-open"]
+
+    def test_model_config_override_by_value_applies(self, monkeypatch):
+        from src.infra.pricing.calculator import PriceRates
+        from src.kernel.schemas.model import ModelConfig
+
+        async def _fake_resolve(*, value, provider=None, model_config_id=None):
+            if model_config_id == "cfg-1":
+                return pricing_service.ResolvedPrice(
+                    rates=PriceRates(input=0.5, output=1.0), source="override"
+                )
+            if value == "glm-5.3":
+                return pricing_service.ResolvedPrice(
+                    rates=PriceRates(input=1.4, output=4.4), source="models_dev"
+                )
+            return None
+
+        lookup_values = []
+
+        async def _fake_get_by_value(value):
+            lookup_values.append(value)
+            if value == "relay/custom-x":
+                return ModelConfig(id="cfg-1", value=value, label="Relay")
+            return None
+
+        import src.infra.agent.model_storage as model_storage_module
+
+        monkeypatch.setattr(pricing_backfill, "resolve_price", _fake_resolve)
+        monkeypatch.setattr(
+            model_storage_module,
+            "get_model_storage",
+            lambda: type("S", (), {"get_by_value": staticmethod(_fake_get_by_value)})(),
+        )
+        usage = _FakeUsageStorage(_logs())
+        summary = asyncio.run(pricing_backfill.backfill_usage_costs(usage_storage=usage))
+        assert summary["priced"] == 2  # t-open（快照价）+ t-unknown（覆盖价）
+        assert "relay/custom-x" in lookup_values
+        doc = usage.collection.docs["t-unknown"]
+        assert doc["cost_usd"] == pytest.approx(100 * 0.5 / 1e6 + 50 * 1.0 / 1e6)

--- a/tests/infra/pricing/test_distributed.py
+++ b/tests/infra/pricing/test_distributed.py
@@ -1,0 +1,251 @@
+"""pricing 分布式支持测试：缓存 TTL 自愈、跨实例失效广播、同步/回填分布式锁。"""
+
+import asyncio
+
+import pytest
+
+from src.infra.pricing import backfill as pricing_backfill
+from src.infra.pricing import pubsub as pricing_pubsub
+from src.infra.pricing import service as pricing_service
+from src.infra.pricing import sync as pricing_sync
+from src.infra.pricing.storage import PricingStorage
+
+
+class _FakePricingCollection:
+    def __init__(self, entries=None, fx=None):
+        self.docs = {}
+        if entries is not None:
+            self.docs["models_dev_snapshot"] = {
+                "entries": entries,
+                "entry_count": len(entries),
+                "model_owners": {},
+                "source_url": "u",
+                "synced_at": "2026-08-30T00:00:00",
+            }
+        if fx is not None:
+            self.docs["fx_rates"] = fx
+
+    async def update_one(self, query, update, **kwargs):
+        doc = dict(update.get("$set", {}))
+        doc["_id"] = query["_id"]
+        self.docs[query["_id"]] = doc
+        return None
+
+    async def find_one(self, query, *args, **kwargs):
+        doc = self.docs.get(query.get("_id"))
+        return None if doc is None else {k: v for k, v in doc.items() if k != "_id"}
+
+    async def create_index(self, *a, **kw):
+        return None
+
+
+def _storage_with(entries=None, fx=None):
+    return PricingStorage(collection=_FakePricingCollection(entries=entries, fx=fx))
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch):
+    monkeypatch.setattr(pricing_service, "get_pricing_storage", lambda: _storage_with())
+    pricing_service.reset_runtime_cache()
+    yield
+    pricing_service.reset_runtime_cache()
+
+
+class TestRuntimeCacheTtl:
+    def test_cache_expires_after_ttl(self, monkeypatch):
+        """其他副本改了 Mongo 后，本地缓存到期要能重新加载（自愈兜底）。"""
+        storage = _storage_with(
+            entries=[
+                {
+                    "provider": "p",
+                    "model_id": "m",
+                    "name": "",
+                    "rates": {"input": 1, "output": 2, "cache_read": None, "cache_write": None},
+                }
+            ]
+        )
+        monkeypatch.setattr(pricing_service, "get_pricing_storage", lambda: storage)
+
+        async def run():
+            idx1 = await pricing_service.get_price_index()
+            # 模拟另一副本写入新快照
+            storage.collection.docs["models_dev_snapshot"]["entries"] = []
+            # TTL 内仍用本地缓存
+            idx2 = await pricing_service.get_price_index()
+            assert idx2 is idx1
+            # 快进 TTL
+            pricing_service._advance_cache_clock(pricing_service.CACHE_TTL_SECONDS + 1)
+            idx3 = await pricing_service.get_price_index()
+            assert idx3 is not idx1
+            assert idx3.entry_count == 0
+
+        asyncio.run(run())
+
+    def test_fx_cache_expires_after_ttl(self, monkeypatch):
+        storage = _storage_with(fx={"base": "USD", "rates": {"CNY": 7.1}, "rate_count": 1})
+        monkeypatch.setattr(pricing_service, "get_pricing_storage", lambda: storage)
+
+        async def run():
+            doc1 = await pricing_service.get_fx_rates()
+            storage.collection.docs.pop("fx_rates")
+            pricing_service._advance_cache_clock(pricing_service.CACHE_TTL_SECONDS + 1)
+            doc2 = await pricing_service.get_fx_rates()
+            assert doc2 is None and doc1 is not None
+
+        asyncio.run(run())
+
+
+class TestPricingPubSub:
+    def test_incoming_message_resets_runtime_cache(self):
+        pub = pricing_pubsub.PricingPubSub()
+        pricing_service._runtime_index = object()  # 模拟已有缓存
+        asyncio.run(pub._handle_message({"data": '{"instance_id": "other"}'}))
+        assert pricing_service._runtime_index is None
+
+    def test_self_message_is_ignored(self):
+        pub = pricing_pubsub.PricingPubSub()
+        sentinel = object()
+        pricing_service._runtime_index = sentinel
+        asyncio.run(pub._handle_message({"data": f'{{"instance_id": "{pub.instance_id}"}}'}))
+        assert pricing_service._runtime_index is sentinel
+
+    def test_publish_is_best_effort(self, monkeypatch):
+        """Redis 挂了不能影响主流程。"""
+
+        class _BoomRedis:
+            async def publish(self, *a, **kw):
+                raise RuntimeError("redis down")
+
+        import src.infra.storage.redis as redis_module
+
+        monkeypatch.setattr(redis_module, "get_redis_client", lambda: _BoomRedis())
+        asyncio.run(pricing_pubsub.publish_pricing_cache_invalidate())  # 不应抛异常
+
+
+class TestSyncDistributedLock:
+    def test_lock_held_by_other_replica_skips_fetch(self, monkeypatch):
+        storage = _storage_with()
+        monkeypatch.setattr(pricing_sync, "get_pricing_storage", lambda: storage)
+
+        async def _contended(lock_key, ttl):
+            return None
+
+        async def _release(lock_key, token):
+            return None
+
+        monkeypatch.setattr(pricing_sync, "acquire_pricing_lock", _contended)
+        monkeypatch.setattr(pricing_sync, "release_pricing_lock", _release)
+
+        def handler(request):
+            raise AssertionError("另一副本持锁时不应发起网络同步")
+
+        monkeypatch.setattr(pricing_sync, "_build_http_client", lambda: _noop_client(handler))
+        status = asyncio.run(pricing_sync.sync_pricing(force=True))
+        assert status["refreshed"] is False
+        assert status["lock_contended"] is True
+
+    def test_redis_failure_falls_back_to_sync(self, monkeypatch):
+        """单机/Redis 不可用时不能因锁而中断同步。"""
+        storage = _storage_with()
+        monkeypatch.setattr(pricing_sync, "get_pricing_storage", lambda: storage)
+
+        async def _boom(lock_key, ttl):
+            raise RuntimeError("redis down")
+
+        async def _release(lock_key, token):
+            return None
+
+        monkeypatch.setattr(pricing_sync, "acquire_pricing_lock", _boom)
+        monkeypatch.setattr(pricing_sync, "release_pricing_lock", _release)
+
+        def handler(request):
+            import httpx
+
+            if "models.dev" in str(request.url):
+                return httpx.Response(
+                    200,
+                    json={
+                        "openai": {
+                            "id": "openai",
+                            "models": {"gpt-4o": {"cost": {"input": 2.5, "output": 10}}},
+                        }
+                    },
+                )
+            return httpx.Response(
+                200,
+                json={"result": "success", "base_code": "USD", "rates": {"USD": 1}},
+            )
+
+        monkeypatch.setattr(pricing_sync, "_build_http_client", lambda: _noop_client(handler))
+        status = asyncio.run(pricing_sync.sync_pricing(force=True))
+        assert status["refreshed"] is True
+        assert status["lock_contended"] is False
+
+
+class TestBackfillDistributedLock:
+    def test_lock_contended_returns_flag(self, monkeypatch):
+        async def _contended(lock_key, ttl):
+            return None
+
+        async def _release(lock_key, token):
+            return None
+
+        monkeypatch.setattr(pricing_backfill, "acquire_pricing_lock", _contended)
+        monkeypatch.setattr(pricing_backfill, "release_pricing_lock", _release)
+        summary = asyncio.run(pricing_backfill.backfill_usage_costs())
+        assert summary.get("lock_contended") is True
+        assert summary["scanned"] == 0
+
+    def test_publishes_and_resets_cache_after_successful_sync(self, monkeypatch):
+        """写入成功后要清本副本缓存并广播其他副本。"""
+        storage = _storage_with()
+        monkeypatch.setattr(pricing_sync, "get_pricing_storage", lambda: storage)
+
+        async def _acquire(lock_key, ttl):
+            return "tok"
+
+        async def _release(lock_key, token):
+            return None
+
+        monkeypatch.setattr(pricing_sync, "acquire_pricing_lock", _acquire)
+        monkeypatch.setattr(pricing_sync, "release_pricing_lock", _release)
+
+        published = []
+
+        async def _fake_publish():
+            published.append(True)
+
+        import src.infra.pricing.pubsub as pubsub_module
+
+        monkeypatch.setattr(pubsub_module, "publish_pricing_cache_invalidate", _fake_publish)
+        pricing_service._runtime_index = object()  # 预置脏缓存
+
+        def handler(request):
+            import httpx
+
+            if "models.dev" in str(request.url):
+                return httpx.Response(
+                    200,
+                    json={
+                        "openai": {
+                            "id": "openai",
+                            "models": {"gpt-4o": {"cost": {"input": 2.5, "output": 10}}},
+                        }
+                    },
+                )
+            return httpx.Response(
+                200,
+                json={"result": "success", "base_code": "USD", "rates": {"USD": 1}},
+            )
+
+        monkeypatch.setattr(pricing_sync, "_build_http_client", lambda: _noop_client(handler))
+        status = asyncio.run(pricing_sync.sync_pricing(force=True))
+        assert status["refreshed"] is True
+        assert published == [True]
+        assert pricing_service._runtime_index is None
+
+
+def _noop_client(handler):
+    import httpx
+
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))

--- a/tests/infra/pricing/test_pricing_sync.py
+++ b/tests/infra/pricing/test_pricing_sync.py
@@ -26,6 +26,20 @@ FX_PAYLOAD = {
 }
 
 
+@pytest.fixture(autouse=True)
+def _no_distributed_lock(monkeypatch):
+    """单进程语义测试：锁恒获取成功，且不触碰真实 Redis。"""
+
+    async def _acquire(lock_key, ttl):
+        return "test-token"
+
+    async def _release(lock_key, token):
+        return None
+
+    monkeypatch.setattr(pricing_sync, "acquire_pricing_lock", _acquire)
+    monkeypatch.setattr(pricing_sync, "release_pricing_lock", _release)
+
+
 class _FakeCollection:
     def __init__(self):
         self.docs: dict = {}


### PR DESCRIPTION
## Summary

#306/#307 之后的两项补强：**存量费用回填**（把计价功能上线前的历史 usage_logs 补上金额）与 **pricing 全链路多副本分布式加固**。

## Changes

### 存量费用回填
- `src/infra/pricing/backfill.py`：按当前价格快照补算未计价记录，幂等可重复执行；模型配置价格覆盖按模型值同样生效；无法计价的按模型名汇总返回
- `UsageStorage` 新增 `list_unpriced_usage_logs`（游标式分批）与 `update_usage_cost`
- 管理端点 `POST /api/pricing/backfill-usage?dry_run=`，模型配置工具栏新增「补算历史费用」按钮（含结果统计 toast），i18n 五语言
- 本地实测：80 条历史记录回填 43 条（glm-5.3 / glm-5.3-flash / gpt-5.6-sol 均命中官方价），总费用 $0.35 立即可统计

### 分布式加固（多副本部署）
- **缓存 TTL**：service 层价格索引/汇率运行时缓存加 10 分钟 TTL，广播丢失时副本自愈兜底
- **失效广播**：新增 `PricingPubSub`（Redis channel `pricing:cache_invalidate`），同步写入成功后清本副本缓存并通知其他副本；监听器接入 runtime_services，与 ModelConfigPubSub 同范式
- **同步互斥**：同步循环持 `pricing:sync:lock`（Redis SET NX EX + Lua 释放），同一时刻仅一个副本发起网络同步；锁竞争跳过本轮流，Redis 故障退化为本地执行（写入幂等）
- **回填互斥**：`pricing:backfill:lock`，竞争时端点返回 409
- 测试基线：pricing 相关测试不再触碰真实 Redis（锁函数注入），避免跨用例键污染

## Testing

- [x] 后端 `uv run pytest` 3237 passed（4 个失败为 develop 存量问题，与本 PR 无关）
- [x] `make lint` / `make typecheck` 通过
- [x] 前端 `pnpm test` 1912 passed，`pnpm run lint` / `pnpm run build` 通过
