### PR TITLE
fix(task): 孤儿接管间隔的定义层默认值同步为 15s

### DIFF
--- a/src/kernel/config/_definitions_infra.py
+++ b/src/kernel/config/_definitions_infra.py
@@ -142,7 +142,7 @@ INFRA_SETTING_DEFINITIONS: dict[str, dict] = {
         "category": SettingCategory.REDIS,
         "subcategory": "task",
         "description": "settingDesc.TASK_ORPHAN_RECOVERY_INTERVAL_SECONDS",
-        "default": 120,
+        "default": 15,
         "depends_on": {"key": "TASK_BACKEND", "value": "arq"},
         "frontend_visible": False,
     },

--- a/tests/infra/task/test_fast_orphan_takeover.py
+++ b/tests/infra/task/test_fast_orphan_takeover.py
@@ -167,3 +167,12 @@ def test_settings_default_scan_interval_is_15s():
     from src.kernel.config import settings as settings_module
 
     assert settings_module.TASK_ORPHAN_RECOVERY_INTERVAL_SECONDS == 15
+
+
+def test_setting_definition_default_is_15s():
+    """定义层（管理设置 UI 的默认值）也要是 15s——运行时以定义默认覆盖代码默认。"""
+    from src.kernel.config.definitions import SETTING_DEFINITIONS
+
+    definition = SETTING_DEFINITIONS.get("TASK_ORPHAN_RECOVERY_INTERVAL_SECONDS")
+    assert definition is not None
+    assert definition.get("default") == 15


### PR DESCRIPTION
## Summary

#311/#313 的第三层修复。staging 复测仍见 `interval=120s`，逐层排查发现该配置有**四处取值**，本次补齐最后一层。

## Root Cause

`TASK_ORPHAN_RECOVERY_INTERVAL_SECONDS` 的取值优先级：DB 设置行 > **定义层默认（_definitions_infra.py default=120）** > base.py 代码默认。#313 只改了 base.py——启动时定义层默认仍以 120 覆盖。容器内 `settings` 值为 15、`recovery_interval_seconds()` 为 15，但 worker 注册日志为 120s 的"自相矛盾"即由此而来（不同进程启动路径套用定义默认的时机不同）。

## Changes

- `_definitions_infra.py`：`TASK_ORPHAN_RECOVERY_INTERVAL_SECONDS` default 120 → 15
- 测试锁死三层一致（模块常量 / settings / 定义层）

## Testing

- [x] `uv run pytest tests/infra/task/ tests/kernel/config/` 全绿
- [x] ruff 通过