### PR TITLE
fix(hitl): ask_human 工具描述补充 rejected 语义，防止忽略后重复弹窗提问

### DIFF
--- a/src/infra/tool/human_tool/tool.py
+++ b/src/infra/tool/human_tool/tool.py
@@ -47,7 +47,8 @@ class AskHumanTool(BaseTool):
 
     name: str = "ask_human"
     description: str = """向用户提问并等待回复。仅在缺少必要信息、需要用户选择，或需确认敏感/不可逆操作时使用。
-简单选项用 choices（multiple 控制多选）；结构化表单用 fields。返回字段 JSON 或拒绝状态。"""
+简单选项用 choices（multiple 控制多选）；结构化表单用 fields。返回字段 JSON 或拒绝状态。
+若返回 rejected（用户拒绝或忽略），不要重复提问：基于现有信息以合理低风险假设继续，或说明无法确认后收尾。"""
     args_schema: Type[AskHumanInput] = AskHumanInput
     return_direct: bool = False
 

--- a/tests/infra/tool/test_human_tool.py
+++ b/tests/infra/tool/test_human_tool.py
@@ -271,3 +271,12 @@ async def test_ask_human_forwards_request_trace_id_to_approval_event(
         TraceContext.clear_request_context()
 
     assert captured == [{"session_id": "session-ctx", "run_id": "run-ctx", "trace_id": "trace-ctx"}]
+
+
+def test_description_defines_rejected_semantics() -> None:
+    """忽略（rejected）后模型不得重复提问：描述需写明兜底行为。"""
+    description = human_tool.AskHumanTool().description
+
+    assert "rejected" in description
+    assert "不要重复提问" in description
+    assert "合理" in description


### PR DESCRIPTION
## Summary

用户「忽略」ask_human 审批后，恢复运行把 `{"status": "rejected", "message": "用户拒绝了此请求"}` 作为工具结果回给模型，但工具描述与系统提示词均未定义 rejected 的行为，模型常因信息仍缺失而再次调用 ask_human，表单反复弹出。本 PR 在工具描述中明确拒绝语义，让模型收到 rejected 后自行兜底而不是重复提问。

## Changes

- `src/infra/tool/human_tool/tool.py`：ask_human 工具描述补充一句——「若返回 rejected（用户拒绝或忽略），不要重复提问：基于现有信息以合理低风险假设继续，或说明无法确认后收尾」。
- `tests/infra/tool/test_human_tool.py`：新增 `test_description_defines_rejected_semantics`，锁定描述必须包含 rejected 语义、禁止重复提问与合理兜底三个要素（TDD 先红后绿）。

## Testing

- [x] 新增测试先 RED 后 GREEN
- [x] `uv run pytest tests/infra/tool/ tests/api/routes/test_human_wait.py`（338 passed）
- [x] `uv run pytest tests/agents/test_agent_nodes_hitl_flag.py tests/infra/task/test_hitl_resume.py tests/infra/task/test_hitl_approval_event_persistence.py tests/agents/core/test_subagent_prompts.py`（42 passed）
- [x] `make lint` / `make typecheck` 通过
- [x] 内置工具 schema 预算 5610 / 5700，仍在限内（`test_internal_tool_schema_token_budget` 通过）
