### PR TITLE
fix(memory): 记忆删除 SOP 验证闭环 + 延迟加载关闭时指南对齐

### DIFF
--- a/src/agents/core/subagent_prompts.py
+++ b/src/agents/core/subagent_prompts.py
@@ -67,10 +67,19 @@ def get_memory_guide() -> str:
     if getattr(settings, "ENABLE_MEMORY_VFS", False):
         from src.infra.memory.client.types import NATIVE_MEMORY_GUIDE_VFS
 
-        return NATIVE_MEMORY_GUIDE_VFS
-    from src.infra.memory.client.types import NATIVE_MEMORY_GUIDE
+        guide = NATIVE_MEMORY_GUIDE_VFS
+    else:
+        from src.infra.memory.client.types import NATIVE_MEMORY_GUIDE
 
-    return NATIVE_MEMORY_GUIDE
+        guide = NATIVE_MEMORY_GUIDE
+    if not settings.ENABLE_DEFERRED_TOOL_LOADING:
+        from src.infra.memory.client.types import (
+            MEMORY_DELETE_DEFERRED_SEGMENT,
+            MEMORY_DELETE_INLINE_SEGMENT,
+        )
+
+        return guide.replace(MEMORY_DELETE_DEFERRED_SEGMENT, MEMORY_DELETE_INLINE_SEGMENT)
+    return guide
 
 
 _SUBAGENT_BASE = """You are a subagent completing a scoped objective. Stay within scope, prefer evidence, name uncertainty, verify checkable claims, and hand results to the main agent rather than promising the user a final outcome."""

--- a/src/infra/memory/client/types.py
+++ b/src/infra/memory/client/types.py
@@ -26,6 +26,12 @@ class MemoryType(str, Enum):
 # System prompt guide for native backend
 # ---------------------------------------------------------------------------
 
+# memory_delete 的两种暴露说法：延迟加载开启时走 search_tools 发现；关闭时随
+# retain/recall 一起直挂。get_memory_guide() 按设置把前者替换成后者，保证指南
+# 与 Context 的实际挂载方式一致（关闭时不存在 search_tools，指引会断）。
+MEMORY_DELETE_DEFERRED_SEGMENT = ". `memory_delete` is deferred: load via `search_tools`."
+MEMORY_DELETE_INLINE_SEGMENT = ", `memory_delete` (remove)"
+
 NATIVE_MEMORY_GUIDE = """
 ## Cross-Session Memory
 

--- a/tests/agents/test_deferred_system_tools.py
+++ b/tests/agents/test_deferred_system_tools.py
@@ -116,6 +116,63 @@ async def test_memory_delete_stays_inline_when_deferred_loading_disabled(
     assert context.deferred_manager is None
 
 
+@pytest.mark.parametrize(
+    ("module", "context_type"),
+    [(fast_context, FastAgentContext), (search_context, SearchAgentContext)],
+)
+@pytest.mark.asyncio
+async def test_memory_sop_search_tools_loads_memory_delete(
+    monkeypatch,
+    lean_settings,
+    module,
+    context_type,
+) -> None:
+    """记忆指南 SOP 端到端：search_tools 按名/按能力词搜索都能命中并提升 memory_delete。"""
+    monkeypatch.setattr(module.settings, "ENABLE_MEMORY", True)
+
+    async def no_internal(**_kwargs):
+        return [], []
+
+    monkeypatch.setattr(module, "get_internal_tools_by_exposure_for_user", no_internal)
+    context = context_type(session_id="session-1")
+
+    await context.setup()
+    await context.get_tools()
+
+    # SOP 前提：memory_delete 在延迟通道里，search_tools 入口由节点注入
+    assert context.deferred_manager is not None
+    assert context.deferred_manager.get_tool("memory_delete") is not None
+
+    from src.infra.tool.tool_search_tool import ToolSearchTool
+
+    search_tool = ToolSearchTool(manager=context.deferred_manager, search_limit=25)
+
+    # 指南点名工具名 → 按名搜索可提升
+    result = await search_tool.ainvoke({"query": "memory_delete"})
+    assert "## memory_delete" in result
+    assert context.deferred_manager.is_discovered("memory_delete")
+    discovered_names = [t.name for t in context.deferred_manager.get_discovered_tools()]
+    assert "memory_delete" in discovered_names
+
+    # 自然语言能力词也要命中
+    result = await search_tool.ainvoke({"query": "delete memory"})
+    assert "## memory_delete" in result
+
+
+def test_agent_nodes_wire_search_tool_whenever_deferred_manager_exists() -> None:
+    """结构断言：主 Agent 节点在 deferred_manager 非空时注入 search_tools（SOP 入口）。"""
+    from inspect import getsource
+
+    from src.agents.fast_agent import nodes as fast_nodes
+    from src.agents.search_agent import nodes as search_nodes
+
+    for nodes in (fast_nodes, search_nodes):
+        source = getsource(nodes)
+        assert "context.deferred_manager is not None" in source
+        assert "ToolSearchTool(" in source
+        assert "ToolSearchMiddleware(" in source
+
+
 @pytest.mark.asyncio
 async def test_compatibility_registration_does_not_reinline_deferred_env_tool(
     monkeypatch,

--- a/tests/infra/memory/test_tools.py
+++ b/tests/infra/memory/test_tools.py
@@ -737,3 +737,26 @@ def test_get_memory_guide_selects_variant_by_vfs_setting(monkeypatch):
 
     monkeypatch.setattr(settings, "ENABLE_MEMORY_VFS", True)
     assert subagent_prompts.get_memory_guide() == NATIVE_MEMORY_GUIDE_VFS
+
+
+def test_get_memory_guide_keeps_delete_deferred_when_deferred_loading_enabled(monkeypatch):
+    from src.agents.core import subagent_prompts
+    from src.kernel.config import settings
+
+    monkeypatch.setattr(settings, "ENABLE_MEMORY_VFS", False)
+    monkeypatch.setattr(settings, "ENABLE_DEFERRED_TOOL_LOADING", True)
+    guide = subagent_prompts.get_memory_guide()
+    assert "search_tools" in guide
+    assert "(remove)" not in guide
+
+
+def test_get_memory_guide_lists_delete_inline_when_deferred_loading_disabled(monkeypatch):
+    """延迟加载关闭时 memory_delete 直挂，指南不得再指向不存在的 search_tools。"""
+    from src.agents.core import subagent_prompts
+    from src.kernel.config import settings
+
+    monkeypatch.setattr(settings, "ENABLE_MEMORY_VFS", False)
+    monkeypatch.setattr(settings, "ENABLE_DEFERRED_TOOL_LOADING", False)
+    guide = subagent_prompts.get_memory_guide()
+    assert "search_tools" not in guide
+    assert "`memory_delete` (remove)" in guide


### PR DESCRIPTION
## 背景

#353 把 memory_delete 改走 search_tools 延迟通道后，记忆指南 SOP 承诺「load via search_tools」。本 PR 确保该链路真实可用，并修复一个配置组合下的断链。

## 变更

### 1. SOP 端到端验证测试（证明链路通）

- `search_tools` 按工具名（`memory_delete`）与能力词（`delete memory`）搜索都命中并提升该工具（`ToolSearchTool` → `DeferredToolManager.discover_tools` → `get_discovered_tools`，Fast/Search 两 Context 参数化）
- 结构断言：主 Agent 节点在 `deferred_manager` 非空时注入 `ToolSearchTool` + `ToolSearchMiddleware`（SOP 入口接线）
- 已核对的既有机制：`ToolSearchMiddleware.awrap_model_call` 每次模型调用把已发现工具追加进 request.tools；发现状态按会话持久化（重启后 restore）；子代理经 fork 共享 system 延迟工具；压缩 agent 用独立的 memory_compaction_delete，不受影响

### 2. 修复：ENABLE_DEFERRED_TOOL_LOADING=False 时指南断链

该模式下 memory_delete 回退直挂且不存在 search_tools，但指南仍指向 search_tools。`get_memory_guide()` 现按设置把延迟说法替换为 `` , `memory_delete` (remove) ``，与 Context 实际挂载一致（两种 VFS 变体同样处理）。

## 验证

- [x] `uv run pytest tests/agents tests/infra/memory tests/infra/tool` — 713 passed
- [x] 提示词预算与指南契约测试全过（≤960 字符约束不受影响，常量未变）
- [x] ruff / ruff format / mypy 全绿