### PR TITLE
fix(task): 任务队列路径持久化用户消息运行模式

### DIFF
--- a/src/infra/task/manager.py
+++ b/src/infra/task/manager.py
@@ -15,6 +15,7 @@ from arq.connections import create_pool
 
 from src.infra.logging import get_logger
 from src.infra.session.storage import SessionStorage
+from src.infra.writer.presenter_events import derive_user_message_run_modes
 from src.kernel.config import settings
 
 from .arq_payloads import TaskArqPayloadStore, UserMessageSearchIndexPayloadStore
@@ -130,6 +131,7 @@ class BackgroundTaskManager:
         enabled_skills: Optional[List[str]] = None,
         attachment_references_claimed: bool = False,
         schedule_search_index: bool = True,
+        run_modes: Optional[List[str]] = None,
     ) -> str:
         """Persist the user message before the background worker starts."""
         from src.agents.core import resolve_agent_name
@@ -161,6 +163,7 @@ class BackgroundTaskManager:
             enabled_skills=enabled_skills,
             attachment_references_claimed=attachment_references_claimed,
             schedule_search_index=schedule_search_index,
+            run_modes=run_modes,
         )
         return presenter.trace_id
 
@@ -357,6 +360,7 @@ class BackgroundTaskManager:
                     attachments=attachments,
                     enabled_skills=enabled_skills,
                     attachment_references_claimed=attachment_references_claimed,
+                    run_modes=derive_user_message_run_modes(auto_mode, active_goal),
                 )
                 user_message_written = True
 
@@ -488,6 +492,7 @@ class BackgroundTaskManager:
                     enabled_skills=enabled_skills,
                     attachment_references_claimed=attachment_references_claimed,
                     schedule_search_index=False,
+                    run_modes=derive_user_message_run_modes(auto_mode, active_goal),
                 )
                 user_message_written = True
 

--- a/tests/infra/task/test_arq_submission.py
+++ b/tests/infra/task/test_arq_submission.py
@@ -117,6 +117,7 @@ class _FakePresenter:
         enabled_skills=None,
         attachment_references_claimed: bool = False,
         schedule_search_index: bool = True,
+        run_modes=None,
     ) -> None:
         self.calls.append(
             (
@@ -126,6 +127,7 @@ class _FakePresenter:
                 enabled_skills,
                 attachment_references_claimed,
                 schedule_search_index,
+                run_modes,
             )
         )
 
@@ -504,7 +506,7 @@ async def test_submit_persists_user_message_before_background_task_starts(
     assert (run_id, trace_id) == ("run-1", "trace-1")
     assert _FakePresenter.calls[1:] == [
         ("ensure_trace", "trace-1"),
-        ("emit_user_message", "hello", [{"name": "a.txt"}], ["planning"], True, True),
+        ("emit_user_message", "hello", [{"name": "a.txt"}], ["planning"], True, True, []),
     ]
 
 
@@ -704,7 +706,7 @@ async def test_submit_arq_can_persist_user_message_before_enqueue(
 
     assert _FakePresenter.calls[1:] == [
         ("ensure_trace", "trace-1"),
-        ("emit_user_message", "hello", None, None, True, False),
+        ("emit_user_message", "hello", None, None, True, False, []),
     ]
     assert payload_store.saved[0][1]["user_message_written"] is True
     assert payload_store.saved[0][1]["attachment_references_claimed"] is True
@@ -750,7 +752,7 @@ async def test_submit_arq_persists_scheduled_task_message_with_enabled_skills(
 
     assert _FakePresenter.calls[1:] == [
         ("ensure_trace", "trace-1"),
-        ("emit_user_message", "hello", None, ["planning"], False, False),
+        ("emit_user_message", "hello", None, ["planning"], False, False, ["auto"]),
     ]
     assert fake_executor.ensure_calls[0][1]["session_metadata"] == session_metadata
     assert payload_store.saved[0][1]["enabled_skills"] == ["planning"]

--- a/tests/infra/task/test_manager_user_message_run_modes.py
+++ b/tests/infra/task/test_manager_user_message_run_modes.py
@@ -1,0 +1,123 @@
+"""TaskManager 初始用户消息持久化必须携带运行模式（auto/goal）。
+
+staging 实测发现走任务队列路径时 user:message 事件缺失 run_modes：
+根因是 BackgroundTaskManager._persist_initial_user_message 未透传运行模式。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from src.infra.task.manager import BackgroundTaskManager
+
+
+class _RecordingPresenter:
+    calls: list[dict[str, Any]] = []
+
+    def __init__(self, config) -> None:
+        self.trace_id = config.trace_id or "generated-trace"
+
+    async def _ensure_trace(self) -> None:
+        pass
+
+    async def emit_user_message(self, message: str, **kwargs) -> None:
+        type(self).calls.append({"message": message, **kwargs})
+
+
+class _FakeExecutor:
+    async def ensure_session(self, *args, **kwargs) -> None:
+        return None
+
+    async def _update_session_status(self, *args, **kwargs) -> None:
+        return None
+
+    async def run_task(self, *args, **kwargs) -> None:
+        return None
+
+
+async def _executor_fn(*args, **kwargs):
+    if False:
+        yield None
+
+
+@pytest.mark.asyncio
+async def test_submit_persists_auto_run_mode_on_initial_user_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = BackgroundTaskManager()
+    _RecordingPresenter.calls = []
+    monkeypatch.setattr(manager, "_executor", _FakeExecutor())  # type: ignore[assignment]
+
+    async def _release_no_op(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(manager, "_release_concurrency", _release_no_op)
+    monkeypatch.setattr("src.infra.writer.present.Presenter", _RecordingPresenter)
+
+    await manager.submit(
+        session_id="session-1",
+        agent_id="search",
+        message="hello",
+        user_id="user-1",
+        executor=_executor_fn,
+        run_id="run-1",
+        trace_id="trace-1",
+        auto_mode=True,
+        write_user_message_immediately=True,
+    )
+
+    await asyncio.sleep(0)
+
+    assert _RecordingPresenter.calls == [
+        {
+            "message": "hello",
+            "attachments": None,
+            "enabled_skills": None,
+            "attachment_references_claimed": False,
+            "schedule_search_index": True,
+            "run_modes": ["auto"],
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_submit_persists_goal_run_mode_on_initial_user_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = BackgroundTaskManager()
+    _RecordingPresenter.calls = []
+    monkeypatch.setattr(manager, "_executor", _FakeExecutor())  # type: ignore[assignment]
+
+    async def _release_no_op(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(manager, "_release_concurrency", _release_no_op)
+    monkeypatch.setattr("src.infra.writer.present.Presenter", _RecordingPresenter)
+
+    await manager.submit(
+        session_id="session-2",
+        agent_id="search",
+        message="with goal",
+        user_id="user-1",
+        executor=_executor_fn,
+        run_id="run-2",
+        trace_id="trace-2",
+        active_goal={"objective": "ship it"},
+        write_user_message_immediately=True,
+    )
+
+    await asyncio.sleep(0)
+
+    assert _RecordingPresenter.calls == [
+        {
+            "message": "with goal",
+            "attachments": None,
+            "enabled_skills": None,
+            "attachment_references_claimed": False,
+            "schedule_search_index": True,
+            "run_modes": ["goal"],
+        }
+    ]


### PR DESCRIPTION
## Description / 描述

修复 #322 遗留的运行模式徽章持久化缺口。

staging 实测（develop-20260830-155912）发现：开启「自动」模式发送消息后，实时气泡正常回显徽章（乐观消息走前端状态），但刷新页面后历史消息**不显示徽章**。排查确认：

- 前端请求体正确携带 `auto_mode: true`
- 落库的 `user:message` 事件缺失 `run_modes` 字段
- 根因：`BackgroundTaskManager._persist_initial_user_message`（`src/infra/task/manager.py`）未透传运行模式。staging 走任务队列提交路径，用户消息在 manager 侧持久化，而 #322 只覆盖了 `chat.py` 与 `executor.py` 两个调用点

## Changes

- `manager.py`：`_persist_initial_user_message` 新增 `run_modes` 参数并透传给 `emit_user_message`；`submit` 与 `submit_arq` 两处调用点按 `auto_mode` / `active_goal` 推导传入
- 新增 `tests/infra/task/test_manager_user_message_run_modes.py`：auto / goal 两个场景的持久化行为测试（先 RED 后 GREEN）
- `test_arq_submission.py`：`_FakePresenter` 记录 `run_modes`，同步 3 处既有断言（定时任务场景 `auto_mode=True` 期望 `["auto"]`）

## Type of Change / 更改类型

- [x] 🐛 Bug fix / Bug 修复
- [ ] ✨ New feature / 新功能
- [ ] 💥 Breaking change / 破坏性更改
- [ ] 📝 Documentation update / 文档更新
- [ ] 🔧 Refactoring / 代码重构
- [ ] 🎨 Style update / 样式更新
- [ ] ⚡ Performance improvement / 性能优化

## How Has This Been Tested? / 测试情况

- [x] Unit Tests / 单元测试
- [x] Manual Testing / 手动测试

- `uv run pytest` — 全量 3265 passed / 1 skipped
- `ruff check` + `ruff format --check` + `mypy` — 通过
- staging 实测复现路径已验证：请求体含 `auto_mode: true`、Mongo 事件缺失 `run_modes`（修复后将重验）

## Checklist / 检查清单

- [x] 我的代码遵循项目的代码风格 / My code follows the project's code style
- [x] 我已经进行了自我审查 / I have performed a self-review
- [x] 我已经对代码进行了注释 / I have commented my code
- [x] 我已经更新了相关文档 / I have made corresponding changes to the documentation
- [x] 我的更改没有产生新的警告 / My changes generate no new warnings
- [x] 我已经添加了测试 / I have added tests
- [x] 新旧测试都通过 / New and existing unit tests pass

## Screenshots (if applicable) / 截图（如适用）

无

## Related Issues / 相关 Issue

跟进 #322（运行模式徽章）
