### PR TITLE
fix(frontend): 无终态 run 历史折叠停转挂起部件并复位中断残留全局态

### DIFF
--- a/frontend/src/hooks/useAgent/__tests__/runResumed.test.ts
+++ b/frontend/src/hooks/useAgent/__tests__/runResumed.test.ts
@@ -9,26 +9,38 @@ import type { HistoryEvent, StreamEvent } from "../types.ts";
 function createLiveContext(initial: Message[]): {
   ctx: EventHandlerContext;
   messages: () => Message[];
+  effects: () => { sandboxCleared: number; sandboxErrorCleared: number };
 } {
   let messages = initial;
+  let sandboxCleared = 0;
+  let sandboxErrorCleared = 0;
   return {
     ctx: {
       sessionIdRef: { current: "session-1" },
       processedEventIdsRef: { current: new Set<string>() },
       lastHistoryTimestampRef: { current: null },
-      activeSubagentStackRef: { current: [] },
+      activeSubagentStackRef: {
+        current: [
+          { agent_id: "researcher", depth: 1, message_id: "run-1" },
+        ],
+      },
       streamVersionRef: { current: 0 },
       setSessionId: () => undefined,
       setMessages: (updater: React.SetStateAction<Message[]>) => {
         messages = typeof updater === "function" ? updater(messages) : updater;
       },
       setConnectionStatus: () => undefined,
-      setIsInitializingSandbox: () => undefined,
-      setSandboxError: () => undefined,
+      setIsInitializingSandbox: () => {
+        sandboxCleared += 1;
+      },
+      setSandboxError: (error: unknown) => {
+        if (error === null) sandboxErrorCleared += 1;
+      },
       setActiveGoal: () => undefined,
       setGoalsByRunId: () => undefined,
     } as EventHandlerContext,
     messages: () => messages,
+    effects: () => ({ sandboxCleared, sandboxErrorCleared }),
   };
 }
 
@@ -81,6 +93,23 @@ describe("live run:resumed event", () => {
     expect(message?.role).toBe("assistant");
     expect(message?.isStreaming).toBe(true);
     expect(message?.parts).toEqual([]);
+  });
+
+  test("run:resumed resets stuck subagent stack and sandbox loader", () => {
+    const { ctx, effects } = createLiveContext([]);
+
+    handleStreamEvent(
+      { event: "run:resumed", data: JSON.stringify({ run_id: "run-1" }) },
+      "run-1",
+      "evt-resumed-globals",
+      undefined,
+      ctx,
+    );
+
+    // 中断卡住的全局态随恢复一并复位
+    expect(ctx.activeSubagentStackRef.current).toEqual([]);
+    expect(effects().sandboxCleared).toBe(1);
+    expect(effects().sandboxErrorCleared).toBe(1);
   });
 
   test("post-resume chunks rebuild content from scratch", () => {
@@ -169,5 +198,169 @@ describe("history rebuild with run:resumed", () => {
     const assistant = messages.find((m) => m.role === "assistant");
 
     expect(assistant?.content).toBe("中断前的半截");
+  });
+});
+
+describe("history folding of unfinished runs", () => {
+  const fold = (events: HistoryEvent[]) =>
+    reconstructMessagesFromEvents(events, new Set<string>(), {
+      activeSubagentStack: [],
+    });
+
+  test("run without terminal event leaves no pending tool/thinking spinners", () => {
+    const messages = fold([
+      {
+        event_type: "user:message",
+        run_id: "run-1",
+        data: { content: "原问题" },
+        timestamp: "2026-09-01T00:00:00Z",
+      },
+      {
+        event_type: "tool:start",
+        run_id: "run-1",
+        data: { tool: "bash", tool_call_id: "t1", args: { cmd: "ls" } },
+        timestamp: "2026-09-01T00:00:01Z",
+      },
+      {
+        event_type: "thinking",
+        run_id: "run-1",
+        data: { content: "半截思考" },
+        timestamp: "2026-09-01T00:00:02Z",
+      },
+      // 无 tool:result / 无 done：中断后未恢复的 run
+    ]);
+    const assistant = messages.find((m) => m.role === "assistant");
+
+    const tool = assistant?.parts?.find((p) => p.type === "tool");
+    expect(tool).toMatchObject({ isPending: false, cancelled: true });
+    const thinking = assistant?.parts?.find((p) => p.type === "thinking");
+    expect(thinking).toMatchObject({ isStreaming: false });
+  });
+
+  test("streaming tool args (tool:args:chunk) partial also stops loading", () => {
+    const messages = fold([
+      {
+        event_type: "user:message",
+        run_id: "run-1",
+        data: { content: "原问题" },
+        timestamp: "2026-09-01T00:00:00Z",
+      },
+      {
+        event_type: "tool:args:chunk",
+        run_id: "run-1",
+        data: { tool: "bash", tool_call_id: "t9", content: "ls -l" },
+        timestamp: "2026-09-01T00:00:01Z",
+      },
+    ]);
+    const assistant = messages.find((m) => m.role === "assistant");
+    const tool = assistant?.parts?.find((p) => p.type === "tool");
+
+    expect(tool).toMatchObject({ isPending: false, cancelled: true });
+    // 半截参数内容保留
+    expect((tool as { args?: Record<string, unknown> })?.args).toMatchObject({
+      partial: "ls -l",
+    });
+  });
+
+  test("subagent with pending nested tool is cleaned recursively", () => {
+    const messages = fold([
+      {
+        event_type: "user:message",
+        run_id: "run-1",
+        data: { content: "原问题" },
+        timestamp: "2026-09-01T00:00:00Z",
+      },
+      {
+        event_type: "agent:call",
+        run_id: "run-1",
+        data: { agent_id: "researcher", depth: 1 },
+        timestamp: "2026-09-01T00:00:01Z",
+      },
+      {
+        event_type: "tool:start",
+        run_id: "run-1",
+        data: { tool: "bash", tool_call_id: "t2", args: {}, depth: 1 },
+        timestamp: "2026-09-01T00:00:02Z",
+      },
+    ]);
+    const assistant = messages.find((m) => m.role === "assistant");
+    const subagent = assistant?.parts?.find((p) => p.type === "subagent") as
+      | { parts?: Array<Record<string, unknown>>; isPending?: boolean }
+      | undefined;
+
+    expect(subagent).toBeDefined();
+    expect(subagent?.isPending).toBe(false);
+    const nestedTool = subagent?.parts?.find((p) => p.type === "tool");
+    expect(nestedTool).toMatchObject({ isPending: false });
+  });
+
+  test("unfinished HITL run keeps its ask-human card responsive", () => {
+    const messages = fold([
+      {
+        event_type: "user:message",
+        run_id: "run-1",
+        data: { content: "ask human" },
+        timestamp: "2026-09-01T00:00:00Z",
+      },
+      {
+        event_type: "approval_required",
+        run_id: "run-1",
+        data: { id: "approval-1", message: "请回答", fields: [] },
+        timestamp: "2026-09-01T00:00:01Z",
+      },
+    ]);
+    const assistant = messages.find((m) => m.role === "assistant");
+    const askHuman = assistant?.parts?.find((p) => p.type === "tool");
+
+    expect(askHuman).toMatchObject({ name: "ask_human", isPending: true });
+  });
+
+  test("partial text content is preserved untouched", () => {
+    const messages = fold([
+      {
+        event_type: "user:message",
+        run_id: "run-1",
+        data: { content: "原问题" },
+        timestamp: "2026-09-01T00:00:00Z",
+      },
+      {
+        event_type: "message:chunk",
+        run_id: "run-1",
+        data: { content: "写到一半的正文" },
+        timestamp: "2026-09-01T00:00:01Z",
+      },
+    ]);
+    const assistant = messages.find((m) => m.role === "assistant");
+
+    expect(assistant?.content).toBe("写到一半的正文");
+  });
+
+  test("completed run keeps its tool parts untouched", () => {
+    const messages = fold([
+      {
+        event_type: "user:message",
+        run_id: "run-1",
+        data: { content: "原问题" },
+        timestamp: "2026-09-01T00:00:00Z",
+      },
+      {
+        event_type: "tool:start",
+        run_id: "run-1",
+        data: { tool: "bash", tool_call_id: "t1", args: {} },
+        timestamp: "2026-09-01T00:00:01Z",
+      },
+      {
+        event_type: "done",
+        run_id: "run-1",
+        data: {},
+        timestamp: "2026-09-01T00:00:02Z",
+      },
+    ]);
+    const assistant = messages.find((m) => m.role === "assistant");
+    const tool = assistant?.parts?.find((p) => p.type === "tool");
+
+    // done 之后的 run 已终态：工具保持原样（是否有结果由事件决定，不做清理判定）
+    expect(assistant?.parts?.length).toBeGreaterThan(0);
+    expect(tool).toBeDefined();
   });
 });

--- a/frontend/src/hooks/useAgent/eventHandlers.ts
+++ b/frontend/src/hooks/useAgent/eventHandlers.ts
@@ -307,6 +307,11 @@ export function handleStreamEvent(
     case "run:resumed": {
       // 系统中断后同 run 无缝续跑：清空气泡里的半截输出/错误/取消状态，
       // 回到流式空态接收重新生成的完整回答（模型会重跑这一轮）。
+      // 中断瞬间可能卡住的全局态一并复位：子代理栈残留（agent:call 无配对
+      // agent:result）、沙箱初始化中/错误（sandbox:starting 无 ready/error）。
+      ctx.activeSubagentStackRef.current.length = 0;
+      ctx.setIsInitializingSandbox(false);
+      ctx.setSandboxError(null);
       ctx.setMessages((prev) => {
         const reset = {
           parts: [],

--- a/frontend/src/hooks/useAgent/historyLoader.ts
+++ b/frontend/src/hooks/useAgent/historyLoader.ts
@@ -590,6 +590,40 @@ export function reconstructMessagesFromEvents(
     pushMessage(currentAssistantMessage);
   }
 
+  // 无终态事件的 run（中断后未恢复/旧数据）不允许留下"执行中"部件：
+  // 静默停转半截工具/参数流/思考/子代理的 loading（内容保留），避免历史里
+  // 永远转圈。终态判定在折叠完成后统一进行，steer 封存的中间轮次也能等到
+  // 自己 run 的 done；有终态的 run 完全不动。
+  const settledRunIds = new Set<string>();
+  for (const event of anchoredEvents) {
+    if (
+      event.run_id &&
+      (event.event_type === "done" ||
+        event.event_type === "complete" ||
+        event.event_type === "error" ||
+        event.event_type === "user:cancel")
+    ) {
+      settledRunIds.add(event.run_id);
+    }
+  }
+  for (let index = 0; index < reconstructedMessages.length; index += 1) {
+    const message = reconstructedMessages[index];
+    if (
+      message.role === "assistant" &&
+      message.runId &&
+      !settledRunIds.has(message.runId)
+    ) {
+      reconstructedMessages[index] = {
+        ...message,
+        // ask_human 卡片保持待响应：HITL 挂起中的 run 同样没有终态事件，
+        // 但审批卡必须继续可交互（恢复走审批响应路径，不走无缝续跑）
+        parts: clearAllLoadingStates(message.parts || [], {
+          preserveAskHuman: true,
+        }),
+      };
+    }
+  }
+
   // Some runs emit lifecycle events (for example `agent:start`) without ever
   // producing assistant content. They still create a placeholder while the
   // event stream is being folded, which leaves an empty assistant bubble in


### PR DESCRIPTION
## 问题

系统中断续跑落地后仍剩两类"永远运行中"的残留（用户不可见原则下修复，无任何新增中断提示文案）：

1. **历史视图**：中断后未恢复（或旧数据）的 run 折叠出的部件保持 loading——半截 `tool:start`、`tool:args:chunk` 参数流、`thinking`、嵌套 subagent 的 pending 工具全部永远转圈
2. **实时残留全局态**：中断恰好发生在 `agent:call` 后（子代理栈残留）、`sandbox:starting` 后（沙箱加载态卡死）时，恢复后这些状态不复位

## 修复（全部静默，无用户可见变化）

- 历史折叠完成后统一做终态判定：**无终态事件（done/complete/error/user:cancel）的 run** 对其 assistant 消息执行 `clearAllLoadingStates`（内容保留、转圈停止、工具显示为静态灰色 Ban 态——与既有取消语义一致）；有终态的 run 完全不动
- `preserveAskHuman: true`：HITL 挂起中的 run 同样没有终态事件，但 ask_human 审批卡必须保持待响应可交互（恢复走审批响应路径）
- `run:resumed` 处理器顺带复位：子代理栈（`activeSubagentStackRef`）、沙箱加载/错误全局态

## 边界覆盖（测试）

tool:start 半截 / tool:args:chunk 参数流半截 / thinking 半截 / subagent 嵌套 pending 工具（递归清理）/ 文本半截（内容原样保留）/ 已完成 run 不动 / HITL ask_human 保持待响应 / run:resumed 复位全局态

前端 2108 passed + lint + build ✓