### PR TITLE
perf(agent): memory_delete 走延迟通道 + 代码解释器禁用 JS 编排注入

### DIFF
--- a/src/agents/fast_agent/context.py
+++ b/src/agents/fast_agent/context.py
@@ -229,6 +229,29 @@ class FastAgentContext:
         self.tools.append(transfer_path_tool)
         logger.info("[FastAgentContext] Added transfer_path tool")
 
+        # Memory 工具（原生 MongoDB 后端）：retain/recall 直挂；delete 是破坏性
+        # 低频操作，走 search_tools 延迟通道，不常驻工具 schema。
+        if settings.ENABLE_MEMORY:
+            try:
+                from src.infra.memory.tools import (
+                    get_deferred_memory_tools,
+                    get_inline_memory_tools,
+                )
+
+                self.tools.extend(get_inline_memory_tools())
+                if settings.ENABLE_DEFERRED_TOOL_LOADING:
+                    self._deferred_system_tools.extend(get_deferred_memory_tools())
+                else:
+                    self.tools.extend(get_deferred_memory_tools())
+                logger.info(
+                    "[FastAgentContext] Added memory tools (delete deferred=%s)",
+                    settings.ENABLE_DEFERRED_TOOL_LOADING,
+                )
+            except ImportError:
+                logger.warning("[FastAgentContext] memory tools import failed, skipping")
+            except Exception as e:
+                logger.warning(f"[FastAgentContext] Failed to load memory tools: {e}")
+
         try:
             from src.infra.mcp.quota import resolve_user_mcp_access
 
@@ -245,9 +268,9 @@ class FastAgentContext:
                 deferred_internal = []
             self._append_unique_tools(direct_internal)
             direct_names = {getattr(tool, "name", "") for tool in self.tools}
-            self._deferred_system_tools = [
+            self._deferred_system_tools.extend(
                 tool for tool in deferred_internal if getattr(tool, "name", "") not in direct_names
-            ]
+            )
             if self._deferred_system_tools:
                 from src.infra.tool.deferred_manager import DeferredToolManager
 
@@ -281,19 +304,6 @@ class FastAgentContext:
             logger.info(f"[FastAgentContext] Added {len(env_var_tools)} env var tools")
         except Exception as e:
             logger.warning(f"[FastAgentContext] Failed to load env var tools: {e}")
-
-        # Memory 工具（原生 MongoDB 后端）
-        if settings.ENABLE_MEMORY:
-            try:
-                from src.infra.memory.tools import get_all_memory_tools
-
-                memory_tools = get_all_memory_tools()
-                self.tools.extend(memory_tools)
-                logger.info(f"[FastAgentContext] Added {len(memory_tools)} memory tools")
-            except ImportError:
-                logger.warning("[FastAgentContext] memory tools import failed, skipping")
-            except Exception as e:
-                logger.warning(f"[FastAgentContext] Failed to load memory tools: {e}")
 
         # MCP 工具延迟加载（不在 setup 时初始化）
         logger.info("[FastAgentContext] MCP tools will be lazy loaded on first use")

--- a/src/agents/search_agent/context.py
+++ b/src/agents/search_agent/context.py
@@ -249,6 +249,29 @@ class SearchAgentContext:
         self.tools.append(transfer_path_tool)
         logger.info("[SearchAgentContext] Added transfer_path tool")
 
+        # Memory 工具（原生 MongoDB 后端）：retain/recall 直挂；delete 是破坏性
+        # 低频操作，走 search_tools 延迟通道，不常驻工具 schema。
+        if settings.ENABLE_MEMORY:
+            try:
+                from src.infra.memory.tools import (
+                    get_deferred_memory_tools,
+                    get_inline_memory_tools,
+                )
+
+                self.tools.extend(get_inline_memory_tools())
+                if settings.ENABLE_DEFERRED_TOOL_LOADING:
+                    self._deferred_system_tools.extend(get_deferred_memory_tools())
+                else:
+                    self.tools.extend(get_deferred_memory_tools())
+                logger.info(
+                    "[SearchAgentContext] Added memory tools (delete deferred=%s)",
+                    settings.ENABLE_DEFERRED_TOOL_LOADING,
+                )
+            except ImportError:
+                logger.warning("[SearchAgentContext] memory tools import failed, skipping")
+            except Exception as e:
+                logger.warning(f"[SearchAgentContext] Failed to load memory tools: {e}")
+
         try:
             from src.infra.mcp.quota import resolve_user_mcp_access
 
@@ -265,9 +288,9 @@ class SearchAgentContext:
                 deferred_internal = []
             self._append_unique_tools(direct_internal)
             direct_names = {getattr(tool, "name", "") for tool in self.tools}
-            self._deferred_system_tools = [
+            self._deferred_system_tools.extend(
                 tool for tool in deferred_internal if getattr(tool, "name", "") not in direct_names
-            ]
+            )
             if self._deferred_system_tools:
                 from src.infra.tool.deferred_manager import DeferredToolManager
 
@@ -301,19 +324,6 @@ class SearchAgentContext:
             logger.info(f"[SearchAgentContext] Added {len(env_var_tools)} env var tools")
         except Exception as e:
             logger.warning(f"[SearchAgentContext] Failed to load env var tools: {e}")
-
-        # Memory 工具（原生 MongoDB 后端）
-        if settings.ENABLE_MEMORY:
-            try:
-                from src.infra.memory.tools import get_all_memory_tools
-
-                memory_tools = get_all_memory_tools()
-                self.tools.extend(memory_tools)
-                logger.info(f"[SearchAgentContext] Added {len(memory_tools)} memory tools")
-            except ImportError:
-                logger.warning("[SearchAgentContext] memory tools import failed, skipping")
-            except Exception as e:
-                logger.warning(f"[SearchAgentContext] Failed to load memory tools: {e}")
 
         # 沙箱专属工具
         if settings.ENABLE_SANDBOX:

--- a/src/infra/agent/middleware/code_interpreter.py
+++ b/src/infra/agent/middleware/code_interpreter.py
@@ -115,6 +115,10 @@ def create_code_interpreter_middleware(
         return []
 
     return [
-        CodeInterpreterMiddleware(),
+        # subagents=False：不装 JS task() 桥。开启时上游会往每次模型调用的
+        # system message 注入约 9.8k 字符的 JS 子代理编排教程（dynamic
+        # subagents），且 JS 内派发绕过父级 interrupt_on/HITL 审批；本项目的
+        # REPL 定位是纯计算（见上方路由文案），子代理统一走正常 task 工具。
+        CodeInterpreterMiddleware(subagents=False),
         CodeInterpreterRoutingMiddleware(sandbox_active=sandbox_active),
     ]

--- a/src/infra/memory/__init__.py
+++ b/src/infra/memory/__init__.py
@@ -14,6 +14,8 @@ from src.infra.memory.client.base import (
 )
 from src.infra.memory.tools import (
     get_all_memory_tools,
+    get_deferred_memory_tools,
+    get_inline_memory_tools,
     get_memory_delete_tool,
     get_memory_recall_tool,
     get_memory_retain_tool,
@@ -22,6 +24,8 @@ from src.infra.memory.tools import (
 __all__ = [
     # Unified tools (preferred API)
     "get_all_memory_tools",
+    "get_inline_memory_tools",
+    "get_deferred_memory_tools",
     "get_memory_retain_tool",
     "get_memory_recall_tool",
     "get_memory_delete_tool",

--- a/src/infra/memory/client/types.py
+++ b/src/infra/memory/client/types.py
@@ -29,21 +29,21 @@ class MemoryType(str, Enum):
 NATIVE_MEMORY_GUIDE = """
 ## Cross-Session Memory
 
-Tools: `memory_retain` (store/update), `memory_recall` (search), `memory_delete` (remove). Use only these tools, never `/memories/` paths.
+Tools: `memory_retain` (store/update), `memory_recall` (search). `memory_delete` is deferred: load via `search_tools`. Use only these tools, never `/memories/` paths.
 
 `<memory_index>` entries are hint only, not ground truth. Recall selectively when prior context matters.
 
 | Type | Keep |
 |---|---|
 | `user` | role, preferences, knowledge, working style |
-| `feedback` | corrections, confirmations, why, and application |
+| `feedback` | corrections, confirmations, why, application |
 | `project` | goals, constraints, bugs, decisions; use absolute dates |
-| `reference` | external systems, docs, and URLs |
+| `reference` | external systems, docs, URLs |
 
-**Remember:** durable preferences, project context, non-obvious decisions, useful references, and positive feedback; update instead of duplicating.
-**Skip:** greetings, ephemeral state, activity logs, code/git history, and debugging already captured in code.
+**Remember:** durable preferences, project context, non-obvious decisions, useful references, positive feedback; update instead of duplicating.
+**Skip:** greetings, ephemeral state, activity logs, code/git history, debugging already captured in code.
 
-Delete inaccurate entries and honor ignore/forget requests. Content older than 30 days may be stale; verify current paths, flags, and observations.
+Delete inaccurate entries; honor ignore/forget requests. Content older than 30 days may be stale; verify current paths, flags, observations.
 """
 
 # ENABLE_MEMORY_VFS=true 时的变体：放开 /memories/working/ 作为多轮长任务工作
@@ -52,16 +52,16 @@ Delete inaccurate entries and honor ignore/forget requests. Content older than 3
 NATIVE_MEMORY_GUIDE_VFS = """
 ## Cross-Session Memory
 
-Tools: `memory_retain` (store/update), `memory_recall` (search), `memory_delete` (remove). Durable facts: these tools only. `/memories/working/`: multi-turn task notes (plans, findings) only, never durable facts.
+Tools: `memory_retain` (store/update), `memory_recall` (search). Durable facts: these tools only. `/memories/working/`: multi-turn task notes (plans, findings) only, never durable facts. `memory_delete` is deferred: load via `search_tools`.
 
 `<memory_index>` entries are hint only, not ground truth. Recall selectively when prior context matters.
 
 | Type | Keep |
 |---|---|
-| `user` | role, preferences, working style |
+| `user` | role, preferences, knowledge, working style |
 | `feedback` | corrections, confirmations, why |
 | `project` | goals, constraints, decisions; use absolute dates |
-| `reference` | external systems, docs, and URLs |
+| `reference` | external systems, docs, URLs |
 
 **Remember:** durable preferences, project context, key decisions, references; update instead of duplicating.
 **Skip:** greetings, ephemeral state, activity logs, code/git history, debugging captured in code.

--- a/src/infra/memory/tools.py
+++ b/src/infra/memory/tools.py
@@ -310,7 +310,17 @@ def get_memory_delete_tool() -> BaseTool:
 
 def get_all_memory_tools() -> list[BaseTool]:
     """Get all unified memory tools (works with any backend)."""
-    return [memory_retain, memory_recall, memory_delete]
+    return [*get_inline_memory_tools(), *get_deferred_memory_tools()]
+
+
+def get_inline_memory_tools() -> list[BaseTool]:
+    """High-frequency, non-destructive tools mounted directly on the agent."""
+    return [memory_retain, memory_recall]
+
+
+def get_deferred_memory_tools() -> list[BaseTool]:
+    """Destructive, low-frequency tools exposed through the `search_tools` channel."""
+    return [memory_delete]
 
 
 def _background_task_error(task: asyncio.Task) -> None:

--- a/tests/agents/test_deferred_system_tools.py
+++ b/tests/agents/test_deferred_system_tools.py
@@ -61,6 +61,61 @@ async def test_context_defers_system_tools_even_when_mcp_is_disabled(
     assert context.deferred_manager.get_tool("deferred_system") is deferred
 
 
+@pytest.mark.parametrize(
+    ("module", "context_type"),
+    [(fast_context, FastAgentContext), (search_context, SearchAgentContext)],
+)
+@pytest.mark.asyncio
+async def test_memory_delete_is_deferred_while_retain_and_recall_stay_inline(
+    monkeypatch,
+    lean_settings,
+    module,
+    context_type,
+) -> None:
+    monkeypatch.setattr(module.settings, "ENABLE_MEMORY", True)
+
+    async def no_internal(**_kwargs):
+        return [], []
+
+    monkeypatch.setattr(module, "get_internal_tools_by_exposure_for_user", no_internal)
+    context = context_type(session_id="session-1")
+
+    await context.setup()
+    await context.get_tools()
+
+    direct = {tool.name for tool in context.tools}
+    assert {"memory_retain", "memory_recall"}.issubset(direct)
+    assert "memory_delete" not in direct
+    assert context.deferred_manager is not None
+    assert context.deferred_manager.get_tool("memory_delete") is not None
+    assert "memory_delete" in context.deferred_manager.get_deferred_stubs_string()
+
+
+@pytest.mark.asyncio
+async def test_memory_delete_stays_inline_when_deferred_loading_disabled(
+    monkeypatch,
+    lean_settings,
+) -> None:
+    monkeypatch.setattr(fast_context.settings, "ENABLE_MEMORY", True)
+    monkeypatch.setattr(fast_context.settings, "ENABLE_DEFERRED_TOOL_LOADING", False)
+
+    async def no_internal(**_kwargs):
+        return [], []
+
+    monkeypatch.setattr(
+        fast_context,
+        "get_internal_tools_by_exposure_for_user",
+        no_internal,
+    )
+    context = FastAgentContext(session_id="session-1")
+
+    await context.setup()
+
+    direct = {tool.name for tool in context.tools}
+    assert {"memory_retain", "memory_recall", "memory_delete"}.issubset(direct)
+    assert context.deferred_manager is None
+
+
 @pytest.mark.asyncio
 async def test_compatibility_registration_does_not_reinline_deferred_env_tool(
     monkeypatch,

--- a/tests/infra/agent/test_code_interpreter_middleware.py
+++ b/tests/infra/agent/test_code_interpreter_middleware.py
@@ -50,8 +50,57 @@ def test_code_interpreter_middleware_created_when_both_switches_enabled(monkeypa
 
     assert len(middleware) == 2
     assert isinstance(middleware[0], FakeCodeInterpreterMiddleware)
-    assert middleware[0].kwargs == {}
+    # subagents=False：不安装 JS task() 桥，也不注入 ~9.8k 的 JS 子代理编排教程。
+    assert middleware[0].kwargs == {"subagents": False}
     assert isinstance(middleware[1], CodeInterpreterRoutingMiddleware)
+
+
+async def test_subagent_orchestration_prompt_is_not_injected() -> None:
+    from langchain_quickjs import CodeInterpreterMiddleware
+    from pydantic import BaseModel
+
+    class TaskArgs(BaseModel):
+        description: str
+        subagent_type: str
+
+    class TaskTool(BaseTool):
+        name: str = "task"
+        description: str = "Dispatch a subagent."
+        args_schema: type = TaskArgs
+
+        def _run(self, *args, **kwargs):  # pragma: no cover - test stub
+            return "ok"
+
+    class EvalTool(BaseTool):
+        name: str = "eval"
+        description: str = "Execute JavaScript in a sandboxed REPL."
+
+        def _run(self, *args, **kwargs):  # pragma: no cover - test stub
+            return "ok"
+
+    class Request:
+        def __init__(self) -> None:
+            self.messages = []
+            self.system_message = SystemMessage(content="base")
+            self.tools = [EvalTool(), TaskTool()]
+
+        def override(self, **kwargs):
+            request = Request()
+            request.tools = kwargs.get("tools", self.tools)
+            request.system_message = kwargs.get("system_message", self.system_message)
+            return request
+
+    async def handler(request):
+        return request
+
+    middleware = CodeInterpreterMiddleware(subagents=False)
+    result = await middleware.awrap_model_call(Request(), handler)
+
+    content = result.system_message.content
+    injected = content[-1]["text"] if isinstance(content, list) else str(content)
+    assert "### Interpreter" in injected
+    assert "Dispatching Subagents" not in injected
+    assert len(injected) < 1000
 
 
 class _EvalTool(BaseTool):

--- a/tests/infra/memory/test_tools.py
+++ b/tests/infra/memory/test_tools.py
@@ -23,6 +23,13 @@ def test_all_memory_tools_excludes_consolidation_tool():
     assert "memory_consolidate" not in tool_names
 
 
+def test_memory_tool_exposure_split_keeps_delete_deferred():
+    from src.infra.memory.tools import get_deferred_memory_tools, get_inline_memory_tools
+
+    assert {tool.name for tool in get_inline_memory_tools()} == {"memory_retain", "memory_recall"}
+    assert {tool.name for tool in get_deferred_memory_tools()} == {"memory_delete"}
+
+
 def test_native_memory_guide_does_not_advertise_consolidation_tool():
     from src.infra.memory.client.types import NATIVE_MEMORY_GUIDE
 
@@ -36,6 +43,7 @@ def test_native_memory_guide_preserves_compact_behavior_contract() -> None:
         "memory_retain",
         "memory_recall",
         "memory_delete",
+        "search_tools",
         "hint only",
         "user",
         "feedback",
@@ -697,6 +705,7 @@ def test_native_memory_guide_vfs_preserves_compact_behavior_contract() -> None:
         "memory_retain",
         "memory_recall",
         "memory_delete",
+        "search_tools",
         "hint only",
         "user",
         "feedback",


### PR DESCRIPTION
## 摘要

系统提示词/工具面瘦身两项（均出自本 session 提示词评审）：

### 1. memory_delete 改走 search_tools 延迟通道（5d9950bd）

- `memory_retain` / `memory_recall` 保持直挂；`memory_delete` 是破坏性低频操作，挪入 `DeferredToolManager` 的 System Tools (Deferred) 通道，经 `search_tools` 发现后可正常调用并按会话持久化
- `ENABLE_DEFERRED_TOOL_LOADING=False` 时回退为直挂，与内部工具行为一致
- 记忆指南两个变体（NATIVE_MEMORY_GUIDE / _VFS）注明 delete 延迟发现，压缩措辞保住 ≤960 字符契约（958/960）
- 附带收益：delete 进入延迟通道后经过 `disabled_tools` 过滤

### 2. 代码解释器禁用 JS 子代理编排（e47a1997）

- `CodeInterpreterMiddleware(subagents=False)`：langchain-quickjs 默认在每次模型调用向 system message 注入约 10.5k 字符（其中 9,830 为 JS 子代理编排教程，实测）。改后仅注入 678 字符（### Interpreter 基础说明）
- 官方文档警告 JS 内 `task()` 派发不触发父级 interrupt_on/HITL 审批，关闭后恢复每次派发审批一致性（对齐 ask_human 审批流 #218）
- LambChat 无代码/提示词/前端依赖 JS task() 桥；子代理派发仍走正常 task 工具，REPL 定位保持纯计算
- 上游 0.3.5（PyPI 最新）无精简开关，只能构造期关闭

## 验证

- [x] `uv run pytest tests/agents tests/infra/memory tests/infra/tool` — 708 passed（改前基线一致）
- [x] `uv run pytest tests/infra/agent` — 261 passed
- [x] `cd frontend && pnpm test` — 2112 passed（专属 Item 扫描确认 memory_delete 无需前端改动）
- [x] `make lint` / `make typecheck`（mypy 463 文件）全绿