### PR TITLE
chore(release): develop → main 晋升（跨副本取消终态修复）

### DIFF
--- a/src/infra/task/cancellation.py
+++ b/src/infra/task/cancellation.py
@@ -283,6 +283,16 @@ class TaskCancellation:
         return run_id in _interrupted_runs
 
     @staticmethod
+    def set_local_interrupt(run_id: str) -> None:
+        """在执行副本本地标记中断（跨副本 pubsub 取消时先于 task.cancel 调用）。
+
+        executor 的取消路径靠该标志区分「用户取消」与「系统中断」；pubsub
+        监听器收到取消消息后必须先设置本地标志，否则用户取消会被误判为
+        系统中断而吞掉终态事件。
+        """
+        _interrupted_runs[run_id] = time.time()
+
+    @staticmethod
     async def check_interrupt(run_id: str) -> None:
         """
         检查是否有中断信号，如果有则抛出 TaskInterruptedError

--- a/src/infra/task/executor.py
+++ b/src/infra/task/executor.py
@@ -305,11 +305,18 @@ class TaskExecutor:
         presenter: Any,
     ) -> None:
         """处理任务取消错误"""
-        # 无 interrupt 标志的取消是系统中断（优雅关停/部署），不是用户操作：
+        # 无中断信号的取消是系统中断（优雅关停/部署），不是用户操作：
         # 不写 user:cancel/error/done 终态事件、不终结 trace、不过期 stream，
         # 只 flush 缓冲让半截事件落库。recoverable 元数据由调用方标记
         # （manager.shutdown / arq_worker），随后同 run_id 无缝续跑。
-        if not TaskCancellation.check_interrupt_fast(run_id):
+        # 用户取消判定用权威信号（内存 + Redis）：跨副本取消时本副本内存标志
+        # 可能尚未同步，Redis 中断键才是可靠依据（系统中断从不设置）。
+        user_cancelled = False
+        try:
+            await TaskCancellation.check_interrupt(run_id)
+        except TaskInterruptedError:
+            user_cancelled = True
+        if not user_cancelled:
             if dual_writer is None:
                 dual_writer = get_dual_writer()
             try:

--- a/src/infra/task/pubsub.py
+++ b/src/infra/task/pubsub.py
@@ -104,6 +104,12 @@ class TaskPubSub:
                     f"Received cancel signal for run_id={run_id}, agent_id={agent_id}, session_id={session_id}"
                 )
 
+                # 先设本地中断标志再取消：executor 靠它区分「用户取消」与
+                # 「系统中断」（跨副本时本副本内存标志尚未同步会被误判）。
+                from .cancellation import TaskCancellation
+
+                TaskCancellation.set_local_interrupt(run_id)
+
                 # 调用自定义回调
                 if on_message:
                     try:

--- a/tests/infra/task/test_executor_interrupted_resume.py
+++ b/tests/infra/task/test_executor_interrupted_resume.py
@@ -88,9 +88,13 @@ def _executor_fixture(
         return None
 
     monkeypatch.setattr(cancellation.TaskCancellation, "clear_interrupt", _no_op)
-    monkeypatch.setattr(
-        cancellation.TaskCancellation, "check_interrupt_fast", lambda run_id: interrupt_flag
-    )
+
+    async def _check_interrupt(run_id: str) -> None:
+        # 权威判定（内存 + Redis）：用户取消时抛 TaskInterruptedError
+        if interrupt_flag:
+            raise cancellation.TaskInterruptedError(f"Task interrupted: {run_id}")
+
+    monkeypatch.setattr(cancellation.TaskCancellation, "check_interrupt", _check_interrupt)
 
     status_updates: list[str] = []
 

--- a/tests/infra/task/test_pubsub.py
+++ b/tests/infra/task/test_pubsub.py
@@ -86,3 +86,35 @@ async def test_cancel_pubsub_flushes_event_buffer_before_completing_trace(
     )
 
     assert call_order == ["on_message", "flush_mongo_buffer", "complete_trace"]
+
+
+@pytest.mark.asyncio
+async def test_cancel_pubsub_sets_local_interrupt_flag_before_cancelling(monkeypatch):
+    """跨副本取消：执行副本收到 pubsub 消息必须先设本地中断标志再取消任务。
+
+    否则 executor 的取消路径会把用户取消误判为系统中断（无缝续跑分支），
+    吞掉 user:cancel/error 终态事件（回归 R1-跨副本取消）。
+    """
+    from src.infra.task.cancellation import TaskCancellation, _interrupted_runs
+
+    _interrupted_runs.pop("run-local-flag", None)
+
+    cancelled_at: list[float | None] = [{"flag_age": None}]
+
+    class _Task:
+        def __init__(self):
+            self._done = False
+
+        def done(self):
+            return self._done
+
+        def cancel(self):
+            age = TaskCancellation.check_interrupt_fast("run-local-flag")
+            cancelled_at[0]["flag_age"] = age
+
+    pubsub = TaskPubSub(asyncio.Lock(), {"run-local-flag": _Task()})
+
+    await pubsub._handle_cancel_message({"data": json.dumps({"run_id": "run-local-flag"})})
+
+    assert cancelled_at[0]["flag_age"] is True, "cancel() 前本地中断标志必须已设置"
+    _interrupted_runs.pop("run-local-flag", None)


### PR DESCRIPTION
晋升 develop → main：包含 #347（跨副本取消终态修复，回归 R1）。staging 已在 develop-20260831-184345 验证过无缝续跑主链路，本修复经全量测试 + 回归复验。