### PR TITLE
fix(frontend): ask-human 快捷键不再劫持卡片内文本输入的按键

### DIFF
--- a/frontend/src/components/panels/ApprovalPanel.tsx
+++ b/frontend/src/components/panels/ApprovalPanel.tsx
@@ -17,6 +17,7 @@ import { useTranslation } from "react-i18next";
 import ReactMarkdown from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import type { PendingApproval, FormField } from "../../types";
+import { isEditableEventTarget } from "./askHumanKeyboardGuard";
 import { ScheduledTaskApprovalContent } from "./ScheduledTaskApprovalContent";
 import { Checkbox } from "../common/Checkbox";
 import { Input, Select, Textarea } from "../common";
@@ -606,6 +607,8 @@ export function ApprovalPanel({
           }`}
           key={currentApproval.id}
           onKeyDown={(event) => {
+            // 卡片内文本控件（如“其他”自由填写）优先走原生输入，快捷键让位
+            if (isEditableEventTarget(event.target)) return;
             if (!isAskHuman || !askHumanKeyboardField?.options?.length) return;
             const count = askHumanKeyboardField.options.length;
             if (event.key === "ArrowDown" || event.key === "Tab") {

--- a/frontend/src/components/panels/__tests__/askHumanKeyboardGuard.test.ts
+++ b/frontend/src/components/panels/__tests__/askHumanKeyboardGuard.test.ts
@@ -1,0 +1,21 @@
+/** @vitest-environment jsdom */
+import { isEditableEventTarget } from "../askHumanKeyboardGuard";
+
+test("yields ask-human shortcuts for text inputs like the other-opinion field", () => {
+  expect(isEditableEventTarget(document.createElement("input"))).toBe(true);
+});
+
+test("yields ask-human shortcuts for textareas, selects and contenteditable regions", () => {
+  expect(isEditableEventTarget(document.createElement("textarea"))).toBe(true);
+  expect(isEditableEventTarget(document.createElement("select"))).toBe(true);
+  // jsdom 不计算 isContentEditable，这里直接桩掉只读属性来验证分支逻辑
+  const richText = document.createElement("div");
+  Object.defineProperty(richText, "isContentEditable", { value: true });
+  expect(isEditableEventTarget(richText)).toBe(true);
+});
+
+test("keeps ask-human shortcuts for the card surface and choice buttons", () => {
+  expect(isEditableEventTarget(document.createElement("div"))).toBe(false);
+  expect(isEditableEventTarget(document.createElement("button"))).toBe(false);
+  expect(isEditableEventTarget(null)).toBe(false);
+});

--- a/frontend/src/components/panels/__tests__/askHumanLayout.test.ts
+++ b/frontend/src/components/panels/__tests__/askHumanLayout.test.ts
@@ -320,3 +320,9 @@ test("shows desktop-only keyboard shortcut hint for ask-human choices", () => {
 test("supports number-key selection for ask-human choices", () => {
   expect(approvalSource).toMatch(/event\.key >= "1"/);
 });
+
+test("skips ask-human shortcuts while typing inside card text controls", () => {
+  expect(approvalSource).toMatch(
+    /isEditableEventTarget\(event\.target\)[\s\S]*?event\.key >= "1"/,
+  );
+});

--- a/frontend/src/components/panels/askHumanKeyboardGuard.ts
+++ b/frontend/src/components/panels/askHumanKeyboardGuard.ts
@@ -1,0 +1,16 @@
+/**
+ * Whether a keyboard event originates from an editable control (e.g. the
+ * ask-human "other opinion" input). Card-level shortcuts such as digit
+ * quick-select must yield to native text entry in that case.
+ */
+export function isEditableEventTarget(target: EventTarget | null): boolean {
+  if (!target || typeof HTMLElement === "undefined") return false;
+  if (
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    target instanceof HTMLSelectElement
+  ) {
+    return true;
+  }
+  return Boolean(target instanceof HTMLElement && target.isContentEditable);
+}


### PR DESCRIPTION
## 问题

聊天输入框偶发性无法输入数字 1、2、3、4（其他字符正常）。

## 根因

ask-human 审批挂起时，`ChatView.tsx` 会隐藏正常 `ChatInput`，`ApprovalPanel` 以 `approval-card--composer` 形态渲染在输入框原位置。该卡片根 div 上的 keydown 处理器（数字 1-9 快捷选择 / 方向键 / Enter / Space）没有豁免事件来源：

- keydown 从卡片内文本控件（如 `_other`「其他」自由填写字段、text/textarea/number 字段）冒泡到根 div；
- 处理器命中数字分支后 `preventDefault()`，按键永远到不了输入框；
- 选项数为 4 时被吞的正好是 1、2、3、4（5-9 及字母正常），且仅在 ask-human 带选项挂起时复现——表现为「偶发」。

同段代码对空格 / 回车 / 方向键有同样劫持。

## 修复

新增纯守卫 `isEditableEventTarget`（写法对齐既有 `utils/mobile.ts` / `AppShell.tsx` 守卫）：事件目标为 `input / textarea / select / contentEditable` 时直接放行原生输入，卡片级快捷键让位。

## 测试

- [x] `askHumanKeyboardGuard.test.ts`（新增，jsdom）：文本控件让位 / 卡片表面与选项按钮保持快捷键
- [x] `askHumanLayout.test.ts`：结构断言守卫先于数字拦截生效（TDD 先行，已见 RED）
- [x] 前端全量 `pnpm test`：469 文件 / 2105 用例全绿
- [x] `pnpm run lint` + `pnpm run build` 通过