### PR TITLE
chore(release): 晋升 develop → main（eval 结果值常规尺寸展示）

### DIFF
--- a/frontend/src/components/chat/ChatMessage/items/EvalItem.tsx
+++ b/frontend/src/components/chat/ChatMessage/items/EvalItem.tsx
@@ -2,10 +2,7 @@ import { memo } from "react";
 import { Code2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { CollapsiblePill, CopyButton } from "../../../common";
-import {
-  isProminentEvalValue,
-  parseEvalWireResult,
-} from "./evalWireResult";
+import { parseEvalWireResult } from "./evalWireResult";
 import {
   openToolLivePanel,
   toolDetailPropsFromPanelData,
@@ -144,7 +141,7 @@ function EvalResultContent({
     );
   }
 
-  const { stdout, kind, value, error } = parsed;
+  const { stdout, value, error } = parsed;
 
   return (
     <div className="space-y-3 min-w-0">
@@ -171,19 +168,6 @@ function EvalResultContent({
           <p className="text-xs font-mono italic text-theme-text-tertiary">
             undefined
           </p>
-        ) : isProminentEvalValue(value) ? (
-          <div className="flex flex-wrap items-baseline gap-x-2.5 gap-y-1">
-            <span
-              className={`font-serif tabular-nums tracking-tight text-theme-text ${
-                compact
-                  ? "text-base font-semibold"
-                  : "text-2xl font-semibold leading-tight"
-              }`}
-            >
-              {value}
-            </span>
-            {kind && <span className={evalKindBadgeClassName}>{kind}</span>}
-          </div>
         ) : (
           <pre
             className={

--- a/frontend/src/components/chat/ChatMessage/items/__tests__/evalToolPreviewSource.test.ts
+++ b/frontend/src/components/chat/ChatMessage/items/__tests__/evalToolPreviewSource.test.ts
@@ -52,9 +52,10 @@ test("eval item renders the parsed wire result instead of raw tags", () => {
   expect(source).not.toMatch(/<ToolResultContent/);
 });
 
-test("numeric eval results render prominently with serif lining digits", () => {
+test("eval result values render in the standard mono block without oversized display", () => {
   const source = readSource("../EvalItem.tsx");
 
-  expect(source).toMatch(/font-serif/);
-  expect(source).toMatch(/tabular-nums/);
+  expect(source).not.toMatch(/text-2xl/);
+  expect(source).not.toMatch(/isProminentEvalValue/);
+  expect(source).toMatch(/evalCodePreviewClassName/);
 });

--- a/frontend/src/components/chat/ChatMessage/items/evalWireResult.ts
+++ b/frontend/src/components/chat/ChatMessage/items/evalWireResult.ts
@@ -51,9 +51,3 @@ export function parseEvalWireResult(raw: string): EvalWireResult | null {
   }
   return parsed;
 }
-
-/** 数字/短值走醒目展示，长文本与多行值走代码块展示 */
-export function isProminentEvalValue(value: string | undefined): boolean {
-  if (!value || value === "undefined") return false;
-  return value.length <= 32 && !value.includes("\n");
-}


### PR DESCRIPTION
## 晋升内容（PR #333，develop 领先 main 的全部变更）

- 修复生产实测反馈：eval 数字结果 text-2xl serif 放大呈现过大、观感不佳
- 所有返回值统一走 eval-code-preview 等宽块，与代码预览、控制台输出视觉一致；错误类型徽标保留

## 验证
- PR #333 CI 全绿（Ruff / MyPy / ESLint / 前端 2054 测试 / 后端测试 / 双架构镜像）
- `pnpm test` 459 文件 / 2054 测试全过；lint / build 通过

## 部署
合并后执行 yang:/data/lambchat-k8s/update.sh，回归 bash /root/disttest/run-all.sh