### PR TITLE
chore: bump version to 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## v2.8.0 (2026-08-31)
+
+### ✨ New Features
+
+- Align all LLM channels with Codex-style prompt-cache (KV) request shaping: session-level `prompt_cache_key` on both /v1/responses and /v1/chat/completions, encrypted-reasoning replay with a stateless store on responses, an Anthropic tools-block cache breakpoint shared across sessions/sub-agents, and deterministic deferred-tool restore order; measured 86-90% cache hits on gpt-5.6-terra (37% for the bare-parameter control) and 98%+ on GLM channels, recorded via `token:usage` cache_read_tokens (#328).
+- Chat replies and session titles now follow the UI locale, with a prompt-cache stability contract on the language section (#327).
+- Unify the error-code system end to end: kernel `ErrorCode`/`AppError` everywhere (no route-level HTTPException), SSE error events carry codes, and the frontend translates all backend codes into five locales (#325, #326).
+- Add model pricing: per-model price management, live cost display on usage events, historical usage backfill, and distributed-safe syncing (#306, #307, #308, #309).
+- Add run modes: agent-mode selection with per-message badges, usage-chip popover with live refresh, and task-manager run-mode support (#318, #320, #321, #322, #323, #324).
+- Give every built-in system tool a dedicated inline Item (code interpreter and 10+ tools) instead of the generic wrench fallback (#310, #317).
+- Stream tool call arguments as they arrive with a live tool sidebar panel (#294, #300, #301, #303, #304).
+- Redesign the thinking-intensity control into four always-on levels gated by model capability (#286), and stream the latest reasoning fragment into the thinking label (#291).
+- Extend conversation thumbnails and file covers across all providers (#275, #283).
+- Add usage-backfill auto-entry with dimension validation and cache bounds, resolving issue #278 (#280).
+- Add font-size scale levels and the user info page (#319, #320).
+
+### 🐛 Bug Fixes
+
+- Fix the v2.7.0 client build (explicit .tsx import) (#272); fix document-preview copy-link and patrol findings (#288, #289).
+- Add a stall watchdog for streaming runs and flush poison events (#296, #297).
+- Fix memory code-marker false positives (#305); fix tool-overflow i18n (#314).
+- Speed up orphan-task takeover and fix its interval definition/settings (#311, #313, #316).
+- Fix distributed-runtime issues promoted with the file-cover and memory batches (#277).
+
+### ♻️ Refactors
+
+- Upgrade the full dependency set (#312).
+
+### 🧪 Tests & Infrastructure
+
+- Add a k8s/Qdrant deployment example (#315) and distributed pricing-backfill coverage (#308).
+
+---
+
 ## v2.7.0 (2026-08-28)
 
 ### ✨ New Features

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 title: "LambChat"
-version: 2.7.0
+version: 2.8.0
 date-released: 2026-08-23
 url: "https://github.com/Yanyutin753/LambChat"
 abstract: Full-featured AI DeepAgents system with FastAPI, LangGraph, and LangSmith

--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.lambchat.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 270
-        versionName "2.7.0"
+        versionCode 280
+        versionName "2.8.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/frontend/ios/App/App.xcodeproj/project.pbxproj
+++ b/frontend/ios/App/App.xcodeproj/project.pbxproj
@@ -352,7 +352,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 2.7.0;
+				MARKETING_VERSION = 2.8.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.lambchat.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -372,7 +372,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 2.7.0;
+				MARKETING_VERSION = 2.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lambchat.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lambchat-frontend",
   "private": true,
-  "version": "2.7.0",
+  "version": "2.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambchat"
-version = "2.7.0"
+version = "2.8.0"
 description = "LambChat desktop app"
 authors = ["LambChat"]
 license = ""

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LambChat",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "identifier": "com.lambchat.app",
   "build": {
     "frontendDist": "../dist",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lambchat"
-version = "2.7.0"
+version = "2.8.0"
 description = "Full-featured AI Agent system with FastAPI, LangGraph, and LangSmith"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2006,7 +2006,7 @@ wheels = [
 
 [[package]]
 name = "lambchat"
-version = "2.7.0"
+version = "2.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
版本号 2.7.0 → 2.8.0：CHANGELOG v2.8.0 条目 + package.json/pyproject/uv.lock/CITATION/Android/iOS/Tauri 全量同步。

本版覆盖 v2.7.0 以来的全部变更（#272–#328）：插话系统后续、模型计价、运行模式、内置工具 Item、工具参数流式、思考控件重做、统一错误码五语化、回复语言跟随、全渠道 KV 缓存优化等。