### PR TITLE
perf(task): 实例死亡后的对话接管停顿从分钟级缩短到 ~30 秒内

### DIFF
--- a/src/infra/task/constants.py
+++ b/src/infra/task/constants.py
@@ -9,6 +9,8 @@ HEARTBEAT_PREFIX = "task:heartbeat:"
 INTERRUPT_PREFIX = "task:interrupt:"  # 中断信号前缀
 HEARTBEAT_INTERVAL = 10  # 心跳间隔（秒）
 HEARTBEAT_TIMEOUT = 60  # 心跳超时阈值（秒）
+# 按时间戳判过期的阈值：超过该时长没有新心跳即视为执行实例死亡
+HEARTBEAT_STALE_THRESHOLD_SECONDS = max(30, HEARTBEAT_INTERVAL * 3)
 
 # Settings sync channel (distributed instances)
 SETTINGS_CHANNEL = "settings:changed"

--- a/src/infra/task/heartbeat.py
+++ b/src/infra/task/heartbeat.py
@@ -110,9 +110,7 @@ class TaskHeartbeat:
         值缺失 → 过期；解析失败 → 按存活处理（避免误接管活任务）。
         """
         threshold = (
-            max_age_seconds
-            if max_age_seconds is not None
-            else HEARTBEAT_STALE_THRESHOLD_SECONDS
+            max_age_seconds if max_age_seconds is not None else HEARTBEAT_STALE_THRESHOLD_SECONDS
         )
         try:
             value = await get_redis_client().get(f"{HEARTBEAT_PREFIX}{run_id}")

--- a/src/infra/task/heartbeat.py
+++ b/src/infra/task/heartbeat.py
@@ -7,12 +7,18 @@ Manages task heartbeat for detecting stale/failed tasks in distributed scenarios
 
 import asyncio
 from collections.abc import Awaitable, Callable
+from datetime import datetime, timezone
 
 from src.infra.logging import get_logger
 from src.infra.storage.redis import get_redis_client
 from src.infra.utils.datetime import utc_now_iso
 
-from .constants import HEARTBEAT_INTERVAL, HEARTBEAT_PREFIX, HEARTBEAT_TIMEOUT
+from .constants import (
+    HEARTBEAT_INTERVAL,
+    HEARTBEAT_PREFIX,
+    HEARTBEAT_STALE_THRESHOLD_SECONDS,
+    HEARTBEAT_TIMEOUT,
+)
 from .startup_cleanup import _gather_limited
 
 logger = get_logger(__name__)
@@ -95,6 +101,33 @@ class TaskHeartbeat:
             stop_factories.append(_stop_current)
 
         await _gather_limited(stop_factories)
+
+    async def is_stale(self, run_id: str, max_age_seconds: int | None = None) -> bool:
+        """按时间戳判断心跳是否过期。
+
+        与 check_exists（等 Redis key 120s TTL 自然消失）相比，按「距最后一次
+        心跳的时长」判定可以把实例死亡后的接管检测从 ~2 分钟缩到 ~30 秒。
+        值缺失 → 过期；解析失败 → 按存活处理（避免误接管活任务）。
+        """
+        threshold = (
+            max_age_seconds
+            if max_age_seconds is not None
+            else HEARTBEAT_STALE_THRESHOLD_SECONDS
+        )
+        try:
+            value = await get_redis_client().get(f"{HEARTBEAT_PREFIX}{run_id}")
+        except Exception as e:
+            logger.warning(f"Heartbeat read failed for run_id={run_id}: {e}")
+            return False  # Redis 不可用时按存活处理，避免误接管
+        if value is None:
+            return True
+        try:
+            last_beat = datetime.fromisoformat(str(value))
+        except ValueError:
+            return False
+        if last_beat.tzinfo is None:
+            last_beat = last_beat.replace(tzinfo=timezone.utc)
+        return (datetime.now(timezone.utc) - last_beat).total_seconds() > threshold
 
     async def check_exists(self, run_id: str) -> bool:
         """

--- a/src/infra/task/orphan_recovery.py
+++ b/src/infra/task/orphan_recovery.py
@@ -18,7 +18,7 @@ from src.kernel.config import settings
 
 logger = get_logger(__name__)
 
-DEFAULT_ORPHAN_RECOVERY_INTERVAL_SECONDS = 120
+DEFAULT_ORPHAN_RECOVERY_INTERVAL_SECONDS = 15
 
 
 def recovery_interval_seconds() -> int:

--- a/src/infra/task/startup_cleanup.py
+++ b/src/infra/task/startup_cleanup.py
@@ -398,6 +398,21 @@ class TaskStartupCleanupService:
             async for running_sessions in _iter_cursor_batches(cursor):
                 cleaned_count += await self._process_running_sessions(running_sessions)
 
+            # --- FAILED recoverable tasks ---
+            # 优雅关停（滚动更新）标记的 server_restart 失败任务没有存活执行者，
+            # 周期扫描也要接管，否则要等「任意 Pod 重启」才能恢复。
+            cursor = self._storage.collection.find(
+                {
+                    "metadata.task_status": TaskStatus.FAILED.value,
+                    "metadata.task_recoverable": True,
+                    "metadata.task_error_code": "server_restart",
+                }
+            )
+            async for failed_recoverable_sessions in _iter_cursor_batches(cursor):
+                cleaned_count += await self._process_failed_recoverable_sessions(
+                    failed_recoverable_sessions
+                )
+
             if running_only:
                 return
 
@@ -490,7 +505,8 @@ class TaskStartupCleanupService:
         for _, _, _, run_id in candidates:
 
             async def _check_heartbeat(run_id: str = run_id) -> bool:
-                return await self._heartbeat.check_exists(run_id)
+                # 存活 = 心跳未过期（按时间戳判定，不等 Redis TTL 自然消失）
+                return not await self._heartbeat.is_stale(run_id)
 
             heartbeat_factories.append(_check_heartbeat)
 

--- a/tests/infra/task/test_fast_orphan_takeover.py
+++ b/tests/infra/task/test_fast_orphan_takeover.py
@@ -1,0 +1,162 @@
+"""缩短滚动更新/实例死亡后的对话恢复停顿：
+
+1. 心跳按时间戳判过期（而非等 Redis key 的 120s TTL 自然消失）
+2. 周期孤儿扫描同时接管 FAILED+recoverable（server_restart）任务，
+   不再等「任意 Pod 重启」才恢复
+3. 扫描周期默认 120s → 15s
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.infra.task import orphan_recovery
+from src.infra.task.heartbeat import HEARTBEAT_INTERVAL, TaskHeartbeat
+from src.infra.task.startup_cleanup import TaskStartupCleanupService
+
+
+class _FakeRedis:
+    def __init__(self, data: dict[str, str]):
+        self._data = data
+
+    async def get(self, key: str):
+        return self._data.get(key)
+
+    async def set(self, key, value, **kwargs):
+        self._data[key] = value
+        return True
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+class TestHeartbeatIsStale:
+    @staticmethod
+    def _with_redis(monkeypatch, data: dict[str, str]):
+        monkeypatch.setattr("src.infra.task.heartbeat.get_redis_client", lambda: _FakeRedis(data))
+
+    @pytest.mark.asyncio
+    async def test_fresh_heartbeat_is_alive(self, monkeypatch):
+        now = datetime.now(timezone.utc)
+        self._with_redis(monkeypatch, {"task:heartbeat:run-1": _iso(now - timedelta(seconds=5))})
+        assert await TaskHeartbeat().is_stale("run-1") is False
+
+    @pytest.mark.asyncio
+    async def test_old_heartbeat_is_stale_before_ttl_expiry(self, monkeypatch):
+        # 35 秒没心跳即判死，无需等 120s TTL 自然过期
+        now = datetime.now(timezone.utc)
+        self._with_redis(monkeypatch, {"task:heartbeat:run-1": _iso(now - timedelta(seconds=35))})
+        assert await TaskHeartbeat().is_stale("run-1") is True
+
+    @pytest.mark.asyncio
+    async def test_missing_heartbeat_is_stale(self, monkeypatch):
+        self._with_redis(monkeypatch, {})
+        assert await TaskHeartbeat().is_stale("run-1") is True
+
+    @pytest.mark.asyncio
+    async def test_unparseable_value_falls_back_to_alive(self, monkeypatch):
+        # 解析失败按「存活」处理，避免误接管活任务
+        self._with_redis(monkeypatch, {"task:heartbeat:run-1": "garbage"})
+        assert await TaskHeartbeat().is_stale("run-1") is False
+
+    def test_stale_threshold_is_three_beats(self):
+        from src.infra.task.heartbeat import HEARTBEAT_STALE_THRESHOLD_SECONDS
+
+        assert HEARTBEAT_STALE_THRESHOLD_SECONDS >= HEARTBEAT_INTERVAL * 3
+
+
+class _FakeCursor:
+    def __init__(self, docs):
+        self._docs = docs
+
+    async def to_list(self, length: int = 100) -> list:
+        return self._docs
+
+
+class _FakeCollection:
+    def __init__(self):
+        self.queries: list[dict] = []
+
+    def find(self, query: dict) -> _FakeCursor:
+        self.queries.append(query)
+        return _FakeCursor([])
+
+
+class _FakeStorage:
+    def __init__(self):
+        self.collection = _FakeCollection()
+
+
+class _FakeHeartbeat:
+    async def is_stale(self, run_id: str) -> bool:
+        return True
+
+
+def _make_service() -> TaskStartupCleanupService:
+    return TaskStartupCleanupService(
+        storage=_FakeStorage(),
+        heartbeat=_FakeHeartbeat(),
+        ensure_executor=lambda: None,
+        load_session_record=None,
+        resume_interrupted_run=None,
+        cleanup_stale_queues=None,
+        replay_pending_queued_tasks=None,
+    )
+
+
+@pytest.fixture
+def _lease_passthrough(monkeypatch: pytest.MonkeyPatch):
+    from types import SimpleNamespace
+
+    async def _fake_acquire_lease(redis):
+        return SimpleNamespace(redis=redis, token=None)
+
+    async def _no_op(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "src.infra.task.startup_cleanup._acquire_startup_cleanup_lease", _fake_acquire_lease
+    )
+    monkeypatch.setattr(
+        "src.infra.task.startup_cleanup._start_startup_cleanup_lease_renewal",
+        lambda lease: None,
+    )
+    monkeypatch.setattr("src.infra.task.startup_cleanup._release_startup_cleanup_lease", _no_op)
+    monkeypatch.setattr("src.infra.task.startup_cleanup._renew_startup_cleanup_lease", _no_op)
+
+
+class TestPeriodicScanIncludesFailedRecoverable:
+    @pytest.mark.asyncio
+    async def test_running_only_scans_running_and_failed_recoverable(self, _lease_passthrough):
+        """周期扫描也要接管优雅关停标记的 FAILED+recoverable 任务。"""
+        service = _make_service()
+        await service.cleanup_stale_tasks(running_only=True)
+
+        queries = service._storage.collection.queries
+        assert {"metadata.task_status": "running"} in queries
+        assert {
+            "metadata.task_status": "failed",
+            "metadata.task_recoverable": True,
+            "metadata.task_error_code": "server_restart",
+        } in queries
+        # PENDING/QUEUED 重放仍仅在启动时执行
+        pending_query = {"metadata.task_status": {"$in": ["pending", "queued"]}}
+        assert (
+            pending_query
+            not in [q for q in queries if "$in" in str(q.get("metadata.task_status", ""))]
+            or pending_query not in queries
+        )
+
+
+def test_default_scan_interval_is_fast(monkeypatch: pytest.MonkeyPatch):
+    """默认扫描间隔 15 秒，缩短恢复停顿。"""
+    monkeypatch.setattr(
+        orphan_recovery.settings,
+        "TASK_ORPHAN_RECOVERY_INTERVAL_SECONDS",
+        None,
+        raising=False,
+    )
+    assert orphan_recovery.DEFAULT_ORPHAN_RECOVERY_INTERVAL_SECONDS == 15

--- a/tests/infra/task/test_manager_recovery.py
+++ b/tests/infra/task/test_manager_recovery.py
@@ -46,6 +46,9 @@ class _FakeHeartbeat:
     async def check_exists(self, run_id: str) -> bool:
         return self.exists
 
+    async def is_stale(self, run_id: str) -> bool:
+        return not self.exists
+
 
 @pytest.mark.asyncio
 async def test_cancel_session_persists_cancelled_status_without_local_run_info() -> None:
@@ -509,7 +512,6 @@ async def test_cleanup_stale_tasks_attempts_auto_recovery_for_failed_recoverable
     storage.collection = _FakeCollection(
         [
             [],
-            [],
             [
                 {
                     "_id": "mongo-1",
@@ -522,6 +524,7 @@ async def test_cleanup_stale_tasks_attempts_auto_recovery_for_failed_recoverable
                     },
                 }
             ],
+            [],
         ]
     )
     manager._storage = storage

--- a/tests/infra/task/test_manager_services.py
+++ b/tests/infra/task/test_manager_services.py
@@ -39,6 +39,9 @@ class _FakeHeartbeat:
     async def check_exists(self, run_id: str) -> bool:
         return self.exists
 
+    async def is_stale(self, run_id: str) -> bool:
+        return not self.exists
+
 
 class _FakeRedis:
     def __init__(self, acquired: bool = True) -> None:
@@ -638,7 +641,6 @@ async def test_startup_cleanup_service_recovers_latest_explicit_system_restart_f
     storage.collection = _FakeCollection(
         [
             [],
-            [],
             [
                 {
                     "_id": "mongo-1",
@@ -652,6 +654,7 @@ async def test_startup_cleanup_service_recovers_latest_explicit_system_restart_f
                     },
                 }
             ],
+            [],
         ]
     )
     heartbeat = _FakeHeartbeat(exists=False)

--- a/tests/infra/task/test_orphan_recovery.py
+++ b/tests/infra/task/test_orphan_recovery.py
@@ -63,7 +63,7 @@ async def test_scheduled_recovery_runs_running_only(monkeypatch: pytest.MonkeyPa
 
 
 @pytest.mark.asyncio
-async def test_running_only_cleanup_scans_running_but_not_pending_or_failed(
+async def test_running_only_cleanup_scans_running_and_failed_recoverable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     storage = _FakeStorage()
@@ -100,8 +100,18 @@ async def test_running_only_cleanup_scans_running_but_not_pending_or_failed(
 
     await service.cleanup_stale_tasks(running_only=True)
 
-    assert len(storage.collection.queries) == 1
-    assert storage.collection.queries[0] == {"metadata.task_status": "running"}
+    # 周期扫描接管 RUNNING（心跳过期）与 FAILED+recoverable（优雅关停标记），
+    # 但不重放 PENDING/QUEUED
+    assert {"metadata.task_status": "running"} in storage.collection.queries
+    assert {
+        "metadata.task_status": "failed",
+        "metadata.task_recoverable": True,
+        "metadata.task_error_code": "server_restart",
+    } in storage.collection.queries
+    assert not any(
+        isinstance(q.get("metadata.task_status"), dict) and "$in" in q["metadata.task_status"]
+        for q in storage.collection.queries
+    )
 
 
 def test_recovery_interval_reads_settings(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

缩短滚动更新/实例崩溃时，正在进行的对话被自动接管重跑的停顿：**从最坏 ~4 分钟降到 ~30 秒内**。

## 问题定位（三个环节叠加）

1. **心跳判定等 Redis key TTL**：RUNNING 任务的存活检测用「key 是否存在」，而 key TTL 是 `HEARTBEAT_TIMEOUT * 2 = 120s`——执行实例死亡后 key 还要挂 2 分钟，扫描器才能判定任务已死
2. **扫描周期 120s**：周期孤儿接管默认间隔再叠加一段延迟
3. **FAILED 恢复缺口**：优雅关停（SIGTERM）把在途 run 标记为 `FAILED + recoverable(server_restart)`，但周期扫描是 `running_only` 会跳过它们——只等「任意 Pod 重启」才恢复；滚动更新里最后被杀副本的任务可能无限期等待

## Changes

- `TaskHeartbeat.is_stale(run_id)`：按心跳时间戳判龄，阈值 `HEARTBEAT_STALE_THRESHOLD_SECONDS = 30s`（3 个心跳周期）。值缺失 → 判死；解析失败 / Redis 异常 → 按存活处理（避免误接管活任务）。RUNNING 扫描改用该判定，不再等 key TTL
- 周期扫描（`running_only=True`）同时接管 `FAILED+recoverable(server_restart)`：这类任务由垂死副本主动标记、无存活执行者，立即接管安全；PENDING/QUEUED 重放仍仅启动时执行
- 周期扫描默认间隔 120s → **15s**（`TASK_ORPHAN_RECOVERY_INTERVAL_SECONDS` 可调）

接管安全性沿用既有保护：分布式恢复锁（每 run 一把）、`current_run_id` 一致性校验、用户取消过滤、superseded 过滤、启动清理租约互斥。

## 预期延迟

| 场景 | 之前 | 现在 |
|------|------|------|
| 优雅关停（滚动更新） | 等下一次任意 Pod 重启（可能无限期） | ~15s |
| 硬杀（OOM/节点故障） | 120s TTL + 最多 120s 扫描 ≈ 2-4 分钟 | 30s 判定 + 最多 15s 扫描 ≈ 30-45s |

## Testing

- [x] 新增 `test_fast_orphan_takeover.py`：is_stale 各分支（新鲜/过期/缺失/解析失败）、running_only 查询包含 FAILED+recoverable 且不含 PENDING/QUEUED、默认间隔
- [x] 既有测试夹具按新查询顺序更新（FAILED 块移至 RUNNING 之后）
- [x] `uv run pytest` 3244 passed（4 个失败为 develop 存量环境问题）
- [x] `make lint` / `make typecheck` 通过
