### PR TITLE
fix(task): 孤儿接管 settings 默认间隔同步降为 15s

### DIFF
--- a/src/kernel/config/base.py
+++ b/src/kernel/config/base.py
@@ -144,7 +144,8 @@ class Settings(BaseSettings):
     ARQ_WORKER_MAX_JOBS: int = 128
     ARQ_JOB_TIMEOUT_SECONDS: int = 86400
     TASK_STARTUP_CLEANUP_CONCURRENCY: int = 16
-    TASK_ORPHAN_RECOVERY_INTERVAL_SECONDS: int = 120
+    # 周期孤儿接管间隔：缩短实例死亡后对话自动恢复的停顿（心跳按龄判死 ~30s + 扫描间隔）
+    TASK_ORPHAN_RECOVERY_INTERVAL_SECONDS: int = 15
     # 流式分片的时间维 flush 间隔（秒）：正文/思考/工具参数攒不够大小阈值时，
     # 每隔该时长也强制下发一次，避免小尾巴要等流结束才出来（<=0 禁用）。
     STREAM_CHUNK_FLUSH_INTERVAL: float = 1.0

--- a/tests/infra/task/test_fast_orphan_takeover.py
+++ b/tests/infra/task/test_fast_orphan_takeover.py
@@ -160,3 +160,10 @@ def test_default_scan_interval_is_fast(monkeypatch: pytest.MonkeyPatch):
         raising=False,
     )
     assert orphan_recovery.DEFAULT_ORPHAN_RECOVERY_INTERVAL_SECONDS == 15
+
+
+def test_settings_default_scan_interval_is_15s():
+    """settings 默认值（真正生效的配置源）也要是 15s。"""
+    from src.kernel.config import settings as settings_module
+
+    assert settings_module.TASK_ORPHAN_RECOVERY_INTERVAL_SECONDS == 15


### PR DESCRIPTION
## Summary

#311 的补充修复：staging 硬杀实测发现恢复仍耗时 **2 分 14 秒**——新 Pod 日志显示 `Periodic takeover registered: interval=120s`。

## Root Cause

#311 只把 `orphan_recovery.py` 的模块默认常量改为 15s，但真正生效的配置源是 `settings.TASK_ORPHAN_RECOVERY_INTERVAL_SECONDS`（base.py 默认 120），模块常量仅作 getattr 兜底、从未被读到。实测中等的是新 Pod 启动后的首个 120s 周期 tick。

## Changes

- `base.py`：`TASK_ORPHAN_RECOVERY_INTERVAL_SECONDS: int = 120 → 15`（附注释）
- 补测试：断言 settings 默认值为 15，防止再次改错层

## 预期效果（配合 #311 其余改动）

- 硬杀：心跳按龄判死 ~30s + ≤15s 扫描 ≈ **30-45s 接管**（本次实测该场景 2m14s → 修正后复测）
- 优雅关停（滚动更新）：FAILED+recoverable 周期接管 ≈ **~15s**

## Testing

- [x] `uv run pytest tests/infra/task/` 216 passed
- [x] ruff format/check 通过