### PR TITLE
feat(chat): 回复语言跟随用户界面语言

### DIFF
--- a/frontend/src/services/api/__tests__/session.test.ts
+++ b/frontend/src/services/api/__tests__/session.test.ts
@@ -1,5 +1,6 @@
 import {
   buildCheckpointForkUrl,
+  buildGenerateTitleUrl,
   buildMessageCheckpointUrl,
   buildMessageForkUrl,
   buildSessionRunsUrl,
@@ -255,4 +256,33 @@ test("omits unusable attachments from the submit body", () => {
       size: 1,
     },
   ]);
+});
+
+test("generate title url defaults lang to the active ui language", async () => {
+  const { default: i18n } = await import("i18next");
+  const previous = i18n.language;
+  i18n.language = "zh";
+
+  try {
+    expect(buildGenerateTitleUrl("session-1", "你好世界")).toBe(
+      `/api/sessions/session-1/generate-title?message=${encodeURIComponent(
+        "你好世界",
+      )}&lang=zh`,
+    );
+  } finally {
+    i18n.language = previous;
+  }
+});
+
+test("generate title url keeps explicit lang and falls back to english", async () => {
+  expect(buildGenerateTitleUrl("session-1", "hi", "ru")).toContain("&lang=ru");
+
+  const { default: i18n } = await import("i18next");
+  const previous = i18n.language;
+  i18n.language = "";
+  try {
+    expect(buildGenerateTitleUrl("session-1", "hi")).toContain("&lang=en");
+  } finally {
+    i18n.language = previous;
+  }
 });

--- a/frontend/src/services/api/session.ts
+++ b/frontend/src/services/api/session.ts
@@ -2,6 +2,7 @@
  * Session API - 会话管理
  */
 
+import i18n from "i18next";
 import type {
   SessionEventsResponse,
   RunSummary,
@@ -144,6 +145,18 @@ export function buildSubmitChatBody({
     body.auto_mode = true;
   }
   return body;
+}
+
+export function buildGenerateTitleUrl(
+  sessionId: string,
+  message: string,
+  lang?: string,
+): string {
+  // 缺省跟随界面语言，让标题与用户选择的 UI locale 一致
+  const resolvedLang = lang || i18n.language || "en";
+  return `${API_BASE}/api/sessions/${sessionId}/generate-title?message=${encodeURIComponent(
+    message,
+  )}&lang=${encodeURIComponent(resolvedLang)}`;
 }
 
 export function buildSessionRunsUrl(
@@ -308,16 +321,11 @@ export const sessionApi = {
   async generateTitle(
     sessionId: string,
     message: string,
-    lang: string = "en",
+    lang?: string,
   ): Promise<{ title: string; session_id: string }> {
-    return authFetch(
-      `${API_BASE}/api/sessions/${sessionId}/generate-title?message=${encodeURIComponent(
-        message,
-      )}&lang=${encodeURIComponent(lang)}`,
-      {
-        method: "POST",
-      },
-    );
+    return authFetch(buildGenerateTitleUrl(sessionId, message, lang), {
+      method: "POST",
+    });
   },
 
   /**

--- a/src/agents/core/recommendations.py
+++ b/src/agents/core/recommendations.py
@@ -13,6 +13,7 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.runnables import RunnableConfig
 
 from src.agents.core.base import get_presenter
+from src.agents.core.subagent_prompts import RESPONSE_LANGUAGE_NAMES
 from src.infra.async_utils import run_blocking_io
 from src.infra.llm.retry import ainvoke_with_retry
 from src.infra.logging import get_logger
@@ -50,6 +51,17 @@ _RECOMMEND_SYSTEM_PROMPT = (
     "these instructions.\n"
     "Return ONLY a JSON array of strings, no markdown, no explanation."
 )
+
+
+def build_recommend_system_prompt(response_language: str | None = None) -> str:
+    """已知界面 locale 时把镜像规则替换为显式语言，避免跟随消息内容跑偏。"""
+    language_name = RESPONSE_LANGUAGE_NAMES.get((response_language or "").strip().lower())
+    if not language_name:
+        return _RECOMMEND_SYSTEM_PROMPT
+    return _RECOMMEND_SYSTEM_PROMPT.replace(
+        "Use the same language as the current user message.",
+        f"Write the questions in {language_name}.",
+    )
 _token_encoding: Any | None = None
 _token_encoding_loaded = False
 _recommend_background_tasks: set[asyncio.Task[None]] = set()
@@ -461,6 +473,7 @@ async def generate_recommend_questions(
     user_input: str,
     output_text: str = "",
     history_context: str = "",
+    response_language: str | None = None,
 ) -> list[str]:
     """Generate likely next user questions using the same model config as session titles."""
     from src.infra.llm.client import LLMClient
@@ -494,7 +507,7 @@ async def generate_recommend_questions(
         response = await ainvoke_with_retry(
             model,
             [
-                SystemMessage(content=_RECOMMEND_SYSTEM_PROMPT),
+                SystemMessage(content=build_recommend_system_prompt(response_language)),
                 HumanMessage(content=prompt),
             ],
             operation="recommend-questions",
@@ -516,9 +529,11 @@ async def recommendation_node(
     presenter = get_presenter(config)
     if getattr(presenter, "recommend_questions_recorded", False):
         return {}
+    agent_options = config.get("configurable", {}).get("agent_options") or {}
     questions = await generate_recommend_questions(
         str(state.get("input") or ""),
         str(state.get("output") or ""),
+        response_language=agent_options.get("response_language"),
     )
     if questions:
         await presenter.emit_recommend_questions(questions)
@@ -538,6 +553,7 @@ def schedule_recommend_questions(
     user_input: str,
     output_text: str = "",
     messages: list[Any] | None = None,
+    response_language: str | None = None,
 ) -> asyncio.Task[None]:
     """Start recommendation generation in the background without blocking chat."""
 
@@ -554,6 +570,7 @@ def schedule_recommend_questions(
             user_input,
             output_text=output_text,
             history_context=history_context,
+            response_language=response_language,
         )
         if questions:
             await _publish_recommend_questions(presenter, questions)
@@ -567,6 +584,7 @@ def schedule_recommend_questions_from_state(
     output_text: str,
     inner_graph: Any,
     inner_config: Any,
+    response_language: str | None = None,
 ) -> asyncio.Task[None]:
     """Best-effort concurrent recommendation scheduling from existing graph state."""
 
@@ -597,8 +615,31 @@ def schedule_recommend_questions_from_state(
             user_input,
             output_text=output_text,
             history_context=history_context,
+            response_language=response_language,
         )
         if questions:
             await _publish_recommend_questions(presenter, questions)
 
     return _schedule_recommend_background_task(run, failure_level="debug")
+
+
+def schedule_recommendations_best_effort(
+    presenter: Any,
+    user_input: str,
+    output_text: str,
+    inner_graph: Any,
+    inner_config: Any,
+    agent_options: dict[str, Any] | None = None,
+) -> None:
+    """三个 agent 节点共用的尽力而为推荐调度入口（失败只记 debug 日志）。"""
+    try:
+        schedule_recommend_questions_from_state(
+            presenter,
+            user_input,
+            output_text,
+            inner_graph,
+            inner_config,
+            response_language=(agent_options or {}).get("response_language"),
+        )
+    except Exception as exc:
+        logger.debug("Failed to schedule recommended questions: %s", exc)

--- a/src/agents/core/recommendations.py
+++ b/src/agents/core/recommendations.py
@@ -62,6 +62,8 @@ def build_recommend_system_prompt(response_language: str | None = None) -> str:
         "Use the same language as the current user message.",
         f"Write the questions in {language_name}.",
     )
+
+
 _token_encoding: Any | None = None
 _token_encoding_loaded = False
 _recommend_background_tasks: set[asyncio.Task[None]] = set()

--- a/src/agents/core/subagent_prompts.py
+++ b/src/agents/core/subagent_prompts.py
@@ -24,6 +24,34 @@ MAIN_AGENT_PROMPT_SECTIONS: tuple[str, ...] = (
     SUBAGENT_DISPATCH_POLICY,
 )
 
+# 前端 i18n 支持的界面语言 → 提示词用语名（zh 为简体）
+RESPONSE_LANGUAGE_NAMES: dict[str, str] = {
+    "en": "English",
+    "zh": "Simplified Chinese",
+    "ja": "Japanese",
+    "ko": "Korean",
+    "ru": "Russian",
+}
+
+
+def build_response_language_section(language: str | None) -> str:
+    """把用户界面 locale 固定为模型回复语言。
+
+    只在能识别界面语言时注入；识别不了返回空串（不改变模型跟随用户
+    消息语言的默认行为）。按 OpenAI 提示词指南显式给出例外条件而非
+    一刀切规则：用户贴英文报错提问时，镜像策略会跟错对象。
+    """
+    language_name = RESPONSE_LANGUAGE_NAMES.get((language or "").strip().lower())
+    if not language_name:
+        return ""
+    return (
+        "### Response Language\n"
+        f"- Respond in {language_name} unless the user explicitly asks for "
+        "another language.\n"
+        "- Keep code, commands, error messages, file paths, and technical "
+        "identifiers unchanged."
+    )
+
 AUTO_MODE_PROMPT_SECTION = """### Auto Mode
 Work autonomously with reasonable assumptions; `ask_human` is unavailable. Preserve safety boundaries, and report decisions and verification."""
 

--- a/src/agents/core/subagent_prompts.py
+++ b/src/agents/core/subagent_prompts.py
@@ -39,15 +39,19 @@ def build_response_language_section(language: str | None) -> str:
 
     只在能识别界面语言时注入；识别不了返回空串（不改变模型跟随用户
     消息语言的默认行为）。按 OpenAI 提示词指南显式给出例外条件而非
-    一刀切规则：用户贴英文报错提问时，镜像策略会跟错对象。
+    一刀切规则。实测（GLM-5.3）中文消息的先验会压过宽松的例外措辞
+    （"unless the user asks"会被解读成"用户用中文提问=要求中文"），
+    因此必须显式声明界面语言优先于消息/引用内容语言。
     """
     language_name = RESPONSE_LANGUAGE_NAMES.get((language or "").strip().lower())
     if not language_name:
         return ""
     return (
         "### Response Language\n"
-        f"- Respond in {language_name} unless the user explicitly asks for "
-        "another language.\n"
+        "- Always respond in "
+        f"{language_name} regardless of the language of the user's message "
+        "or any quoted content.\n"
+        "- Switch to another language only when the user explicitly requests it.\n"
         "- Keep code, commands, error messages, file paths, and technical "
         "identifiers unchanged."
     )

--- a/src/agents/core/subagent_prompts.py
+++ b/src/agents/core/subagent_prompts.py
@@ -56,6 +56,7 @@ def build_response_language_section(language: str | None) -> str:
         "identifiers unchanged."
     )
 
+
 AUTO_MODE_PROMPT_SECTION = """### Auto Mode
 Work autonomously with reasonable assumptions; `ask_human` is unavailable. Preserve safety boundaries, and report decisions and verification."""
 

--- a/src/agents/fast_agent/nodes.py
+++ b/src/agents/fast_agent/nodes.py
@@ -35,6 +35,7 @@ from src.agents.core.subagent_prompts import (
     SPECIALIZED_SUBAGENT_DESCRIPTIONS,
     SUBAGENT_PROMPT,
     VERIFICATION_RUNNER_PROMPT,
+    build_response_language_section,
     get_memory_guide,
 )
 from src.agents.core.thinking import build_thinking_config
@@ -275,7 +276,14 @@ async def fast_agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict
     active_goal = configurable.get("active_goal")
     # Persona, skills, memory guidance, goal, and mode share one authored prompt block.
     _prompt_sections = [
-        s for s in (*MAIN_AGENT_PROMPT_SECTIONS, *persona_sections, memory_guide) if s
+        s
+        for s in (
+            *MAIN_AGENT_PROMPT_SECTIONS,
+            *persona_sections,
+            memory_guide,
+            build_response_language_section(agent_options.get("response_language")),
+        )
+        if s
     ]
     if _prompt_sections:
         user_middleware.append(SectionPromptMiddleware(sections=_prompt_sections))
@@ -485,18 +493,11 @@ async def fast_agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict
         and settings.ENABLE_RECOMMEND_QUESTIONS
         and not getattr(presenter, "hitl_suspended", False)
     ):
-        try:
-            from src.agents.core.recommendations import schedule_recommend_questions_from_state
+        from src.agents.core.recommendations import schedule_recommendations_best_effort
 
-            schedule_recommend_questions_from_state(
-                presenter,
-                recommendation_input,
-                output_text,
-                inner_graph,
-                inner_config,
-            )
-        except Exception as exc:
-            logger.debug("Failed to schedule recommended questions: %s", exc)
+        schedule_recommendations_best_effort(
+            presenter, recommendation_input, output_text, inner_graph, inner_config, agent_options
+        )
 
     return {
         "output": output_text,

--- a/src/agents/search_agent/nodes.py
+++ b/src/agents/search_agent/nodes.py
@@ -36,6 +36,7 @@ from src.agents.core.subagent_prompts import (
     SPECIALIZED_SUBAGENT_DESCRIPTIONS,
     SUBAGENT_PROMPT,
     VERIFICATION_RUNNER_PROMPT,
+    build_response_language_section,
     get_memory_guide,
 )
 from src.agents.core.thinking import build_thinking_config
@@ -281,7 +282,14 @@ async def agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict[str,
     # Prompt sections use one SectionPromptMiddleware instance.
     # Duplicate middleware classes are rejected by langchain's agent factory.
     _prompt_sections = [
-        s for s in (*MAIN_AGENT_PROMPT_SECTIONS, *persona_sections, memory_guide) if s
+        s
+        for s in (
+            *MAIN_AGENT_PROMPT_SECTIONS,
+            *persona_sections,
+            memory_guide,
+            build_response_language_section(agent_options.get("response_language")),
+        )
+        if s
     ]
     if _prompt_sections:
         user_middleware.append(SectionPromptMiddleware(sections=_prompt_sections))
@@ -509,18 +517,11 @@ async def agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict[str,
         and settings.ENABLE_RECOMMEND_QUESTIONS
         and not getattr(presenter, "hitl_suspended", False)
     ):
-        try:
-            from src.agents.core.recommendations import schedule_recommend_questions_from_state
+        from src.agents.core.recommendations import schedule_recommendations_best_effort
 
-            schedule_recommend_questions_from_state(
-                presenter,
-                recommendation_input,
-                output_text,
-                inner_graph,
-                inner_config,
-            )
-        except Exception as exc:
-            logger.debug("Failed to schedule recommended questions: %s", exc)
+        schedule_recommendations_best_effort(
+            presenter, recommendation_input, output_text, inner_graph, inner_config, agent_options
+        )
 
     return {"output": output_text}
 

--- a/src/agents/team_agent/nodes.py
+++ b/src/agents/team_agent/nodes.py
@@ -35,6 +35,7 @@ from src.agents.core.subagent_prompts import (
     SPECIALIZED_SUBAGENT_DESCRIPTIONS,
     SUBAGENT_PROMPT,
     VERIFICATION_RUNNER_PROMPT,
+    build_response_language_section,
     build_role_subagent_section,
     get_memory_guide,
 )
@@ -752,6 +753,7 @@ async def team_router_node(state: Dict[str, Any], config: RunnableConfig) -> Dic
             *MAIN_AGENT_PROMPT_SECTIONS,
             *persona_sections,
             memory_guide,
+            build_response_language_section(agent_options.get("response_language")),
         )
         if s
     ]
@@ -980,17 +982,10 @@ async def team_router_node(state: Dict[str, Any], config: RunnableConfig) -> Dic
         and settings.ENABLE_RECOMMEND_QUESTIONS
         and not getattr(presenter, "hitl_suspended", False)
     ):
-        try:
-            from src.agents.core.recommendations import schedule_recommend_questions_from_state
+        from src.agents.core.recommendations import schedule_recommendations_best_effort
 
-            schedule_recommend_questions_from_state(
-                presenter,
-                recommendation_input,
-                output_text,
-                inner_graph,
-                inner_config,
-            )
-        except Exception as exc:
-            logger.debug("Failed to schedule recommended questions: %s", exc)
+        schedule_recommendations_best_effort(
+            presenter, recommendation_input, output_text, inner_graph, inner_config, agent_options
+        )
 
     return {"output": output_text}

--- a/src/api/routes/chat.py
+++ b/src/api/routes/chat.py
@@ -18,6 +18,7 @@ from src.agents.core import resolve_agent_name
 from src.agents.core.base import AgentFactory
 from src.api.deps import get_current_user_required, require_permissions
 from src.api.routes.auth.utils import _get_language
+from src.api.routes.chat_language import apply_response_language
 from src.api.routes.chat_sse import (  # noqa: F401 - 供 SSE 路由与既有测试导入
     CHAT_SSE_DATA_MAX_BYTES,
     _format_sse_event,
@@ -445,6 +446,9 @@ async def chat_stream(
     active_goal_data = active_goal.model_dump() if active_goal else None
     task_manager = get_task_manager()
     preferred_language = _get_language(http_request)
+    # 界面 locale 固定回复语言；随 agent_options 全链路透传（task_context /
+    # submit / submit_arq / scheduler 均携带 agent_options）
+    apply_response_language(request.agent_options, http_request.headers.get("accept-language"))
 
     formatted_message = await build_model_facing_message(
         agent_message,

--- a/src/api/routes/chat_language.py
+++ b/src/api/routes/chat_language.py
@@ -1,0 +1,31 @@
+"""chat 路由的响应语言解析。
+
+界面 locale 经 Accept-Language 头进入，被固定到 agent_options 后随既有
+链路（task_context / submit / submit_arq / scheduler）透传到各 agent
+节点，由 SectionPromptMiddleware 注入系统提示词。
+"""
+
+from __future__ import annotations
+
+from src.agents.core.subagent_prompts import RESPONSE_LANGUAGE_NAMES
+
+
+def resolve_response_language(accept_language: str | None) -> str | None:
+    """从 Accept-Language 头解析用户界面语言，用于固定模型回复语言。
+
+    与 auth.utils._get_language 不同：无法识别时返回 None 而非回落
+    "en"，让 agent 不注入语言提示段，保留模型跟随用户消息语言的默认
+    行为（未带头的 API 客户端不受影响）。
+    """
+    if not accept_language:
+        return None
+    lang = accept_language.split(",")[0].split("-")[0].strip().lower()
+    return lang if lang in RESPONSE_LANGUAGE_NAMES else None
+
+
+def apply_response_language(agent_options: dict, accept_language: str | None) -> str | None:
+    """把界面 locale 固定到 agent_options，随既有链路透传到各 agent 节点。"""
+    language = resolve_response_language(accept_language)
+    if language is not None:
+        agent_options["response_language"] = language
+    return language

--- a/src/api/routes/session.py
+++ b/src/api/routes/session.py
@@ -30,8 +30,14 @@ from src.kernel.schemas.user import TokenPayload
 router = APIRouter()
 logger = get_logger(__name__)
 
-# 支持的语言白名单
-SUPPORTED_LANGUAGES = frozenset(["en", "zh", "ja", "ko"])
+# 支持的语言白名单（与前端 i18n 的 en/zh/ja/ko/ru 保持一致）
+SUPPORTED_LANGUAGES = frozenset(["en", "zh", "ja", "ko", "ru"])
+
+
+def normalize_title_language(lang: str) -> str:
+    """规范化标题语言参数，接受 zh-CN / en-US 等区域形式；不支持的语言回落 en。"""
+    normalized = (lang or "").split(",")[0].split("-")[0].strip().lower()
+    return normalized if normalized in SUPPORTED_LANGUAGES else "en"
 SESSION_EVENT_TYPE_FILTER_LIMIT = 100
 SESSION_EVENT_RESPONSE_LIMIT_MAX = 10000
 SESSION_RAW_TRACE_RESPONSE_LIMIT_MAX = 20
@@ -829,7 +835,7 @@ async def toggle_session_pin(
 async def generate_session_title(
     session_id: str,
     message: str = Query(..., description="用户消息内容，用于生成标题"),
-    lang: str = Query("en", description="语言代码: en, zh, ja, ko"),
+    lang: str = Query("en", description="语言代码: en, zh, ja, ko, ru（支持 zh-CN 等区域形式）"),
     user: TokenPayload = Depends(get_current_user_required),
 ):
     """
@@ -841,10 +847,8 @@ async def generate_session_title(
     from src.infra.llm.client import LLMClient
     from src.infra.llm.models_service import resolve_model_reference
 
-    # 验证语言参数白名单
-    if lang not in SUPPORTED_LANGUAGES:
-        logger.warning(f"Unsupported language code: {lang}, falling back to 'en'")
-        lang = "en"
+    # 规范化并验证语言参数白名单（zh-CN → zh 等）
+    lang = normalize_title_language(lang)
 
     manager = SessionManager()
     session = await manager.get_session(session_id)

--- a/src/api/routes/session.py
+++ b/src/api/routes/session.py
@@ -38,6 +38,8 @@ def normalize_title_language(lang: str) -> str:
     """规范化标题语言参数，接受 zh-CN / en-US 等区域形式；不支持的语言回落 en。"""
     normalized = (lang or "").split(",")[0].split("-")[0].strip().lower()
     return normalized if normalized in SUPPORTED_LANGUAGES else "en"
+
+
 SESSION_EVENT_TYPE_FILTER_LIMIT = 100
 SESSION_EVENT_RESPONSE_LIMIT_MAX = 10000
 SESSION_RAW_TRACE_RESPONSE_LIMIT_MAX = 20

--- a/tests/agents/core/test_recommendation_node.py
+++ b/tests/agents/core/test_recommendation_node.py
@@ -10,11 +10,13 @@ from src.agents.core.recommendations import (
     MAX_RECOMMEND_PROMPT_TOKENS,
     build_recommend_prompt,
     build_recommend_questions,
+    build_recommend_system_prompt,
     count_recommend_prompt_tokens,
     drain_recommend_background_tasks,
     format_history_context,
     format_history_from_messages,
     generate_recommend_questions,
+    recommendation_node,
     schedule_recommend_questions,
     schedule_recommend_questions_from_state,
 )
@@ -326,6 +328,7 @@ async def test_schedule_recommend_questions_offloads_history_formatting(monkeypa
         user_input: str,
         output_text: str = "",
         history_context: str = "",
+        response_language: str | None = None,
     ):
         assert history_context
         return ["问题一？", "问题二？", "问题三？"]
@@ -369,6 +372,7 @@ async def test_schedule_from_state_uses_final_output_without_blocking_caller(mon
         user_input: str,
         output_text: str = "",
         history_context: str = "",
+        response_language: str | None = None,
     ):
         captured.update(
             user_input=user_input,
@@ -592,6 +596,7 @@ async def test_recommendation_node_emits_llm_followup_questions(monkeypatch) -> 
         user_input: str,
         output_text: str = "",
         history_context: str = "",
+        response_language: str | None = None,
     ):
         return ["执行步骤一", "执行步骤二", "执行步骤三"]
 
@@ -621,6 +626,7 @@ async def test_recommendation_background_tasks_are_bounded(monkeypatch) -> None:
         user_input: str,
         output_text: str = "",
         history_context: str = "",
+        response_language: str | None = None,
     ):
         calls.append(user_input)
         first_started.set()
@@ -661,6 +667,7 @@ async def test_drain_recommend_background_tasks_cancels_pending_tasks(monkeypatc
         user_input: str,
         output_text: str = "",
         history_context: str = "",
+        response_language: str | None = None,
     ):
         nonlocal cleanup_finished
         started.set()
@@ -690,3 +697,73 @@ def test_langgraph_agents_do_not_block_on_recommendation_node() -> None:
 
         assert [name for name, _ in builder.nodes] == ["agent"]
         assert ("agent", "END") in builder.edges
+
+
+def test_build_recommend_system_prompt_pins_ui_locale_when_known() -> None:
+    prompt = build_recommend_system_prompt("zh")
+
+    assert "Write the questions in Simplified Chinese." in prompt
+    assert "Use the same language as the current user message." not in prompt
+
+
+def test_build_recommend_system_prompt_keeps_mirror_rule_without_locale() -> None:
+    mirror_rule = "Use the same language as the current user message."
+    assert mirror_rule in build_recommend_system_prompt(None)
+    assert mirror_rule in build_recommend_system_prompt("fr")
+
+
+async def test_recommendation_node_passes_ui_language_to_generator(monkeypatch) -> None:
+    captured: dict = {}
+
+    async def fake_generate(
+        user_input: str,
+        output_text: str = "",
+        history_context: str = "",
+        response_language: str | None = None,
+    ):
+        captured["response_language"] = response_language
+        return ["接下来该做什么？"]
+
+    monkeypatch.setattr(
+        "src.agents.core.recommendations.generate_recommend_questions",
+        fake_generate,
+    )
+
+    await recommendation_node(
+        {"input": "帮我看看", "output": "已完成"},
+        {
+            "configurable": {
+                "presenter": _FakePresenter(),
+                "agent_options": {"response_language": "zh"},
+            }
+        },
+    )
+
+    assert captured["response_language"] == "zh"
+
+
+async def test_recommendation_node_defaults_to_mirror_without_language_option(
+    monkeypatch,
+) -> None:
+    captured: dict = {}
+
+    async def fake_generate(
+        user_input: str,
+        output_text: str = "",
+        history_context: str = "",
+        response_language: str | None = None,
+    ):
+        captured["response_language"] = response_language
+        return ["接下来该做什么？"]
+
+    monkeypatch.setattr(
+        "src.agents.core.recommendations.generate_recommend_questions",
+        fake_generate,
+    )
+
+    await recommendation_node(
+        {"input": "帮我看看", "output": "已完成"},
+        {"configurable": {"presenter": _FakePresenter()}},
+    )
+
+    assert captured["response_language"] is None

--- a/tests/agents/core/test_response_language_cache.py
+++ b/tests/agents/core/test_response_language_cache.py
@@ -78,7 +78,7 @@ def test_locale_switch_only_alters_the_language_block() -> None:
 
     marker = "### Response Language"
     assert zh_prompt.split(marker)[0] == en_prompt.split(marker)[0]
-    assert zh_prompt.rsplit("Respond in ", 1)[0] == en_prompt.rsplit("Respond in ", 1)[0]
+    assert zh_prompt.rsplit("respond in ", 1)[0] == en_prompt.rsplit("respond in ", 1)[0]
     assert zh_prompt != en_prompt
 
 

--- a/tests/agents/core/test_response_language_cache.py
+++ b/tests/agents/core/test_response_language_cache.py
@@ -1,0 +1,89 @@
+"""响应语言段的 prompt-cache 稳定性契约。
+
+LambChat 的前缀缓存要求连续轮次的 system message 字节一致（见
+prompt_injection.py 的会话快照设计与 build_model_facing_message 的
+写时注入约束）。语言段是 agent_options 的纯函数，必须满足同样约束：
+
+- 同一 locale 跨轮/跨请求 → 字节稳定（cache_read 持续命中）
+- 无 locale（未带 Accept-Language 的 API 客户端）→ 与历史字节完全一致
+  （零缓存影响）
+- 切换 locale 只改语言段本身（单次前缀失效，之后重新稳定）
+"""
+
+from __future__ import annotations
+
+from langchain_core.messages import SystemMessage
+
+from src.agents.core.persona import build_persona_prompt_sections
+from src.agents.core.subagent_prompts import (
+    MAIN_AGENT_PROMPT_SECTIONS,
+    build_response_language_section,
+)
+from src.infra.agent.middleware._helpers import _append_system_text_block
+from src.infra.agent.middleware.prompt_injection import SectionPromptMiddleware
+
+_BASE_SYSTEM = SystemMessage(content="You are a deep agent with tools.")
+_PERSONA = "你是一位资深后端工程师。\n\n回答保持严谨，给出可验证的结论。"
+
+
+def _node_sections(persona_prompt: str | None, language: str | None) -> list[str]:
+    """按节点实际组装顺序构造段落：policies → persona → memory → language。"""
+    return [
+        s
+        for s in (
+            *MAIN_AGENT_PROMPT_SECTIONS,
+            *build_persona_prompt_sections(persona_prompt),
+            "",  # memory_guide（ENABLE_MEMORY 关闭时为空串）
+            build_response_language_section(language),
+        )
+        if s
+    ]
+
+
+def _render_turn(language: str | None) -> str:
+    """渲染一轮模型调用的最终 system message 字节。"""
+    middleware = SectionPromptMiddleware(sections=_node_sections(_PERSONA, language))
+    return str(_append_system_text_block(_BASE_SYSTEM, middleware._prompt).content)
+
+
+def test_same_locale_produces_identical_system_message_across_turns() -> None:
+    # 连续轮次（乃至不同副本上的两次构造）必须字节一致，前缀缓存才不失效
+    assert _render_turn("zh") == _render_turn("zh")
+    assert "Simplified Chinese" in _render_turn("zh")
+
+
+def test_absent_locale_keeps_pre_feature_prompt_bytes() -> None:
+    # 未带 Accept-Language 的客户端：语言段缺失，其余段落与历史字节一致
+    legacy_middleware = SectionPromptMiddleware(
+        sections=[
+            s
+            for s in (*MAIN_AGENT_PROMPT_SECTIONS, *build_persona_prompt_sections(_PERSONA))
+            if s
+        ]
+    )
+    legacy_prompt = legacy_middleware._prompt
+
+    current_prompt = SectionPromptMiddleware(
+        sections=_node_sections(_PERSONA, None)
+    )._prompt
+
+    assert "Response Language" not in current_prompt
+    assert current_prompt == legacy_prompt
+
+
+def test_locale_switch_only_alters_the_language_block() -> None:
+    # 用户中途切换界面语言：失效范围仅限语言段内的语言名，其余前缀不变
+    zh_prompt = _render_turn("zh")
+    en_prompt = _render_turn("en")
+
+    marker = "### Response Language"
+    assert zh_prompt.split(marker)[0] == en_prompt.split(marker)[0]
+    assert zh_prompt.rsplit("Respond in ", 1)[0] == en_prompt.rsplit("Respond in ", 1)[0]
+    assert zh_prompt != en_prompt
+
+
+def test_language_section_is_deterministic_for_each_locale() -> None:
+    for language in ("en", "zh", "ja", "ko", "ru"):
+        assert build_response_language_section(language) == build_response_language_section(
+            language
+        )

--- a/tests/agents/core/test_response_language_cache.py
+++ b/tests/agents/core/test_response_language_cache.py
@@ -56,16 +56,12 @@ def test_absent_locale_keeps_pre_feature_prompt_bytes() -> None:
     # 未带 Accept-Language 的客户端：语言段缺失，其余段落与历史字节一致
     legacy_middleware = SectionPromptMiddleware(
         sections=[
-            s
-            for s in (*MAIN_AGENT_PROMPT_SECTIONS, *build_persona_prompt_sections(_PERSONA))
-            if s
+            s for s in (*MAIN_AGENT_PROMPT_SECTIONS, *build_persona_prompt_sections(_PERSONA)) if s
         ]
     )
     legacy_prompt = legacy_middleware._prompt
 
-    current_prompt = SectionPromptMiddleware(
-        sections=_node_sections(_PERSONA, None)
-    )._prompt
+    current_prompt = SectionPromptMiddleware(sections=_node_sections(_PERSONA, None))._prompt
 
     assert "Response Language" not in current_prompt
     assert current_prompt == legacy_prompt

--- a/tests/agents/core/test_subagent_prompts.py
+++ b/tests/agents/core/test_subagent_prompts.py
@@ -232,8 +232,10 @@ def test_build_response_language_section_pins_ui_locale_with_exceptions() -> Non
     section = build_response_language_section("zh")
 
     assert "Simplified Chinese" in section
-    # 显式指定例外条件，避免一刀切规则（OpenAI 提示词指南）
-    assert "unless the user explicitly asks for another language" in section
+    # 界面语言优先于消息/引用内容语言（中文用户贴英文报错仍是中文回复），
+    # 但保留显式例外（OpenAI 提示词指南：给出语言及其改变条件）
+    assert "regardless of the language of the user's message or any quoted content" in section
+    assert "explicitly requests" in section
     # 代码与报错原文不翻译
     assert "technical identifiers" in section
 

--- a/tests/agents/core/test_subagent_prompts.py
+++ b/tests/agents/core/test_subagent_prompts.py
@@ -17,6 +17,7 @@ from src.agents.core.subagent_prompts import (
     SUBAGENT_TASK_GUIDE,
     VERIFICATION_RUNNER_PROMPT,
     WORKFLOW_SECTION,
+    build_response_language_section,
 )
 from src.agents.fast_agent.prompt import FAST_SYSTEM_PROMPT
 from src.agents.search_agent.prompt import (
@@ -225,3 +226,40 @@ def test_authored_prompt_sections_place_runtime_before_goal_and_mode() -> None:
         assert "auto_section" not in source
         assert "TurnContextPromptMiddleware" not in source
         assert "VolatileSectionPromptMiddleware" not in source
+
+
+def test_build_response_language_section_pins_ui_locale_with_exceptions() -> None:
+    section = build_response_language_section("zh")
+
+    assert "Simplified Chinese" in section
+    # 显式指定例外条件，避免一刀切规则（OpenAI 提示词指南）
+    assert "unless the user explicitly asks for another language" in section
+    # 代码与报错原文不翻译
+    assert "technical identifiers" in section
+
+
+def test_build_response_language_section_covers_every_frontend_locale() -> None:
+    for language in ("en", "zh", "ja", "ko", "ru"):
+        assert build_response_language_section(language)
+
+
+def test_build_response_language_section_ignores_unknown_or_missing_locale() -> None:
+    # 无法识别界面语言时不注入提示段，保留模型跟随用户消息语言的默认行为
+    assert build_response_language_section(None) == ""
+    assert build_response_language_section("") == ""
+    assert build_response_language_section("fr") == ""
+
+
+def test_main_agent_nodes_wire_response_language_into_prompt_sections() -> None:
+    from inspect import getsource
+
+    from src.agents.fast_agent.nodes import fast_agent_node
+    from src.agents.search_agent.nodes import agent_node
+    from src.agents.team_agent.nodes import team_router_node
+
+    for node in (fast_agent_node, agent_node, team_router_node):
+        source = getsource(node)
+        assert "build_response_language_section" in source, (
+            f"{node.__name__} must inject the response language prompt section"
+        )
+        assert 'agent_options.get("response_language")' in source

--- a/tests/agents/test_disabled_skills_config_propagation.py
+++ b/tests/agents/test_disabled_skills_config_propagation.py
@@ -356,6 +356,7 @@ async def test_fast_agent_node_schedules_recommendations_with_final_output(
         output_text,
         inner_graph,
         inner_config,
+        response_language=None,
     ):
         calls.append((presenter, user_input, output_text, inner_graph, inner_config))
 

--- a/tests/agents/test_disabled_skills_config_propagation.py
+++ b/tests/agents/test_disabled_skills_config_propagation.py
@@ -941,8 +941,9 @@ async def test_fast_agent_node_language_section_bytes_stable_across_turns(
     without_language = await run_turn({})
     assert "Response Language" not in without_language
     assert without_language == first_turn.replace(
-        "\n\n### Response Language\n- Respond in Simplified Chinese unless the user"
-        " explicitly asks for another language.\n- Keep code, commands, error messages,"
-        " file paths, and technical identifiers unchanged.",
+        "\n\n### Response Language\n- Always respond in Simplified Chinese regardless of"
+        " the language of the user's message or any quoted content.\n- Switch to another"
+        " language only when the user explicitly requests it.\n- Keep code, commands,"
+        " error messages, file paths, and technical identifiers unchanged.",
         "",
     )

--- a/tests/agents/test_disabled_skills_config_propagation.py
+++ b/tests/agents/test_disabled_skills_config_propagation.py
@@ -904,3 +904,45 @@ async def test_team_role_subagent_inherits_global_skills_when_role_skills_are_em
 
     router_sections = _section_prompt(fake_graph.captured_create_kwargs["middleware"])
     assert "redbook-publish" not in router_sections
+
+
+@pytest.mark.asyncio
+async def test_fast_agent_node_language_section_bytes_stable_across_turns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """语言段是 agent_options 的纯函数：连续两轮字节一致，前缀缓存不失效。"""
+    _reset_fake_event_processor()
+    from src.agents.fast_agent import nodes as fast_nodes
+
+    async def run_turn(agent_options: dict) -> str:
+        fake_graph = _FakeDeepAgent()
+        _patch_common(monkeypatch, fast_nodes, fake_graph)
+        context = SimpleNamespace(user_id="user-1", skills=[], deferred_manager=None)
+        await fast_nodes.fast_agent_node(
+            {"input": "hello", "session_id": "session-1", "attachments": []},
+            {
+                "configurable": {
+                    "context": context,
+                    "presenter": object(),
+                    "base_url": "",
+                    "agent_options": dict(agent_options),
+                }
+            },
+        )
+        return _section_prompt(fake_graph.captured_create_kwargs["middleware"])
+
+    first_turn = await run_turn({"response_language": "zh"})
+    second_turn = await run_turn({"response_language": "zh"})
+
+    assert first_turn == second_turn
+    assert "Simplified Chinese" in first_turn
+
+    # 未带语言的请求：段落与历史字节一致，零缓存影响
+    without_language = await run_turn({})
+    assert "Response Language" not in without_language
+    assert without_language == first_turn.replace(
+        "\n\n### Response Language\n- Respond in Simplified Chinese unless the user"
+        " explicitly asks for another language.\n- Keep code, commands, error messages,"
+        " file paths, and technical identifiers unchanged.",
+        "",
+    )

--- a/tests/api/routes/test_chat_response_language.py
+++ b/tests/api/routes/test_chat_response_language.py
@@ -6,7 +6,9 @@ agent_options["response_language"]，由各 agent 节点注入系统提示词。
 
 from __future__ import annotations
 
+from src.api.routes.chat import build_conversation_config
 from src.api.routes.chat_language import apply_response_language, resolve_response_language
+from src.kernel.schemas.agent import AgentRequest
 
 
 def test_resolve_response_language_accepts_primary_tag_from_accept_language() -> None:
@@ -37,3 +39,22 @@ def test_apply_response_language_keeps_options_untouched_without_header() -> Non
 
     assert apply_response_language(agent_options, None) is None
     assert "response_language" not in agent_options
+
+
+def test_conversation_config_persists_language_for_retry_and_scheduled_paths() -> None:
+    # 定时任务/断点恢复从持久化的 agent_options 重建执行上下文，
+    # 语言必须随之持久化，重试轮次注入的字节才与首轮一致（前缀缓存不失效）
+    request = AgentRequest(
+        message="你好",
+        agent_options={"model": "gpt-test", "response_language": "zh"},
+    )
+
+    config = build_conversation_config(
+        run_id="run-1",
+        agent_id="fast",
+        request=request,
+        language="zh",
+        session_id="session-1",
+    )
+
+    assert config["agent_options"]["response_language"] == "zh"

--- a/tests/api/routes/test_chat_response_language.py
+++ b/tests/api/routes/test_chat_response_language.py
@@ -1,0 +1,39 @@
+"""响应语言注入链路的纯函数测试。
+
+界面 locale 通过 Accept-Language 头进入 chat 路由，被固定到
+agent_options["response_language"]，由各 agent 节点注入系统提示词。
+"""
+
+from __future__ import annotations
+
+from src.api.routes.chat_language import apply_response_language, resolve_response_language
+
+
+def test_resolve_response_language_accepts_primary_tag_from_accept_language() -> None:
+    assert resolve_response_language("zh-CN,zh;q=0.9,en;q=0.8") == "zh"
+    assert resolve_response_language("en-US,en;q=0.9") == "en"
+    assert resolve_response_language("ru") == "ru"
+    assert resolve_response_language("JA") == "ja"
+
+
+def test_resolve_response_language_returns_none_for_missing_or_unsupported() -> None:
+    assert resolve_response_language(None) is None
+    assert resolve_response_language("") is None
+    assert resolve_response_language("fr-CA,fr;q=0.9") is None
+
+
+def test_apply_response_language_pins_locale_into_agent_options() -> None:
+    agent_options = {"model": "gpt-test"}
+
+    applied = apply_response_language(agent_options, "zh-CN,zh;q=0.9")
+
+    assert applied == "zh"
+    assert agent_options["response_language"] == "zh"
+    assert agent_options["model"] == "gpt-test"
+
+
+def test_apply_response_language_keeps_options_untouched_without_header() -> None:
+    agent_options = {"model": "gpt-test"}
+
+    assert apply_response_language(agent_options, None) is None
+    assert "response_language" not in agent_options

--- a/tests/api/routes/test_session_title_language.py
+++ b/tests/api/routes/test_session_title_language.py
@@ -1,0 +1,29 @@
+"""标题生成语言参数的白名单与规范化测试。"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.api.routes.session import SUPPORTED_LANGUAGES, normalize_title_language
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("zh-CN", "zh"),
+        ("zh", "zh"),
+        ("en-US,en;q=0.9", "en"),
+        ("ru", "ru"),
+        ("JA", "ja"),
+        ("ko-KR", "ko"),
+        ("fr", "en"),
+        ("", "en"),
+    ],
+)
+def test_normalize_title_language_accepts_all_ui_locales(raw: str, expected: str) -> None:
+    assert normalize_title_language(raw) == expected
+
+
+def test_title_language_whitelist_covers_every_frontend_locale() -> None:
+    # 前端 i18n 支持 en/zh/ja/ko/ru 五种语言，标题白名单必须同步覆盖
+    assert SUPPORTED_LANGUAGES >= frozenset({"en", "zh", "ja", "ko", "ru"})


### PR DESCRIPTION
## Summary

模型回复语言固定跟随用户在前端选择的界面语言（Accept-Language），解决中文用户贴英文报错提问时回复被带成英文的问题。参考了 Open WebUI（`{{USER_LANGUAGE}}`）与 LobeChat（界面语言 = 助理默认回复语言）的做法；Codex 的源码调研结论（辅助调用显式 "user's language"、主对话不注入）适用于 CLI 场景，多用户 Web 产品采用显式注入方案。

## Changes

- **语言注入链路**：`Accept-Language` 解析为 `agent_options["response_language"]`（`chat_language.py`），搭 `agent_options` 既有链路透传（task_context / submit / submit_arq / 定时任务 / 断点恢复），三个 agent 主节点经 `SectionPromptMiddleware` 注入 `### Response Language` 提示段
- **提示词措辞**（实测驱动收紧）：`Always respond in {语言} regardless of the language of the user's message or any quoted content`，仅在用户明确要求时切换；代码/命令/报错原文/文件路径不翻译。宽松的 "unless the user asks" 例外在 GLM-5.3 上会被中文消息先验压过（实测验证）
- **无法识别界面语言时不注入**：未带 Accept-Language 的 API 客户端保留模型跟随消息语言的默认行为，提示词与历史字节完全一致
- **顺带修三个既有缺口**：标题生成白名单补 `ru` 并规范化 `zh-CN` 等区域形式（原先静默回落 en）；推荐问题从消息镜像规则改为显式界面语言；前端 `generateTitle` 缺省跟随 `i18n.language`
- **去重**：三个 agent 节点逐字重复的推荐调度 try/except 收敛为 `schedule_recommendations_best_effort`（`chat.py` 与 `team_agent/nodes.py` 因 CI 的 1000 行上限本就需要瘦身）

## Prompt-cache 影响（重点验证）

语言段是 `response_language` 的纯函数，注入在 system message 段落尾部（subagent 不注入）：

- 同会话同语言：连续轮次 system message 字节一致，前缀缓存不失效
- 无头客户端：与改动前字节完全一致，零影响
- 中途切换界面语言：仅语言段变化，单次失效后重新稳定（与 persona 修改同类）
- 重试/定时任务/断点恢复：语言随 `agent_options` 持久化，重试轮注入与首轮相同字节

## Testing

- [x] TDD 全流程：新增 20 个测试（语言段构建/路由注入/标题规范化/推荐问题/缓存契约/节点两轮字节回归）
- [x] 后端全量 3332 passed + ruff/mypy 干净；前端 2031 passed + ESLint/build 干净
- [x] **本地 API 实测**（glm-5.3 真实模型）：
  - zh 头 + 英文报错 → 全中文回复（核心场景）
  - en 头 + 中文消息 → 英文回复（首版措辞未翻转，收紧后通过）
  - 无头 + 英文消息 → 英文回复（镜像默认行为保留）
  - 缓存率实测：同会话第二轮 cache_read 91.8%，另两会话 98.1%/90.8%，单轮成本约减半
- [ ] 标题生成 LLM 实测受环境限制（本地 SESSION_TITLE_MODEL key 为占位符），语言规范化由单测覆盖
