### PR TITLE
fix(hitl): ask_human 拒绝语义提示词修复（develop → main 晋升）

### DIFF
--- a/src/infra/tool/human_tool/tool.py
+++ b/src/infra/tool/human_tool/tool.py
@@ -47,7 +47,8 @@ class AskHumanTool(BaseTool):
 
     name: str = "ask_human"
     description: str = """向用户提问并等待回复。仅在缺少必要信息、需要用户选择，或需确认敏感/不可逆操作时使用。
-简单选项用 choices（multiple 控制多选）；结构化表单用 fields。返回字段 JSON 或拒绝状态。"""
+简单选项用 choices（multiple 控制多选）；结构化表单用 fields。返回字段 JSON 或拒绝状态。
+若返回 rejected（用户拒绝或忽略），不要重复提问：基于现有信息以合理低风险假设继续，或说明无法确认后收尾。"""
     args_schema: Type[AskHumanInput] = AskHumanInput
     return_direct: bool = False
 

--- a/tests/infra/tool/test_human_tool.py
+++ b/tests/infra/tool/test_human_tool.py
@@ -271,3 +271,12 @@ async def test_ask_human_forwards_request_trace_id_to_approval_event(
         TraceContext.clear_request_context()
 
     assert captured == [{"session_id": "session-ctx", "run_id": "run-ctx", "trace_id": "trace-ctx"}]
+
+
+def test_description_defines_rejected_semantics() -> None:
+    """忽略（rejected）后模型不得重复提问：描述需写明兜底行为。"""
+    description = human_tool.AskHumanTool().description
+
+    assert "rejected" in description
+    assert "不要重复提问" in description
+    assert "合理" in description


### PR DESCRIPTION
## Summary

develop → main 晋升：包含 ask_human 忽略后重复弹窗的提示词修复（#358）。

## Changes

- #358 `fix(hitl)`: ask_human 工具描述补充 rejected 语义——用户忽略/拒绝后不要重复提问，基于现有信息以合理低风险假设继续或收尾，消除忽略后表单反复弹出。

## Testing

- [x] develop CI 全绿（Ruff / Mypy / 前后端测试 / 镜像构建）
- [x] staging 验证：`develop-20260901-053931` 滚动更新 + 健康检查通过
- [x] staging 真实对话一轮：模型正常回复，run 状态 completed
- [x] staging Pod 内确认部署镜像已包含新工具描述
