### PR TITLE
chore(release): develop → main 晋升（ask-human 快捷键 + 跨副本取消 + 挂起部件修复）

### DIFF
--- a/frontend/src/components/panels/ApprovalPanel.tsx
+++ b/frontend/src/components/panels/ApprovalPanel.tsx
@@ -17,6 +17,7 @@ import { useTranslation } from "react-i18next";
 import ReactMarkdown from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import type { PendingApproval, FormField } from "../../types";
+import { isEditableEventTarget } from "./askHumanKeyboardGuard";
 import { ScheduledTaskApprovalContent } from "./ScheduledTaskApprovalContent";
 import { Checkbox } from "../common/Checkbox";
 import { Input, Select, Textarea } from "../common";
@@ -606,6 +607,8 @@ export function ApprovalPanel({
           }`}
           key={currentApproval.id}
           onKeyDown={(event) => {
+            // 卡片内文本控件（如“其他”自由填写）优先走原生输入，快捷键让位
+            if (isEditableEventTarget(event.target)) return;
             if (!isAskHuman || !askHumanKeyboardField?.options?.length) return;
             const count = askHumanKeyboardField.options.length;
             if (event.key === "ArrowDown" || event.key === "Tab") {

--- a/frontend/src/components/panels/__tests__/askHumanKeyboardGuard.test.ts
+++ b/frontend/src/components/panels/__tests__/askHumanKeyboardGuard.test.ts
@@ -1,0 +1,21 @@
+/** @vitest-environment jsdom */
+import { isEditableEventTarget } from "../askHumanKeyboardGuard";
+
+test("yields ask-human shortcuts for text inputs like the other-opinion field", () => {
+  expect(isEditableEventTarget(document.createElement("input"))).toBe(true);
+});
+
+test("yields ask-human shortcuts for textareas, selects and contenteditable regions", () => {
+  expect(isEditableEventTarget(document.createElement("textarea"))).toBe(true);
+  expect(isEditableEventTarget(document.createElement("select"))).toBe(true);
+  // jsdom 不计算 isContentEditable，这里直接桩掉只读属性来验证分支逻辑
+  const richText = document.createElement("div");
+  Object.defineProperty(richText, "isContentEditable", { value: true });
+  expect(isEditableEventTarget(richText)).toBe(true);
+});
+
+test("keeps ask-human shortcuts for the card surface and choice buttons", () => {
+  expect(isEditableEventTarget(document.createElement("div"))).toBe(false);
+  expect(isEditableEventTarget(document.createElement("button"))).toBe(false);
+  expect(isEditableEventTarget(null)).toBe(false);
+});

--- a/frontend/src/components/panels/__tests__/askHumanLayout.test.ts
+++ b/frontend/src/components/panels/__tests__/askHumanLayout.test.ts
@@ -320,3 +320,9 @@ test("shows desktop-only keyboard shortcut hint for ask-human choices", () => {
 test("supports number-key selection for ask-human choices", () => {
   expect(approvalSource).toMatch(/event\.key >= "1"/);
 });
+
+test("skips ask-human shortcuts while typing inside card text controls", () => {
+  expect(approvalSource).toMatch(
+    /isEditableEventTarget\(event\.target\)[\s\S]*?event\.key >= "1"/,
+  );
+});

--- a/frontend/src/components/panels/askHumanKeyboardGuard.ts
+++ b/frontend/src/components/panels/askHumanKeyboardGuard.ts
@@ -1,0 +1,16 @@
+/**
+ * Whether a keyboard event originates from an editable control (e.g. the
+ * ask-human "other opinion" input). Card-level shortcuts such as digit
+ * quick-select must yield to native text entry in that case.
+ */
+export function isEditableEventTarget(target: EventTarget | null): boolean {
+  if (!target || typeof HTMLElement === "undefined") return false;
+  if (
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    target instanceof HTMLSelectElement
+  ) {
+    return true;
+  }
+  return Boolean(target instanceof HTMLElement && target.isContentEditable);
+}

--- a/frontend/src/hooks/useAgent/__tests__/runResumed.test.ts
+++ b/frontend/src/hooks/useAgent/__tests__/runResumed.test.ts
@@ -9,26 +9,38 @@ import type { HistoryEvent, StreamEvent } from "../types.ts";
 function createLiveContext(initial: Message[]): {
   ctx: EventHandlerContext;
   messages: () => Message[];
+  effects: () => { sandboxCleared: number; sandboxErrorCleared: number };
 } {
   let messages = initial;
+  let sandboxCleared = 0;
+  let sandboxErrorCleared = 0;
   return {
     ctx: {
       sessionIdRef: { current: "session-1" },
       processedEventIdsRef: { current: new Set<string>() },
       lastHistoryTimestampRef: { current: null },
-      activeSubagentStackRef: { current: [] },
+      activeSubagentStackRef: {
+        current: [
+          { agent_id: "researcher", depth: 1, message_id: "run-1" },
+        ],
+      },
       streamVersionRef: { current: 0 },
       setSessionId: () => undefined,
       setMessages: (updater: React.SetStateAction<Message[]>) => {
         messages = typeof updater === "function" ? updater(messages) : updater;
       },
       setConnectionStatus: () => undefined,
-      setIsInitializingSandbox: () => undefined,
-      setSandboxError: () => undefined,
+      setIsInitializingSandbox: () => {
+        sandboxCleared += 1;
+      },
+      setSandboxError: (error: unknown) => {
+        if (error === null) sandboxErrorCleared += 1;
+      },
       setActiveGoal: () => undefined,
       setGoalsByRunId: () => undefined,
     } as EventHandlerContext,
     messages: () => messages,
+    effects: () => ({ sandboxCleared, sandboxErrorCleared }),
   };
 }
 
@@ -81,6 +93,23 @@ describe("live run:resumed event", () => {
     expect(message?.role).toBe("assistant");
     expect(message?.isStreaming).toBe(true);
     expect(message?.parts).toEqual([]);
+  });
+
+  test("run:resumed resets stuck subagent stack and sandbox loader", () => {
+    const { ctx, effects } = createLiveContext([]);
+
+    handleStreamEvent(
+      { event: "run:resumed", data: JSON.stringify({ run_id: "run-1" }) },
+      "run-1",
+      "evt-resumed-globals",
+      undefined,
+      ctx,
+    );
+
+    // 中断卡住的全局态随恢复一并复位
+    expect(ctx.activeSubagentStackRef.current).toEqual([]);
+    expect(effects().sandboxCleared).toBe(1);
+    expect(effects().sandboxErrorCleared).toBe(1);
   });
 
   test("post-resume chunks rebuild content from scratch", () => {
@@ -169,5 +198,169 @@ describe("history rebuild with run:resumed", () => {
     const assistant = messages.find((m) => m.role === "assistant");
 
     expect(assistant?.content).toBe("中断前的半截");
+  });
+});
+
+describe("history folding of unfinished runs", () => {
+  const fold = (events: HistoryEvent[]) =>
+    reconstructMessagesFromEvents(events, new Set<string>(), {
+      activeSubagentStack: [],
+    });
+
+  test("run without terminal event leaves no pending tool/thinking spinners", () => {
+    const messages = fold([
+      {
+        event_type: "user:message",
+        run_id: "run-1",
+        data: { content: "原问题" },
+        timestamp: "2026-09-01T00:00:00Z",
+      },
+      {
+        event_type: "tool:start",
+        run_id: "run-1",
+        data: { tool: "bash", tool_call_id: "t1", args: { cmd: "ls" } },
+        timestamp: "2026-09-01T00:00:01Z",
+      },
+      {
+        event_type: "thinking",
+        run_id: "run-1",
+        data: { content: "半截思考" },
+        timestamp: "2026-09-01T00:00:02Z",
+      },
+      // 无 tool:result / 无 done：中断后未恢复的 run
+    ]);
+    const assistant = messages.find((m) => m.role === "assistant");
+
+    const tool = assistant?.parts?.find((p) => p.type === "tool");
+    expect(tool).toMatchObject({ isPending: false, cancelled: true });
+    const thinking = assistant?.parts?.find((p) => p.type === "thinking");
+    expect(thinking).toMatchObject({ isStreaming: false });
+  });
+
+  test("streaming tool args (tool:args:chunk) partial also stops loading", () => {
+    const messages = fold([
+      {
+        event_type: "user:message",
+        run_id: "run-1",
+        data: { content: "原问题" },
+        timestamp: "2026-09-01T00:00:00Z",
+      },
+      {
+        event_type: "tool:args:chunk",
+        run_id: "run-1",
+        data: { tool: "bash", tool_call_id: "t9", content: "ls -l" },
+        timestamp: "2026-09-01T00:00:01Z",
+      },
+    ]);
+    const assistant = messages.find((m) => m.role === "assistant");
+    const tool = assistant?.parts?.find((p) => p.type === "tool");
+
+    expect(tool).toMatchObject({ isPending: false, cancelled: true });
+    // 半截参数内容保留
+    expect((tool as { args?: Record<string, unknown> })?.args).toMatchObject({
+      partial: "ls -l",
+    });
+  });
+
+  test("subagent with pending nested tool is cleaned recursively", () => {
+    const messages = fold([
+      {
+        event_type: "user:message",
+        run_id: "run-1",
+        data: { content: "原问题" },
+        timestamp: "2026-09-01T00:00:00Z",
+      },
+      {
+        event_type: "agent:call",
+        run_id: "run-1",
+        data: { agent_id: "researcher", depth: 1 },
+        timestamp: "2026-09-01T00:00:01Z",
+      },
+      {
+        event_type: "tool:start",
+        run_id: "run-1",
+        data: { tool: "bash", tool_call_id: "t2", args: {}, depth: 1 },
+        timestamp: "2026-09-01T00:00:02Z",
+      },
+    ]);
+    const assistant = messages.find((m) => m.role === "assistant");
+    const subagent = assistant?.parts?.find((p) => p.type === "subagent") as
+      | { parts?: Array<Record<string, unknown>>; isPending?: boolean }
+      | undefined;
+
+    expect(subagent).toBeDefined();
+    expect(subagent?.isPending).toBe(false);
+    const nestedTool = subagent?.parts?.find((p) => p.type === "tool");
+    expect(nestedTool).toMatchObject({ isPending: false });
+  });
+
+  test("unfinished HITL run keeps its ask-human card responsive", () => {
+    const messages = fold([
+      {
+        event_type: "user:message",
+        run_id: "run-1",
+        data: { content: "ask human" },
+        timestamp: "2026-09-01T00:00:00Z",
+      },
+      {
+        event_type: "approval_required",
+        run_id: "run-1",
+        data: { id: "approval-1", message: "请回答", fields: [] },
+        timestamp: "2026-09-01T00:00:01Z",
+      },
+    ]);
+    const assistant = messages.find((m) => m.role === "assistant");
+    const askHuman = assistant?.parts?.find((p) => p.type === "tool");
+
+    expect(askHuman).toMatchObject({ name: "ask_human", isPending: true });
+  });
+
+  test("partial text content is preserved untouched", () => {
+    const messages = fold([
+      {
+        event_type: "user:message",
+        run_id: "run-1",
+        data: { content: "原问题" },
+        timestamp: "2026-09-01T00:00:00Z",
+      },
+      {
+        event_type: "message:chunk",
+        run_id: "run-1",
+        data: { content: "写到一半的正文" },
+        timestamp: "2026-09-01T00:00:01Z",
+      },
+    ]);
+    const assistant = messages.find((m) => m.role === "assistant");
+
+    expect(assistant?.content).toBe("写到一半的正文");
+  });
+
+  test("completed run keeps its tool parts untouched", () => {
+    const messages = fold([
+      {
+        event_type: "user:message",
+        run_id: "run-1",
+        data: { content: "原问题" },
+        timestamp: "2026-09-01T00:00:00Z",
+      },
+      {
+        event_type: "tool:start",
+        run_id: "run-1",
+        data: { tool: "bash", tool_call_id: "t1", args: {} },
+        timestamp: "2026-09-01T00:00:01Z",
+      },
+      {
+        event_type: "done",
+        run_id: "run-1",
+        data: {},
+        timestamp: "2026-09-01T00:00:02Z",
+      },
+    ]);
+    const assistant = messages.find((m) => m.role === "assistant");
+    const tool = assistant?.parts?.find((p) => p.type === "tool");
+
+    // done 之后的 run 已终态：工具保持原样（是否有结果由事件决定，不做清理判定）
+    expect(assistant?.parts?.length).toBeGreaterThan(0);
+    expect(tool).toBeDefined();
   });
 });

--- a/frontend/src/hooks/useAgent/eventHandlers.ts
+++ b/frontend/src/hooks/useAgent/eventHandlers.ts
@@ -307,6 +307,11 @@ export function handleStreamEvent(
     case "run:resumed": {
       // 系统中断后同 run 无缝续跑：清空气泡里的半截输出/错误/取消状态，
       // 回到流式空态接收重新生成的完整回答（模型会重跑这一轮）。
+      // 中断瞬间可能卡住的全局态一并复位：子代理栈残留（agent:call 无配对
+      // agent:result）、沙箱初始化中/错误（sandbox:starting 无 ready/error）。
+      ctx.activeSubagentStackRef.current.length = 0;
+      ctx.setIsInitializingSandbox(false);
+      ctx.setSandboxError(null);
       ctx.setMessages((prev) => {
         const reset = {
           parts: [],

--- a/frontend/src/hooks/useAgent/historyLoader.ts
+++ b/frontend/src/hooks/useAgent/historyLoader.ts
@@ -590,6 +590,40 @@ export function reconstructMessagesFromEvents(
     pushMessage(currentAssistantMessage);
   }
 
+  // 无终态事件的 run（中断后未恢复/旧数据）不允许留下"执行中"部件：
+  // 静默停转半截工具/参数流/思考/子代理的 loading（内容保留），避免历史里
+  // 永远转圈。终态判定在折叠完成后统一进行，steer 封存的中间轮次也能等到
+  // 自己 run 的 done；有终态的 run 完全不动。
+  const settledRunIds = new Set<string>();
+  for (const event of anchoredEvents) {
+    if (
+      event.run_id &&
+      (event.event_type === "done" ||
+        event.event_type === "complete" ||
+        event.event_type === "error" ||
+        event.event_type === "user:cancel")
+    ) {
+      settledRunIds.add(event.run_id);
+    }
+  }
+  for (let index = 0; index < reconstructedMessages.length; index += 1) {
+    const message = reconstructedMessages[index];
+    if (
+      message.role === "assistant" &&
+      message.runId &&
+      !settledRunIds.has(message.runId)
+    ) {
+      reconstructedMessages[index] = {
+        ...message,
+        // ask_human 卡片保持待响应：HITL 挂起中的 run 同样没有终态事件，
+        // 但审批卡必须继续可交互（恢复走审批响应路径，不走无缝续跑）
+        parts: clearAllLoadingStates(message.parts || [], {
+          preserveAskHuman: true,
+        }),
+      };
+    }
+  }
+
   // Some runs emit lifecycle events (for example `agent:start`) without ever
   // producing assistant content. They still create a placeholder while the
   // event stream is being folded, which leaves an empty assistant bubble in

--- a/src/infra/task/cancellation.py
+++ b/src/infra/task/cancellation.py
@@ -283,6 +283,16 @@ class TaskCancellation:
         return run_id in _interrupted_runs
 
     @staticmethod
+    def set_local_interrupt(run_id: str) -> None:
+        """在执行副本本地标记中断（跨副本 pubsub 取消时先于 task.cancel 调用）。
+
+        executor 的取消路径靠该标志区分「用户取消」与「系统中断」；pubsub
+        监听器收到取消消息后必须先设置本地标志，否则用户取消会被误判为
+        系统中断而吞掉终态事件。
+        """
+        _interrupted_runs[run_id] = time.time()
+
+    @staticmethod
     async def check_interrupt(run_id: str) -> None:
         """
         检查是否有中断信号，如果有则抛出 TaskInterruptedError

--- a/src/infra/task/executor.py
+++ b/src/infra/task/executor.py
@@ -305,11 +305,18 @@ class TaskExecutor:
         presenter: Any,
     ) -> None:
         """处理任务取消错误"""
-        # 无 interrupt 标志的取消是系统中断（优雅关停/部署），不是用户操作：
+        # 无中断信号的取消是系统中断（优雅关停/部署），不是用户操作：
         # 不写 user:cancel/error/done 终态事件、不终结 trace、不过期 stream，
         # 只 flush 缓冲让半截事件落库。recoverable 元数据由调用方标记
         # （manager.shutdown / arq_worker），随后同 run_id 无缝续跑。
-        if not TaskCancellation.check_interrupt_fast(run_id):
+        # 用户取消判定用权威信号（内存 + Redis）：跨副本取消时本副本内存标志
+        # 可能尚未同步，Redis 中断键才是可靠依据（系统中断从不设置）。
+        user_cancelled = False
+        try:
+            await TaskCancellation.check_interrupt(run_id)
+        except TaskInterruptedError:
+            user_cancelled = True
+        if not user_cancelled:
             if dual_writer is None:
                 dual_writer = get_dual_writer()
             try:

--- a/src/infra/task/pubsub.py
+++ b/src/infra/task/pubsub.py
@@ -104,6 +104,12 @@ class TaskPubSub:
                     f"Received cancel signal for run_id={run_id}, agent_id={agent_id}, session_id={session_id}"
                 )
 
+                # 先设本地中断标志再取消：executor 靠它区分「用户取消」与
+                # 「系统中断」（跨副本时本副本内存标志尚未同步会被误判）。
+                from .cancellation import TaskCancellation
+
+                TaskCancellation.set_local_interrupt(run_id)
+
                 # 调用自定义回调
                 if on_message:
                     try:

--- a/tests/infra/task/test_executor_interrupted_resume.py
+++ b/tests/infra/task/test_executor_interrupted_resume.py
@@ -88,9 +88,13 @@ def _executor_fixture(
         return None
 
     monkeypatch.setattr(cancellation.TaskCancellation, "clear_interrupt", _no_op)
-    monkeypatch.setattr(
-        cancellation.TaskCancellation, "check_interrupt_fast", lambda run_id: interrupt_flag
-    )
+
+    async def _check_interrupt(run_id: str) -> None:
+        # 权威判定（内存 + Redis）：用户取消时抛 TaskInterruptedError
+        if interrupt_flag:
+            raise cancellation.TaskInterruptedError(f"Task interrupted: {run_id}")
+
+    monkeypatch.setattr(cancellation.TaskCancellation, "check_interrupt", _check_interrupt)
 
     status_updates: list[str] = []
 

--- a/tests/infra/task/test_pubsub.py
+++ b/tests/infra/task/test_pubsub.py
@@ -86,3 +86,35 @@ async def test_cancel_pubsub_flushes_event_buffer_before_completing_trace(
     )
 
     assert call_order == ["on_message", "flush_mongo_buffer", "complete_trace"]
+
+
+@pytest.mark.asyncio
+async def test_cancel_pubsub_sets_local_interrupt_flag_before_cancelling(monkeypatch):
+    """跨副本取消：执行副本收到 pubsub 消息必须先设本地中断标志再取消任务。
+
+    否则 executor 的取消路径会把用户取消误判为系统中断（无缝续跑分支），
+    吞掉 user:cancel/error 终态事件（回归 R1-跨副本取消）。
+    """
+    from src.infra.task.cancellation import TaskCancellation, _interrupted_runs
+
+    _interrupted_runs.pop("run-local-flag", None)
+
+    cancelled_at: list[float | None] = [{"flag_age": None}]
+
+    class _Task:
+        def __init__(self):
+            self._done = False
+
+        def done(self):
+            return self._done
+
+        def cancel(self):
+            age = TaskCancellation.check_interrupt_fast("run-local-flag")
+            cancelled_at[0]["flag_age"] = age
+
+    pubsub = TaskPubSub(asyncio.Lock(), {"run-local-flag": _Task()})
+
+    await pubsub._handle_cancel_message({"data": json.dumps({"run_id": "run-local-flag"})})
+
+    assert cancelled_at[0]["flag_age"] is True, "cancel() 前本地中断标志必须已设置"
+    _interrupted_runs.pop("run-local-flag", None)


### PR DESCRIPTION
## 本次晋升内容（main..develop，3 个实质提交）

| 提交 | PR | 内容 |
|------|-----|------|
| f667524d | #347 | 后端：跨副本取消先设本地中断标志，executor 改用权威信号（内存+Redis）判定用户取消，避免用户取消被误判为系统中断而吞掉终态事件 |
| f13fee07 | #349 | 前端：无终态 run 历史折叠时静默停转挂起部件（ask_human 卡保持可交互）；run:resumed 复位子代理栈/沙箱中断残留全局态 |
| fa460723 | #351 | 前端：ask-human 卡片快捷键不再劫持内部文本输入（数字 1-4 / 空格 / 回车 / 方向键输不进「其他」输入框的偶发 bug） |

## 验证

- [x] 各 PR 合入前完整 CI 绿（Ruff / MyPy / 前后端测试 / 双架构镜像构建）
- [x] develop HEAD（c079d318）CI 绿：Lint / Build / Main Merge Gate
- [x] #351 本地全量验证：469 测试文件 / 2105 用例 + lint + build
- [ ] staging 验证：按负责人指示直接晋升，部署后回归补验

## 部署提醒

合并后生产部署仍为人工操作：yang 上 `/data/lambchat-k8s/update.sh`（自动取最新 `main-*` tag，失败自动回滚），随后 `bash /root/disttest/run-all.sh` 回归。