### PR TITLE
fix(task): 关闭静默 + 恢复锁僵死自愈（develop → main 晋升）

### DIFF
--- a/src/agents/core/subagent_prompts.py
+++ b/src/agents/core/subagent_prompts.py
@@ -67,10 +67,19 @@ def get_memory_guide() -> str:
     if getattr(settings, "ENABLE_MEMORY_VFS", False):
         from src.infra.memory.client.types import NATIVE_MEMORY_GUIDE_VFS
 
-        return NATIVE_MEMORY_GUIDE_VFS
-    from src.infra.memory.client.types import NATIVE_MEMORY_GUIDE
+        guide = NATIVE_MEMORY_GUIDE_VFS
+    else:
+        from src.infra.memory.client.types import NATIVE_MEMORY_GUIDE
 
-    return NATIVE_MEMORY_GUIDE
+        guide = NATIVE_MEMORY_GUIDE
+    if not settings.ENABLE_DEFERRED_TOOL_LOADING:
+        from src.infra.memory.client.types import (
+            MEMORY_DELETE_DEFERRED_SEGMENT,
+            MEMORY_DELETE_INLINE_SEGMENT,
+        )
+
+        return guide.replace(MEMORY_DELETE_DEFERRED_SEGMENT, MEMORY_DELETE_INLINE_SEGMENT)
+    return guide
 
 
 _SUBAGENT_BASE = """You are a subagent completing a scoped objective. Stay within scope, prefer evidence, name uncertainty, verify checkable claims, and hand results to the main agent rather than promising the user a final outcome."""

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -523,6 +523,11 @@ async def lifespan(app: FastAPI):
     # 启动时初始化
     logger.info("%s v%s starting...", settings.APP_NAME, settings.APP_VERSION)
 
+    # 复位进程关闭标志（进程复用/热重载场景），随后才允许扫描/恢复入口工作
+    from src.infra.task.lifecycle import clear_shutting_down
+
+    clear_shutting_down()
+
     # 初始化日志系统
     setup_logging()
 
@@ -678,6 +683,12 @@ async def lifespan(app: FastAPI):
         # 关闭时清理
         from src.agents import AgentFactory
         from src.infra.sandbox import SandboxFactory
+
+        # 第一时间置进程关闭标志：此后周期扫描/孤儿接管不再发起新的恢复，
+        # 否则依赖逐个断开期间，垂死实例会把恢复任务塞给自己并随即被杀掉。
+        from src.infra.task.lifecycle import mark_shutting_down
+
+        mark_shutting_down()
 
         # 先关闭飞书长连接并释放 lease，避免快速重启时旧锁阻止新实例启动。
         await _stop_feishu_channels_for_shutdown(app)

--- a/src/infra/memory/client/types.py
+++ b/src/infra/memory/client/types.py
@@ -26,6 +26,12 @@ class MemoryType(str, Enum):
 # System prompt guide for native backend
 # ---------------------------------------------------------------------------
 
+# memory_delete 的两种暴露说法：延迟加载开启时走 search_tools 发现；关闭时随
+# retain/recall 一起直挂。get_memory_guide() 按设置把前者替换成后者，保证指南
+# 与 Context 的实际挂载方式一致（关闭时不存在 search_tools，指引会断）。
+MEMORY_DELETE_DEFERRED_SEGMENT = ". `memory_delete` is deferred: load via `search_tools`."
+MEMORY_DELETE_INLINE_SEGMENT = ", `memory_delete` (remove)"
+
 NATIVE_MEMORY_GUIDE = """
 ## Cross-Session Memory
 

--- a/src/infra/task/arq_runtime.py
+++ b/src/infra/task/arq_runtime.py
@@ -144,6 +144,10 @@ _runtime: EmbeddedArqRuntime | None = None
 
 async def _recover_stale_tasks_after_worker_restart() -> None:
     """Worker 崩溃重启后补一次全量恢复（与启动清理等价，有租约互斥保护）。"""
+    from .lifecycle import is_shutting_down
+
+    if is_shutting_down():
+        return
     try:
         from .manager import get_task_manager
 

--- a/src/infra/task/arq_worker.py
+++ b/src/infra/task/arq_worker.py
@@ -68,6 +68,14 @@ async def worker_startup(ctx: dict[str, Any]) -> None:
     validate_distributed_runtime_settings(settings)
 
 
+async def worker_shutdown(ctx: dict[str, Any]) -> None:
+    """Mark the worker process as shutting down so recovery entrypoints go quiet."""
+    del ctx
+    from .lifecycle import mark_shutting_down
+
+    mark_shutting_down()
+
+
 def _resolve_executor(executor_key: str) -> Any:
     executor_fn = get_registered_executor(executor_key)
     if executor_fn is not None:
@@ -293,3 +301,4 @@ async def update_user_message_search_index(ctx: dict[str, Any], run_id: str) -> 
 class WorkerSettings:
     functions = [run_agent_task, update_user_message_search_index]
     on_startup = worker_startup
+    on_shutdown = worker_shutdown

--- a/src/infra/task/lifecycle.py
+++ b/src/infra/task/lifecycle.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import threading
+
+"""进程级关闭标志：lifespan 关闭开始后，本实例不得再发起新的恢复/接管。
+
+为什么需要：优雅关闭顺序里 trace/merger 等依赖先于周期调度器关闭，执行器会
+先失败并被标记 recoverable；若此时孤儿扫描器仍在跑，垂死实例会把恢复任务
+提交给自己即将关闭的 worker，随后被再次杀掉——多一次无效生成，还把恢复锁
+占满整个 TTL。该标志只约束本进程（每个副本自治），跨副本协同仍靠 Redis。
+"""
+
+_shutting_down = threading.Event()
+
+
+def mark_shutting_down() -> None:
+    """lifespan 关闭入口调用；此后本进程所有扫描/恢复入口静默。"""
+    _shutting_down.set()
+
+
+def clear_shutting_down() -> None:
+    """lifespan 启动入口调用，保证进程复用（如测试）间不串状态。"""
+    _shutting_down.clear()
+
+
+def is_shutting_down() -> bool:
+    return _shutting_down.is_set()

--- a/src/infra/task/orphan_recovery.py
+++ b/src/infra/task/orphan_recovery.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from src.infra.logging import get_logger
 from src.infra.scheduler.runtime import ScheduledJob, get_runtime_scheduler
+from src.infra.task.lifecycle import is_shutting_down
 from src.infra.task.manager import get_task_manager
 from src.kernel.config import settings
 
@@ -29,6 +30,9 @@ def recovery_interval_seconds() -> int:
 
 
 async def run_scheduled_orphan_recovery() -> dict[str, Any]:
+    if is_shutting_down():
+        # 关闭中的实例不再接管任务，交还给存活副本（关闭静默的调度器层闸门）。
+        return {"status": "skipped", "reason": "shutting_down"}
     task_manager = get_task_manager()
     await task_manager.cleanup_stale_tasks(running_only=True)
     return {"status": "ok"}

--- a/src/infra/task/recovery.py
+++ b/src/infra/task/recovery.py
@@ -23,8 +23,38 @@ logger = get_logger(__name__)
 
 RECOVERY_LOCK_PREFIX = "task:recovery:"
 RECOVERY_LOCK_TTL_SECONDS = 300
+# 恢复锁僵死接管阈值：锁龄（原 TTL - 剩余 TTL）超过该值且执行者心跳仍判定
+# 死亡时，允许原子接管。健康的恢复交接在秒级完成并落下 task_recoverable=False；
+# 锁挂到这个年龄还没有任何进展，说明持锁实例已死/提交空转（生产实测强杀场景
+# 被死锁堵满整个 300s TTL），此时等待只剩坏处。
+RECOVERY_LOCK_STALE_TAKEOVER_SECONDS = 60
 # 同一 run 的无缝恢复提交次数上限：超限视为毒消息，落终态 FAILED 防止无限重跑。
 MAX_SEAMLESS_RESUME_ATTEMPTS = 3
+
+# 僵死锁接管（原子）：锁缺失 → 直接获取；TTL 异常（-1 无过期/-2 竞态消失）或
+# 锁龄（ARGV[2] 自设定的 TTL - 剩余 TTL）达标 → 覆写 token 并重置 TTL；否则
+# 不动锁。旧持有者事后按旧 token 释放因不匹配为 no-op，不会误删新持有者的锁。
+RECOVERY_LOCK_TAKEOVER_LUA = """
+local current = redis.call("get", KEYS[1])
+if not current then
+    redis.call("set", KEYS[1], ARGV[1], "EX", tonumber(ARGV[2]))
+    return 1
+end
+local ttl = redis.call("ttl", KEYS[1])
+if ttl <= 0 or tonumber(ARGV[2]) - ttl >= tonumber(ARGV[3]) then
+    redis.call("set", KEYS[1], ARGV[1], "EX", tonumber(ARGV[2]))
+    return 1
+end
+return 0
+"""
+
+# 令牌匹配才删除：接管后旧持有者的释放是安全的 no-op。
+RECOVERY_LOCK_RELEASE_LUA = """
+if redis.call("get", KEYS[1]) == ARGV[1] then
+    return redis.call("del", KEYS[1])
+end
+return 0
+"""
 
 
 def _get_enabled_skills_from_metadata(session_metadata: dict[str, Any]) -> list[str] | None:
@@ -412,12 +442,24 @@ class TaskRecoveryService:
             nx=True,
         )
         if not acquired:
-            return {
-                "success": False,
-                "run_id": None,
-                "resumed_from_run_id": source_run_id,
-                "message": "恢复任务已在其他实例中启动",
-            }
+            # 锁被占用通常意味着别的实例正在恢复；但持锁实例也可能已死
+            # （提交后崩溃 / arq job 空转），死锁会把恢复堵满整个 TTL。
+            # 执行者心跳仍判定死亡且锁龄超阈值时原子接管；心跳新鲜则不动锁。
+            took_over = False
+            if await self._heartbeat.is_stale(source_run_id):
+                took_over = await self._takeover_stale_recovery_lock(
+                    redis_client, lock_key, lock_token
+                )
+            if not took_over:
+                return {
+                    "success": False,
+                    "run_id": None,
+                    "resumed_from_run_id": source_run_id,
+                    "message": "恢复任务已在其他实例中启动",
+                }
+            logger.warning(
+                "Took over stale recovery lock: key=%s run_id=%s", lock_key, source_run_id
+            )
 
         try:
             session_metadata = getattr(session, "metadata", None) or {}
@@ -516,17 +558,34 @@ class TaskRecoveryService:
                 "message": f"恢复任务失败: {e}",
             }
 
+    async def _takeover_stale_recovery_lock(
+        self, redis_client: Any, lock_key: str, lock_token: str
+    ) -> bool:
+        """Atomically take over an aged recovery lock whose holder is gone.
+
+        Lua 侧校验锁龄（原 TTL - 剩余 TTL ≥ 接管阈值）后才覆写 token，多个
+        扫描器并发接管时只有一个成功；失败方按普通锁冲突退避。
+        """
+        try:
+            result = redis_client.eval(
+                RECOVERY_LOCK_TAKEOVER_LUA,
+                1,
+                lock_key,
+                lock_token,
+                RECOVERY_LOCK_TTL_SECONDS,
+                RECOVERY_LOCK_STALE_TAKEOVER_SECONDS,
+            )
+            if inspect.isawaitable(result):
+                result = await result
+            return bool(result)
+        except Exception as e:
+            logger.warning("Failed to takeover stale recovery lock %s: %s", lock_key, e)
+            return False
+
     async def release_recovery_lock(self, lock_key: str, token: str) -> None:
         """Release a distributed recovery lock when immediate retry is safe."""
         try:
-            lua_script = """
-            if redis.call("get", KEYS[1]) == ARGV[1] then
-                return redis.call("del", KEYS[1])
-            else
-                return 0
-            end
-            """
-            result = get_redis_client().eval(lua_script, 1, lock_key, token)
+            result = get_redis_client().eval(RECOVERY_LOCK_RELEASE_LUA, 1, lock_key, token)
             if inspect.isawaitable(result):
                 await result
         except Exception as e:

--- a/src/infra/task/startup_cleanup.py
+++ b/src/infra/task/startup_cleanup.py
@@ -11,6 +11,7 @@ from src.infra.async_utils.blocking import run_blocking_io
 from src.infra.logging import get_logger
 from src.kernel.config import settings
 
+from .lifecycle import is_shutting_down
 from .status import TaskStatus
 
 logger = get_logger(__name__)
@@ -378,6 +379,12 @@ class TaskStartupCleanupService:
             running_only: 仅接管 RUNNING 且心跳过期的任务（周期调用的保守模式，
                 跳过 PENDING/QUEUED 重放与 FAILED 恢复，避免误重放排队中的任务）。
         """
+        if is_shutting_down():
+            # 本实例正在关闭：依赖逐个断开会把执行器标记成 recoverable，此时
+            # 接管等于把恢复任务塞给垂死的自己（生产实测会白跑一轮再被杀）。
+            logger.info("Skipping stale task cleanup: instance is shutting down")
+            return
+
         from .concurrency import get_concurrency_limiter
 
         limiter = get_concurrency_limiter()

--- a/tests/agents/test_deferred_system_tools.py
+++ b/tests/agents/test_deferred_system_tools.py
@@ -116,6 +116,63 @@ async def test_memory_delete_stays_inline_when_deferred_loading_disabled(
     assert context.deferred_manager is None
 
 
+@pytest.mark.parametrize(
+    ("module", "context_type"),
+    [(fast_context, FastAgentContext), (search_context, SearchAgentContext)],
+)
+@pytest.mark.asyncio
+async def test_memory_sop_search_tools_loads_memory_delete(
+    monkeypatch,
+    lean_settings,
+    module,
+    context_type,
+) -> None:
+    """记忆指南 SOP 端到端：search_tools 按名/按能力词搜索都能命中并提升 memory_delete。"""
+    monkeypatch.setattr(module.settings, "ENABLE_MEMORY", True)
+
+    async def no_internal(**_kwargs):
+        return [], []
+
+    monkeypatch.setattr(module, "get_internal_tools_by_exposure_for_user", no_internal)
+    context = context_type(session_id="session-1")
+
+    await context.setup()
+    await context.get_tools()
+
+    # SOP 前提：memory_delete 在延迟通道里，search_tools 入口由节点注入
+    assert context.deferred_manager is not None
+    assert context.deferred_manager.get_tool("memory_delete") is not None
+
+    from src.infra.tool.tool_search_tool import ToolSearchTool
+
+    search_tool = ToolSearchTool(manager=context.deferred_manager, search_limit=25)
+
+    # 指南点名工具名 → 按名搜索可提升
+    result = await search_tool.ainvoke({"query": "memory_delete"})
+    assert "## memory_delete" in result
+    assert context.deferred_manager.is_discovered("memory_delete")
+    discovered_names = [t.name for t in context.deferred_manager.get_discovered_tools()]
+    assert "memory_delete" in discovered_names
+
+    # 自然语言能力词也要命中
+    result = await search_tool.ainvoke({"query": "delete memory"})
+    assert "## memory_delete" in result
+
+
+def test_agent_nodes_wire_search_tool_whenever_deferred_manager_exists() -> None:
+    """结构断言：主 Agent 节点在 deferred_manager 非空时注入 search_tools（SOP 入口）。"""
+    from inspect import getsource
+
+    from src.agents.fast_agent import nodes as fast_nodes
+    from src.agents.search_agent import nodes as search_nodes
+
+    for nodes in (fast_nodes, search_nodes):
+        source = getsource(nodes)
+        assert "context.deferred_manager is not None" in source
+        assert "ToolSearchTool(" in source
+        assert "ToolSearchMiddleware(" in source
+
+
 @pytest.mark.asyncio
 async def test_compatibility_registration_does_not_reinline_deferred_env_tool(
     monkeypatch,

--- a/tests/infra/memory/test_tools.py
+++ b/tests/infra/memory/test_tools.py
@@ -737,3 +737,26 @@ def test_get_memory_guide_selects_variant_by_vfs_setting(monkeypatch):
 
     monkeypatch.setattr(settings, "ENABLE_MEMORY_VFS", True)
     assert subagent_prompts.get_memory_guide() == NATIVE_MEMORY_GUIDE_VFS
+
+
+def test_get_memory_guide_keeps_delete_deferred_when_deferred_loading_enabled(monkeypatch):
+    from src.agents.core import subagent_prompts
+    from src.kernel.config import settings
+
+    monkeypatch.setattr(settings, "ENABLE_MEMORY_VFS", False)
+    monkeypatch.setattr(settings, "ENABLE_DEFERRED_TOOL_LOADING", True)
+    guide = subagent_prompts.get_memory_guide()
+    assert "search_tools" in guide
+    assert "(remove)" not in guide
+
+
+def test_get_memory_guide_lists_delete_inline_when_deferred_loading_disabled(monkeypatch):
+    """延迟加载关闭时 memory_delete 直挂，指南不得再指向不存在的 search_tools。"""
+    from src.agents.core import subagent_prompts
+    from src.kernel.config import settings
+
+    monkeypatch.setattr(settings, "ENABLE_MEMORY_VFS", False)
+    monkeypatch.setattr(settings, "ENABLE_DEFERRED_TOOL_LOADING", False)
+    guide = subagent_prompts.get_memory_guide()
+    assert "search_tools" not in guide
+    assert "`memory_delete` (remove)" in guide

--- a/tests/infra/task/test_concurrency_queue_lua_integration.py
+++ b/tests/infra/task/test_concurrency_queue_lua_integration.py
@@ -131,3 +131,68 @@ async def test_limiter_methods_against_real_redis(real_redis) -> None:
         assert await limiter.get_queue_position(user_id, "run-b") == 1
     finally:
         await real_redis.delete(key)
+
+
+async def test_recovery_lock_takeover_script_semantics(real_redis) -> None:
+    """恢复锁僵死接管脚本对真实 Redis 的语义验证。
+
+    - 锁龄（原 TTL - 剩余 TTL）低于阈值：不动锁，返回 0
+    - 锁龄达到阈值：覆写 token 并重置 TTL，返回 1
+    - 旧持有者按旧 token 释放：no-op；新 token 释放：成功
+    """
+    from src.infra.task.recovery import (
+        RECOVERY_LOCK_STALE_TAKEOVER_SECONDS,
+        RECOVERY_LOCK_TAKEOVER_LUA,
+        RECOVERY_LOCK_TTL_SECONDS,
+    )
+
+    key = f"task:recovery:lua-test:{uuid.uuid4().hex}"
+    try:
+        # 新鲜锁（TTL 只消耗了 10s，龄 10 < 60）：拒绝接管
+        await real_redis.set(key, "old-token", ex=RECOVERY_LOCK_TTL_SECONDS - 10)
+        result = await real_redis.eval(
+            RECOVERY_LOCK_TAKEOVER_LUA,
+            1,
+            key,
+            "new-token",
+            RECOVERY_LOCK_TTL_SECONDS,
+            RECOVERY_LOCK_STALE_TAKEOVER_SECONDS,
+        )
+        assert result == 0
+        assert await real_redis.get(key) == "old-token"
+
+        # 僵死锁（TTL 只剩 100s，龄 200 ≥ 60）：接管
+        await real_redis.set(key, "old-token", ex=100)
+        result = await real_redis.eval(
+            RECOVERY_LOCK_TAKEOVER_LUA,
+            1,
+            key,
+            "new-token",
+            RECOVERY_LOCK_TTL_SECONDS,
+            RECOVERY_LOCK_STALE_TAKEOVER_SECONDS,
+        )
+        assert result == 1
+        assert await real_redis.get(key) == "new-token"
+        assert await real_redis.ttl(key) == RECOVERY_LOCK_TTL_SECONDS
+
+        # 接管后旧 token 释放为 no-op，新 token 才能释放（复用 release Lua 语义）
+        from src.infra.task.recovery import RECOVERY_LOCK_RELEASE_LUA
+
+        assert await real_redis.eval(RECOVERY_LOCK_RELEASE_LUA, 1, key, "old-token") == 0
+        assert await real_redis.exists(key) == 1
+        assert await real_redis.eval(RECOVERY_LOCK_RELEASE_LUA, 1, key, "new-token") == 1
+        assert await real_redis.exists(key) == 0
+
+        # 锁不存在时直接获取（重投/竞态窗口）
+        result = await real_redis.eval(
+            RECOVERY_LOCK_TAKEOVER_LUA,
+            1,
+            key,
+            "third-token",
+            RECOVERY_LOCK_TTL_SECONDS,
+            RECOVERY_LOCK_STALE_TAKEOVER_SECONDS,
+        )
+        assert result == 1
+        assert await real_redis.get(key) == "third-token"
+    finally:
+        await real_redis.delete(key)

--- a/tests/infra/task/test_recovery_lock_takeover.py
+++ b/tests/infra/task/test_recovery_lock_takeover.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+"""恢复锁僵死自愈：持锁实例死亡未释放时，不得把恢复堵满整个锁 TTL。
+
+生产事故（staging 强杀演练）：垂死实例拿到恢复锁并提交 resume，随后实例死亡、
+payload 被关闭清理删除，重投的 arq job 空转退出——锁无主人挂满 300s，期间
+所有副本的扫描器都收到「已在其他实例中启动」。执行者心跳已死 + 锁龄超阈值
+时必须原子接管（Lua 校验锁龄后覆写 token，旧持有者按 token 释放为 no-op）。
+"""
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.infra.task import recovery as recovery_module
+from src.infra.task.recovery import TaskRecoveryService
+
+
+class _LockHeldRedis:
+    """模拟已被占用的恢复锁；eval 返回值可注入。"""
+
+    def __init__(self, *, eval_result: int = 1) -> None:
+        self.set_calls: list[tuple] = []
+        self.eval_calls: list[tuple] = []
+        self.eval_result = eval_result
+
+    async def set(self, key, value, ex=None, nx=False):
+        self.set_calls.append((key, value, ex, nx))
+        return False  # 锁始终被占
+
+    async def eval(self, script, num_keys, *args):
+        self.eval_calls.append((script, num_keys, args))
+        return self.eval_result
+
+
+class _FreeLockRedis(_LockHeldRedis):
+    async def set(self, key, value, ex=None, nx=False):
+        self.set_calls.append((key, value, ex, nx))
+        return True
+
+
+class _FakeStorage:
+    def __init__(self, session=None) -> None:
+        self.session = session
+        self.updates: list[tuple[str, Any]] = []
+
+    async def update(self, session_id, session_update) -> None:
+        self.updates.append((session_id, session_update))
+
+
+def _make_service(
+    monkeypatch: pytest.MonkeyPatch,
+    redis: Any,
+    *,
+    stale: bool,
+) -> tuple[TaskRecoveryService, AsyncMock]:
+    session = SimpleNamespace(
+        id="session-1",
+        user_id="user-1",
+        agent_id="search",
+        metadata={
+            "current_run_id": "run-old",
+            "task_status": "failed",
+            "task_recoverable": True,
+            "task_error_code": "server_restart",
+            "agent_id": "search",
+            "executor_key": "agent_stream",
+            "resume_attempts": 0,
+        },
+    )
+    submit_task = AsyncMock(return_value=("run-old", "trace-1"))
+
+    async def _stale_flag(run_id: str) -> bool:
+        return stale
+
+    service = TaskRecoveryService(
+        storage=_FakeStorage(session),
+        run_info={},
+        heartbeat=SimpleNamespace(check_exists=lambda run_id: False, is_stale=_stale_flag),
+        ensure_executor=lambda: SimpleNamespace(),
+        submit_task=submit_task,
+        mark_run_failed=AsyncMock(),
+    )
+
+    class _FakeUserStorage:
+        async def get_by_id(self, user_id):
+            return SimpleNamespace(metadata={"language": "zh-CN"}, roles=[])
+
+    monkeypatch.setattr(recovery_module, "get_redis_client", lambda: redis)
+    monkeypatch.setattr(recovery_module, "UserStorage", _FakeUserStorage)
+    monkeypatch.setattr(recovery_module, "get_trace_storage", _FakeTraceStorage)
+    monkeypatch.setattr(
+        "src.infra.session.dual_writer.get_dual_writer",
+        lambda: SimpleNamespace(redis=SimpleNamespace(xrange=AsyncMock(return_value=[]))),
+    )
+    monkeypatch.setattr(recovery_module, "get_registered_executor", lambda key: _noop_executor)
+    monkeypatch.setattr(recovery_module, "get_concurrency_limiter", lambda: _FakeLimiter())
+    monkeypatch.setattr(recovery_module, "_resolve_recovery_agent_id", lambda m, s: "search")
+    monkeypatch.setattr("src.kernel.config.settings.TASK_BACKEND", "local")
+    return service, submit_task
+
+
+class _FakeTraceStorage:
+    reopened: list[str] = []
+
+    def __init__(self) -> None:
+        self.collection = SimpleNamespace(
+            find=lambda query, projection=None: SimpleNamespace(
+                sort=lambda k, d=None: SimpleNamespace(
+                    limit=lambda n: SimpleNamespace(to_list=_return_trace_docs)
+                )
+            )
+        )
+
+    async def reopen_interrupted_trace(self, trace_id: str) -> bool:
+        self.reopened.append(trace_id)
+        return True
+
+
+async def _return_trace_docs(length=None):
+    return [{"trace_id": "trace-1"}]
+
+
+class _FakeLimiter:
+    async def try_acquire_run_slot(self, user_id, run_id) -> bool:
+        return True
+
+    async def release(self, user_id, run_id, dequeue=True) -> None:
+        return None
+
+
+async def _noop_executor(*args, **kwargs):
+    if False:
+        yield None
+
+
+_FakeTraceStorageInstance = _FakeTraceStorage()
+
+
+@pytest.mark.asyncio
+async def test_takes_over_stale_aged_lock_when_executor_dead(monkeypatch) -> None:
+    redis = _LockHeldRedis(eval_result=1)
+    service, submit_task = _make_service(monkeypatch, redis, stale=True)
+
+    result = await service.resume_interrupted_run(_session_of(service), "run-old", "server_restart")
+
+    assert result["success"] is True
+    assert redis.eval_calls, "锁被占时应尝试 Lua 僵死接管"
+    submit_task.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_respects_fresh_lock_held_by_live_recovery(monkeypatch) -> None:
+    redis = _LockHeldRedis(eval_result=0)
+    service, submit_task = _make_service(monkeypatch, redis, stale=True)
+
+    result = await service.resume_interrupted_run(_session_of(service), "run-old", "server_restart")
+
+    assert result["success"] is False
+    assert "已在其他实例中启动" in result["message"]
+    submit_task.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_takeover_attempt_when_executor_heartbeat_fresh(monkeypatch) -> None:
+    redis = _LockHeldRedis(eval_result=1)
+    service, submit_task = _make_service(monkeypatch, redis, stale=False)
+
+    result = await service.resume_interrupted_run(_session_of(service), "run-old", "server_restart")
+
+    assert result["success"] is False
+    assert "已在其他实例中启动" in result["message"]
+    assert redis.eval_calls == [], "心跳新鲜时不得动锁（可能是活实例在恢复）"
+    submit_task.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_normal_acquire_skips_takeover_path(monkeypatch) -> None:
+    redis = _FreeLockRedis()
+    service, submit_task = _make_service(monkeypatch, redis, stale=True)
+
+    result = await service.resume_interrupted_run(_session_of(service), "run-old", "server_restart")
+
+    assert result["success"] is True
+    assert redis.eval_calls == [], "NX 直接拿到锁时不应触发接管脚本"
+    submit_task.assert_awaited_once()
+
+
+def _session_of(service: TaskRecoveryService) -> Any:
+    return service._storage.session

--- a/tests/infra/task/test_shutdown_quiesce.py
+++ b/tests/infra/task/test_shutdown_quiesce.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+"""关闭静默：实例进入 lifespan 关闭后不得再发起新的恢复/接管。
+
+生产事故（staging 强杀演练）：旧 Pod 收到终止信号后，executor 先因依赖关闭
+而失败并标记 recoverable，而 15s 周期孤儿扫描器仍存活——垂死实例把恢复任务
+提交给自己即将关闭的 arq worker，run:resumed 后随即被再次杀掉。结果：
+多一次无效生成、payload 被关闭清理删除、恢复锁被死实例占满整个 TTL。
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.infra.task import startup_cleanup as startup_cleanup_module
+from src.infra.task.lifecycle import clear_shutting_down, is_shutting_down, mark_shutting_down
+
+
+@pytest.fixture(autouse=True)
+def _reset_shutdown_flag():
+    clear_shutting_down()
+    yield
+    clear_shutting_down()
+
+
+def test_lifecycle_flag_roundtrip() -> None:
+    assert is_shutting_down() is False
+    mark_shutting_down()
+    assert is_shutting_down() is True
+    clear_shutting_down()
+    assert is_shutting_down() is False
+
+
+@pytest.mark.asyncio
+async def test_cleanup_stale_tasks_noops_when_shutting_down(monkeypatch) -> None:
+    service = startup_cleanup_module.TaskStartupCleanupService(
+        storage=SimpleNamespace(
+            collection=SimpleNamespace(find=_fail("find")),
+        ),
+        heartbeat=SimpleNamespace(check_exists=_fail("check_exists")),
+        ensure_executor=_fail("ensure_executor"),
+        load_session_record=_fail("load_session_record"),
+        resume_interrupted_run=_fail("resume_interrupted_run"),
+    )
+
+    mark_shutting_down()
+
+    # 不得触碰存储/心跳/恢复路径
+    await service.cleanup_stale_tasks()
+    await service.cleanup_stale_tasks(running_only=True)
+
+
+def _fail(name: str):
+    def _raise(*args, **kwargs):
+        raise AssertionError(f"shutdown 中不应调用 {name}")
+
+    return _raise
+
+
+@pytest.mark.asyncio
+async def test_orphan_recovery_skips_when_shutting_down(monkeypatch) -> None:
+    from src.infra.task import orphan_recovery
+
+    task_manager = SimpleNamespace(cleanup_stale_tasks=AsyncMock())
+    monkeypatch.setattr(orphan_recovery, "get_task_manager", lambda: task_manager)
+
+    mark_shutting_down()
+
+    result = await orphan_recovery.run_scheduled_orphan_recovery()
+
+    assert result["status"] == "skipped"
+    task_manager.cleanup_stale_tasks.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_orphan_recovery_runs_when_not_shutting_down(monkeypatch) -> None:
+    from src.infra.task import orphan_recovery
+
+    task_manager = SimpleNamespace(cleanup_stale_tasks=AsyncMock())
+    monkeypatch.setattr(orphan_recovery, "get_task_manager", lambda: task_manager)
+
+    result = await orphan_recovery.run_scheduled_orphan_recovery()
+
+    assert result["status"] == "ok"
+    task_manager.cleanup_stale_tasks.assert_awaited_once_with(running_only=True)
+
+
+@pytest.mark.asyncio
+async def test_worker_restart_recovery_skips_when_shutting_down(monkeypatch) -> None:
+    from src.infra.task import arq_runtime
+
+    task_manager = SimpleNamespace(cleanup_stale_tasks=AsyncMock())
+    # 函数体内延迟 `from .manager import get_task_manager`，patch 模块属性即可
+    monkeypatch.setattr("src.infra.task.manager.get_task_manager", lambda: task_manager)
+
+    mark_shutting_down()
+
+    await arq_runtime._recover_stale_tasks_after_worker_restart()
+
+    task_manager.cleanup_stale_tasks.assert_not_awaited()


### PR DESCRIPTION
## 晋升内容

PR #355（fix(task): 关闭静默 + 恢复锁僵死自愈，消除强杀场景 5 分钟恢复堵塞）

## staging 验证（develop-20260901-034644，hard-kill 同场景复验）

**修复前事故时间线**（同一强杀场景）：
- 垂死旧 Pod 周期扫描器抢走恢复 → 自己提交给自己 → run:resumed 后被再杀（垃圾 attempt）
- arq 重投 job 空转（payload 已被关闭清理删除）+ 恢复锁死堵 300s
- 总计 3 次提交、2× run:resumed、2 分 53 秒才接管

**修复后复验**：
- 强杀 11:56:26 → 新 Pod 11:56:41 就绪，**15 秒完成无缝续跑提交**（startup 扫描直接接管，锁无争用）
- 事件流：`run:resumed` 恰好 1 次、`done`=1、`error`=0、用户消息无重复
- 无「已在其他实例中启动」刷屏、无 takeover 触发（垂死自提交已消除）

## CI

develop 分支全绿（Backend Tests / Frontend Tests / Ruff / MyPy / ESLint / 双架构镜像构建），全量 3412 passed。