### PR TITLE
feat(task): 系统中断后同 run_id 无缝续跑 + 队列 Lua 原子化与排队位置查询

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -94,6 +94,17 @@ jobs:
   backend-tests:
     name: Backend Tests
     runs-on: ubuntu-latest
+    services:
+      # 队列 Lua 脚本等集成测试需要真实 Redis（不可达时测试自动 skip）
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/frontend/src/hooks/useAgent.ts
+++ b/frontend/src/hooks/useAgent.ts
@@ -36,6 +36,7 @@ import {
   type SSEConnectionContext,
 } from "./useAgent/sseConnection";
 import { createOptimisticMessagesForSend } from "./useAgent/optimisticMessages";
+import { startQueuePositionPolling } from "./useAgent/queuePolling";
 import {
   promoteSteerFollowUps,
   selectSteersForFollowUp,
@@ -611,6 +612,8 @@ export function useAgent(options?: UseAgentOptions): UseAgentReturn {
             i18n.t("chat.queued", { position: submitData.queue_position }),
             { id: "chat-queue", duration: Infinity },
           );
+          // 轮询刷新实时排队位置（自终止：出队/换轮次/网络错误即停）
+          startQueuePositionPolling(newSessionId, newRunId);
         }
 
         if (!sessionId && newSessionId) {

--- a/frontend/src/hooks/useAgent/__tests__/queuePolling.test.ts
+++ b/frontend/src/hooks/useAgent/__tests__/queuePolling.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  resolveQueuePollAction,
+  startQueuePositionPolling,
+} from "../queuePolling";
+
+describe("resolveQueuePollAction", () => {
+  test("queued run keeps polling and returns live position", () => {
+    expect(
+      resolveQueuePollAction(
+        { run_id: "run-1", task_status: "queued", position: 3 },
+        "run-1",
+      ),
+    ).toBe(3);
+  });
+
+  test("pending run is treated as queue-side state", () => {
+    expect(
+      resolveQueuePollAction(
+        { run_id: "run-1", task_status: "pending", position: 1 },
+        "run-1",
+      ),
+    ).toBe(1);
+  });
+
+  test("run id change stops polling (new turn took over)", () => {
+    expect(
+      resolveQueuePollAction(
+        { run_id: "run-2", task_status: "queued", position: 2 },
+        "run-1",
+      ),
+    ).toBeNull();
+  });
+
+  test("processing/terminal states stop polling", () => {
+    for (const task_status of ["running", "completed", "failed", "cancelled"]) {
+      expect(
+        resolveQueuePollAction(
+          { run_id: "run-1", task_status, position: 0 },
+          "run-1",
+        ),
+      ).toBeNull();
+    }
+  });
+});
+
+describe("startQueuePositionPolling", () => {
+  test("updates toast with fresh positions until run leaves queue", async () => {
+    vi.useFakeTimers();
+    const snapshots = [
+      { run_id: "run-1", task_status: "queued", position: 3 },
+      { run_id: "run-1", task_status: "queued", position: 2 },
+      { run_id: "run-1", task_status: "running", position: 0 },
+      { run_id: "run-1", task_status: "queued", position: 9 }, // 不应再被消费
+    ];
+    const updates: number[] = [];
+    const fetchSnapshot = vi.fn(async () => snapshots.shift());
+    const onUpdate = vi.fn((position: number) => updates.push(position));
+
+    startQueuePositionPolling("session-1", "run-1", fetchSnapshot, onUpdate, 10);
+
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(updates).toEqual([3, 2]);
+    expect(fetchSnapshot).toHaveBeenCalledTimes(3);
+    vi.useRealTimers();
+  });
+
+  test("stops on fetch error without throwing", async () => {
+    vi.useFakeTimers();
+    const onUpdate = vi.fn();
+    const fetchSnapshot = vi.fn(async () => {
+      throw new Error("network down");
+    });
+
+    startQueuePositionPolling("session-1", "run-1", fetchSnapshot, onUpdate, 10);
+
+    await vi.advanceTimersByTimeAsync(50);
+    expect(fetchSnapshot).toHaveBeenCalledTimes(1);
+    expect(onUpdate).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+});

--- a/frontend/src/hooks/useAgent/__tests__/runResumed.test.ts
+++ b/frontend/src/hooks/useAgent/__tests__/runResumed.test.ts
@@ -1,0 +1,173 @@
+import type { Message } from "../../../types";
+import { describe, expect, test } from "vitest";
+
+import { handleStreamEvent } from "../eventHandlers.ts";
+import type { EventHandlerContext } from "../eventHandlers.ts";
+import { reconstructMessagesFromEvents } from "../historyLoader.ts";
+import type { HistoryEvent, StreamEvent } from "../types.ts";
+
+function createLiveContext(initial: Message[]): {
+  ctx: EventHandlerContext;
+  messages: () => Message[];
+} {
+  let messages = initial;
+  return {
+    ctx: {
+      sessionIdRef: { current: "session-1" },
+      processedEventIdsRef: { current: new Set<string>() },
+      lastHistoryTimestampRef: { current: null },
+      activeSubagentStackRef: { current: [] },
+      streamVersionRef: { current: 0 },
+      setSessionId: () => undefined,
+      setMessages: (updater: React.SetStateAction<Message[]>) => {
+        messages = typeof updater === "function" ? updater(messages) : updater;
+      },
+      setConnectionStatus: () => undefined,
+      setIsInitializingSandbox: () => undefined,
+      setSandboxError: () => undefined,
+      setActiveGoal: () => undefined,
+      setGoalsByRunId: () => undefined,
+    } as EventHandlerContext,
+    messages: () => messages,
+  };
+}
+
+describe("live run:resumed event", () => {
+  test("resets interrupted bubble content and returns to streaming", () => {
+    const { ctx, messages } = createLiveContext([
+      {
+        id: "run-1",
+        role: "assistant",
+        content: "错误：连接中断",
+        timestamp: new Date(),
+        isStreaming: false,
+        cancelled: true,
+        runId: "run-1",
+        parts: [{ type: "cancelled" }],
+        toolCalls: [{ id: "t1", name: "bash", args: {} }],
+      },
+    ]);
+
+    const event: StreamEvent = {
+      event: "run:resumed",
+      data: JSON.stringify({ run_id: "run-1" }),
+    };
+    handleStreamEvent(event, "run-1", "evt-resumed-1", undefined, ctx);
+
+    const message = messages().find((m) => m.id === "run-1");
+    expect(message).toBeDefined();
+    expect(message?.parts).toEqual([]);
+    expect(message?.content).toBe("");
+    expect(message?.toolCalls).toEqual([]);
+    expect(message?.cancelled).toBe(false);
+    expect(message?.isStreaming).toBe(true);
+  });
+
+  test("creates a streaming placeholder when bubble does not exist yet", () => {
+    const { ctx, messages } = createLiveContext([]);
+
+    handleStreamEvent(
+      {
+        event: "run:resumed",
+        data: JSON.stringify({ run_id: "run-1" }),
+      },
+      "run-1",
+      "evt-resumed-2",
+      undefined,
+      ctx,
+    );
+
+    const message = messages().find((m) => m.id === "run-1");
+    expect(message?.role).toBe("assistant");
+    expect(message?.isStreaming).toBe(true);
+    expect(message?.parts).toEqual([]);
+  });
+
+  test("post-resume chunks rebuild content from scratch", () => {
+    const { ctx, messages } = createLiveContext([
+      {
+        id: "run-1",
+        role: "assistant",
+        content: "半截输出",
+        timestamp: new Date(),
+        isStreaming: true,
+        runId: "run-1",
+        parts: [],
+      },
+    ]);
+
+    handleStreamEvent(
+      { event: "run:resumed", data: JSON.stringify({ run_id: "run-1" }) },
+      "run-1",
+      "evt-resumed-3",
+      undefined,
+      ctx,
+    );
+    handleStreamEvent(
+      {
+        event: "message:chunk",
+        data: JSON.stringify({ content: "重新生成的完整回答" }),
+      },
+      "run-1",
+      "evt-chunk-1",
+      undefined,
+      ctx,
+    );
+
+    expect(messages().find((m) => m.id === "run-1")?.content).toBe(
+      "重新生成的完整回答",
+    );
+  });
+});
+
+describe("history rebuild with run:resumed", () => {
+  const events: HistoryEvent[] = [
+    {
+      event_type: "user:message",
+      run_id: "run-1",
+      data: { content: "原问题" },
+      timestamp: "2026-09-01T00:00:00Z",
+    },
+    {
+      event_type: "message:chunk",
+      run_id: "run-1",
+      data: { content: "中断前的半截" },
+      timestamp: "2026-09-01T00:00:01Z",
+    },
+    {
+      event_type: "run:resumed",
+      run_id: "run-1",
+      data: { run_id: "run-1" },
+      timestamp: "2026-09-01T00:00:10Z",
+    },
+    {
+      event_type: "message:chunk",
+      run_id: "run-1",
+      data: { content: "恢复后的完整回答" },
+      timestamp: "2026-09-01T00:00:11Z",
+    },
+  ];
+
+  test("keeps only post-resume content in the assistant bubble", () => {
+    const messages = reconstructMessagesFromEvents(
+      events,
+      new Set<string>(),
+      { activeSubagentStack: [] },
+    );
+    const assistant = messages.find((m) => m.role === "assistant");
+
+    expect(assistant?.content).toBe("恢复后的完整回答");
+    expect(assistant?.id).toBe("run-1");
+  });
+
+  test("a run interrupted without resume still keeps partial content", () => {
+    const messages = reconstructMessagesFromEvents(
+      events.slice(0, 2),
+      new Set<string>(),
+      { activeSubagentStack: [] },
+    );
+    const assistant = messages.find((m) => m.role === "assistant");
+
+    expect(assistant?.content).toBe("中断前的半截");
+  });
+});

--- a/frontend/src/hooks/useAgent/eventHandlers.ts
+++ b/frontend/src/hooks/useAgent/eventHandlers.ts
@@ -304,6 +304,36 @@ export function handleStreamEvent(
       return;
     }
 
+    case "run:resumed": {
+      // 系统中断后同 run 无缝续跑：清空气泡里的半截输出/错误/取消状态，
+      // 回到流式空态接收重新生成的完整回答（模型会重跑这一轮）。
+      ctx.setMessages((prev) => {
+        const reset = {
+          parts: [],
+          content: "",
+          toolCalls: [],
+          cancelled: false,
+          isStreaming: true,
+        };
+        if (prev.some((message) => message.id === messageId)) {
+          return prev.map((message) =>
+            message.id === messageId ? { ...message, ...reset } : message,
+          );
+        }
+        return [
+          ...prev,
+          {
+            id: messageId,
+            role: "assistant" as const,
+            timestamp: new Date(),
+            runId: typeof data.run_id === "string" ? data.run_id : undefined,
+            ...reset,
+          },
+        ];
+      });
+      return;
+    }
+
     case "complete":
     case "done": {
       ctx.setMessages((prev) =>

--- a/frontend/src/hooks/useAgent/historyLoader.ts
+++ b/frontend/src/hooks/useAgent/historyLoader.ts
@@ -521,6 +521,22 @@ export function reconstructMessagesFromEvents(
       continue;
     }
 
+    // Handle seamless run resume
+    if (eventType === "run:resumed") {
+      // 中断后同 run 恢复：丢弃半截/错误累积，同一气泡从空态继续折叠
+      // 后续事件（模型重新生成完整回答）
+      if (currentAssistantMessage) {
+        currentAssistantMessage = {
+          ...currentAssistantMessage,
+          parts: [],
+          content: "",
+          toolCalls: [],
+          cancelled: false,
+        };
+      }
+      continue;
+    }
+
     if (
       !currentAssistantMessage &&
       canAttachEventTypeToPreviousAssistant(eventType)

--- a/frontend/src/hooks/useAgent/historyLoader.ts
+++ b/frontend/src/hooks/useAgent/historyLoader.ts
@@ -321,6 +321,23 @@ function processHistoryEvent(
  * 旧记录（如推荐问题）可能缺少 run_id 信封；按时间序取前向最近的
  * run_id，无前向时回退到后向第一个 run_id，保持与逐事件反向查找一致的语义。
  */
+/**
+ * 中断后同 run 无缝续跑：丢弃半截/错误累积，同一气泡回到空态，
+ * 后续事件（模型重新生成的完整回答）从零重新折叠。
+ */
+function resetInterruptedAssistantForResume(
+  message: Message | null,
+): Message | null {
+  if (!message) return null;
+  return {
+    ...message,
+    parts: [],
+    content: "",
+    toolCalls: [],
+    cancelled: false,
+  };
+}
+
 export function normalizeEventRunIds(events: HistoryEvent[]): HistoryEvent[] {
   const prevRunIdByIndex: Array<string | undefined> = new Array(
     events.length,
@@ -525,15 +542,9 @@ export function reconstructMessagesFromEvents(
     if (eventType === "run:resumed") {
       // 中断后同 run 恢复：丢弃半截/错误累积，同一气泡从空态继续折叠
       // 后续事件（模型重新生成完整回答）
-      if (currentAssistantMessage) {
-        currentAssistantMessage = {
-          ...currentAssistantMessage,
-          parts: [],
-          content: "",
-          toolCalls: [],
-          cancelled: false,
-        };
-      }
+      currentAssistantMessage = resetInterruptedAssistantForResume(
+        currentAssistantMessage,
+      );
       continue;
     }
 

--- a/frontend/src/hooks/useAgent/queuePolling.ts
+++ b/frontend/src/hooks/useAgent/queuePolling.ts
@@ -1,0 +1,72 @@
+/**
+ * Queue position polling — keeps the "排队中 (第 N 位)" toast in sync with the
+ * live queue position instead of freezing it at submission time.
+ */
+
+import i18n from "../../i18n";
+import { sessionApi } from "../../services/api/session";
+
+export interface QueuePositionSnapshot {
+  run_id: string | null;
+  task_status: string;
+  position: number;
+}
+
+/**
+ * Decide whether polling should continue after one snapshot.
+ * Returns the position to display, or null when polling should stop
+ * (run changed, task left the queue, or processing already started).
+ */
+export function resolveQueuePollAction(
+  snapshot: QueuePositionSnapshot,
+  expectedRunId: string,
+): number | null {
+  if (snapshot.run_id !== expectedRunId) return null;
+  // 仍在排队侧状态：刷新位置（position 可能为 0，表示即将出队，继续轮询确认）
+  if (snapshot.task_status === "queued" || snapshot.task_status === "pending") {
+    return snapshot.position;
+  }
+  // 已开始处理 / 终态：queue_update 事件会接管 toast，停止轮询
+  return null;
+}
+
+const QUEUE_POLL_INTERVAL_MS = 5000;
+const QUEUE_POLL_MAX_TICKS = 360; // 最多轮询 30 分钟，超时自然停止
+
+/**
+ * Poll the queue position endpoint and update the chat-queue toast in place.
+ * Self-terminating: stops when the run leaves the queue, the run id changes,
+ * a request fails, or the max duration elapses. Fire-and-forget.
+ */
+export function startQueuePositionPolling(
+  sessionId: string,
+  runId: string,
+  fetchSnapshot: (sessionId: string) => Promise<QueuePositionSnapshot> = (
+    id,
+  ) => sessionApi.getQueuePosition(id),
+  onUpdate: (position: number) => void = (position) => {
+    import("react-hot-toast").then(({ default: toast }) => {
+      toast.loading(i18n.t("chat.queued", { position }), {
+        id: "chat-queue",
+        duration: Infinity,
+      });
+    });
+  },
+  intervalMs: number = QUEUE_POLL_INTERVAL_MS,
+): void {
+  const poll = async () => {
+    for (let tick = 0; tick < QUEUE_POLL_MAX_TICKS; tick += 1) {
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+      let snapshot: QueuePositionSnapshot;
+      try {
+        snapshot = await fetchSnapshot(sessionId);
+      } catch {
+        return; // 网络错误/会话删除等：直接停，避免死循环报错
+      }
+      const position = resolveQueuePollAction(snapshot, runId);
+      if (position === null) return;
+      onUpdate(position);
+    }
+  };
+  void poll();
+}

--- a/frontend/src/hooks/useAgent/types.ts
+++ b/frontend/src/hooks/useAgent/types.ts
@@ -14,6 +14,7 @@ export type EventType =
   | "user:message"
   | "steer:message"
   | "user:cancel"
+  | "run:resumed"
   | "thinking"
   | "tool:start"
   | "tool:result"

--- a/frontend/src/services/api/session.ts
+++ b/frontend/src/services/api/session.ts
@@ -347,6 +347,20 @@ export const sessionApi = {
   },
 
   /**
+   * Get live queue position for a queued run (poll while waiting)
+   */
+  async getQueuePosition(sessionId: string): Promise<{
+    session_id: string;
+    run_id: string | null;
+    task_status: string;
+    position: number;
+  }> {
+    return authFetch(
+      `${API_BASE}/api/chat/sessions/${sessionId}/queue-position`,
+    );
+  },
+
+  /**
    * Cancel running task for a session
    */
   async cancel(sessionId: string): Promise<{

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -42,6 +42,7 @@ from src.api.routes import (
     role,
     scheduled_task,
     session,
+    session_queue,
     share,
     skill,
     team,
@@ -821,6 +822,8 @@ def create_app() -> FastAPI:
     app.include_router(version.router, prefix="/api", tags=["Version"])
     # Chat 路由: /api/chat/stream 后台执行, /api/chat/sessions/{id}/stream SSE
     app.include_router(chat.router, prefix="/api/chat", tags=["Chat"])
+    # 会话排队状态查询（与 chat 会话路由同前缀，独立模块控制单文件规模）
+    app.include_router(session_queue.router, prefix="/api/chat", tags=["Chat"])
     # Agent 路由: /api/agents 列表, /api/{agent_id}/stream 和 /api/{agent_id}/chat
     app.include_router(agent.router, prefix="/api", tags=["Agents"])
     # Agent 配置路由: /api/agent/config 全局配置和用户偏好

--- a/src/api/routes/chat.py
+++ b/src/api/routes/chat.py
@@ -874,38 +874,6 @@ async def resume_session(
     return await task_manager.resume_session(session_id)
 
 
-@router.get("/sessions/{session_id}/queue-position")
-async def get_session_queue_position(
-    session_id: str,
-    user: TokenPayload = Depends(get_current_user_required),
-):
-    """查询排队中任务的实时队列位置（前端轮询刷新"排队中（第 N 位）"）。"""
-    session_manager = SessionManager()
-    session = await session_manager.get_session(session_id)
-    if not session:
-        raise AppError(ErrorCode.SESSION_NOT_FOUND)
-    verify_session_ownership(session, user)
-
-    metadata = session.metadata or {}
-    run_id = metadata.get("current_run_id")
-    task_status = str(metadata.get("task_status") or "")
-    position = 0
-    # 排队侧状态（或缺失状态，保守起见同样查询）才查 Redis；running/终态必然不在队列
-    if run_id and (
-        not task_status or task_status in {TaskStatus.QUEUED.value, TaskStatus.PENDING.value}
-    ):
-        from src.infra.task.concurrency import get_concurrency_limiter
-
-        position = await get_concurrency_limiter().get_queue_position(user.sub, str(run_id))
-
-    return {
-        "session_id": session_id,
-        "run_id": run_id,
-        "task_status": task_status,
-        "position": position,
-    }
-
-
 class SteerRequest(BaseModel):
     """运行中插话请求体。"""
 

--- a/src/api/routes/chat.py
+++ b/src/api/routes/chat.py
@@ -874,6 +874,38 @@ async def resume_session(
     return await task_manager.resume_session(session_id)
 
 
+@router.get("/sessions/{session_id}/queue-position")
+async def get_session_queue_position(
+    session_id: str,
+    user: TokenPayload = Depends(get_current_user_required),
+):
+    """查询排队中任务的实时队列位置（前端轮询刷新"排队中（第 N 位）"）。"""
+    session_manager = SessionManager()
+    session = await session_manager.get_session(session_id)
+    if not session:
+        raise AppError(ErrorCode.SESSION_NOT_FOUND)
+    verify_session_ownership(session, user)
+
+    metadata = session.metadata or {}
+    run_id = metadata.get("current_run_id")
+    task_status = str(metadata.get("task_status") or "")
+    position = 0
+    # 排队侧状态（或缺失状态，保守起见同样查询）才查 Redis；running/终态必然不在队列
+    if run_id and (
+        not task_status or task_status in {TaskStatus.QUEUED.value, TaskStatus.PENDING.value}
+    ):
+        from src.infra.task.concurrency import get_concurrency_limiter
+
+        position = await get_concurrency_limiter().get_queue_position(user.sub, str(run_id))
+
+    return {
+        "session_id": session_id,
+        "run_id": run_id,
+        "task_status": task_status,
+        "position": position,
+    }
+
+
 class SteerRequest(BaseModel):
     """运行中插话请求体。"""
 

--- a/src/api/routes/session_queue.py
+++ b/src/api/routes/session_queue.py
@@ -1,0 +1,50 @@
+"""会话排队状态查询路由（从 chat.py 拆出以控制单文件规模）。
+
+挂载在 /api/chat 之下，与 chat.py 的 /sessions/{id}/... 路由同前缀；
+前端轮询 `/api/chat/sessions/{id}/queue-position` 刷新"排队中（第 N 位）"。
+"""
+
+from fastapi import APIRouter, Depends
+
+from src.api.deps import get_current_user_required
+from src.api.routes.session import verify_session_ownership
+from src.infra.logging import get_logger
+from src.infra.session.manager import SessionManager
+from src.infra.task.status import TaskStatus
+from src.kernel.errors import AppError, ErrorCode
+from src.kernel.schemas.user import TokenPayload
+
+logger = get_logger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/sessions/{session_id}/queue-position")
+async def get_session_queue_position(
+    session_id: str,
+    user: TokenPayload = Depends(get_current_user_required),
+):
+    """查询排队中任务的实时队列位置（前端轮询刷新"排队中（第 N 位）"）。"""
+    session = await SessionManager().get_session(session_id)
+    if not session:
+        raise AppError(ErrorCode.SESSION_NOT_FOUND)
+    verify_session_ownership(session, user)
+
+    metadata = session.metadata or {}
+    run_id = metadata.get("current_run_id")
+    task_status = str(metadata.get("task_status") or "")
+    position = 0
+    # 排队侧状态（或缺失状态，保守起见同样查询）才查 Redis；running/终态必然不在队列
+    if run_id and (
+        not task_status or task_status in {TaskStatus.QUEUED.value, TaskStatus.PENDING.value}
+    ):
+        from src.infra.task.concurrency import get_concurrency_limiter
+
+        position = await get_concurrency_limiter().get_queue_position(user.sub, str(run_id))
+
+    return {
+        "session_id": session_id,
+        "run_id": run_id,
+        "task_status": task_status,
+        "position": position,
+    }

--- a/src/infra/session/trace_storage_writes.py
+++ b/src/infra/session/trace_storage_writes.py
@@ -396,6 +396,29 @@ class TraceStorageWriteMixin:
             logger.error(f"Failed to complete trace {trace_id}: {e}")
             return False
 
+    async def reopen_interrupted_trace(self, trace_id: str) -> bool:
+        """Reopen an error-finalized trace so a seamless resume can append events.
+
+        只允许 error → running：旧关停路径把被中断的 run 终结成了 error，同 run
+        无缝续跑需要 trace 回到 running（running 是历史读取判定"活跃 run"的前置）。
+        completed trace 永不重开，与 complete_trace 的终态保护同一原则。
+        """
+        try:
+            result = await self.collection.update_one(
+                {"trace_id": trace_id, "status": "error"},
+                {
+                    "$set": {"status": "running", "updated_at": utc_now()},
+                    "$unset": {"completed_at": ""},
+                },
+            )
+            if result.modified_count:
+                logger.info("Reopened interrupted trace %s for seamless resume", trace_id)
+                return True
+            return False
+        except Exception as e:
+            logger.warning("Failed to reopen trace %s: %s", trace_id, e)
+            return False
+
     async def _complete_trace_after_marker_release(
         self,
         trace_id: str,

--- a/src/infra/task/arq_worker.py
+++ b/src/infra/task/arq_worker.py
@@ -133,7 +133,9 @@ async def run_agent_task(ctx: dict[str, Any], dispatch_id: str) -> None:
     task_manager = get_task_manager()
     task_executor = task_manager._ensure_executor()
 
+    interrupted_resume = bool(payload.get("interrupted_resume"))
     hitl_slot_acquired = False
+    resume_slot_acquired = False
     if payload.get("hitl_resume"):
         startup_token = await _acquire_hitl_resume_startup_lock(run_id)
         if startup_token is None:
@@ -154,12 +156,26 @@ async def run_agent_task(ctx: dict[str, Any], dispatch_id: str) -> None:
                 raise
         finally:
             await _release_hitl_resume_startup_lock(run_id, startup_token)
+    elif interrupted_resume:
+        # 系统中断后的同 run 无缝续跑：源执行者已死（恢复入口校验过心跳），
+        # 只需原子重占并发槽；占不到就 defer 重试，避免排队复制语义。
+        limiter = get_concurrency_limiter()
+        if not await limiter.try_acquire_run_slot(payload["user_id"], run_id):
+            raise Retry(defer=1)
+        resume_slot_acquired = True
+        try:
+            await task_executor._update_session_status(
+                payload["session_id"], TaskStatus.PENDING, run_id=run_id
+            )
+        except BaseException:
+            await _release_concurrency_slot(payload.get("user_id"), run_id, dequeue=False)
+            raise
 
     executor_key = str(payload["executor_key"])
     try:
         executor_fn = _resolve_executor(executor_key)
     except BaseException:
-        if hitl_slot_acquired:
+        if hitl_slot_acquired or resume_slot_acquired:
             await _release_concurrency_slot(payload.get("user_id"), run_id, dequeue=False)
         raise
     if executor_fn is None:
@@ -208,6 +224,7 @@ async def run_agent_task(ctx: dict[str, Any], dispatch_id: str) -> None:
             auto_mode=bool(payload.get("auto_mode", False)),
             attachment_references_claimed=bool(payload.get("attachment_references_claimed", False)),
             hitl_resume=payload.get("hitl_resume"),
+            interrupted_resume=interrupted_resume,
         )
     except TaskInterruptedError:
         await payload_store.delete(dispatch_id)

--- a/src/infra/task/arq_worker.py
+++ b/src/infra/task/arq_worker.py
@@ -159,6 +159,15 @@ async def run_agent_task(ctx: dict[str, Any], dispatch_id: str) -> None:
     elif interrupted_resume:
         # 系统中断后的同 run 无缝续跑：源执行者已死（恢复入口校验过心跳），
         # 只需原子重占并发槽；占不到就 defer 重试，避免排队复制语义。
+        # 提交到 worker 拾取之间若心跳又变新鲜（误判死活），defer 等真死，
+        # 防止与原执行者并发写同一条流。
+        from .heartbeat import TaskHeartbeat
+
+        if not await TaskHeartbeat().is_stale(run_id):
+            logger.info(
+                "Interrupted resume deferred, heartbeat fresh again: run_id=%s", run_id
+            )
+            raise Retry(defer=5)
         limiter = get_concurrency_limiter()
         if not await limiter.try_acquire_run_slot(payload["user_id"], run_id):
             raise Retry(defer=1)

--- a/src/infra/task/arq_worker.py
+++ b/src/infra/task/arq_worker.py
@@ -164,9 +164,7 @@ async def run_agent_task(ctx: dict[str, Any], dispatch_id: str) -> None:
         from .heartbeat import TaskHeartbeat
 
         if not await TaskHeartbeat().is_stale(run_id):
-            logger.info(
-                "Interrupted resume deferred, heartbeat fresh again: run_id=%s", run_id
-            )
+            logger.info("Interrupted resume deferred, heartbeat fresh again: run_id=%s", run_id)
             raise Retry(defer=5)
         limiter = get_concurrency_limiter()
         if not await limiter.try_acquire_run_slot(payload["user_id"], run_id):

--- a/src/infra/task/concurrency.py
+++ b/src/infra/task/concurrency.py
@@ -34,7 +34,74 @@ USER_LOCK_WAIT_SECONDS = 5.0
 USER_LOCK_POLL_INTERVAL = 0.05
 QUEUE_SCAN_PAGE_SIZE = 100
 QUEUE_ENTRY_MAX_BYTES = 2 * 1024 * 1024
-QUEUE_REWRITE_CHUNK_SIZE = 100
+
+# 队列 LIST 的原子变更脚本：此前"客户端分页扫描 + 临时 key 整表重写"在用户锁内
+# 产生 O(队列长度) 次网络往返；脚本在 Redis 服务端单次原子执行，客户端零重写。
+# 队列长度受 max_queued（默认 10）约束，脚本执行时间可忽略。
+_QUEUE_REMOVE_LUA = """
+local queue_key = KEYS[1]
+local field = ARGV[1]
+local value = ARGV[2]
+local entries = redis.call('LRANGE', queue_key, 0, -1)
+local kept = {}
+local removed = 0
+local removed_run_ids = {}
+for _, entry in ipairs(entries) do
+  local ok, data = pcall(cjson.decode, entry)
+  if ok and type(data) == 'table' and data[field] == value then
+    removed = removed + 1
+    if data['run_id'] ~= nil then
+      table.insert(removed_run_ids, tostring(data['run_id']))
+    end
+  else
+    table.insert(kept, entry)
+  end
+end
+if removed == 0 then
+  return 0
+end
+redis.call('DEL', queue_key)
+if #kept > 0 then
+  redis.call('RPUSH', queue_key, unpack(kept))
+end
+return cjson.encode({removed = removed, run_ids = removed_run_ids})
+"""
+
+_QUEUE_MARK_READY_LUA = """
+local queue_key = KEYS[1]
+local run_id = ARGV[1]
+local entries = redis.call('LRANGE', queue_key, 0, -1)
+local found = 0
+for index, entry in ipairs(entries) do
+  local ok, data = pcall(cjson.decode, entry)
+  if ok and type(data) == 'table' and tostring(data['run_id'] or '') == run_id then
+    local context = data['task_context']
+    if type(context) ~= 'table' then
+      context = {}
+    end
+    context['queue_ready'] = true
+    data['task_context'] = context
+    entries[index] = cjson.encode(data)
+    found = 1
+  end
+end
+if found == 1 then
+  redis.call('DEL', queue_key)
+  redis.call('RPUSH', queue_key, unpack(entries))
+end
+return found
+"""
+
+_QUEUE_POSITION_LUA = """
+local entries = redis.call('LRANGE', KEYS[1], 0, -1)
+for index, entry in ipairs(entries) do
+  local ok, data = pcall(cjson.decode, entry)
+  if ok and type(data) == 'table' and tostring(data['run_id'] or '') == ARGV[1] then
+    return index
+  end
+end
+return 0
+"""
 
 
 async def _queue_json_dumps(value: Any) -> str:
@@ -723,28 +790,43 @@ class UserConcurrencyLimiter:
     async def get_queue_position(self, user_id: str, run_id: str) -> int:
         """Get current queue position for a run_id. Returns 0 if not in queue."""
         try:
-            queue_key = self._queue_key(user_id)
-            position = 0
-            async for entry in self._iter_queue_entries(queue_key):
-                position += 1
-                data = await _queue_json_loads(entry)
-                if data.get("run_id") == run_id:
-                    return position
-            return 0
+            result = await self.redis.eval(
+                _QUEUE_POSITION_LUA, 1, self._queue_key(user_id), run_id
+            )
+            return int(result or 0)
         except Exception:
             return 0
+
+    async def _remove_queue_entries_atomic(
+        self,
+        user_id: str,
+        *,
+        field: str,
+        value: str,
+    ) -> tuple[int, list[Any]]:
+        """Atomically drop queue entries matching one exact field (server-side Lua)."""
+        result = await self.redis.eval(
+            _QUEUE_REMOVE_LUA, 1, self._queue_key(user_id), field, str(value)
+        )
+        if not result or result == 0:
+            return 0, []
+        raw = result.decode() if isinstance(result, bytes) else result
+        payload = json.loads(raw)
+        removed = int(payload.get("removed") or 0)
+        run_ids = payload.get("run_ids") or []
+        if isinstance(run_ids, dict):
+            # cjson 把空数组编码成空对象
+            run_ids = list(run_ids.values())
+        return removed, list(run_ids)
 
     async def remove_from_queue(self, user_id: str, session_id: str) -> int:
         """Remove queued tasks matching session_id. Returns count removed."""
         try:
-            lock_key, token = await self._acquire_user_lock(user_id)
-            try:
-                removed, removed_run_ids = await self._remove_from_queue_locked(
-                    user_id,
-                    session_id,
-                )
-            finally:
-                await self._release_user_lock(lock_key, token)
+            removed, removed_run_ids = await self._remove_queue_entries_atomic(
+                user_id,
+                field="session_id",
+                value=session_id,
+            )
 
             if removed:
                 logger.info(f"Removed {removed} queued tasks for session {session_id}")
@@ -780,15 +862,11 @@ class UserConcurrencyLimiter:
     async def remove_queued_run(self, user_id: str, run_id: str) -> int:
         """Remove only the queued entry for ``run_id`` without cancelling sibling runs."""
         try:
-            lock_key, token = await self._acquire_user_lock(user_id)
-            try:
-                removed, _ = await self._rewrite_queue_without_matches(
-                    user_id,
-                    match_field="run_id",
-                    match_value=run_id,
-                )
-            finally:
-                await self._release_user_lock(lock_key, token)
+            removed, _ = await self._remove_queue_entries_atomic(
+                user_id,
+                field="run_id",
+                value=run_id,
+            )
             if removed:
                 logger.info("Removed queued run %s for user %s", run_id, user_id)
             return removed
@@ -824,108 +902,14 @@ class UserConcurrencyLimiter:
             return False
 
     async def _mark_queued_run_ready_locked(self, user_id: str, run_id: str) -> bool:
-        """Rewrite one exact queue entry as ready while holding the user lock."""
-        queue_key = self._queue_key(user_id)
-        tmp_key = f"{queue_key}:ready:{uuid.uuid4().hex}"
-        keep_buffer: list[str] = []
-        found = False
-        wrote_entries = False
+        """Flip one queue entry to ready via server-side Lua while holding the user lock.
 
-        async def _flush() -> None:
-            nonlocal wrote_entries
-            if not keep_buffer:
-                return
-            await self.redis.rpush(tmp_key, *keep_buffer)
-            keep_buffer.clear()
-            wrote_entries = True
-
-        try:
-            async for entry in self._iter_queue_entries(queue_key):
-                data = await _queue_json_loads(entry)
-                if data.get("run_id") == run_id:
-                    task_context = dict(data.get("task_context") or {})
-                    task_context["queue_ready"] = True
-                    data["task_context"] = task_context
-                    entry = await _queue_json_dumps(data)
-                    found = True
-                keep_buffer.append(entry)
-                if len(keep_buffer) >= QUEUE_REWRITE_CHUNK_SIZE:
-                    await _flush()
-
-            if not found:
-                return False
-            await _flush()
-            if wrote_entries:
-                await self.redis.rename(tmp_key, queue_key)
-                tmp_key = ""
-            return True
-        finally:
-            if tmp_key:
-                try:
-                    await self.redis.delete(tmp_key)
-                except Exception:
-                    pass
-
-    async def _remove_from_queue_locked(
-        self, user_id: str, session_id: str
-    ) -> tuple[int, list[Any]]:
-        """Remove queued tasks while the caller holds the per-user lock."""
-        return await self._rewrite_queue_without_matches(
-            user_id,
-            match_field="session_id",
-            match_value=session_id,
+        锁仍保留：mark 与随后的 dequeue 判定必须互斥（脚本只保证 LIST 变更原子）。
+        """
+        result = await self.redis.eval(
+            _QUEUE_MARK_READY_LUA, 1, self._queue_key(user_id), run_id
         )
-
-    async def _rewrite_queue_without_matches(
-        self,
-        user_id: str,
-        *,
-        match_field: str,
-        match_value: str,
-    ) -> tuple[int, list[Any]]:
-        """Rewrite a user queue while omitting entries matching one exact field."""
-        tmp_key: str | None = None
-        try:
-            queue_key = self._queue_key(user_id)
-            removed = 0
-            removed_run_ids = []
-            tmp_key = f"{queue_key}:rewrite:{uuid.uuid4().hex}"
-            keep_buffer: list[str] = []
-            wrote_keep_entries = False
-
-            async def _flush_keep_buffer() -> None:
-                nonlocal wrote_keep_entries
-                if not keep_buffer:
-                    return
-                await self.redis.rpush(tmp_key, *keep_buffer)
-                keep_buffer.clear()
-                wrote_keep_entries = True
-
-            async for entry in self._iter_queue_entries(queue_key):
-                data = await _queue_json_loads(entry)
-                if data.get(match_field) == match_value:
-                    removed += 1
-                    removed_run_ids.append(data.get("run_id"))
-                else:
-                    keep_buffer.append(entry)
-                    if len(keep_buffer) >= QUEUE_REWRITE_CHUNK_SIZE:
-                        await _flush_keep_buffer()
-            if removed:
-                await _flush_keep_buffer()
-                if wrote_keep_entries:
-                    await self.redis.rename(tmp_key, queue_key)
-                    tmp_key = None
-                else:
-                    await self.redis.delete(queue_key)
-                    tmp_key = None
-            return removed, removed_run_ids
-        except Exception:
-            if tmp_key:
-                try:
-                    await self.redis.delete(tmp_key)
-                except Exception:
-                    pass
-            raise
+        return bool(result)
 
 
 # Singleton

--- a/src/infra/task/concurrency.py
+++ b/src/infra/task/concurrency.py
@@ -790,9 +790,7 @@ class UserConcurrencyLimiter:
     async def get_queue_position(self, user_id: str, run_id: str) -> int:
         """Get current queue position for a run_id. Returns 0 if not in queue."""
         try:
-            result = await self.redis.eval(
-                _QUEUE_POSITION_LUA, 1, self._queue_key(user_id), run_id
-            )
+            result = await self.redis.eval(_QUEUE_POSITION_LUA, 1, self._queue_key(user_id), run_id)
             return int(result or 0)
         except Exception:
             return 0
@@ -906,9 +904,7 @@ class UserConcurrencyLimiter:
 
         锁仍保留：mark 与随后的 dequeue 判定必须互斥（脚本只保证 LIST 变更原子）。
         """
-        result = await self.redis.eval(
-            _QUEUE_MARK_READY_LUA, 1, self._queue_key(user_id), run_id
-        )
+        result = await self.redis.eval(_QUEUE_MARK_READY_LUA, 1, self._queue_key(user_id), run_id)
         return bool(result)
 
 

--- a/src/infra/task/executor.py
+++ b/src/infra/task/executor.py
@@ -20,6 +20,7 @@ from src.kernel.config import settings
 from src.kernel.schemas.session import SessionCreate, SessionUpdate
 
 from .exceptions import TaskInterruptedError
+from .cancellation import TaskCancellation
 from .heartbeat import TaskHeartbeat
 from .stall_watchdog import aiter_with_stall_timeout
 from .state_machine import TaskStateMachine
@@ -94,6 +95,7 @@ class TaskExecutor:
         auto_mode: bool = False,
         attachment_references_claimed: bool = False,
         hitl_resume: Optional[Dict[str, Any]] = None,
+        interrupted_resume: bool = False,
     ) -> bool | None:
         """执行任务"""
         from src.infra.writer.present import Presenter, PresenterConfig
@@ -181,6 +183,20 @@ class TaskExecutor:
             self._run_info[run_id] = run_info_entry
 
             dual_writer = get_dual_writer()
+
+            # 系统中断后的同 run 无缝续跑：先发 run:resumed 标记事件，前端据此
+            # 清空原气泡的半截内容再接收重新生成的输出（不写新的 user:message）。
+            if interrupted_resume:
+                await presenter.save_event(
+                    {
+                        "event": "run:resumed",
+                        "data": {
+                            "run_id": run_id,
+                            "trace_id": presenter.trace_id,
+                            "timestamp": utc_now_iso(),
+                        },
+                    }
+                )
 
             if hitl_resume is not None:
                 resolved = hitl_resume.get("approval_resolved")
@@ -275,8 +291,6 @@ class TaskExecutor:
         finally:
             # 无论成功、取消还是失败，都停止心跳并清除中断信号
             await self._heartbeat.stop(run_id)
-            from .cancellation import TaskCancellation
-
             await TaskCancellation.clear_interrupt(run_id)
             # 清除请求上下文，防止 contextvars 泄漏到后续任务
             TraceContext.clear_request_context()
@@ -291,6 +305,23 @@ class TaskExecutor:
         presenter: Any,
     ) -> None:
         """处理任务取消错误"""
+        # 无 interrupt 标志的取消是系统中断（优雅关停/部署），不是用户操作：
+        # 不写 user:cancel/error/done 终态事件、不终结 trace、不过期 stream，
+        # 只 flush 缓冲让半截事件落库。recoverable 元数据由调用方标记
+        # （manager.shutdown / arq_worker），随后同 run_id 无缝续跑。
+        if not TaskCancellation.check_interrupt_fast(run_id):
+            if dual_writer is None:
+                dual_writer = get_dual_writer()
+            try:
+                await dual_writer._flush_redis_buffer()
+                await dual_writer.flush_mongo_buffer()
+            except Exception as e:
+                logger.warning(f"Failed to flush events on system interruption: {e}")
+            logger.info(
+                f"Task interrupted by system shutdown (resumable): "
+                f"session={session_id}, run_id={run_id}"
+            )
+            return
 
         await self._update_session_status(
             session_id, TaskStatus.CANCELLED, "Task cancelled", run_id=run_id

--- a/src/infra/task/executor.py
+++ b/src/infra/task/executor.py
@@ -19,8 +19,8 @@ from src.infra.writer.presenter_events import derive_user_message_run_modes
 from src.kernel.config import settings
 from src.kernel.schemas.session import SessionCreate, SessionUpdate
 
-from .exceptions import TaskInterruptedError
 from .cancellation import TaskCancellation
+from .exceptions import TaskInterruptedError
 from .heartbeat import TaskHeartbeat
 from .stall_watchdog import aiter_with_stall_timeout
 from .state_machine import TaskStateMachine

--- a/src/infra/task/heartbeat.py
+++ b/src/infra/task/heartbeat.py
@@ -115,16 +115,10 @@ class TaskHeartbeat:
             try:
                 from src.kernel.config import settings
 
-                configured = int(
-                    getattr(settings, "TASK_HEARTBEAT_STALE_SECONDS", 0) or 0
-                )
+                configured = int(getattr(settings, "TASK_HEARTBEAT_STALE_SECONDS", 0) or 0)
             except Exception:
                 configured = 0
-            max_age_seconds = (
-                configured
-                if configured > 0
-                else HEARTBEAT_STALE_THRESHOLD_SECONDS
-            )
+            max_age_seconds = configured if configured > 0 else HEARTBEAT_STALE_THRESHOLD_SECONDS
         threshold = max_age_seconds
         try:
             value = await get_redis_client().get(f"{HEARTBEAT_PREFIX}{run_id}")

--- a/src/infra/task/heartbeat.py
+++ b/src/infra/task/heartbeat.py
@@ -106,12 +106,26 @@ class TaskHeartbeat:
         """按时间戳判断心跳是否过期。
 
         与 check_exists（等 Redis key 120s TTL 自然消失）相比，按「距最后一次
-        心跳的时长」判定可以把实例死亡后的接管检测从 ~2 分钟缩到 ~30 秒。
+        心跳的时长」判定可以把实例死亡后的接管检测从 ~2 分钟缩到几十秒。
         值缺失 → 过期；解析失败 → 按存活处理（避免误接管活任务）。
+        恢复入口与 arq worker 侧都有同款复核兜底，短阈值不会误接管活任务。
         """
-        threshold = (
-            max_age_seconds if max_age_seconds is not None else HEARTBEAT_STALE_THRESHOLD_SECONDS
-        )
+        if max_age_seconds is None:
+            # settings 优先（TASK_HEARTBEAT_STALE_SECONDS，<=0 回退内置公式）
+            try:
+                from src.kernel.config import settings
+
+                configured = int(
+                    getattr(settings, "TASK_HEARTBEAT_STALE_SECONDS", 0) or 0
+                )
+            except Exception:
+                configured = 0
+            max_age_seconds = (
+                configured
+                if configured > 0
+                else HEARTBEAT_STALE_THRESHOLD_SECONDS
+            )
+        threshold = max_age_seconds
         try:
             value = await get_redis_client().get(f"{HEARTBEAT_PREFIX}{run_id}")
         except Exception as e:

--- a/src/infra/task/manager.py
+++ b/src/infra/task/manager.py
@@ -193,7 +193,7 @@ class BackgroundTaskManager:
             heartbeat=self._heartbeat,
             ensure_executor=self._ensure_executor,
             submit_task=self.submit,
-            submit_recovery_task=self._submit_recovery_task,
+            submit_arq_task=self.submit_arq,
             mark_run_failed=self._mark_run_failed,
         )
 
@@ -222,26 +222,6 @@ class BackgroundTaskManager:
             error_message,
             error_code=error_code,
         )
-
-    async def _submit_recovery_task(self, **kwargs: Any) -> Tuple[str, str]:
-        executor_key = str(kwargs.pop("executor_key", "agent_stream"))
-        if settings.TASK_BACKEND == "arq":
-            kwargs.pop("executor", None)
-            return await self.submit_arq(
-                executor_key=executor_key,
-                **kwargs,
-            )
-        kwargs.pop("trace_id", None)
-        kwargs.pop("user_message_written", None)
-        return await self.submit(**kwargs)
-
-    async def _submit_recovery_run(
-        self,
-        session: Any,
-        source_run_id: str,
-        reason: str,
-    ) -> Dict[str, Any]:
-        return await self._recovery_service().submit_recovery_run(session, source_run_id, reason)
 
     async def _resume_interrupted_run(
         self,
@@ -294,6 +274,7 @@ class BackgroundTaskManager:
         write_user_message_immediately: bool = False,
         attachment_references_claimed: bool = False,
         hitl_resume: Optional[Dict[str, Any]] = None,
+        interrupted_resume: bool = False,
     ) -> Tuple[str, str]:
         """
         提交后台任务
@@ -398,6 +379,7 @@ class BackgroundTaskManager:
                     user_message_written=user_message_written,
                     attachment_references_claimed=attachment_references_claimed,
                     hitl_resume=hitl_resume,
+                    interrupted_resume=interrupted_resume,
                 )
             )
             self._tasks[run_id] = task
@@ -441,6 +423,7 @@ class BackgroundTaskManager:
         index_user_message: bool = False,
         dispatch_id: Optional[str] = None,
         hitl_resume: Optional[Dict[str, Any]] = None,
+        interrupted_resume: bool = False,
         initial_status: TaskStatus | None = TaskStatus.QUEUED,
     ) -> Tuple[str, str]:
         """Submit a task to arq after persisting serializable task context."""
@@ -521,6 +504,7 @@ class BackgroundTaskManager:
                     "recommendation_input": recommendation_input,
                     "auto_mode": auto_mode,
                     "hitl_resume": hitl_resume,
+                    "interrupted_resume": interrupted_resume,
                 },
             )
             if should_index_user_message and search_index_content:

--- a/src/infra/task/recovery.py
+++ b/src/infra/task/recovery.py
@@ -431,6 +431,17 @@ class TaskRecoveryService:
                     "message": "该任务已由其他恢复流程接管",
                 }
 
+            # 分布式安全闸：心跳仍新鲜说明原执行者可能未死（30s 无心跳才判死）。
+            # 此时恢复会造成同 run 双执行者并发写同一条流，必须跳过。
+            if not await self._heartbeat.is_stale(source_run_id):
+                await self.release_recovery_lock(lock_key, lock_token)
+                return {
+                    "success": False,
+                    "run_id": None,
+                    "resumed_from_run_id": source_run_id,
+                    "message": "任务仍在其他实例运行中，跳过恢复",
+                }
+
             attempts = int(session_metadata.get("resume_attempts") or 0)
             if attempts >= MAX_SEAMLESS_RESUME_ATTEMPTS:
                 # 毒消息防护：同 run 反复中断说明重跑本身在触发崩溃，

--- a/src/infra/task/recovery.py
+++ b/src/infra/task/recovery.py
@@ -5,20 +5,17 @@ import inspect
 import uuid
 from typing import Any, Awaitable, Callable
 
-from src.agents.core import resolve_agent_name
 from src.infra.logging import get_logger
 from src.infra.session.trace_storage import get_trace_storage
 from src.infra.storage.redis import get_redis_client
 from src.infra.user.storage import UserStorage
 from src.infra.utils.datetime import utc_now_iso
-from src.infra.writer.present import Presenter, PresenterConfig
 from src.kernel.config import settings
 from src.kernel.errors import ErrorCode
 from src.kernel.schemas.session import SessionUpdate
 
 from .concurrency import ConcurrencyResult, get_concurrency_limiter, get_registered_executor
 from .recovery_texts import build_recovery_message, normalize_recovery_language
-from .run_ids import generate_run_id
 from .state_machine import TaskStateMachine
 from .status import TaskStatus
 
@@ -26,6 +23,8 @@ logger = get_logger(__name__)
 
 RECOVERY_LOCK_PREFIX = "task:recovery:"
 RECOVERY_LOCK_TTL_SECONDS = 300
+# 同一 run 的无缝恢复提交次数上限：超限视为毒消息，落终态 FAILED 防止无限重跑。
+MAX_SEAMLESS_RESUME_ATTEMPTS = 3
 
 
 def _get_enabled_skills_from_metadata(session_metadata: dict[str, Any]) -> list[str] | None:
@@ -34,6 +33,24 @@ def _get_enabled_skills_from_metadata(session_metadata: dict[str, Any]) -> list[
         return None
     enabled_skills = session_metadata.get("enabled_skills")
     return enabled_skills if isinstance(enabled_skills, list) else None
+
+
+async def _lookup_trace_id_for_run(run_id: str) -> str | None:
+    """按 run_id 查最新 trace，无缝续跑复用它继续追加事件。"""
+    try:
+        trace_storage = get_trace_storage()
+        cursor = (
+            trace_storage.collection.find({"run_id": run_id}, {"trace_id": 1, "_id": 0})
+            .sort("started_at", -1)
+            .limit(1)
+        )
+        traces = await cursor.to_list(length=1)
+        if traces:
+            trace_id = traces[0].get("trace_id")
+            return str(trace_id) if trace_id else None
+    except Exception as e:
+        logger.warning("Failed to lookup trace_id for run %s: %s", run_id, e)
+    return None
 
 
 def _registered_agent_ids() -> set[str]:
@@ -85,14 +102,14 @@ class TaskRecoveryService:
         ensure_executor: Callable[[], Any],
         submit_task: Callable[..., Awaitable[tuple[str, str]]],
         mark_run_failed: Callable[[str, str, Any], Awaitable[None]],
-        submit_recovery_task: Callable[..., Awaitable[tuple[str, str]]] | None = None,
+        submit_arq_task: Callable[..., Awaitable[tuple[str, str]]] | None = None,
     ) -> None:
         self._storage = storage
         self._run_info = run_info
         self._heartbeat = heartbeat
         self._ensure_executor = ensure_executor
         self._submit_task = submit_task
-        self._submit_recovery_task = submit_recovery_task or submit_task
+        self._submit_arq_task = submit_arq_task or submit_task
         self._mark_run_failed = mark_run_failed
         self._state_machine = TaskStateMachine()
 
@@ -245,16 +262,27 @@ class TaskRecoveryService:
             ),
         )
 
-    async def submit_recovery_run(
+    async def submit_seamless_resume(
         self,
         session: Any,
         source_run_id: str,
+        trace_id: str | None,
         reason: str,
     ) -> dict[str, Any]:
-        """Submit a new run that resumes the session from the latest checkpoint."""
+        """以原 run_id/trace_id 提交无缝续跑（模板：submit_hitl_resume_run）。
+
+        恢复指令只面向模型（作为新 HumanMessage 进入 checkpoint），不写
+        user:message UI 事件；executor 端 interrupted_resume=True 会先发
+        run:resumed 标记事件，前端据此清空原气泡后续接新生成的内容。
+        """
         session_metadata = getattr(session, "metadata", None) or {}
-        executor_key = session_metadata.get("executor_key") or "agent_stream"
-        executor_fn = get_registered_executor(str(executor_key))
+        executor_key = str(session_metadata.get("executor_key") or "agent_stream")
+        executor_fn = get_registered_executor(executor_key)
+        if executor_fn is None and executor_key == "agent_stream":
+            from importlib import import_module
+
+            import_module("src.api.routes.chat")
+            executor_fn = get_registered_executor(executor_key)
         if executor_fn is None:
             return {
                 "success": False,
@@ -264,162 +292,79 @@ class TaskRecoveryService:
             }
 
         language = await self.get_preferred_language(session.user_id, session)
-        recovery_message = build_recovery_message(reason, language)
+        hidden_instruction = build_recovery_message(reason, language)
         agent_id = _resolve_recovery_agent_id(session_metadata, session)
-        new_run_id = generate_run_id()
-        recovery_trace = Presenter(
-            PresenterConfig(
-                session_id=session.id,
-                agent_id=agent_id,
-                agent_name=resolve_agent_name(agent_id),
-                user_id=session.user_id,
-                run_id=new_run_id,
-                enable_storage=False,
-            )
-        )
-        recovery_trace_id = recovery_trace.trace_id
-        user_roles = await self.get_user_roles(session.user_id)
-        limiter = get_concurrency_limiter()
-        enabled_skills = _get_enabled_skills_from_metadata(session_metadata)
-        task_context = {
-            "executor_key": executor_key,
-            "agent_id": agent_id,
-            "message": recovery_message,
+        common_kwargs: dict[str, Any] = {
             "disabled_tools": session_metadata.get("disabled_tools") or None,
             "agent_options": session_metadata.get("agent_options") or None,
-            "attachments": None,
-            "trace_id": recovery_trace_id,
-            "user_message_written": True,
             "disabled_skills": session_metadata.get("disabled_skills") or None,
-            "enabled_skills": enabled_skills,
+            "enabled_skills": _get_enabled_skills_from_metadata(session_metadata),
             "persona_system_prompt": (
                 (session_metadata.get("persona_snapshot") or {}).get("system_prompt")
                 if isinstance(session_metadata.get("persona_snapshot"), dict)
                 else None
             ),
             "disabled_mcp_tools": session_metadata.get("disabled_mcp_tools") or None,
+            "project_id": session_metadata.get("project_id"),
+            "session_name": getattr(session, "name", None),
+            "user_message_written": True,
+            "run_id": source_run_id,
+            "trace_id": trace_id or None,
+            "interrupted_resume": True,
             "team_id": session_metadata.get("team_id"),
-            "recommendation_input": recovery_message,
+            "recommendation_input": hidden_instruction,
             "auto_mode": bool(session_metadata.get("auto_mode", False)),
         }
 
-        concurrency_result = await limiter.claim_recovery_slot(
-            user_id=session.user_id,
-            roles=user_roles,
-            old_run_id=source_run_id,
-            new_run_id=new_run_id,
-            session_id=session.id,
-            task_context=task_context,
-        )
-
-        if concurrency_result.result == ConcurrencyResult.REJECTED_QUEUE:
-            return {
-                "success": False,
-                "run_id": None,
-                "resumed_from_run_id": source_run_id,
-                "message": "恢复失败：当前恢复队列已满",
-            }
-
-        if concurrency_result.result == ConcurrencyResult.STARTED:
+        if getattr(settings, "TASK_BACKEND", "local") == "arq":
+            # arq：新 dispatch_id（旧 job 可能仍留档），run_id 沿用原值；
+            # 并发槽由 worker 侧（run_agent_task）获取。
+            dispatch_id = f"resume:{source_run_id}:{uuid.uuid4().hex}"
+            run_id, _ = await self._submit_arq_task(
+                session_id=session.id,
+                agent_id=agent_id,
+                message=hidden_instruction,
+                user_id=str(session.user_id),
+                executor_key=executor_key,
+                dispatch_id=dispatch_id,
+                initial_status=TaskStatus.PENDING,
+                **common_kwargs,
+            )
+        else:
+            limiter = get_concurrency_limiter()
+            if not await limiter.try_acquire_run_slot(str(session.user_id), source_run_id):
+                return {
+                    "success": False,
+                    "run_id": None,
+                    "resumed_from_run_id": source_run_id,
+                    "message": "当前并发任务已满，稍后将自动重试恢复",
+                }
             try:
-                await self._submit_recovery_task(
-                    session_id=session.id,
-                    agent_id=agent_id,
-                    message=recovery_message,
-                    user_id=session.user_id,
-                    executor=executor_fn,
-                    executor_key=executor_key,
-                    disabled_tools=session_metadata.get("disabled_tools") or None,
-                    agent_options=session_metadata.get("agent_options") or None,
-                    attachments=None,
-                    run_id=new_run_id,
-                    trace_id=recovery_trace_id,
-                    project_id=session_metadata.get("project_id"),
-                    disabled_skills=session_metadata.get("disabled_skills") or None,
-                    enabled_skills=enabled_skills,
-                    persona_system_prompt=(
-                        (session_metadata.get("persona_snapshot") or {}).get("system_prompt")
-                        if isinstance(session_metadata.get("persona_snapshot"), dict)
-                        else None
-                    ),
-                    disabled_mcp_tools=session_metadata.get("disabled_mcp_tools") or None,
-                    session_name=getattr(session, "name", None),
-                    team_id=session_metadata.get("team_id"),
-                    auto_mode=bool(session_metadata.get("auto_mode", False)),
+                run_id, _ = await self._submit_task(
+                    session.id,
+                    agent_id,
+                    hidden_instruction,
+                    str(session.user_id),
+                    executor_fn,
+                    **common_kwargs,
                 )
             except Exception:
-                await limiter.release(session.user_id, new_run_id, dequeue=False)
+                await limiter.release(str(session.user_id), source_run_id, dequeue=False)
                 raise
-        else:
-            executor = self._ensure_executor()
-            await executor.ensure_session(
-                session.id,
-                agent_id,
-                session.user_id,
-                project_id=session_metadata.get("project_id"),
-                session_name=getattr(session, "name", None),
-            )
-            await executor._update_session_status(
-                session.id,
-                TaskStatus.QUEUED,
-                run_id=new_run_id,
-            )
-            trace_presenter = Presenter(
-                PresenterConfig(
-                    session_id=session.id,
-                    agent_id=agent_id,
-                    agent_name=resolve_agent_name(agent_id),
-                    user_id=session.user_id,
-                    run_id=new_run_id,
-                    trace_id=recovery_trace_id,
-                    enable_storage=True,
-                )
-            )
-            await trace_presenter._ensure_trace()
-            await trace_presenter.emit_user_message(recovery_message)
-            self._run_info[new_run_id] = {
-                "session_id": session.id,
-                "agent_id": agent_id,
-                "user_id": session.user_id,
-                "trace_id": recovery_trace_id,
-                "user_message_written": True,
-            }
 
-        await self._storage.update(
+        logger.info(
+            "Seamless resume submitted: session=%s run_id=%s trace_id=%s reason=%s",
             session.id,
-            SessionUpdate(
-                metadata={
-                    "current_run_id": new_run_id,
-                    "agent_id": agent_id,
-                    "executor_key": executor_key,
-                    "agent_options": session_metadata.get("agent_options") or {},
-                    "disabled_tools": session_metadata.get("disabled_tools") or [],
-                    "disabled_skills": session_metadata.get("disabled_skills") or [],
-                    "enabled_skills": enabled_skills,
-                    "persona_preset_id": session_metadata.get("persona_preset_id"),
-                    "persona_preset_name": session_metadata.get("persona_preset_name"),
-                    "persona_snapshot": session_metadata.get("persona_snapshot"),
-                    "disabled_mcp_tools": session_metadata.get("disabled_mcp_tools") or [],
-                    "language": language,
-                    "project_id": session_metadata.get("project_id"),
-                    "team_id": session_metadata.get("team_id"),
-                    "auto_mode": bool(session_metadata.get("auto_mode", False)),
-                    "recovery_of_run_id": source_run_id,
-                    "recovery_reason": reason,
-                    "recovery_requested_at": utc_now_iso(),
-                    "task_recoverable": False,
-                    "task_error_code": None,
-                }
-            ),
+            run_id,
+            trace_id,
+            reason,
         )
-
         return {
             "success": True,
-            "run_id": new_run_id,
+            "run_id": run_id,
             "resumed_from_run_id": source_run_id,
-            "message": "任务恢复已开始"
-            if concurrency_result.result == ConcurrencyResult.STARTED
-            else "任务恢复已加入队列",
+            "seamless": True,
+            "message": "任务已在原对话中恢复",
         }
 
     async def _restore_recoverable_failure(
@@ -448,7 +393,7 @@ class TaskRecoveryService:
         source_run_id: str,
         reason: str,
     ) -> dict[str, Any]:
-        """Resume an interrupted run in a distributed-safe way."""
+        """Resume an interrupted run in-place (same run_id/trace, seamless to the user)."""
         if not source_run_id:
             return {
                 "success": False,
@@ -486,11 +431,27 @@ class TaskRecoveryService:
                     "message": "该任务已由其他恢复流程接管",
                 }
 
-            await self._mark_run_failed(
-                source_run_id,
-                "Task interrupted (instance unavailable)",
-                session,
-            )
+            attempts = int(session_metadata.get("resume_attempts") or 0)
+            if attempts >= MAX_SEAMLESS_RESUME_ATTEMPTS:
+                # 毒消息防护：同 run 反复中断说明重跑本身在触发崩溃，
+                # 终态失败（写 error 事件 + trace 终结），扫描器不再接管。
+                await self._mark_run_failed(
+                    source_run_id,
+                    f"Resume attempts exhausted ({attempts})",
+                    session,
+                )
+                return {
+                    "success": False,
+                    "run_id": None,
+                    "resumed_from_run_id": source_run_id,
+                    "message": "恢复次数已达上限，任务已终止",
+                }
+
+            trace_id = await _lookup_trace_id_for_run(source_run_id)
+            if trace_id:
+                await get_trace_storage().reopen_interrupted_trace(trace_id)
+            await self._strip_terminal_stream_events(session.id, source_run_id)
+
             await self._storage.update(
                 session.id,
                 SessionUpdate(
@@ -500,13 +461,31 @@ class TaskRecoveryService:
                     )
                 ),
             )
-            recovery_result = await self.submit_recovery_run(session, source_run_id, reason)
+            recovery_result = await self.submit_seamless_resume(
+                session, source_run_id, trace_id, reason
+            )
             if not recovery_result.get("success"):
                 await self._restore_recoverable_failure(
                     session.id,
                     source_run_id,
                     recovery_result.get("message") or "恢复任务失败",
                 )
+                # 提交失败释放锁，让下一轮扫描/手动重试可以立即接手
+                await self.release_recovery_lock(lock_key, lock_token)
+                return recovery_result
+
+            await self._storage.update(
+                session.id,
+                SessionUpdate(
+                    metadata={
+                        "resume_attempts": attempts + 1,
+                        "recovery_reason": reason,
+                        "recovery_requested_at": utc_now_iso(),
+                        "task_recoverable": False,
+                        "task_error_code": None,
+                    }
+                ),
+            )
             return recovery_result
         except asyncio.CancelledError:
             await self.release_recovery_lock(lock_key, lock_token)

--- a/src/infra/task/recovery.py
+++ b/src/infra/task/recovery.py
@@ -183,6 +183,42 @@ class TaskRecoveryService:
         except Exception as e:
             logger.warning("Failed to mark trace failed for run %s: %s", run_id, e)
 
+    async def _strip_terminal_stream_events(self, session_id: str, run_id: str) -> int:
+        """删除 Redis Stream 中残留的终态事件，恢复后 SSE 重放才不会提前断开。
+
+        SSE 读循环遇 error/done/complete 即断流；旧关停路径或跨版本升级可能已经
+        写入了终态事件，同 run 续跑前必须清掉，非终态事件（半截输出）一律保留。
+        """
+        try:
+            from src.infra.session.dual_writer import get_dual_writer
+
+            dual_writer = get_dual_writer()
+            stream_key = dual_writer._stream_key(session_id, run_id)
+            terminal_types = {"error", "done", "complete"}
+            removed = 0
+            entries = await dual_writer.redis.xrange(stream_key, min="-", max="+")
+            for entry_id, fields in entries:
+                if fields.get("event_type") in terminal_types:
+                    await dual_writer.redis.xdel(stream_key, entry_id)
+                    removed += 1
+            if removed:
+                logger.info(
+                    "Stripped %d terminal stream events before seamless resume: "
+                    "session=%s, run_id=%s",
+                    removed,
+                    session_id,
+                    run_id,
+                )
+            return removed
+        except Exception as e:
+            logger.warning(
+                "Failed to strip terminal stream events (session=%s run=%s): %s",
+                session_id,
+                run_id,
+                e,
+            )
+            return 0
+
     async def mark_run_recoverable_failure(
         self,
         session_id: str,

--- a/src/infra/task/recovery.py
+++ b/src/infra/task/recovery.py
@@ -14,7 +14,7 @@ from src.kernel.config import settings
 from src.kernel.errors import ErrorCode
 from src.kernel.schemas.session import SessionUpdate
 
-from .concurrency import ConcurrencyResult, get_concurrency_limiter, get_registered_executor
+from .concurrency import get_concurrency_limiter, get_registered_executor
 from .recovery_texts import build_recovery_message, normalize_recovery_language
 from .state_machine import TaskStateMachine
 from .status import TaskStatus

--- a/src/infra/task/recovery_texts.py
+++ b/src/infra/task/recovery_texts.py
@@ -1,8 +1,8 @@
 """
-Localized recovery user messages for task resumption.
+Localized recovery instructions for task resumption.
 
-These messages are emitted as normal ``user:message`` events so the frontend
-can keep rendering them without any protocol changes.
+同 run 无缝续跑时这些文案只作为模型面指令注入（新 HumanMessage 进入
+checkpoint），不写 ``user:message`` UI 事件，用户在界面上看不到。
 """
 
 from __future__ import annotations

--- a/src/kernel/config/base.py
+++ b/src/kernel/config/base.py
@@ -147,8 +147,12 @@ class Settings(BaseSettings):
     ARQ_WORKER_MAX_JOBS: int = 128
     ARQ_JOB_TIMEOUT_SECONDS: int = 86400
     TASK_STARTUP_CLEANUP_CONCURRENCY: int = 16
-    # 周期孤儿接管间隔：缩短实例死亡后对话自动恢复的停顿（心跳按龄判死 ~30s + 扫描间隔）
+    # 周期孤儿接管间隔：缩短实例死亡后对话自动恢复的停顿（心跳按龄判死 + 扫描间隔）
     TASK_ORPHAN_RECOVERY_INTERVAL_SECONDS: int = 15
+    # 心跳按龄判死阈值（秒）：实例死亡后允许接管的前置等待。恢复入口与 arq
+    # worker 侧均有同款活性复核兜底，20s（2 个心跳周期）不会误接管活任务。
+    # <=0 时回退到内置公式 max(30, 3×心跳间隔)。
+    TASK_HEARTBEAT_STALE_SECONDS: int = 20
     # 流式分片的时间维 flush 间隔（秒）：正文/思考/工具参数攒不够大小阈值时，
     # 每隔该时长也强制下发一次，避免小尾巴要等流结束才出来（<=0 禁用）。
     STREAM_CHUNK_FLUSH_INTERVAL: float = 1.0

--- a/tests/api/routes/test_chat_queue_position.py
+++ b/tests/api/routes/test_chat_queue_position.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import pytest
 
-from src.api.routes.chat import get_session_queue_position
+from src.api.routes.session_queue import get_session_queue_position
 from src.kernel.errors import AppError
 
 
@@ -43,7 +43,7 @@ def _session(metadata: dict[str, Any]) -> SimpleNamespace:
 
 async def _invoke(monkeypatch: pytest.MonkeyPatch, session: Any, limiter: _FakeLimiter):
     monkeypatch.setattr(
-        "src.api.routes.chat.SessionManager", lambda: _FakeSessionManager(session)
+        "src.api.routes.session_queue.SessionManager", lambda: _FakeSessionManager(session)
     )
     monkeypatch.setattr(
         "src.infra.task.concurrency.get_concurrency_limiter", lambda: limiter
@@ -88,7 +88,7 @@ async def test_non_queued_run_skips_redis_lookup(
 @pytest.mark.asyncio
 async def test_missing_session_raises_session_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
-        "src.api.routes.chat.SessionManager", lambda: _FakeSessionManager(None)
+        "src.api.routes.session_queue.SessionManager", lambda: _FakeSessionManager(None)
     )
 
     with pytest.raises(AppError) as exc_info:

--- a/tests/api/routes/test_chat_queue_position.py
+++ b/tests/api/routes/test_chat_queue_position.py
@@ -45,9 +45,7 @@ async def _invoke(monkeypatch: pytest.MonkeyPatch, session: Any, limiter: _FakeL
     monkeypatch.setattr(
         "src.api.routes.session_queue.SessionManager", lambda: _FakeSessionManager(session)
     )
-    monkeypatch.setattr(
-        "src.infra.task.concurrency.get_concurrency_limiter", lambda: limiter
-    )
+    monkeypatch.setattr("src.infra.task.concurrency.get_concurrency_limiter", lambda: limiter)
     return await get_session_queue_position("session-1", user=_user())
 
 

--- a/tests/api/routes/test_chat_queue_position.py
+++ b/tests/api/routes/test_chat_queue_position.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+"""排队位置查询端点：排队中的 run 可随时查询自己在队列中的当前位置。
+
+此前位置只在提交响应里返回一次，前端 toast 固定显示提交时刻的位次；
+有了查询端点，前端可轮询刷新"排队中（第 N 位）"，出队时自然归零。
+"""
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from src.api.routes.chat import get_session_queue_position
+from src.kernel.errors import AppError
+
+
+class _FakeSessionManager:
+    def __init__(self, session: Any) -> None:
+        self._session = session
+
+    async def get_session(self, session_id: str):
+        return self._session
+
+
+class _FakeLimiter:
+    def __init__(self, position: int) -> None:
+        self.position = position
+        self.calls: list[tuple[str, str]] = []
+
+    async def get_queue_position(self, user_id: str, run_id: str) -> int:
+        self.calls.append((user_id, run_id))
+        return self.position
+
+
+def _user() -> SimpleNamespace:
+    return SimpleNamespace(sub="user-1", user_id="user-1", permissions=[])
+
+
+def _session(metadata: dict[str, Any]) -> SimpleNamespace:
+    return SimpleNamespace(id="session-1", user_id="user-1", metadata=metadata)
+
+
+async def _invoke(monkeypatch: pytest.MonkeyPatch, session: Any, limiter: _FakeLimiter):
+    monkeypatch.setattr(
+        "src.api.routes.chat.SessionManager", lambda: _FakeSessionManager(session)
+    )
+    monkeypatch.setattr(
+        "src.infra.task.concurrency.get_concurrency_limiter", lambda: limiter
+    )
+    return await get_session_queue_position("session-1", user=_user())
+
+
+@pytest.mark.asyncio
+async def test_queued_run_returns_live_position(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = _session({"current_run_id": "run-1", "task_status": "queued"})
+    limiter = _FakeLimiter(position=3)
+
+    result = await _invoke(monkeypatch, session, limiter)
+
+    assert result["position"] == 3
+    assert result["run_id"] == "run-1"
+    assert result["task_status"] == "queued"
+    assert limiter.calls == [("user-1", "run-1")]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("task_status", ["running", "pending", "completed", "failed", None])
+async def test_non_queued_run_skips_redis_lookup(
+    monkeypatch: pytest.MonkeyPatch, task_status: str | None
+) -> None:
+    metadata: dict[str, Any] = {"current_run_id": "run-1"}
+    if task_status:
+        metadata["task_status"] = task_status
+    session = _session(metadata)
+    limiter = _FakeLimiter(position=2)
+
+    result = await _invoke(monkeypatch, session, limiter)
+
+    # 只有 queued 才查 Redis；pending 属于"排队侧"状态同样查询
+    if task_status in {None, "queued", "pending"}:
+        assert limiter.calls == [("user-1", "run-1")]
+    else:
+        assert result["position"] == 0
+        assert limiter.calls == []
+
+
+@pytest.mark.asyncio
+async def test_missing_session_raises_session_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "src.api.routes.chat.SessionManager", lambda: _FakeSessionManager(None)
+    )
+
+    with pytest.raises(AppError) as exc_info:
+        await get_session_queue_position("session-1", user=_user())
+
+    assert exc_info.value.error_code.code == "session_not_found"
+
+
+@pytest.mark.asyncio
+async def test_other_users_session_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = _session({"current_run_id": "run-1", "task_status": "queued"})
+    session.user_id = "user-2"
+    limiter = _FakeLimiter(position=1)
+
+    with pytest.raises(AppError):
+        await _invoke(monkeypatch, session, limiter)
+
+    assert limiter.calls == []

--- a/tests/infra/session/test_trace_reopen.py
+++ b/tests/infra/session/test_trace_reopen.py
@@ -12,7 +12,6 @@ from typing import Any
 import pytest
 
 from src.infra.session import trace_storage as trace_storage_module
-from src.infra.session import trace_storage_writes as writes_module
 from src.infra.session.trace_storage import TraceStorage
 
 

--- a/tests/infra/session/test_trace_reopen.py
+++ b/tests/infra/session/test_trace_reopen.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+"""reopen_interrupted_trace：无缝续跑前重开被旧关停路径终结为 error 的 trace。
+
+约束：只允许 error → running（旧代码在关停时会把 trace 终结为 error）；completed
+trace 永不重开（终态保护，与 complete_trace 的 finalizable 过滤同一原则）。
+"""
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from src.infra.session import trace_storage as trace_storage_module
+from src.infra.session import trace_storage_writes as writes_module
+from src.infra.session.trace_storage import TraceStorage
+
+
+class _FakeCollection:
+    def __init__(self, doc: dict[str, Any] | None = None) -> None:
+        self.doc = doc
+
+    async def update_one(self, query, update, upsert=False):
+        for key, expected in query.items():
+            if self.doc.get(key) != expected:
+                return SimpleNamespace(matched_count=0, modified_count=0)
+        for operator, fields in update.items():
+            if operator == "$set":
+                self.doc.update(fields)
+            elif operator == "$unset":
+                for field in fields:
+                    self.doc.pop(field, None)
+            else:
+                raise AssertionError(f"unsupported update {operator}")
+        return SimpleNamespace(matched_count=1, modified_count=1)
+
+
+def _make_storage(monkeypatch: pytest.MonkeyPatch, trace_doc: dict[str, Any]):
+    storage = object.__new__(TraceStorage)
+    collection = _FakeCollection(trace_doc)
+    monkeypatch.setattr(
+        trace_storage_module.TraceStorage, "collection", property(lambda self: collection)
+    )
+    storage._indexes_ensured = True
+    return storage, collection
+
+
+@pytest.mark.asyncio
+async def test_reopen_resets_error_trace_to_running(monkeypatch):
+    trace_doc = {
+        "trace_id": "trace-1",
+        "status": "error",
+        "completed_at": "2026-09-01T00:00:00",
+    }
+    storage, collection = _make_storage(monkeypatch, trace_doc)
+
+    reopened = await storage.reopen_interrupted_trace("trace-1")
+
+    assert reopened is True
+    assert collection.doc["status"] == "running"
+    assert "completed_at" not in collection.doc
+    assert "updated_at" in collection.doc
+
+
+@pytest.mark.asyncio
+async def test_reopen_never_touches_completed_trace(monkeypatch):
+    trace_doc = {
+        "trace_id": "trace-1",
+        "status": "completed",
+        "completed_at": "2026-09-01T00:00:00",
+    }
+    storage, collection = _make_storage(monkeypatch, trace_doc)
+
+    reopened = await storage.reopen_interrupted_trace("trace-1")
+
+    assert reopened is False
+    assert collection.doc["status"] == "completed"
+    assert "completed_at" in collection.doc
+
+
+@pytest.mark.asyncio
+async def test_reopen_running_trace_is_noop(monkeypatch):
+    trace_doc = {"trace_id": "trace-1", "status": "running"}
+    storage, collection = _make_storage(monkeypatch, trace_doc)
+
+    reopened = await storage.reopen_interrupted_trace("trace-1")
+
+    assert reopened is False
+    assert collection.doc["status"] == "running"

--- a/tests/infra/task/test_concurrency_queue.py
+++ b/tests/infra/task/test_concurrency_queue.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import time
 from typing import Any
 
 import pytest
@@ -143,6 +144,88 @@ class _RaceLockRedis:
         return 0
 
 
+class _AtomicEvalRedis:
+    """模拟队列 Lua 脚本在 Redis 服务端的语义（接线测试用；真实语义见集成测试）。"""
+
+    def __init__(self, entries: list[str]) -> None:
+        self.entries = list(entries)
+        self.eval_calls: list[tuple[str, int, str, tuple[str, ...]]] = []
+
+    async def eval(self, script: str, numkeys: int, key: str, *args: str):
+        self.eval_calls.append((script, numkeys, key, args))
+        if "removed_run_ids" in script:  # remove 脚本
+            field, value = args[0], args[1]
+            kept: list[str] = []
+            removed = 0
+            run_ids: list[str] = []
+            for entry in self.entries:
+                try:
+                    data = json.loads(entry)
+                except json.JSONDecodeError:
+                    kept.append(entry)
+                    continue
+                if data.get(field) == value:
+                    removed += 1
+                    run_ids.append(data.get("run_id"))
+                else:
+                    kept.append(entry)
+            self.entries = kept
+            if removed == 0:
+                return 0
+            return json.dumps({"removed": removed, "run_ids": run_ids})
+        if "queue_ready" in script:  # mark-ready 脚本
+            found = 0
+            for index, entry in enumerate(self.entries):
+                data = json.loads(entry)
+                if str(data.get("run_id", "")) == args[0]:
+                    context = dict(data.get("task_context") or {})
+                    context["queue_ready"] = True
+                    data["task_context"] = context
+                    self.entries[index] = json.dumps(data)
+                    found = 1
+            return found
+        # position 脚本
+        for index, entry in enumerate(self.entries):
+            data = json.loads(entry)
+            if str(data.get("run_id", "")) == args[0]:
+                return index + 1
+        return 0
+
+
+class _MarkReadyRedis(_AtomicEvalRedis):
+    """mark_queued_run_ready 还需要用户锁与空队列 dequeue 的最小支持。"""
+
+    def __init__(self, entries: list[str]) -> None:
+        super().__init__(entries)
+        self.token: str | None = None
+
+    async def set(self, key: str, token: str, **kwargs):
+        del key, kwargs
+        self.token = token
+        return True
+
+    async def get(self, key: str):
+        del key
+        return self.token
+
+    async def delete(self, key: str):
+        del key
+
+    async def llen(self, key: str) -> int:
+        del key
+        return len(self.entries)
+
+    async def lpop(self, key: str):
+        del key
+        if not self.entries:
+            return None
+        return self.entries.pop(0)
+
+    async def lpush(self, key: str, entry: str):
+        del key
+        self.entries.insert(0, entry)
+
+
 class _QueueRedis:
     def __init__(self) -> None:
         self.pushed: list[tuple[str, tuple[str, ...]]] = []
@@ -206,21 +289,25 @@ class _ResumeSlotLimiter(UserConcurrencyLimiter):
 
 
 @pytest.mark.asyncio
-async def test_get_queue_position_scans_queue_in_pages() -> None:
+async def test_get_queue_position_uses_atomic_lua() -> None:
     entries = [
         json.dumps({"run_id": f"run-{index}", "session_id": f"session-{index}"})
         for index in range(5)
     ]
-    redis = _PagedRedis(entries)
+    redis = _AtomicEvalRedis(entries)
     limiter = UserConcurrencyLimiter()
     limiter._redis = redis
 
     position = await limiter.get_queue_position("user-1", "run-3")
 
     assert position == 4
-    assert redis.lrange_calls == [
-        ("chat:queue:user-1", 0, 99),
-    ]
+    assert len(redis.eval_calls) == 1
+    script, numkeys, key, args = redis.eval_calls[0]
+    assert numkeys == 1
+    assert key == "chat:queue:user-1"
+    assert args == ("run-3",)
+
+    assert await limiter.get_queue_position("user-1", "run-missing") == 0
 
 
 @pytest.mark.asyncio
@@ -248,13 +335,15 @@ async def test_resume_slot_reacquire_is_idempotent_and_respects_capacity(
 
 
 @pytest.mark.asyncio
-async def test_remove_from_queue_scans_queue_in_pages(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_remove_from_queue_uses_atomic_lua_without_client_rewrite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     entries = [
         json.dumps({"run_id": "run-1", "session_id": "keep"}),
         json.dumps({"run_id": "run-2", "session_id": "remove"}),
         json.dumps({"run_id": "run-3", "session_id": "keep"}),
     ]
-    redis = _PagedRedis(entries)
+    redis = _AtomicEvalRedis(entries)
     limiter = UserConcurrencyLimiter()
     limiter._redis = redis
 
@@ -274,16 +363,15 @@ async def test_remove_from_queue_scans_queue_in_pages(monkeypatch: pytest.Monkey
     removed = await limiter.remove_from_queue("user-1", "remove")
 
     assert removed == 1
-    assert redis.lrange_calls == [("chat:queue:user-1", 0, 99)]
-    assert "chat:queue:user-1" not in redis.deleted
     assert len(redis.eval_calls) == 1
-    assert redis.eval_calls[0][2] == "chat:lock:user-1"
-    assert len(redis.pushed) == 1
-    tmp_key, kept_entries = redis.pushed[0]
-    assert kept_entries == (entries[0], entries[2])
-    assert redis.renamed == [(tmp_key, "chat:queue:user-1")]
-    assert redis.events == ["lock_acquired", "rpush", "rename", "lock_released"]
+    script, numkeys, key, args = redis.eval_calls[0]
+    assert numkeys == 1
+    assert key == "chat:queue:user-1"
+    assert args == ("session_id", "remove")
     assert fake_storage.updates[0][0] == "remove"
+    metadata = fake_storage.updates[0][1].metadata
+    assert metadata["task_status"] == "cancelled"
+    assert metadata["current_run_id"] == "run-2"
 
 
 @pytest.mark.asyncio
@@ -293,16 +381,15 @@ async def test_remove_queued_run_keeps_other_runs_for_same_session() -> None:
         json.dumps({"run_id": "run-remove", "session_id": "session-1"}),
         json.dumps({"run_id": "run-other", "session_id": "session-2"}),
     ]
-    redis = _PagedRedis(entries)
+    redis = _AtomicEvalRedis(entries)
     limiter = UserConcurrencyLimiter()
     limiter._redis = redis
 
     removed = await limiter.remove_queued_run("user-1", "run-remove")
 
     assert removed == 1
-    assert len(redis.pushed) == 1
-    _tmp_key, kept_entries = redis.pushed[0]
-    assert kept_entries == (entries[0], entries[2])
+    remaining_runs = [json.loads(entry)["run_id"] for entry in redis.entries]
+    assert remaining_runs == ["run-keep", "run-other"]
 
 
 @pytest.mark.asyncio
@@ -327,43 +414,48 @@ async def test_unready_queued_run_cannot_dispatch_before_user_message_persists()
 
 
 @pytest.mark.asyncio
-async def test_remove_from_queue_rewrites_kept_entries_in_chunks(
+async def test_mark_queued_run_ready_flips_flag_via_atomic_lua(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(concurrency, "QUEUE_REWRITE_CHUNK_SIZE", 2, raising=False)
-    entries = [json.dumps({"run_id": f"run-{index}", "session_id": "keep"}) for index in range(5)]
-    entries.insert(2, json.dumps({"run_id": "run-remove", "session_id": "remove"}))
-    redis = _PagedRedis(entries)
+    entries = [
+        json.dumps(
+            {
+                "run_id": "run-1",
+                "session_id": "session-1",
+                "queued_at": time.time(),
+                "task_context": {"queue_ready": False},
+            }
+        ),
+        json.dumps(
+            {
+                "run_id": "run-2",
+                "session_id": "session-1",
+                "queued_at": time.time(),
+                "task_context": {"queue_ready": False},
+            }
+        ),
+    ]
+    redis = _MarkReadyRedis(entries)
     limiter = UserConcurrencyLimiter()
     limiter._redis = redis
 
-    class _FakeSessionStorage:
-        async def update(self, session_id, update):
-            del session_id, update
+    async def _no_dispatch(*_args, **_kwargs):
+        return None
 
-    monkeypatch.setattr(
-        "src.infra.session.storage.SessionStorage",
-        lambda: _FakeSessionStorage(),
-    )
+    monkeypatch.setattr(limiter, "_dispatch_queued_task", _no_dispatch)
+    monkeypatch.setattr(limiter, "get_user_limits_from_cache", lambda _uid: (None, 10))
 
-    removed = await limiter.remove_from_queue("user-1", "remove")
+    marked = await limiter.mark_queued_run_ready("user-1", "run-2")
 
-    assert removed == 1
-    assert len(redis.eval_calls) == 1
-    assert redis.eval_calls[0][2] == "chat:lock:user-1"
-    assert [len(batch) for _, batch in redis.pushed] == [2, 2, 1]
-    tmp_keys = {key for key, _ in redis.pushed}
-    assert len(tmp_keys) == 1
-    tmp_key = next(iter(tmp_keys))
-    assert redis.renamed == [(tmp_key, "chat:queue:user-1")]
-    assert redis.events == [
-        "lock_acquired",
-        "rpush",
-        "rpush",
-        "rpush",
-        "rename",
-        "lock_released",
-    ]
+    assert marked is True
+    eval_targets = [(key, args) for _, _, key, args in redis.eval_calls]
+    assert ("chat:queue:user-1", ("run-2",)) in eval_targets
+    entries_after = [json.loads(entry) for entry in redis.entries]
+    assert entries_after[0]["task_context"]["queue_ready"] is False
+    assert entries_after[1]["task_context"]["queue_ready"] is True
+
+    # 目标不在队列时幂等返回 False
+    assert await limiter.mark_queued_run_ready("user-1", "run-missing") is False
 
 
 @pytest.mark.asyncio

--- a/tests/infra/task/test_concurrency_queue_lua_integration.py
+++ b/tests/infra/task/test_concurrency_queue_lua_integration.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+"""队列 Lua 脚本对真实 Redis 的语义验证（本地 / CI services.redis 真跑）。
+
+接线测试（test_concurrency_queue.py）只验证 Python 侧传参；这里把三个脚本
+（remove / mark-ready / position）发到真实 Redis 执行，验证 cjson 解析、
+顺序保持、损坏条目容错与返回值编码这些 Lua 侧语义。Redis 不可达时自动跳过。
+"""
+
+import json
+import uuid
+
+import pytest
+
+from src.infra.task.concurrency import (
+    _QUEUE_MARK_READY_LUA,
+    _QUEUE_POSITION_LUA,
+    _QUEUE_REMOVE_LUA,
+    UserConcurrencyLimiter,
+)
+from src.kernel.config import settings
+
+
+@pytest.fixture
+async def real_redis():
+    import redis.asyncio as aioredis
+
+    client = aioredis.from_url(settings.REDIS_URL, decode_responses=True)
+    try:
+        await client.ping()
+    except Exception:  # pragma: no cover - 环境无 Redis 时跳过
+        pytest.skip("Redis 不可达，跳过队列 Lua 集成测试")
+    yield client
+    await client.aclose()
+
+
+def _queue_key() -> str:
+    return f"chat:queue:lua-test:{uuid.uuid4().hex}"
+
+
+def _entry(run_id: str, session_id: str, **extra) -> str:
+    return json.dumps({"run_id": run_id, "session_id": session_id, **extra})
+
+
+async def test_remove_script_removes_matches_and_keeps_order(real_redis) -> None:
+    key = _queue_key()
+    entries = [
+        _entry("run-1", "keep"),
+        _entry("run-2", "remove"),
+        "not-json-corrupt-entry",
+        _entry("run-3", "keep"),
+    ]
+    await real_redis.rpush(key, *entries)
+    try:
+        result = await real_redis.eval(_QUEUE_REMOVE_LUA, 1, key, "session_id", "remove")
+
+        payload = json.loads(result)
+        assert payload["removed"] == 1
+        assert payload["run_ids"] == ["run-2"]
+        # 损坏条目（非 JSON）被保留，顺序不变
+        remaining = await real_redis.lrange(key, 0, -1)
+        assert remaining == [entries[0], entries[2], entries[3]]
+
+        # 无匹配时返回整数 0，队列不动
+        assert await real_redis.eval(_QUEUE_REMOVE_LUA, 1, key, "session_id", "absent") == 0
+    finally:
+        await real_redis.delete(key)
+
+
+async def test_remove_script_deletes_queue_when_everything_matches(real_redis) -> None:
+    key = _queue_key()
+    await real_redis.rpush(key, _entry("run-1", "same"), _entry("run-2", "same"))
+    try:
+        result = await real_redis.eval(_QUEUE_REMOVE_LUA, 1, key, "session_id", "same")
+        payload = json.loads(result)
+        assert payload["removed"] == 2
+        assert await real_redis.exists(key) == 0
+    finally:
+        await real_redis.delete(key)
+
+
+async def test_mark_ready_script_flips_nested_task_context(real_redis) -> None:
+    key = _queue_key()
+    await real_redis.rpush(
+        key,
+        _entry("run-1", "session-1", task_context={"persisted": True}),
+        _entry("run-2", "session-1"),
+    )
+    try:
+        assert await real_redis.eval(_QUEUE_MARK_READY_LUA, 1, key, "run-2") == 1
+
+        first, second = await real_redis.lrange(key, 0, -1)
+        assert json.loads(first)["task_context"] == {"persisted": True}
+        assert json.loads(second)["task_context"]["queue_ready"] is True
+
+        # 不存在的 run 幂等返回 0
+        assert await real_redis.eval(_QUEUE_MARK_READY_LUA, 1, key, "run-missing") == 0
+    finally:
+        await real_redis.delete(key)
+
+
+async def test_position_script_returns_one_based_index(real_redis) -> None:
+    key = _queue_key()
+    await real_redis.rpush(
+        key,
+        _entry("run-1", "session-1"),
+        _entry("run-2", "session-1"),
+    )
+    try:
+        assert await real_redis.eval(_QUEUE_POSITION_LUA, 1, key, "run-1") == 1
+        assert await real_redis.eval(_QUEUE_POSITION_LUA, 1, key, "run-2") == 2
+        assert await real_redis.eval(_QUEUE_POSITION_LUA, 1, key, "run-missing") == 0
+    finally:
+        await real_redis.delete(key)
+
+
+async def test_limiter_methods_against_real_redis(real_redis) -> None:
+    """limiter 方法端到端（eval + 返回值解码）跑在真实 Redis 上。"""
+    limiter = UserConcurrencyLimiter()
+    limiter._redis = real_redis
+    user_id = f"lua-test-{uuid.uuid4().hex}"
+    key = limiter._queue_key(user_id)
+    await real_redis.rpush(
+        key,
+        _entry("run-a", "session-x"),
+        _entry("run-b", "session-y"),
+    )
+    try:
+        assert await limiter.get_queue_position(user_id, "run-b") == 2
+        assert await limiter.remove_queued_run(user_id, "run-a") == 1
+        assert await limiter.get_queue_position(user_id, "run-b") == 1
+    finally:
+        await real_redis.delete(key)

--- a/tests/infra/task/test_executor_interrupted_resume.py
+++ b/tests/infra/task/test_executor_interrupted_resume.py
@@ -127,9 +127,7 @@ async def _agent_stream_raising(exc: BaseException):
 @pytest.mark.asyncio
 async def test_shutdown_cancel_writes_no_terminal_events(monkeypatch: pytest.MonkeyPatch) -> None:
     """无 interrupt 标志的取消（系统关停）：不写终态事件、不终结 trace、不过期 stream。"""
-    executor, writer, holder, status_updates = _executor_fixture(
-        monkeypatch, interrupt_flag=False
-    )
+    executor, writer, holder, status_updates = _executor_fixture(monkeypatch, interrupt_flag=False)
 
     with pytest.raises(asyncio.CancelledError):
         await executor.run_task(
@@ -194,13 +192,9 @@ async def test_interrupted_resume_emits_run_resumed_first(monkeypatch: pytest.Mo
 
     presenter = holder["presenter"]
     first_agent_event_index = next(
-        i
-        for i, event in enumerate(presenter.saved_events)
-        if event["event"] == "message:chunk"
+        i for i, event in enumerate(presenter.saved_events) if event["event"] == "message:chunk"
     )
-    resumed_events = [
-        event for event in presenter.saved_events if event["event"] == "run:resumed"
-    ]
+    resumed_events = [event for event in presenter.saved_events if event["event"] == "run:resumed"]
     assert len(resumed_events) == 1
     assert presenter.saved_events.index(resumed_events[0]) < first_agent_event_index
     assert resumed_events[0]["data"]["run_id"] == "run-1"

--- a/tests/infra/task/test_executor_interrupted_resume.py
+++ b/tests/infra/task/test_executor_interrupted_resume.py
@@ -1,0 +1,232 @@
+"""系统中断（非用户取消）时 executor 不得写终态事件；恢复 run 先发 run:resumed。
+
+优雅关停 / 部署把后台任务 cancel 掉时，取消路径历史上与用户取消完全同型：
+写 user:cancel + error + done 事件、终结 trace 为 error、把 Redis Stream TTL 缩到
+60s。这会让「同 run_id 无感续跑」不可能：SSE 重放一碰到终态事件就断开，前端也会
+把气泡渲染成"你已终止本次回答"。系统中断必须改为只 flush 缓冲、留下可恢复的
+running trace，由 manager.shutdown / arq_worker 负责标记 recoverable 元数据。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from src.infra.task import cancellation
+from src.infra.task.executor import TaskExecutor
+
+
+class _FakeHeartbeat:
+    async def start(self, run_id: str, *, user_id: str | None = None) -> None:
+        return None
+
+    async def stop(self, run_id: str) -> None:
+        return None
+
+
+class _FakePresenter:
+    def __init__(self, config) -> None:
+        self.trace_id = config.trace_id or "trace-1"
+        self.run_id = config.run_id
+        self._trace_created = False
+        self.saved_events: list[dict] = []
+        self.completions: list[str] = []
+
+    async def _ensure_trace(self) -> None:
+        self._trace_created = True
+
+    async def emit_user_message(self, message: str, **_kwargs) -> None:
+        self.saved_events.append({"event": "user:message", "data": {"content": message}})
+
+    async def save_event(self, event: dict) -> None:
+        self.saved_events.append(event)
+
+    async def emit(self, event: dict) -> dict:
+        self.saved_events.append(event)
+        return event
+
+    async def complete(self, status: str) -> None:
+        self.completions.append(status)
+
+    async def _ensure_token_usage_event(self) -> None:
+        return None
+
+    def done(self) -> dict:
+        return {"event": "done", "data": {}}
+
+
+class _RecordingWriter:
+    def __init__(self) -> None:
+        self.written: list[dict] = []
+        self.expired: list[dict] = []
+
+    async def _flush_redis_buffer(self, **_kwargs) -> None:
+        return None
+
+    async def flush_mongo_buffer(self, **_kwargs) -> None:
+        return None
+
+    async def write_event(self, **kwargs) -> None:
+        self.written.append(kwargs)
+
+    async def expire_stream(self, **kwargs) -> None:
+        self.expired.append(kwargs)
+
+
+def _executor_fixture(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    interrupt_flag: bool,
+) -> tuple[TaskExecutor, _RecordingWriter, _FakePresenter, list[str]]:
+    monkeypatch.setattr("src.infra.writer.present.Presenter", _FakePresenter)
+    writer = _RecordingWriter()
+    monkeypatch.setattr("src.infra.task.executor.get_dual_writer", lambda: writer)
+
+    async def _no_op(*_args, **_kwargs) -> None:
+        return None
+
+    monkeypatch.setattr(cancellation.TaskCancellation, "clear_interrupt", _no_op)
+    monkeypatch.setattr(
+        cancellation.TaskCancellation, "check_interrupt_fast", lambda run_id: interrupt_flag
+    )
+
+    status_updates: list[str] = []
+
+    async def _record_status(session_id, status, error=None, run_id=None):
+        status_updates.append(status.value if hasattr(status, "value") else str(status))
+
+    executor = TaskExecutor(
+        storage=SimpleNamespace(),  # type: ignore[arg-type]
+        run_info={},
+        heartbeat_manager=_FakeHeartbeat(),
+    )
+    monkeypatch.setattr(executor, "_update_session_status", _record_status)
+    monkeypatch.setattr(executor, "_send_task_notification", _no_op)
+    presenter_holder: dict[str, _FakePresenter] = {}
+
+    original_init = _FakePresenter.__init__
+
+    def _spy_init(self, config):
+        original_init(self, config)
+        presenter_holder["presenter"] = self
+
+    monkeypatch.setattr(_FakePresenter, "__init__", _spy_init)
+    return executor, writer, presenter_holder, status_updates  # type: ignore[return-value]
+
+
+async def _agent_stream_raising(exc: BaseException):
+    async def _stream(*_args, **_kwargs):
+        yield {"event": "thinking", "data": {"content": "部分输出"}}
+        raise exc
+
+    return _stream
+
+
+@pytest.mark.asyncio
+async def test_shutdown_cancel_writes_no_terminal_events(monkeypatch: pytest.MonkeyPatch) -> None:
+    """无 interrupt 标志的取消（系统关停）：不写终态事件、不终结 trace、不过期 stream。"""
+    executor, writer, holder, status_updates = _executor_fixture(
+        monkeypatch, interrupt_flag=False
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await executor.run_task(
+            session_id="session-1",
+            run_id="run-1",
+            agent_id="search",
+            message="hello",
+            user_id="user-1",
+            executor=await _agent_stream_raising(asyncio.CancelledError()),
+            user_message_written=True,
+        )
+
+    presenter = holder["presenter"]
+    assert presenter.completions == []  # trace 保持 running
+    assert writer.written == []  # 没有 user:cancel / error / done 终态事件
+    assert writer.expired == []  # stream TTL 不缩短，供恢复后重放
+    # 系统中断不更新任务状态；recoverable 元数据由调用方（shutdown/arq_worker）标记
+    assert "cancelled" not in status_updates
+
+
+@pytest.mark.asyncio
+async def test_user_cancel_still_writes_terminal_events(monkeypatch: pytest.MonkeyPatch) -> None:
+    """用户取消（interrupt 标志在）保持旧行为：写终态事件并把 trace 终结为 error。"""
+    executor, writer, holder, _ = _executor_fixture(monkeypatch, interrupt_flag=True)
+
+    with pytest.raises(asyncio.CancelledError):
+        await executor.run_task(
+            session_id="session-1",
+            run_id="run-1",
+            agent_id="search",
+            message="hello",
+            user_id="user-1",
+            executor=await _agent_stream_raising(asyncio.CancelledError()),
+            user_message_written=True,
+        )
+
+    presenter = holder["presenter"]
+    assert presenter.completions == ["error"]
+    written_types = [event["event_type"] for event in writer.written]
+    assert "user:cancel" in written_types
+    assert "error" in written_types
+
+
+@pytest.mark.asyncio
+async def test_interrupted_resume_emits_run_resumed_first(monkeypatch: pytest.MonkeyPatch) -> None:
+    """interrupted_resume=True 的恢复 run 在 agent 输出前先落 run:resumed 标记事件。"""
+    executor, writer, holder, _ = _executor_fixture(monkeypatch, interrupt_flag=False)
+
+    async def _agent_stream(*_args, **_kwargs):
+        yield {"event": "message:chunk", "data": {"content": "重新生成"}}
+
+    await executor.run_task(
+        session_id="session-1",
+        run_id="run-1",
+        agent_id="search",
+        message="（隐藏恢复指令）",
+        user_id="user-1",
+        executor=_agent_stream,
+        user_message_written=True,
+        interrupted_resume=True,
+    )
+
+    presenter = holder["presenter"]
+    first_agent_event_index = next(
+        i
+        for i, event in enumerate(presenter.saved_events)
+        if event["event"] == "message:chunk"
+    )
+    resumed_events = [
+        event for event in presenter.saved_events if event["event"] == "run:resumed"
+    ]
+    assert len(resumed_events) == 1
+    assert presenter.saved_events.index(resumed_events[0]) < first_agent_event_index
+    assert resumed_events[0]["data"]["run_id"] == "run-1"
+    # 恢复 run 不写新的 user:message（用户消息早已落库）
+    assert not any(event["event"] == "user:message" for event in presenter.saved_events)
+
+
+@pytest.mark.asyncio
+async def test_normal_run_without_interrupted_resume_has_no_marker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """普通 run 不发 run:resumed。"""
+    executor, _, holder, _ = _executor_fixture(monkeypatch, interrupt_flag=False)
+
+    async def _agent_stream(*_args, **_kwargs):
+        yield {"event": "message:chunk", "data": {"content": "hi"}}
+
+    await executor.run_task(
+        session_id="session-1",
+        run_id="run-1",
+        agent_id="search",
+        message="hello",
+        user_id="user-1",
+        executor=_agent_stream,
+        user_message_written=True,
+    )
+
+    presenter = holder["presenter"]
+    assert not any(event["event"] == "run:resumed" for event in presenter.saved_events)

--- a/tests/infra/task/test_heartbeat.py
+++ b/tests/infra/task/test_heartbeat.py
@@ -143,3 +143,37 @@ async def test_heartbeat_stop_all_limits_parallel_redis_cleanup(
         "task:heartbeat:run-3",
         "task:heartbeat:run-4",
     ]
+
+
+@pytest.mark.asyncio
+async def test_is_stale_threshold_honors_settings_override(monkeypatch):
+    """TASK_HEARTBEAT_STALE_SECONDS 生效：20s 阈值下 21s 旧心跳判死、19s 判活。"""
+    from datetime import datetime, timedelta, timezone
+
+    from src.infra.task import heartbeat as heartbeat_module
+    from src.infra.task.heartbeat import TaskHeartbeat
+
+    class _ClientProvider:
+        def __init__(self):
+            self.age = 21.0
+
+        def __call__(self):
+            value = (
+                datetime.now(timezone.utc) - timedelta(seconds=self.age)
+            ).isoformat()
+
+            class _Client:
+                async def get(self, key):
+                    return value
+
+            return _Client()
+
+    provider = _ClientProvider()
+    monkeypatch.setattr(heartbeat_module, "get_redis_client", provider)
+    monkeypatch.setattr("src.kernel.config.settings.TASK_HEARTBEAT_STALE_SECONDS", 20)
+
+    heartbeat = TaskHeartbeat()
+    provider.age = 21.0
+    assert await heartbeat.is_stale("run-1") is True
+    provider.age = 19.0
+    assert await heartbeat.is_stale("run-1") is False

--- a/tests/infra/task/test_heartbeat.py
+++ b/tests/infra/task/test_heartbeat.py
@@ -158,9 +158,7 @@ async def test_is_stale_threshold_honors_settings_override(monkeypatch):
             self.age = 21.0
 
         def __call__(self):
-            value = (
-                datetime.now(timezone.utc) - timedelta(seconds=self.age)
-            ).isoformat()
+            value = (datetime.now(timezone.utc) - timedelta(seconds=self.age)).isoformat()
 
             class _Client:
                 async def get(self, key):

--- a/tests/infra/task/test_manager_recovery.py
+++ b/tests/infra/task/test_manager_recovery.py
@@ -260,7 +260,9 @@ async def test_resume_session_submits_localized_recovery_message(
     monkeypatch.setattr(
         recovery_module,
         "get_trace_storage",
-        lambda: SimpleNamespace(collection=SimpleNamespace(find=lambda q, p=None: _EmptyTraceCursor())),
+        lambda: SimpleNamespace(
+            collection=SimpleNamespace(find=lambda q, p=None: _EmptyTraceCursor())
+        ),
     )
     monkeypatch.setattr("src.kernel.config.settings.TASK_BACKEND", "local")
     monkeypatch.setattr(manager, "submit", _fake_submit)
@@ -1044,5 +1046,3 @@ async def test_shutdown_awaits_cancelled_tasks_to_finish_cleanup(
     await shutdown_task
     assert task.done()
     assert cleanup_finished is True
-
-

--- a/tests/infra/task/test_manager_recovery.py
+++ b/tests/infra/task/test_manager_recovery.py
@@ -220,13 +220,12 @@ async def test_resume_session_submits_localized_recovery_message(
     redis = _FakeRedis(acquired=True)
     submit_calls = []
 
-    async def _fake_submit(**kwargs):
-        submit_calls.append(kwargs)
+    async def _fake_submit(*args, **kwargs):
+        submit_calls.append({"args": args, **kwargs})
         return kwargs["run_id"], ""
 
     async def _fake_mark_failed(run_id: str, reason: str, loaded_session) -> None:
-        assert run_id == "run-old"
-        assert loaded_session.id == "session-1"
+        raise AssertionError("seamless resume must not mark the run failed")
 
     class _FakeUserStorage:
         async def get_by_id(self, user_id: str):
@@ -237,9 +236,32 @@ async def test_resume_session_submits_localized_recovery_message(
         if False:
             yield None
 
+    class _FakeLimiter:
+        async def try_acquire_run_slot(self, user_id: str, run_id: str) -> bool:
+            return True
+
+        async def release(self, *args, **kwargs):
+            return None
+
+    class _EmptyTraceCursor:
+        def sort(self, key, direction=None):
+            return self
+
+        def limit(self, limit):
+            return self
+
+        async def to_list(self, length=None):
+            return []
+
     monkeypatch.setattr(recovery_module, "get_redis_client", lambda: redis)
     monkeypatch.setattr(recovery_module, "UserStorage", _FakeUserStorage)
     monkeypatch.setattr(recovery_module, "get_registered_executor", lambda key: _fake_executor)
+    monkeypatch.setattr(recovery_module, "get_concurrency_limiter", lambda: _FakeLimiter())
+    monkeypatch.setattr(
+        recovery_module,
+        "get_trace_storage",
+        lambda: SimpleNamespace(collection=SimpleNamespace(find=lambda q, p=None: _EmptyTraceCursor())),
+    )
     monkeypatch.setattr("src.kernel.config.settings.TASK_BACKEND", "local")
     monkeypatch.setattr(manager, "submit", _fake_submit)
     monkeypatch.setattr(manager, "_mark_run_failed", _fake_mark_failed)
@@ -247,15 +269,22 @@ async def test_resume_session_submits_localized_recovery_message(
     result = await manager.resume_session("session-1")
 
     assert result["success"] is True
+    assert result["run_id"] == "run-old"
     assert result["resumed_from_run_id"] == "run-old"
     assert len(submit_calls) == 1
-    assert submit_calls[0]["session_id"] == "session-1"
-    assert submit_calls[0]["project_id"] == "project-1"
-    assert submit_calls[0]["disabled_tools"] == ["bash"]
-    assert submit_calls[0]["auto_mode"] is True
-    assert submit_calls[0]["message"] == "请继续处理当前会话中未完成的内容。"
+    call = submit_calls[0]
+    assert call["args"][0] == "session-1"
+    assert call["args"][2] == "请继续处理当前会话中未完成的内容。"
+    assert call["project_id"] == "project-1"
+    assert call["disabled_tools"] == ["bash"]
+    assert call["auto_mode"] is True
+    # 无缝续跑契约：复用原 run_id、不写新用户消息事件、带 resume 标记
+    assert call["run_id"] == "run-old"
+    assert call["user_message_written"] is True
+    assert call["interrupted_resume"] is True
     assert redis.set_calls
     assert storage.updates[-1][0] == "session-1"
+    assert storage.updates[-1][1].metadata["resume_attempts"] == 1
 
 
 @pytest.mark.asyncio
@@ -287,17 +316,12 @@ async def test_resume_session_uses_arq_submission_when_task_backend_is_arq(
     local_submit_calls = []
     arq_submit_calls = []
 
-    async def _fake_submit(**kwargs):
-        local_submit_calls.append(kwargs)
-        return kwargs["run_id"], ""
-
     async def _fake_submit_arq(**kwargs):
         arq_submit_calls.append(kwargs)
         return kwargs["run_id"], kwargs.get("trace_id") or ""
 
     async def _fake_mark_failed(run_id: str, reason: str, loaded_session) -> None:
-        assert run_id == "run-old"
-        assert loaded_session.id == "session-1"
+        raise AssertionError("seamless resume must not mark the run failed")
 
     class _FakeUserStorage:
         async def get_by_id(self, user_id: str):
@@ -308,36 +332,56 @@ async def test_resume_session_uses_arq_submission_when_task_backend_is_arq(
         if False:
             yield None
 
-    class _FakeLimiter:
-        async def claim_recovery_slot(self, **kwargs):
-            return SimpleNamespace(result=recovery_module.ConcurrencyResult.STARTED)
+    class _TraceCursor:
+        def sort(self, key, direction=None):
+            return self
 
-        async def release(self, *args, **kwargs):
-            return None
+        def limit(self, limit):
+            return self
+
+        async def to_list(self, length=None):
+            return [{"trace_id": "trace-old"}]
+
+    class _FakeTraceStorage:
+        reopened: list[str] = []
+
+        collection = SimpleNamespace(find=lambda q, p=None: _TraceCursor())
+
+        async def reopen_interrupted_trace(self, trace_id: str) -> bool:
+            self.reopened.append(trace_id)
+            return True
+
+    trace_storage = _FakeTraceStorage()
 
     monkeypatch.setattr(recovery_module, "get_redis_client", lambda: redis)
     monkeypatch.setattr(recovery_module, "UserStorage", _FakeUserStorage)
     monkeypatch.setattr(recovery_module, "get_registered_executor", lambda key: _fake_executor)
-    monkeypatch.setattr(recovery_module, "get_concurrency_limiter", lambda: _FakeLimiter())
+    monkeypatch.setattr(recovery_module, "get_trace_storage", lambda: trace_storage)
     monkeypatch.setattr("src.kernel.config.settings.TASK_BACKEND", "arq")
-    monkeypatch.setattr(manager, "submit", _fake_submit)
     monkeypatch.setattr(manager, "submit_arq", _fake_submit_arq)
     monkeypatch.setattr(manager, "_mark_run_failed", _fake_mark_failed)
 
     result = await manager.resume_session("session-1")
 
     assert result["success"] is True
+    assert result["run_id"] == "run-old"
     assert local_submit_calls == []
     assert len(arq_submit_calls) == 1
-    assert arq_submit_calls[0]["executor_key"] == "agent_stream"
-    assert arq_submit_calls[0]["trace_id"]
-    assert arq_submit_calls[0]["auto_mode"] is True
-    assert arq_submit_calls[0].get("user_message_written") is not True
-    assert arq_submit_calls[0]["message"] == "请继续处理当前会话中未完成的内容。"
+    call = arq_submit_calls[0]
+    assert call["executor_key"] == "agent_stream"
+    assert call["run_id"] == "run-old"
+    assert call["trace_id"] == "trace-old"
+    assert call["auto_mode"] is True
+    assert call["user_message_written"] is True
+    assert call["interrupted_resume"] is True
+    assert call["initial_status"].value == "pending"
+    assert call["dispatch_id"].startswith("resume:run-old:")
+    assert call["message"] == "请继续处理当前会话中未完成的内容。"
+    assert trace_storage.reopened == ["trace-old"]
 
 
 @pytest.mark.asyncio
-async def test_submit_recovery_run_falls_back_from_legacy_default_agent(
+async def test_seamless_resume_falls_back_from_legacy_default_agent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from src.agents.core import base as base_module
@@ -363,8 +407,8 @@ async def test_submit_recovery_run_falls_back_from_legacy_default_agent(
 
     submit_calls = []
 
-    async def _fake_submit(**kwargs):
-        submit_calls.append(kwargs)
+    async def _fake_submit(*args, **kwargs):
+        submit_calls.append({"args": args, **kwargs})
         return kwargs["run_id"], kwargs.get("trace_id") or ""
 
     async def _fake_executor(*args, **kwargs):
@@ -372,8 +416,8 @@ async def test_submit_recovery_run_falls_back_from_legacy_default_agent(
             yield None
 
     class _FakeLimiter:
-        async def claim_recovery_slot(self, **kwargs):
-            return SimpleNamespace(result=recovery_module.ConcurrencyResult.STARTED)
+        async def try_acquire_run_slot(self, user_id: str, run_id: str) -> bool:
+            return True
 
         async def release(self, *args, **kwargs):
             return None
@@ -388,13 +432,44 @@ async def test_submit_recovery_run_falls_back_from_legacy_default_agent(
     monkeypatch.setattr(recovery_module, "UserStorage", _FakeUserStorage)
     monkeypatch.setattr(recovery_module, "get_registered_executor", lambda key: _fake_executor)
     monkeypatch.setattr(recovery_module, "get_concurrency_limiter", lambda: _FakeLimiter())
-    monkeypatch.setattr(manager, "_submit_recovery_task", _fake_submit)
+    monkeypatch.setattr(
+        recovery_module,
+        "get_trace_storage",
+        lambda: SimpleNamespace(
+            collection=SimpleNamespace(find=lambda q, p=None: _EmptyTraceCursorStub())
+        ),
+    )
+    monkeypatch.setattr("src.kernel.config.settings.TASK_BACKEND", "local")
 
-    result = await manager._submit_recovery_run(session, "run-old", "server_restart")
+    service = recovery_module.TaskRecoveryService(
+        storage=storage,
+        run_info=manager._run_info,
+        heartbeat=SimpleNamespace(check_exists=lambda run_id: False),
+        ensure_executor=lambda: SimpleNamespace(),
+        submit_task=_fake_submit,
+        mark_run_failed=_stub_noop,
+    )
+    monkeypatch.setattr(recovery_module, "get_redis_client", lambda: _FakeRedis(acquired=True))
+
+    result = await service.resume_interrupted_run(session, "run-old", "server_restart")
 
     assert result["success"] is True
-    assert submit_calls[0]["agent_id"] == "search"
-    assert storage.updates[-1][1].metadata["agent_id"] == "search"
+    assert submit_calls[0]["args"][1] == "search"
+
+
+class _EmptyTraceCursorStub:
+    def sort(self, key, direction=None):
+        return self
+
+    def limit(self, limit):
+        return self
+
+    async def to_list(self, length=None):
+        return []
+
+
+async def _stub_noop(*_args, **_kwargs):
+    return None
 
 
 @pytest.mark.asyncio
@@ -585,15 +660,15 @@ async def test_resume_interrupted_run_releases_lock_after_failed_recovery(
     async def _fake_mark_failed(run_id: str, reason: str, loaded_session) -> None:
         return None
 
-    async def _fake_submit_recovery_run(self, *args, **kwargs):
+    async def _fake_submit_seamless_resume(self, *args, **kwargs):
         raise RuntimeError("submit failed")
 
     monkeypatch.setattr(recovery_module, "get_redis_client", lambda: redis)
     monkeypatch.setattr(manager, "_mark_run_failed", _fake_mark_failed)
     monkeypatch.setattr(
         recovery_module.TaskRecoveryService,
-        "submit_recovery_run",
-        _fake_submit_recovery_run,
+        "submit_seamless_resume",
+        _fake_submit_seamless_resume,
     )
 
     result = await manager._resume_interrupted_run(session, "run-old", "manual_resume")
@@ -622,17 +697,17 @@ async def test_resume_interrupted_run_releases_lock_when_cancelled(
     manager._storage = _FakeStorage(session)
 
     redis = _FakeRedis(acquired=True)
-    mark_failed_started = asyncio.Event()
+    lookup_started = asyncio.Event()
 
-    async def _blocking_mark_failed(run_id: str, reason: str, loaded_session) -> None:
-        mark_failed_started.set()
+    async def _blocking_lookup(run_id: str):
+        lookup_started.set()
         await asyncio.Event().wait()
 
     monkeypatch.setattr(recovery_module, "get_redis_client", lambda: redis)
-    monkeypatch.setattr(manager, "_mark_run_failed", _blocking_mark_failed)
+    monkeypatch.setattr(recovery_module, "_lookup_trace_id_for_run", _blocking_lookup)
 
     task = asyncio.create_task(manager._resume_interrupted_run(session, "run-old", "manual_resume"))
-    await asyncio.wait_for(mark_failed_started.wait(), timeout=1)
+    await asyncio.wait_for(lookup_started.wait(), timeout=1)
 
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
@@ -666,13 +741,17 @@ async def test_resume_interrupted_run_skips_when_recovery_lock_is_held(
     async def _fake_mark_failed(*args, **kwargs):
         mark_failed_calls.append((args, kwargs))
 
-    async def _fake_submit_recovery_run(*args, **kwargs):
+    async def _fake_submit_seamless_resume(*args, **kwargs):
         submit_calls.append((args, kwargs))
         return {"success": True}
 
     monkeypatch.setattr(recovery_module, "get_redis_client", lambda: redis)
     monkeypatch.setattr(manager, "_mark_run_failed", _fake_mark_failed)
-    monkeypatch.setattr(manager, "_submit_recovery_run", _fake_submit_recovery_run)
+    monkeypatch.setattr(
+        recovery_module.TaskRecoveryService,
+        "submit_seamless_resume",
+        _fake_submit_seamless_resume,
+    )
 
     result = await manager._resume_interrupted_run(session, "run-old", "server_restart")
 
@@ -705,27 +784,22 @@ async def test_resume_interrupted_run_restores_recoverable_failure_when_submissi
     async def _fake_mark_failed(run_id: str, reason: str, loaded_session) -> None:
         recoverable_failures.append((run_id, reason, loaded_session.id))
 
-    async def _fake_submit_recovery_run(*args, **kwargs):
-        return {"success": False, "message": "恢复任务失败：当前恢复队列已满"}
-
-    class _FakeLimiter:
-        async def claim_recovery_slot(self, **kwargs):
-            return recovery_module.ConcurrencyResponse(
-                result=recovery_module.ConcurrencyResult.REJECTED_QUEUE
-            )
+    async def _fake_submit_seamless_resume(*args, **kwargs):
+        return {"success": False, "message": "当前并发任务已满，稍后将自动重试恢复"}
 
     monkeypatch.setattr(recovery_module, "get_redis_client", lambda: redis)
-    monkeypatch.setattr(recovery_module, "get_registered_executor", lambda _key: object())
-    monkeypatch.setattr(recovery_module, "get_concurrency_limiter", lambda: _FakeLimiter())
     monkeypatch.setattr(manager, "_mark_run_failed", _fake_mark_failed)
-    monkeypatch.setattr(manager, "_submit_recovery_run", _fake_submit_recovery_run)
+    monkeypatch.setattr(
+        recovery_module.TaskRecoveryService,
+        "submit_seamless_resume",
+        _fake_submit_seamless_resume,
+    )
 
     result = await manager._resume_interrupted_run(session, "run-old", "server_restart")
 
     assert result["success"] is False
-    assert recoverable_failures == [
-        ("run-old", "Task interrupted (instance unavailable)", "session-1")
-    ]
+    # 无缝恢复失败不 mark_run_failed（trace 保持可续跑），只恢复 recoverable 元数据
+    assert recoverable_failures == []
     assert storage.updates[-1][0] == "session-1"
     assert storage.updates[-1][1].metadata["task_status"] == "failed"
     assert storage.updates[-1][1].metadata["task_recoverable"] is True
@@ -966,91 +1040,3 @@ async def test_shutdown_awaits_cancelled_tasks_to_finish_cleanup(
     assert cleanup_finished is True
 
 
-@pytest.mark.asyncio
-async def test_submit_recovery_run_reuses_trace_for_queued_recovery(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    session = SimpleNamespace(
-        id="session-1",
-        user_id="user-1",
-        agent_id="search",
-        name="Queued Recovery Session",
-        metadata={
-            "current_run_id": "run-old",
-            "task_status": "failed",
-            "agent_id": "search",
-            "executor_key": "agent_stream",
-            "agent_options": {"model": "gpt-test"},
-            "disabled_tools": ["bash"],
-            "disabled_skills": ["demo-skill"],
-            "disabled_mcp_tools": ["mcp.tool"],
-            "project_id": "project-1",
-            "team_id": "team-1",
-        },
-    )
-    storage = _FakeStorage(session)
-    manager = BackgroundTaskManager()
-    manager._storage = storage
-
-    captured_task_context = {}
-
-    class _FakeLimiter:
-        async def claim_recovery_slot(
-            self,
-            *,
-            user_id: str,
-            roles: list[str],
-            old_run_id: str,
-            new_run_id: str,
-            session_id: str,
-            task_context,
-        ):
-            captured_task_context.update(task_context)
-            return SimpleNamespace(result=recovery_module.ConcurrencyResult.QUEUED)
-
-    class _FakeExecutor:
-        async def ensure_session(self, *args, **kwargs):
-            return None
-
-        async def _update_session_status(self, *args, **kwargs):
-            return None
-
-    presenter_calls = []
-
-    class _FakePresenter:
-        def __init__(self, config):
-            self.trace_id = config.trace_id or "generated-trace"
-            presenter_calls.append(config)
-
-        async def _ensure_trace(self):
-            return None
-
-        async def emit_user_message(self, message: str):
-            presenter_calls.append(message)
-
-    class _FakeUserStorage:
-        async def get_by_id(self, user_id: str):
-            return SimpleNamespace(metadata={"language": "zh-CN"}, roles=["admin"])
-
-    async def _fake_executor(*args, **kwargs):
-        if False:
-            yield None
-
-    monkeypatch.setattr(recovery_module, "Presenter", _FakePresenter)
-    monkeypatch.setattr(recovery_module, "UserStorage", _FakeUserStorage)
-    monkeypatch.setattr(recovery_module, "get_concurrency_limiter", lambda: _FakeLimiter())
-    monkeypatch.setattr(recovery_module, "get_registered_executor", lambda key: _fake_executor)
-    manager._executor = _FakeExecutor()
-
-    result = await manager._submit_recovery_run(session, "run-old", "server_restart")
-
-    assert result["success"] is True
-    assert result["message"] == "任务恢复已加入队列"
-    assert captured_task_context["team_id"] == "team-1"
-    assert captured_task_context["user_message_written"] is True
-    assert captured_task_context["trace_id"] == "generated-trace"
-    assert storage.updates[-1][1].metadata["team_id"] == "team-1"
-    assert manager._run_info[result["run_id"]]["trace_id"] == "generated-trace"
-    assert (
-        presenter_calls[-1] == "由于系统重启，上一轮任务已中断。请继续处理当前会话中未完成的内容。"
-    )

--- a/tests/infra/task/test_manager_recovery.py
+++ b/tests/infra/task/test_manager_recovery.py
@@ -444,7 +444,7 @@ async def test_seamless_resume_falls_back_from_legacy_default_agent(
     service = recovery_module.TaskRecoveryService(
         storage=storage,
         run_info=manager._run_info,
-        heartbeat=SimpleNamespace(check_exists=lambda run_id: False),
+        heartbeat=SimpleNamespace(check_exists=lambda run_id: False, is_stale=_always_stale),
         ensure_executor=lambda: SimpleNamespace(),
         submit_task=_fake_submit,
         mark_run_failed=_stub_noop,
@@ -470,6 +470,10 @@ class _EmptyTraceCursorStub:
 
 async def _stub_noop(*_args, **_kwargs):
     return None
+
+
+async def _always_stale(_run_id: str) -> bool:
+    return True
 
 
 @pytest.mark.asyncio
@@ -696,6 +700,7 @@ async def test_resume_interrupted_run_releases_lock_when_cancelled(
     manager = BackgroundTaskManager()
     manager._storage = _FakeStorage(session)
 
+    manager._heartbeat = _FakeHeartbeat(exists=False)
     redis = _FakeRedis(acquired=True)
     lookup_started = asyncio.Event()
 
@@ -777,6 +782,7 @@ async def test_resume_interrupted_run_restores_recoverable_failure_when_submissi
     storage = _FakeStorage(session)
     manager = BackgroundTaskManager()
     manager._storage = storage
+    manager._heartbeat = _FakeHeartbeat(exists=False)
 
     redis = _FakeRedis(acquired=True)
     recoverable_failures = []

--- a/tests/infra/task/test_manager_services.py
+++ b/tests/infra/task/test_manager_services.py
@@ -166,13 +166,12 @@ async def test_recovery_service_resume_session_submits_localized_recovery_messag
     redis = _FakeRedis(acquired=True)
     submit_calls = []
 
-    async def _fake_submit(**kwargs):
-        submit_calls.append(kwargs)
+    async def _fake_submit(*args, **kwargs):
+        submit_calls.append({"args": args, **kwargs})
         return kwargs["run_id"], ""
 
     async def _fake_mark_failed(run_id: str, reason: str, loaded_session) -> None:
-        assert run_id == "run-old"
-        assert loaded_session.id == "session-1"
+        raise AssertionError("seamless resume must not mark the run failed")
 
     class _FakeUserStorage:
         async def get_by_id(self, user_id: str):
@@ -183,9 +182,35 @@ async def test_recovery_service_resume_session_submits_localized_recovery_messag
         if False:
             yield None
 
+    class _FakeLimiter:
+        async def try_acquire_run_slot(self, user_id: str, run_id: str) -> bool:
+            return True
+
+        async def release(self, *args, **kwargs):
+            return None
+
+    class _EmptyTraceCursor:
+        def sort(self, key, direction=None):
+            return self
+
+        def limit(self, limit):
+            return self
+
+        async def to_list(self, length=None):
+            return []
+
     monkeypatch.setattr(recovery_module, "get_redis_client", lambda: redis)
     monkeypatch.setattr(recovery_module, "UserStorage", _FakeUserStorage)
     monkeypatch.setattr(recovery_module, "get_registered_executor", lambda key: _fake_executor)
+    monkeypatch.setattr(recovery_module, "get_concurrency_limiter", lambda: _FakeLimiter())
+    monkeypatch.setattr("src.kernel.config.settings.TASK_BACKEND", "local")
+    monkeypatch.setattr(
+        recovery_module,
+        "get_trace_storage",
+        lambda: SimpleNamespace(
+            collection=SimpleNamespace(find=lambda q, p=None: _EmptyTraceCursor())
+        ),
+    )
 
     service = recovery_module.TaskRecoveryService(
         storage=storage,
@@ -199,18 +224,23 @@ async def test_recovery_service_resume_session_submits_localized_recovery_messag
     result = await service.resume_session("session-1")
 
     assert result["success"] is True
+    assert result["run_id"] == "run-old"
     assert result["resumed_from_run_id"] == "run-old"
     assert len(submit_calls) == 1
-    assert submit_calls[0]["session_id"] == "session-1"
-    assert submit_calls[0]["project_id"] == "project-1"
-    assert submit_calls[0]["disabled_tools"] == ["bash"]
-    assert submit_calls[0]["team_id"] == "team-1"
-    assert "active_goal" not in submit_calls[0]
-    assert submit_calls[0]["message"] == "请继续处理当前会话中未完成的内容。"
-    assert submit_calls[0]["enabled_skills"] is None
+    call = submit_calls[0]
+    assert call["args"][0] == "session-1"
+    assert call["project_id"] == "project-1"
+    assert call["disabled_tools"] == ["bash"]
+    assert call["team_id"] == "team-1"
+    assert "active_goal" not in call
+    assert call["args"][2] == "请继续处理当前会话中未完成的内容。"
+    assert call["enabled_skills"] is None
+    assert call["run_id"] == "run-old"
+    assert call["user_message_written"] is True
+    assert call["interrupted_resume"] is True
     assert redis.set_calls
     assert storage.updates[-1][0] == "session-1"
-    assert storage.updates[-1][1].metadata["team_id"] == "team-1"
+    assert storage.updates[-1][1].metadata["resume_attempts"] == 1
 
 
 @pytest.mark.asyncio
@@ -235,8 +265,8 @@ async def test_recovery_service_preserves_empty_enabled_skills_whitelist(
     redis = _FakeRedis(acquired=True)
     submit_calls = []
 
-    async def _fake_submit(**kwargs):
-        submit_calls.append(kwargs)
+    async def _fake_submit(*args, **kwargs):
+        submit_calls.append({"args": args, **kwargs})
         return kwargs["run_id"], ""
 
     async def _fake_mark_failed(run_id: str, reason: str, loaded_session) -> None:
@@ -253,6 +283,17 @@ async def test_recovery_service_preserves_empty_enabled_skills_whitelist(
     monkeypatch.setattr(recovery_module, "get_redis_client", lambda: redis)
     monkeypatch.setattr(recovery_module, "UserStorage", _FakeUserStorage)
     monkeypatch.setattr(recovery_module, "get_registered_executor", lambda key: _fake_executor)
+    monkeypatch.setattr(
+        recovery_module, "get_concurrency_limiter", lambda: _SeamlessFakeLimiter()
+    )
+    monkeypatch.setattr("src.kernel.config.settings.TASK_BACKEND", "local")
+    monkeypatch.setattr(
+        recovery_module,
+        "get_trace_storage",
+        lambda: SimpleNamespace(
+            collection=SimpleNamespace(find=lambda q, p=None: _SeamlessEmptyTraceCursor())
+        ),
+    )
 
     service = recovery_module.TaskRecoveryService(
         storage=storage,
@@ -267,8 +308,26 @@ async def test_recovery_service_preserves_empty_enabled_skills_whitelist(
 
     assert result["success"] is True
     assert submit_calls[0]["enabled_skills"] == []
-    metadata = storage.updates[-1][1].metadata
-    assert metadata["enabled_skills"] == []
+    assert submit_calls[0]["user_message_written"] is True
+
+
+class _SeamlessFakeLimiter:
+    async def try_acquire_run_slot(self, user_id: str, run_id: str) -> bool:
+        return True
+
+    async def release(self, *args, **kwargs):
+        return None
+
+
+class _SeamlessEmptyTraceCursor:
+    def sort(self, key, direction=None):
+        return self
+
+    def limit(self, limit):
+        return self
+
+    async def to_list(self, length=None):
+        return []
 
 
 @pytest.mark.asyncio

--- a/tests/infra/task/test_manager_services.py
+++ b/tests/infra/task/test_manager_services.py
@@ -283,9 +283,7 @@ async def test_recovery_service_preserves_empty_enabled_skills_whitelist(
     monkeypatch.setattr(recovery_module, "get_redis_client", lambda: redis)
     monkeypatch.setattr(recovery_module, "UserStorage", _FakeUserStorage)
     monkeypatch.setattr(recovery_module, "get_registered_executor", lambda key: _fake_executor)
-    monkeypatch.setattr(
-        recovery_module, "get_concurrency_limiter", lambda: _SeamlessFakeLimiter()
-    )
+    monkeypatch.setattr(recovery_module, "get_concurrency_limiter", lambda: _SeamlessFakeLimiter())
     monkeypatch.setattr("src.kernel.config.settings.TASK_BACKEND", "local")
     monkeypatch.setattr(
         recovery_module,

--- a/tests/infra/task/test_recovery_stream_strip.py
+++ b/tests/infra/task/test_recovery_stream_strip.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+"""_strip_terminal_stream_events：恢复前清理 Redis Stream 内残留的终态事件。
+
+SSE 读循环遇到 error/done/complete 事件即断开（dual_writer.
+_should_stop_stream_on_event），旧关停路径或跨版本升级可能已把终态事件写进流里；
+同 run 续跑前必须删掉，重放才不会提前断流。非终态事件一律保留。
+"""
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from src.infra.task import recovery as recovery_module
+from src.infra.task.recovery import TaskRecoveryService
+
+
+class _FakeRedis:
+    def __init__(self, entries: list[tuple[str, dict[str, Any]]]) -> None:
+        self._entries = list(entries)
+        self.deleted: list[tuple[str, str]] = []
+
+    async def xrange(self, stream_key, min="-", max="+"):
+        return list(self._entries)
+
+    async def xdel(self, stream_key, entry_id):
+        self.deleted.append((stream_key, entry_id))
+        self._entries = [e for e in self._entries if e[0] != entry_id]
+
+
+class _FakeDualWriter:
+    def __init__(self, redis: _FakeRedis) -> None:
+        self.redis = redis
+
+    @staticmethod
+    def _stream_key(session_id, run_id):
+        return f"session:{session_id}:run:{run_id}:events"
+
+
+def _make_service() -> TaskRecoveryService:
+    return TaskRecoveryService(
+        storage=SimpleNamespace(),
+        run_info={},
+        heartbeat=SimpleNamespace(check_exists=lambda run_id: False),
+        ensure_executor=lambda: SimpleNamespace(),
+        submit_task=_stub,
+        mark_run_failed=_stub,
+    )
+
+
+async def _stub(*_args, **_kwargs):
+    return None
+
+
+@pytest.mark.asyncio
+async def test_strip_removes_only_terminal_events(monkeypatch):
+    entries = [
+        ("1-1", {"event_type": "thinking", "data": "{}"}),
+        ("1-2", {"event_type": "error", "data": "{}"}),
+        ("1-3", {"event_type": "done", "data": "{}"}),
+        ("1-4", {"event_type": "complete", "data": "{}"}),
+        ("1-5", {"event_type": "message:chunk", "data": "{}"}),
+    ]
+    redis = _FakeRedis(entries)
+    monkeypatch.setattr(
+        "src.infra.session.dual_writer.get_dual_writer", lambda: _FakeDualWriter(redis)
+    )
+    service = _make_service()
+
+    removed = await service._strip_terminal_stream_events("session-1", "run-1")
+
+    assert removed == 3
+    assert [entry_id for _, entry_id in redis.deleted] == ["1-2", "1-3", "1-4"]
+    remaining_types = [fields["event_type"] for _, fields in redis._entries]
+    assert remaining_types == ["thinking", "message:chunk"]
+
+
+@pytest.mark.asyncio
+async def test_strip_returns_zero_and_swallows_redis_errors(monkeypatch):
+    class _BrokenRedis:
+        async def xrange(self, *args, **kwargs):
+            raise RuntimeError("redis down")
+
+    monkeypatch.setattr(
+        "src.infra.session.dual_writer.get_dual_writer",
+        lambda: _FakeDualWriter(_BrokenRedis()),
+    )
+    service = _make_service()
+
+    removed = await service._strip_terminal_stream_events("session-1", "run-1")
+
+    assert removed == 0
+
+
+@pytest.mark.asyncio
+async def test_strip_is_noop_when_no_terminal_events(monkeypatch):
+    entries = [("1-1", {"event_type": "thinking", "data": "{}"})]
+    redis = _FakeRedis(entries)
+    monkeypatch.setattr(
+        "src.infra.session.dual_writer.get_dual_writer", lambda: _FakeDualWriter(redis)
+    )
+    service = _make_service()
+
+    removed = await service._strip_terminal_stream_events("session-1", "run-1")
+
+    assert removed == 0
+    assert redis.deleted == []
+    assert recovery_module.logger is not None

--- a/tests/infra/task/test_seamless_resume.py
+++ b/tests/infra/task/test_seamless_resume.py
@@ -120,11 +120,17 @@ def _fixture(
     *,
     resume_attempts: int = 0,
     limiter: _FakeLimiter | None = None,
+    stale: bool = True,
 ) -> tuple[TaskRecoveryService, SimpleNamespace, dict[str, Any]]:
     session = _make_session(resume_attempts)
     storage = _FakeStorage(session)
     limiter = limiter or _FakeLimiter()
     trace_storage = _FakeTraceStorage()
+    # is_stale 可被个别测试覆盖；默认 stale=True（执行者已死，允许恢复）
+    stale_holder = {"stale": stale}
+
+    async def _stale_flag(run_id: str) -> bool:
+        return stale_holder["stale"]
     redis_stream = _FakeRedisStream(
         [
             ("1-1", {"event_type": "thinking", "data": "{}"}),
@@ -136,7 +142,10 @@ def _fixture(
     service = TaskRecoveryService(
         storage=storage,
         run_info={},
-        heartbeat=SimpleNamespace(check_exists=lambda run_id: False),
+        heartbeat=SimpleNamespace(
+            check_exists=lambda run_id: False,
+            is_stale=_stale_flag,
+        ),
         ensure_executor=lambda: SimpleNamespace(),
         submit_task=submit_task,
         mark_run_failed=mark_run_failed,
@@ -226,6 +235,23 @@ async def test_resume_caps_attempts_at_three(monkeypatch: pytest.MonkeyPatch) ->
     assert "上限" in result["message"]
     assert artifacts["submit_task"].await_count == 0
     artifacts["mark_run_failed"].assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_resume_skips_when_heartbeat_still_fresh(monkeypatch: pytest.MonkeyPatch) -> None:
+    """心跳未过期（实例可能仍活着）时不得恢复，防同 run 并发执行。"""
+    service, session, artifacts = _fixture(monkeypatch)
+
+    async def _fresh_heartbeat(run_id: str) -> bool:
+        return False  # is_stale=False → 仍存活
+
+    monkeypatch.setattr(service._heartbeat, "is_stale", _fresh_heartbeat)
+
+    result = await service.resume_interrupted_run(session, "run-old", "server_restart")
+
+    assert result["success"] is False
+    assert "仍在其他实例" in result["message"]
+    assert artifacts["submit_task"].await_count == 0
 
 
 @pytest.mark.asyncio

--- a/tests/infra/task/test_seamless_resume.py
+++ b/tests/infra/task/test_seamless_resume.py
@@ -54,9 +54,7 @@ class _FakeTraceCursor:
 class _FakeTraceStorage:
     def __init__(self) -> None:
         self.reopened: list[str] = []
-        self.collection = SimpleNamespace(
-            find=lambda query, projection=None: _FakeTraceCursor()
-        )
+        self.collection = SimpleNamespace(find=lambda query, projection=None: _FakeTraceCursor())
 
     async def reopen_interrupted_trace(self, trace_id: str) -> bool:
         self.reopened.append(trace_id)
@@ -131,6 +129,7 @@ def _fixture(
 
     async def _stale_flag(run_id: str) -> bool:
         return stale_holder["stale"]
+
     redis_stream = _FakeRedisStream(
         [
             ("1-1", {"event_type": "thinking", "data": "{}"}),
@@ -258,9 +257,7 @@ async def test_resume_skips_when_heartbeat_still_fresh(monkeypatch: pytest.Monke
 async def test_resume_failure_restores_recoverable_state(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    service, session, artifacts = _fixture(
-        monkeypatch, limiter=_FakeLimiter(acquire=False)
-    )
+    service, session, artifacts = _fixture(monkeypatch, limiter=_FakeLimiter(acquire=False))
 
     result = await service.resume_interrupted_run(session, "run-old", "server_restart")
 

--- a/tests/infra/task/test_seamless_resume.py
+++ b/tests/infra/task/test_seamless_resume.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+"""无缝续跑：resume_interrupted_run 必须复用原 run_id/trace、用隐藏恢复指令、限次。
+
+旧行为：先 mark_run_failed（写 error 事件 + trace 终结 error），再开新 run 并把
+恢复提示当 user:message 显示给用户。新行为：同 run/trace 续跑，恢复指令只给模型
+（user_message_written=True，不落 UI 事件），超限后终态失败防止毒消息无限重跑。
+"""
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.infra.task import recovery as recovery_module
+from src.infra.task.recovery import TaskRecoveryService
+
+
+class _FakeStorage:
+    def __init__(self, session=None) -> None:
+        self.session = session
+        self.updates: list[tuple[str, Any]] = []
+
+    async def update(self, session_id, session_update) -> None:
+        self.updates.append((session_id, session_update))
+
+
+class _FakeRedis:
+    def __init__(self) -> None:
+        self.set_calls: list[tuple] = []
+        self.eval_calls: list[tuple] = []
+
+    async def set(self, key, value, ex=None, nx=False):
+        self.set_calls.append((key, value, ex, nx))
+        return True
+
+    async def eval(self, script, num_keys, *args):
+        self.eval_calls.append((script, num_keys, *args))
+        return 1
+
+
+class _FakeTraceCursor:
+    def sort(self, key, direction=None):
+        return self
+
+    def limit(self, limit):
+        return self
+
+    async def to_list(self, length=None):
+        return [{"trace_id": "trace-1"}]
+
+
+class _FakeTraceStorage:
+    def __init__(self) -> None:
+        self.reopened: list[str] = []
+        self.collection = SimpleNamespace(
+            find=lambda query, projection=None: _FakeTraceCursor()
+        )
+
+    async def reopen_interrupted_trace(self, trace_id: str) -> bool:
+        self.reopened.append(trace_id)
+        return True
+
+
+class _FakeRedisStream:
+    def __init__(self, entries: list[tuple[str, dict[str, Any]]]) -> None:
+        self.entries = list(entries)
+        self.deleted: list[str] = []
+
+    async def xrange(self, stream_key, min="-", max="+"):
+        return list(self.entries)
+
+    async def xdel(self, stream_key, entry_id):
+        self.deleted.append(entry_id)
+        self.entries = [e for e in self.entries if e[0] != entry_id]
+
+
+class _FakeDualWriter:
+    def __init__(self, redis_stream: _FakeRedisStream) -> None:
+        self.redis = redis_stream
+
+    @staticmethod
+    def _stream_key(session_id, run_id):
+        return f"session:{session_id}:run:{run_id}:events"
+
+
+class _FakeLimiter:
+    def __init__(self, acquire: bool = True) -> None:
+        self.acquire = acquire
+        self.released: list[tuple] = []
+
+    async def try_acquire_run_slot(self, user_id: str, run_id: str) -> bool:
+        return self.acquire
+
+    async def release(self, user_id: str, run_id: str, dequeue: bool = True) -> None:
+        self.released.append((user_id, run_id, dequeue))
+
+
+def _make_session(resume_attempts: int = 0) -> SimpleNamespace:
+    return SimpleNamespace(
+        id="session-1",
+        user_id="user-1",
+        agent_id="search",
+        name="Seamless Session",
+        metadata={
+            "current_run_id": "run-old",
+            "task_status": "failed",
+            "task_recoverable": True,
+            "task_error_code": "server_restart",
+            "agent_id": "search",
+            "executor_key": "agent_stream",
+            "resume_attempts": resume_attempts,
+        },
+    )
+
+
+def _fixture(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    resume_attempts: int = 0,
+    limiter: _FakeLimiter | None = None,
+) -> tuple[TaskRecoveryService, SimpleNamespace, dict[str, Any]]:
+    session = _make_session(resume_attempts)
+    storage = _FakeStorage(session)
+    limiter = limiter or _FakeLimiter()
+    trace_storage = _FakeTraceStorage()
+    redis_stream = _FakeRedisStream(
+        [
+            ("1-1", {"event_type": "thinking", "data": "{}"}),
+            ("1-2", {"event_type": "error", "data": "{}"}),
+        ]
+    )
+    submit_task = AsyncMock(return_value=("run-old", "trace-1"))
+    mark_run_failed = AsyncMock()
+    service = TaskRecoveryService(
+        storage=storage,
+        run_info={},
+        heartbeat=SimpleNamespace(check_exists=lambda run_id: False),
+        ensure_executor=lambda: SimpleNamespace(),
+        submit_task=submit_task,
+        mark_run_failed=mark_run_failed,
+    )
+
+    class _FakeUserStorage:
+        async def get_by_id(self, user_id: str):
+            return SimpleNamespace(metadata={"language": "zh-CN"}, roles=[])
+
+    async def _fake_executor(*args, **kwargs):
+        if False:
+            yield None
+
+    monkeypatch.setattr(recovery_module, "get_redis_client", lambda: _FakeRedis())
+    monkeypatch.setattr(recovery_module, "UserStorage", _FakeUserStorage)
+    monkeypatch.setattr(recovery_module, "get_trace_storage", lambda: trace_storage)
+    monkeypatch.setattr(
+        "src.infra.session.dual_writer.get_dual_writer",
+        lambda: _FakeDualWriter(redis_stream),
+    )
+    monkeypatch.setattr(recovery_module, "get_registered_executor", lambda key: _fake_executor)
+    monkeypatch.setattr(recovery_module, "get_concurrency_limiter", lambda: limiter)
+    monkeypatch.setattr(recovery_module, "_resolve_recovery_agent_id", lambda m, s: "search")
+    monkeypatch.setattr("src.kernel.config.settings.TASK_BACKEND", "local")
+
+    artifacts = {
+        "storage": storage,
+        "limiter": limiter,
+        "trace_storage": trace_storage,
+        "redis_stream": redis_stream,
+        "submit_task": submit_task,
+        "mark_run_failed": mark_run_failed,
+    }
+    return service, session, artifacts
+
+
+@pytest.mark.asyncio
+async def test_resume_reuses_run_and_trace(monkeypatch: pytest.MonkeyPatch) -> None:
+    service, session, artifacts = _fixture(monkeypatch)
+
+    result = await service.resume_interrupted_run(session, "run-old", "server_restart")
+
+    assert result["success"] is True
+    assert result["run_id"] == "run-old"
+    assert result["resumed_from_run_id"] == "run-old"
+    assert result.get("seamless") is True
+
+    submit_task = artifacts["submit_task"]
+    assert submit_task.await_count == 1
+    call = submit_task.await_args
+    assert call.args[:4] == ("session-1", "search", call.args[2], "user-1")
+    assert call.args[2] == "由于系统重启，上一轮任务已中断。请继续处理当前会话中未完成的内容。"
+    kwargs = call.kwargs
+    assert kwargs["run_id"] == "run-old"
+    assert kwargs["trace_id"] == "trace-1"
+    assert kwargs["user_message_written"] is True
+    assert kwargs["interrupted_resume"] is True
+
+    # 成功后：恢复次数 +1、清掉 recoverable 标记（扫描器不再重复接管）
+    last_metadata = artifacts["storage"].updates[-1][1].metadata
+    assert last_metadata["resume_attempts"] == 1
+    assert last_metadata["task_recoverable"] is False
+    assert last_metadata["task_error_code"] is None
+
+
+@pytest.mark.asyncio
+async def test_resume_reopens_error_trace_and_strips_terminal_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, session, artifacts = _fixture(monkeypatch)
+
+    await service.resume_interrupted_run(session, "run-old", "server_restart")
+
+    assert artifacts["trace_storage"].reopened == ["trace-1"]
+    assert artifacts["redis_stream"].deleted == ["1-2"]  # 只删 error，保留 thinking
+    remaining = [fields["event_type"] for _, fields in artifacts["redis_stream"].entries]
+    assert remaining == ["thinking"]
+
+
+@pytest.mark.asyncio
+async def test_resume_caps_attempts_at_three(monkeypatch: pytest.MonkeyPatch) -> None:
+    service, session, artifacts = _fixture(monkeypatch, resume_attempts=3)
+
+    result = await service.resume_interrupted_run(session, "run-old", "server_restart")
+
+    assert result["success"] is False
+    assert "上限" in result["message"]
+    assert artifacts["submit_task"].await_count == 0
+    artifacts["mark_run_failed"].assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_resume_failure_restores_recoverable_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, session, artifacts = _fixture(
+        monkeypatch, limiter=_FakeLimiter(acquire=False)
+    )
+
+    result = await service.resume_interrupted_run(session, "run-old", "server_restart")
+
+    assert result["success"] is False
+    assert artifacts["submit_task"].await_count == 0
+    last_metadata = artifacts["storage"].updates[-1][1].metadata
+    assert last_metadata["task_status"] == "failed"
+    assert last_metadata["task_recoverable"] is True
+    assert last_metadata["task_error_code"] == "server_restart"
+
+
+@pytest.mark.asyncio
+async def test_resume_submit_exception_releases_slot_and_restores(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    limiter = _FakeLimiter()
+    service, session, artifacts = _fixture(monkeypatch, limiter=limiter)
+    artifacts["submit_task"].side_effect = RuntimeError("boom")
+
+    result = await service.resume_interrupted_run(session, "run-old", "server_restart")
+
+    assert result["success"] is False
+    assert limiter.released == [("user-1", "run-old", False)]
+    last_metadata = artifacts["storage"].updates[-1][1].metadata
+    assert last_metadata["task_status"] == "failed"
+    assert last_metadata["task_recoverable"] is True


### PR DESCRIPTION
## 概要

后端中断（部署重启 / 进程死亡 / OOM）后，自动恢复不再新开 run、不再显示系统恢复消息，而是**复用原 run_id 与 trace 在原对话气泡里继续**，用户基本无感。同时把并发队列的热点操作改成了 Redis Lua 原子脚本，并新增排队位置实时查询。

## 中断续跑（核心）

- **优雅关停**：executor 取消路径区分「用户取消」与「系统中断」（interrupt 标志判定）；系统中断不再写 user:cancel/error/done 终态事件、不终结 trace、不过期 stream（`executor.py`）
- **恢复流程**：`resume_interrupted_run` 改为同 run/trace 无缝提交（模板复用 HITL 恢复），恢复指令只作为隐藏的模型面指令，不落 user:message UI 事件；超限（3 次）落终态 FAILED 防毒消息无限重跑（`recovery.py`）
- **trace 重开**：`reopen_interrupted_trace` 只允许 error→running，completed 永不动；恢复前清理 Redis Stream 内残留终态事件，SSE 重放不会提前断流
- **arq 分布式**：payload 带 `interrupted_resume`，worker 侧原子重占并发槽 + 心跳活性复核，defer 重试防双执行
- **心跳判死提速**：`TASK_HEARTBEAT_STALE_SECONDS`（默认 20s，原 30s）可配置；恢复入口与 worker 双重活性复核兜底，短阈值不误接管
- **前端**：新增 `run:resumed` 事件处理——清空原气泡的半截内容/错误/取消状态后继续接收重新生成的回答（实时 + 历史重建两条路径）

## 队列优化

- `remove_from_queue` / `remove_queued_run` / `mark_queued_run_ready` / `get_queue_position` 从「锁内分页扫描 + 临时 key 整表重写」改为 **Redis Lua 原子脚本**（cjson 服务端解析，保持顺序，容错损坏条目），remove 类操作不再需要用户锁
- CI backend-tests 增加 `services: redis`，Lua 脚本有真实 Redis 集成测试（不可达自动 skip）
- 新增 `GET /api/chat/sessions/{id}/queue-position`（`session_queue.py`，守住 chat.py 1000 行上限）；前端排队 toast 每 5s 轮询刷新实时位置

## 验证

- 后端 2882 passed（含新增 executor 中断分支 / 无缝恢复 / Lua 接线 + 真实 Redis 集成测试）；前端 2101 passed + build ✓
- **端到端（真实 Redis + Mongo）双后端验证**：local 与 arq（专属队列 + 生产同款 Worker 构造 + SIGKILL worker 模拟实例死亡 → 新 worker 接手）均通过：同 run_id/trace 续跑、run:resumed 入流、无 error 事件、单一 trace completed、仅一条用户消息

Closes #（待关联）