### PR TITLE
docs(k8s): secret 示例补充 Qdrant 向量索引三键配置

### DIFF
--- a/k8s/lambchat-secret.yaml.example
+++ b/k8s/lambchat-secret.yaml.example
@@ -29,6 +29,11 @@ stringData:
   # NATIVE_MEMORY_EMBEDDING_API_KEY: "sk-your-siliconflow-key"
   # NATIVE_MEMORY_EMBEDDING_MODEL: "BAAI/bge-m3"
   # NATIVE_MEMORY_EMBEDDING_DIMENSIONS: "1024"
+  # ── Qdrant vector index (optional; default mongo. Auto-backfills existing
+  #    Mongo embeddings on first start, silently degrades to Mongo on failure) ──
+  # NATIVE_MEMORY_VECTOR_BACKEND: "qdrant"
+  # NATIVE_MEMORY_QDRANT_URL: "http://127.0.0.1:6333"
+  # NATIVE_MEMORY_QDRANT_API_KEY: "your-qdrant-api-key"  # dims must match NATIVE_MEMORY_EMBEDDING_DIMENSIONS
   # NATIVE_MEMORY_MODEL: "glm-5.3-flash"  # fast channel for memory extraction
   # NATIVE_MEMORY_QUERY_CONTEXT_ENABLED: "true"  # A1 injection
   # NATIVE_MEMORY_SELF_EVOLVE_ENABLED: "true"    # requires ENABLE_SCHEDULED_TASK=true


### PR DESCRIPTION
## 变更内容
- `k8s/lambchat-secret.yaml.example` 的 Memory 注释块补充可选的 Qdrant 向量索引三键（`NATIVE_MEMORY_VECTOR_BACKEND` / `NATIVE_MEMORY_QDRANT_URL` / `NATIVE_MEMORY_QDRANT_API_KEY`）
- 注明维度须与 `NATIVE_MEMORY_EMBEDDING_DIMENSIONS` 一致；默认 mongo 不变，启用后自动回填、故障静默降级
- 与 `docs/zh|en/env/memory.md` 已有的环境变量文档保持呼应，纯注释示例，无行为变更

## 验证
- 纯文档注释变更，无代码影响