### PR TITLE
fix: 分享页图片点击预览与 reveal_file 坏 URL 校验（develop → main 晋升）

### DIFF
--- a/frontend/src/components/chat/ChatMessage/MessageImageGallery.tsx
+++ b/frontend/src/components/chat/ChatMessage/MessageImageGallery.tsx
@@ -1,8 +1,9 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { ExternalLink } from "lucide-react";
 import { ImageWithSkeleton } from "./ImageWithSkeleton";
 import { useSessionImageGallery } from "./sessionImageGallery";
 import { buildChatThumbUrl } from "../../../utils/chatThumbs";
+import { ImageViewer } from "../../common";
 import type { RevealFileImageInfo } from "./revealFileImageUtils";
 
 interface MessageImageGalleryProps {
@@ -11,11 +12,20 @@ interface MessageImageGalleryProps {
 
 export function MessageImageGallery({ images }: MessageImageGalleryProps) {
   const sessionImageGallery = useSessionImageGallery();
+  // 分享页等未挂 SessionImageGalleryProvider 的场景，用本地灯箱兜底，
+  // 避免点击预览变成静默 no-op
+  const [fallbackImage, setFallbackImage] = useState<RevealFileImageInfo | null>(
+    null,
+  );
 
   const handleImageClick = (image: RevealFileImageInfo) => {
-    sessionImageGallery?.openImage(image.src, image.fileName, {
-      group: "reveal-file",
-    });
+    if (sessionImageGallery) {
+      sessionImageGallery.openImage(image.src, image.fileName, {
+        group: "reveal-file",
+      });
+    } else {
+      setFallbackImage(image);
+    }
   };
 
   const layoutClass = useMemo(() => {
@@ -26,7 +36,8 @@ export function MessageImageGallery({ images }: MessageImageGalleryProps) {
   }, [images.length]);
 
   return (
-    <div className={layoutClass}>
+    <>
+      <div className={layoutClass}>
       {images.map((image, index) => {
         const isFirstOfThree = images.length === 3 && index === 0;
         return (
@@ -72,5 +83,13 @@ export function MessageImageGallery({ images }: MessageImageGalleryProps) {
         );
       })}
     </div>
+
+      <ImageViewer
+        src={fallbackImage?.src || ""}
+        alt={fallbackImage?.fileName || ""}
+        isOpen={!!fallbackImage}
+        onClose={() => setFallbackImage(null)}
+      />
+    </>
   );
 }

--- a/frontend/src/components/chat/ChatMessage/MessageImageGallery.tsx
+++ b/frontend/src/components/chat/ChatMessage/MessageImageGallery.tsx
@@ -14,9 +14,8 @@ export function MessageImageGallery({ images }: MessageImageGalleryProps) {
   const sessionImageGallery = useSessionImageGallery();
   // 分享页等未挂 SessionImageGalleryProvider 的场景，用本地灯箱兜底，
   // 避免点击预览变成静默 no-op
-  const [fallbackImage, setFallbackImage] = useState<RevealFileImageInfo | null>(
-    null,
-  );
+  const [fallbackImage, setFallbackImage] =
+    useState<RevealFileImageInfo | null>(null);
 
   const handleImageClick = (image: RevealFileImageInfo) => {
     if (sessionImageGallery) {
@@ -38,51 +37,51 @@ export function MessageImageGallery({ images }: MessageImageGalleryProps) {
   return (
     <>
       <div className={layoutClass}>
-      {images.map((image, index) => {
-        const isFirstOfThree = images.length === 3 && index === 0;
-        return (
-          <div
-            key={image.id}
-            className={
-              isFirstOfThree
-                ? "col-span-2"
-                : images.length === 1
-                  ? "w-full max-w-md"
-                  : "break-inside-avoid"
-            }
-          >
+        {images.map((image, index) => {
+          const isFirstOfThree = images.length === 3 && index === 0;
+          return (
             <div
-              className="group/img relative cursor-pointer rounded-xl border overflow-hidden transition-shadow hover:shadow-lg border-theme-border bg-theme-bg-card dark:bg-theme-bg"
-              onClick={() => handleImageClick(image)}
+              key={image.id}
+              className={
+                isFirstOfThree
+                  ? "col-span-2"
+                  : images.length === 1
+                    ? "w-full max-w-md"
+                    : "break-inside-avoid"
+              }
             >
-              <ImageWithSkeleton
-                src={image.src}
-                thumbSrc={buildChatThumbUrl(image.src)}
-                alt={image.fileName}
-                skipUrlResolve
-                inline
-                className="w-full h-auto object-contain"
-                loading="lazy"
-              />
-              {/* Hover overlay — top-right icon */}
-              <div className="absolute top-2 right-2 opacity-0 group-hover/img:opacity-100 transition-opacity pointer-events-none z-[2]">
-                <div className="p-1.5 rounded-lg bg-black/40 shadow pointer-events-auto">
-                  <ExternalLink size={14} className="text-white" />
+              <div
+                className="group/img relative cursor-pointer rounded-xl border overflow-hidden transition-shadow hover:shadow-lg border-theme-border bg-theme-bg-card dark:bg-theme-bg"
+                onClick={() => handleImageClick(image)}
+              >
+                <ImageWithSkeleton
+                  src={image.src}
+                  thumbSrc={buildChatThumbUrl(image.src)}
+                  alt={image.fileName}
+                  skipUrlResolve
+                  inline
+                  className="w-full h-auto object-contain"
+                  loading="lazy"
+                />
+                {/* Hover overlay — top-right icon */}
+                <div className="absolute top-2 right-2 opacity-0 group-hover/img:opacity-100 transition-opacity pointer-events-none z-[2]">
+                  <div className="p-1.5 rounded-lg bg-black/40 shadow pointer-events-auto">
+                    <ExternalLink size={14} className="text-white" />
+                  </div>
                 </div>
-              </div>
-              {/* File name label on hover */}
-              <div className="absolute bottom-0 left-0 right-0 opacity-0 group-hover/img:opacity-100 transition-opacity">
-                <div className="px-2 py-1 bg-gradient-to-t from-black/60 to-transparent">
-                  <span className="text-11 text-white/90 truncate block">
-                    {image.fileName}
-                  </span>
+                {/* File name label on hover */}
+                <div className="absolute bottom-0 left-0 right-0 opacity-0 group-hover/img:opacity-100 transition-opacity">
+                  <div className="px-2 py-1 bg-gradient-to-t from-black/60 to-transparent">
+                    <span className="text-11 text-white/90 truncate block">
+                      {image.fileName}
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        );
-      })}
-    </div>
+          );
+        })}
+      </div>
 
       <ImageViewer
         src={fallbackImage?.src || ""}

--- a/frontend/src/components/chat/ChatMessage/__tests__/MessageImageGallery.test.tsx
+++ b/frontend/src/components/chat/ChatMessage/__tests__/MessageImageGallery.test.tsx
@@ -49,7 +49,7 @@ describe("MessageImageGallery", () => {
   });
 
   it("opens session image gallery on click", () => {
-    expect(source).toContain("sessionImageGallery?.openImage");
+    expect(source).toContain("sessionImageGallery.openImage");
     expect(source).toContain('"reveal-file"');
   });
 

--- a/frontend/src/components/chat/ChatMessage/__tests__/MessageImageGalleryLightbox.test.tsx
+++ b/frontend/src/components/chat/ChatMessage/__tests__/MessageImageGalleryLightbox.test.tsx
@@ -23,7 +23,7 @@ test("opens a local lightbox fallback when session gallery context is absent", (
   expect(screen.getAllByAltText("img-1.png")).toHaveLength(2);
 });
 
-test("routes clicks through the session gallery provider when present", () => {
+test("opens lightbox when the session gallery provider is present", () => {
   render(
     <SessionImageGalleryProvider messages={[]}>
       <MessageImageGallery images={[IMAGE]} />

--- a/frontend/src/components/chat/ChatMessage/__tests__/MessageImageGalleryLightbox.test.tsx
+++ b/frontend/src/components/chat/ChatMessage/__tests__/MessageImageGalleryLightbox.test.tsx
@@ -1,0 +1,38 @@
+/** @vitest-environment jsdom */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { expect, test } from "vitest";
+import { MessageImageGallery } from "../MessageImageGallery";
+import { SessionImageGalleryProvider } from "../sessionImageGallery";
+
+const IMAGE = {
+  id: "reveal-1",
+  src: "https://app.example.com/api/upload/file/generated-images/img-1.png",
+  fileName: "img-1.png",
+};
+
+test("opens a local lightbox fallback when session gallery context is absent", () => {
+  // 分享页未挂 SessionImageGalleryProvider，此时点击不能是静默 no-op
+  render(<MessageImageGallery images={[IMAGE]} />);
+
+  expect(screen.getAllByAltText("img-1.png")).toHaveLength(1);
+
+  fireEvent.click(screen.getByAltText("img-1.png"));
+
+  // 点击后应弹出 ImageViewer 灯箱（出现第二张同 alt 的大图）
+  expect(screen.getAllByAltText("img-1.png")).toHaveLength(2);
+});
+
+test("routes clicks through the session gallery provider when present", () => {
+  render(
+    <SessionImageGalleryProvider messages={[]}>
+      <MessageImageGallery images={[IMAGE]} />
+    </SessionImageGalleryProvider>,
+  );
+
+  expect(screen.getAllByAltText("img-1.png")).toHaveLength(1);
+
+  fireEvent.click(screen.getByAltText("img-1.png"));
+
+  expect(screen.getAllByAltText("img-1.png")).toHaveLength(2);
+});

--- a/frontend/src/components/share/SharedPage.tsx
+++ b/frontend/src/components/share/SharedPage.tsx
@@ -27,6 +27,7 @@ import { shareApi } from "../../services/api/share";
 import { useSharedPageTheme } from "./useSharedPageTheme";
 import type { SharedContentResponse } from "../../types";
 import { ChatMessage } from "../chat/ChatMessage";
+import { SessionImageGalleryProvider } from "../chat/ChatMessage/sessionImageGallery";
 import { ImageWithSkeleton } from "../chat/ChatMessage/ImageWithSkeleton";
 import { BrandLogo } from "../common/BrandLogo";
 import { RevealPreviewHost } from "../chat/ChatMessage/items/RevealPreviewHost";
@@ -598,6 +599,7 @@ export function SharedPage({
 
       {/* Scrollable article area */}
       <main className="relative flex-1 overflow-x-hidden scroll-smooth">
+        <SessionImageGalleryProvider messages={messages}>
         <article className="max-w-4xl lg:max-w-5xl xl:max-w-6xl mx-auto">
           {/* Editorial hero */}
           <header className="pt-[calc(5rem+var(--app-safe-area-top,0px))] sm:pt-[calc(7rem+var(--app-safe-area-top,0px))] lg:pt-[calc(9rem+var(--app-safe-area-top,0px))] pb-0 animate-in fade-in duration-800">
@@ -802,6 +804,7 @@ export function SharedPage({
             </div>
           )}
         </article>
+        </SessionImageGalleryProvider>
       </main>
 
       {/* Footer */}

--- a/frontend/src/components/share/__tests__/sharedPageImageGallerySource.test.ts
+++ b/frontend/src/components/share/__tests__/sharedPageImageGallerySource.test.ts
@@ -9,5 +9,5 @@ const sharedPageSource = readFileSync(
 test("shared page mounts the session image gallery provider over its messages", () => {
   // 分享页没有挂 SessionImageGalleryProvider 时，reveal_file 图片卡片
   // 点击预览是静默 no-op（MessageImageGallery 只依赖该 context）。
-  expect(sharedPageSource).toMatch(/SessionImageGalleryProvider/);
+  expect(sharedPageSource).toMatch(/<SessionImageGalleryProvider messages=\{messages\}>/);
 });

--- a/frontend/src/components/share/__tests__/sharedPageImageGallerySource.test.ts
+++ b/frontend/src/components/share/__tests__/sharedPageImageGallerySource.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const sharedPageSource = readFileSync(
+  join(import.meta.dirname, "../SharedPage.tsx"),
+  "utf8",
+);
+
+test("shared page mounts the session image gallery provider over its messages", () => {
+  // 分享页没有挂 SessionImageGalleryProvider 时，reveal_file 图片卡片
+  // 点击预览是静默 no-op（MessageImageGallery 只依赖该 context）。
+  expect(sharedPageSource).toMatch(/SessionImageGalleryProvider/);
+});

--- a/src/infra/tool/reveal_file_tool.py
+++ b/src/infra/tool/reveal_file_tool.py
@@ -466,6 +466,35 @@ def _is_remote_url(path: str) -> bool:
     return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
 
 
+_UPLOAD_PROXY_URL_PREFIX = "/api/upload/file/"
+
+
+def _extract_self_upload_key(url: str) -> str | None:
+    """提取指向本站上传代理路由（/api/upload/file/<key>）的 URL 的 storage key。
+
+    agent 常把 image_generate 等工具返回的长 URL 重新抄写后再传给
+    reveal_file，hex id 抄错一个字符即得到不存在的对象；此类 URL 必须
+    先校验存在性再透传。其他远程 URL 不属于本站 storage，返回 None。
+    """
+    parsed = urlparse(url.strip())
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return None
+    path = unquote(parsed.path or "")
+    if _UPLOAD_PROXY_URL_PREFIX not in path:
+        return None
+    key = path.split(_UPLOAD_PROXY_URL_PREFIX, 1)[1].strip("/")
+    return key or None
+
+
+async def _self_upload_url_missing(storage: Any, key: str) -> bool | None:
+    """检查本站上传 key 是否存在；检查本身失败时返回 None（保持透传可用性）。"""
+    try:
+        return not await storage.file_exists(key)
+    except Exception as e:
+        logger.warning(f"[reveal_file] Existence check failed for key {key}: {e}")
+        return None
+
+
 def _get_filename_from_path(path: str) -> str:
     """从本地路径或 URL 中提取文件名。"""
     if _is_remote_url(path):
@@ -693,6 +722,29 @@ async def reveal_file(
     """向用户实际展示一个可点击的单个文件或 URL；仅回复路径不够。
     目录或多文件项目必须使用 reveal_project。"""
     if _is_remote_url(file_path):
+        self_upload_key = _extract_self_upload_key(file_path)
+        if self_upload_key is not None:
+            storage = await _get_storage()
+            missing = await _self_upload_url_missing(storage, self_upload_key)
+            if missing:
+                logger.warning(
+                    f"[reveal_file] Self-hosted upload URL not found in storage: {file_path}"
+                )
+                return await _json_dumps_result(
+                    {
+                        "type": "file_reveal",
+                        "file": {
+                            "path": file_path,
+                            "description": description or "",
+                            "error": "remote_url_not_found",
+                            "hint": (
+                                "This upload URL does not match any stored file "
+                                "(ids are easy to mistype when re-copying long URLs). "
+                                "Re-copy the exact url from the original tool result and retry."
+                            ),
+                        },
+                    }
+                )
         filename = _get_filename_from_path(file_path)
         mime_type = get_mime_type(filename)
         file_category = get_file_category(mime_type)

--- a/src/infra/tool/reveal_file_tool.py
+++ b/src/infra/tool/reveal_file_tool.py
@@ -470,11 +470,11 @@ _UPLOAD_PROXY_URL_PREFIX = "/api/upload/file/"
 
 
 def _extract_self_upload_key(url: str) -> str | None:
-    """提取指向本站上传代理路由（/api/upload/file/<key>）的 URL 的 storage key。
+    """提取指向本站上传代理路由（/api/upload/file/<key>）形态 URL 的 storage key。
 
     agent 常把 image_generate 等工具返回的长 URL 重新抄写后再传给
     reveal_file，hex id 抄错一个字符即得到不存在的对象；此类 URL 必须
-    先校验存在性再透传。其他远程 URL 不属于本站 storage，返回 None。
+    先校验存在性再透传。不含该路径前缀的远程 URL 返回 None，不校验。
     """
     parsed = urlparse(url.strip())
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
@@ -486,9 +486,10 @@ def _extract_self_upload_key(url: str) -> str | None:
     return key or None
 
 
-async def _self_upload_url_missing(storage: Any, key: str) -> bool | None:
-    """检查本站上传 key 是否存在；检查本身失败时返回 None（保持透传可用性）。"""
+async def _self_upload_url_missing(key: str) -> bool | None:
+    """检查本站上传 key 是否存在；存储不可用（含初始化失败）时返回 None（保持透传可用性）。"""
     try:
+        storage = await _get_storage()
         return not await storage.file_exists(key)
     except Exception as e:
         logger.warning(f"[reveal_file] Existence check failed for key {key}: {e}")
@@ -724,8 +725,7 @@ async def reveal_file(
     if _is_remote_url(file_path):
         self_upload_key = _extract_self_upload_key(file_path)
         if self_upload_key is not None:
-            storage = await _get_storage()
-            missing = await _self_upload_url_missing(storage, self_upload_key)
+            missing = await _self_upload_url_missing(self_upload_key)
             if missing:
                 logger.warning(
                     f"[reveal_file] Self-hosted upload URL not found in storage: {file_path}"

--- a/tests/infra/tool/test_reveal_file_remote_url_validation.py
+++ b/tests/infra/tool/test_reveal_file_remote_url_validation.py
@@ -1,0 +1,135 @@
+"""reveal_file 对本站上传代理 URL（/api/upload/file/<key>）的存在性校验。
+
+背景：agent 常把 image_generate 返回的长 URL 重新抄写一遍再传给
+reveal_file，24 位 hex user id 抄错一个字符就会把坏 URL 当成功结果
+推给前端，渲染成裂图。这里强制：本站 key 必须在 storage 里真实存在，
+否则返回结构化错误让 agent 自纠；外部 URL 保持透传不校验。
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.infra.tool import reveal_file_tool
+
+_SELF_UPLOAD_URL = (
+    "https://app.example.com/api/upload/file/generated-images/"
+    "69a77b14f5bc37143e7769f0/20260825_024036_60017aa8_generated.png"
+)
+_SELF_UPLOAD_KEY = (
+    "generated-images/69a77b14f5bc37143e7769f0/20260825_024036_60017aa8_generated.png"
+)
+
+
+class _FakeStorage:
+    def __init__(self, exists: bool) -> None:
+        self.exists = exists
+        self.checked_keys: list[str] = []
+
+    async def file_exists(self, key: str) -> bool:
+        self.checked_keys.append(key)
+        return self.exists
+
+
+@pytest.mark.asyncio
+async def test_reveal_file_rejects_self_upload_url_with_missing_object(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _FakeStorage(exists=False)
+
+    def _fail_index():
+        raise AssertionError("missing URL must not be indexed as a revealed file")
+
+    async def _fake_get_storage():
+        return storage
+
+    monkeypatch.setattr(reveal_file_tool, "_get_storage", _fake_get_storage)
+    monkeypatch.setattr(reveal_file_tool, "get_revealed_file_storage", _fail_index)
+
+    result = json.loads(
+        await reveal_file_tool.reveal_file.coroutine(
+            _SELF_UPLOAD_URL,
+            description="broken portrait",
+            runtime=object(),
+        )
+    )
+
+    assert result["type"] == "file_reveal"
+    assert result["file"]["path"] == _SELF_UPLOAD_URL
+    assert result["file"]["error"] == "remote_url_not_found"
+    assert storage.checked_keys == [_SELF_UPLOAD_KEY]
+
+
+@pytest.mark.asyncio
+async def test_reveal_file_passes_through_self_upload_url_with_existing_object(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _FakeStorage(exists=True)
+
+    async def _fake_get_storage():
+        return storage
+
+    monkeypatch.setattr(reveal_file_tool, "_get_storage", _fake_get_storage)
+    monkeypatch.setattr(reveal_file_tool, "get_revealed_file_storage", lambda: _FakeIndex())
+
+    result = json.loads(
+        await reveal_file_tool.reveal_file.coroutine(
+            _SELF_UPLOAD_URL,
+            description="generated portrait",
+            runtime=object(),
+        )
+    )
+
+    assert result["key"] == _SELF_UPLOAD_URL
+    assert result["url"] == _SELF_UPLOAD_URL
+    assert result["type"] == "image"
+    assert result["_meta"]["source"] == "remote_url"
+    assert storage.checked_keys == [_SELF_UPLOAD_KEY]
+
+
+@pytest.mark.asyncio
+async def test_reveal_file_urlencodes_key_before_existence_check(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _FakeStorage(exists=False)
+
+    async def _fake_get_storage():
+        return storage
+
+    monkeypatch.setattr(reveal_file_tool, "_get_storage", _fake_get_storage)
+
+    encoded_url = "https://app.example.com/api/upload/file/generated-images%2Fuser-1%2Fportrait.png"
+
+    result = json.loads(await reveal_file_tool.reveal_file.coroutine(encoded_url, runtime=object()))
+
+    assert result["file"]["error"] == "remote_url_not_found"
+    assert storage.checked_keys == ["generated-images/user-1/portrait.png"]
+
+
+@pytest.mark.asyncio
+async def test_reveal_file_self_upload_existence_check_failure_passes_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _BrokenStorage:
+        async def file_exists(self, key: str) -> bool:
+            raise RuntimeError("storage unavailable")
+
+    async def _fake_get_storage():
+        return _BrokenStorage()
+
+    monkeypatch.setattr(reveal_file_tool, "_get_storage", _fake_get_storage)
+    monkeypatch.setattr(reveal_file_tool, "get_revealed_file_storage", lambda: _FakeIndex())
+
+    result = json.loads(
+        await reveal_file_tool.reveal_file.coroutine(_SELF_UPLOAD_URL, runtime=object())
+    )
+
+    assert result["url"] == _SELF_UPLOAD_URL
+    assert result["_meta"]["source"] == "remote_url"
+
+
+class _FakeIndex:
+    async def upsert_by_name(self, **kwargs):
+        del kwargs

--- a/tests/infra/tool/test_reveal_file_remote_url_validation.py
+++ b/tests/infra/tool/test_reveal_file_remote_url_validation.py
@@ -33,20 +33,26 @@ class _FakeStorage:
         return self.exists
 
 
+class _RecordingIndex:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    async def upsert_by_name(self, **kwargs):
+        self.calls.append(kwargs)
+
+
 @pytest.mark.asyncio
 async def test_reveal_file_rejects_self_upload_url_with_missing_object(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     storage = _FakeStorage(exists=False)
-
-    def _fail_index():
-        raise AssertionError("missing URL must not be indexed as a revealed file")
+    index = _RecordingIndex()
 
     async def _fake_get_storage():
         return storage
 
     monkeypatch.setattr(reveal_file_tool, "_get_storage", _fake_get_storage)
-    monkeypatch.setattr(reveal_file_tool, "get_revealed_file_storage", _fail_index)
+    monkeypatch.setattr(reveal_file_tool, "get_revealed_file_storage", lambda: index)
 
     result = json.loads(
         await reveal_file_tool.reveal_file.coroutine(
@@ -60,6 +66,7 @@ async def test_reveal_file_rejects_self_upload_url_with_missing_object(
     assert result["file"]["path"] == _SELF_UPLOAD_URL
     assert result["file"]["error"] == "remote_url_not_found"
     assert storage.checked_keys == [_SELF_UPLOAD_KEY]
+    assert index.calls == []
 
 
 @pytest.mark.asyncio
@@ -72,7 +79,7 @@ async def test_reveal_file_passes_through_self_upload_url_with_existing_object(
         return storage
 
     monkeypatch.setattr(reveal_file_tool, "_get_storage", _fake_get_storage)
-    monkeypatch.setattr(reveal_file_tool, "get_revealed_file_storage", lambda: _FakeIndex())
+    monkeypatch.setattr(reveal_file_tool, "get_revealed_file_storage", lambda: _RecordingIndex())
 
     result = json.loads(
         await reveal_file_tool.reveal_file.coroutine(
@@ -120,7 +127,7 @@ async def test_reveal_file_self_upload_existence_check_failure_passes_through(
         return _BrokenStorage()
 
     monkeypatch.setattr(reveal_file_tool, "_get_storage", _fake_get_storage)
-    monkeypatch.setattr(reveal_file_tool, "get_revealed_file_storage", lambda: _FakeIndex())
+    monkeypatch.setattr(reveal_file_tool, "get_revealed_file_storage", lambda: _RecordingIndex())
 
     result = json.loads(
         await reveal_file_tool.reveal_file.coroutine(_SELF_UPLOAD_URL, runtime=object())
@@ -130,6 +137,21 @@ async def test_reveal_file_self_upload_existence_check_failure_passes_through(
     assert result["_meta"]["source"] == "remote_url"
 
 
-class _FakeIndex:
-    async def upsert_by_name(self, **kwargs):
-        del kwargs
+@pytest.mark.asyncio
+async def test_reveal_file_storage_init_failure_passes_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """storage 初始化本身失败也必须走透传，不能让整个工具调用报错。"""
+
+    async def _broken_get_storage():
+        raise RuntimeError("storage init failed")
+
+    monkeypatch.setattr(reveal_file_tool, "_get_storage", _broken_get_storage)
+    monkeypatch.setattr(reveal_file_tool, "get_revealed_file_storage", lambda: _RecordingIndex())
+
+    result = json.loads(
+        await reveal_file_tool.reveal_file.coroutine(_SELF_UPLOAD_URL, runtime=object())
+    )
+
+    assert result["url"] == _SELF_UPLOAD_URL
+    assert result["_meta"]["source"] == "remote_url"


### PR DESCRIPTION
## Summary

develop → main 晋升：分享页图片点击预览修复 + reveal_file 坏 URL 校验（PR #360）。

## 变更内容

- **后端** `src/infra/tool/reveal_file_tool.py`：`reveal_file` 收到本站上传代理 URL（`/api/upload/file/<key>`）时先做 `storage.file_exists` 存在性校验；key 不存在返回 `remote_url_not_found` 结构化错误（hint 引导 agent 回原始工具结果重抄 URL），storage 初始化/查询失败时保持透传可用性。外部 URL 行为不变。修复 agent 抄错长 URL 中 hex id 导致前端渲染裂图的问题。
- **前端**：`MessageImageGallery` 无 `SessionImageGalleryProvider` 时点击用本地 `ImageViewer` 兜底；`SharedPage` 挂载 `SessionImageGalleryProvider`。修复分享页 reveal_file 图片点击静默无反应。

## 验证

- CI 全绿（ruff / mypy / 前后端测试 / 镜像构建），develop 镜像 `develop-20260901-100643`
- staging 真实验证通过：
  - 多轮真实对话正常（搜索助手 + 工具调用）
  - `reveal_file` 对不存在的本站 URL 在真实会话中返回 `remote_url_not_found` + hint（新校验生效）
  - `reveal_file` 本地路径流程无回归（write_file → SVG 上传 → 展示正常）
  - 分享页图片卡渲染无裂图，点击弹出全屏灯箱（修复生效）

## 关联

- 原始排查：https://lambchat.com/shared/Om8KsSwRbcN5
- 功能 PR：#360
