### PR TITLE
fix(task): 恢复次数达上限的终止不再把会话重新标记为可恢复，掐断恢复风暴

### DIFF
--- a/src/infra/task/manager.py
+++ b/src/infra/task/manager.py
@@ -206,8 +206,8 @@ class BackgroundTaskManager:
             resume_interrupted_run=self._resume_interrupted_run,
         )
 
-    async def _mark_run_failed(self, run_id: str, reason: str, session: Any) -> None:
-        await self._recovery_service().mark_run_failed(run_id, reason, session)
+    async def _mark_run_failed(self, run_id: str, reason: str, session: Any, **kwargs) -> None:
+        await self._recovery_service().mark_run_failed(run_id, reason, session, **kwargs)
 
     async def _mark_run_recoverable_failure(
         self,

--- a/src/infra/task/recovery.py
+++ b/src/infra/task/recovery.py
@@ -131,7 +131,7 @@ class TaskRecoveryService:
         heartbeat: Any,
         ensure_executor: Callable[[], Any],
         submit_task: Callable[..., Awaitable[tuple[str, str]]],
-        mark_run_failed: Callable[[str, str, Any], Awaitable[None]],
+        mark_run_failed: Callable[..., Awaitable[None]],
         submit_arq_task: Callable[..., Awaitable[tuple[str, str]]] | None = None,
     ) -> None:
         self._storage = storage
@@ -169,8 +169,20 @@ class TaskRecoveryService:
             logger.warning("Failed to load user roles for recovery: %s", e)
             return []
 
-    async def mark_run_failed(self, run_id: str, reason: str, session: Any) -> None:
-        """Mark a stale run and its trace as failed before recovery."""
+    async def mark_run_failed(
+        self,
+        run_id: str,
+        reason: str,
+        session: Any,
+        *,
+        recoverable: bool = True,
+    ) -> None:
+        """Mark a stale run and its trace as failed before recovery.
+
+        recoverable=False 用于「恢复次数已达上限」的终态终止：此时会话不得
+        再被标为可恢复，否则 startup 扫描谓词（task_recoverable=True +
+        task_error_code=server_restart）每轮都会重新接管，形成恢复风暴。
+        """
         executor = self._ensure_executor()
         await executor._update_session_status(
             session.id,
@@ -182,7 +194,7 @@ class TaskRecoveryService:
             session.id,
             SessionUpdate(
                 metadata={
-                    "task_recoverable": True,
+                    "task_recoverable": recoverable,
                     "task_error_code": "server_restart",
                     "interrupted_run_id": run_id,
                 }
@@ -487,12 +499,16 @@ class TaskRecoveryService:
             attempts = int(session_metadata.get("resume_attempts") or 0)
             if attempts >= MAX_SEAMLESS_RESUME_ATTEMPTS:
                 # 毒消息防护：同 run 反复中断说明重跑本身在触发崩溃，
-                # 终态失败（写 error 事件 + trace 终结），扫描器不再接管。
+                # 终态失败（写 error 事件 + trace 终结）。recoverable=False
+                # 是关键：会话不再满足扫描谓词，否则每轮扫描都会重新接管，
+                # 反复重复本分支（生产曾因此 25h 刷 500+ 轮恢复风暴）。
                 await self._mark_run_failed(
                     source_run_id,
                     f"Resume attempts exhausted ({attempts})",
                     session,
+                    recoverable=False,
                 )
+                await self.release_recovery_lock(lock_key, lock_token)
                 return {
                     "success": False,
                     "run_id": None,

--- a/tests/infra/task/test_recovery_exhausted_unrecoverable.py
+++ b/tests/infra/task/test_recovery_exhausted_unrecoverable.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+"""Regression tests: resume-exhausted termination must not re-arm auto-recovery.
+
+Production symptom (k3s dual pods): a scheduled run failed (upstream content
+moderation), auto-recovery resumed it until ``resume_attempts`` hit the cap,
+and every later scan loop called mark_run_failed again — which persisted
+``task_recoverable=True`` + ``task_error_code="server_restart"``. That is
+exactly the predicate ``_is_latest_explicit_system_restart_failure`` matches,
+so both pods re-took the recovery lock in circles for hours (~1200 scan hits,
+500+ "已在其他实例中启动", 147 lock takeovers, and 553 duplicated
+"Resume attempts exhausted" error events appended to one trace).
+"""
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from src.infra.task import recovery as recovery_module
+from src.infra.task.recovery import TaskRecoveryService
+
+
+class _FakeStorage:
+    def __init__(self, session=None) -> None:
+        self.session = session
+        self.updates: list[tuple[str, Any]] = []
+
+    async def update(self, session_id, session_update) -> None:
+        self.updates.append((session_id, session_update))
+
+
+class _FakeExecutor:
+    async def _update_session_status(self, session_id, status, reason=None, run_id=None):
+        return None
+
+
+class _FakeHeartbeat:
+    def __init__(self, stale: bool = True) -> None:
+        self._stale = stale
+
+    async def is_stale(self, run_id: str) -> bool:
+        return self._stale
+
+    async def check_exists(self, run_id: str) -> bool:
+        return False
+
+
+class _FakeRedis:
+    async def set(self, key, value, ex=None, nx=False):
+        return True
+
+    def eval(self, *args, **kwargs):
+        return 1
+
+
+def _metadata_of(update) -> dict:
+    # storage.update 记录为 (session_id, SessionUpdate) 元组
+    session_update = update[1] if isinstance(update, tuple) else update
+    return session_update.metadata
+
+
+def _make_service(storage, mark_calls: list[dict]) -> TaskRecoveryService:
+    async def _mark_run_failed(run_id, reason, session, **kwargs):
+        mark_calls.append({"run_id": run_id, "reason": reason, **kwargs})
+
+    async def _submit(*_args, **_kwargs):
+        return ("", "")
+
+    return TaskRecoveryService(
+        storage=storage,
+        run_info={},
+        heartbeat=_FakeHeartbeat(stale=True),
+        ensure_executor=lambda: _FakeExecutor(),
+        submit_task=_submit,
+        mark_run_failed=_mark_run_failed,
+    )
+
+
+@pytest.mark.asyncio
+async def test_mark_run_failed_defaults_to_recoverable(monkeypatch: pytest.MonkeyPatch) -> None:
+    storage = _FakeStorage()
+    service = TaskRecoveryService(
+        storage=storage,
+        run_info={},
+        heartbeat=_FakeHeartbeat(),
+        ensure_executor=lambda: _FakeExecutor(),
+        submit_task=_stub,
+        mark_run_failed=_noop_mark,
+    )
+    monkeypatch.setattr(recovery_module, "get_trace_storage", _raise_trace_storage_unavailable)
+
+    await service.mark_run_failed("run-1", "Task interrupted", SimpleNamespace(id="s1"))
+
+    assert storage.updates, "session metadata must be persisted"
+    assert _metadata_of(storage.updates[0])["task_recoverable"] is True
+
+
+@pytest.mark.asyncio
+async def test_mark_run_failed_can_persist_unrecoverable(monkeypatch: pytest.MonkeyPatch) -> None:
+    storage = _FakeStorage()
+    service = TaskRecoveryService(
+        storage=storage,
+        run_info={},
+        heartbeat=_FakeHeartbeat(),
+        ensure_executor=lambda: _FakeExecutor(),
+        submit_task=_stub,
+        mark_run_failed=_noop_mark,
+    )
+    monkeypatch.setattr(recovery_module, "get_trace_storage", _raise_trace_storage_unavailable)
+
+    await service.mark_run_failed(
+        "run-1", "Resume attempts exhausted (3)", SimpleNamespace(id="s1"), recoverable=False
+    )
+
+    assert _metadata_of(storage.updates[0])["task_recoverable"] is False
+
+
+@pytest.mark.asyncio
+async def test_resume_interrupted_run_marks_exhausted_run_unrecoverable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """达到恢复上限的终止必须让扫描器不再接管（task_recoverable=False）。"""
+    from datetime import datetime, timezone
+
+    monkeypatch.setattr(recovery_module, "get_redis_client", lambda: _FakeRedis())
+
+    session = SimpleNamespace(
+        id="session-1",
+        metadata={
+            "current_run_id": "run-exhausted",
+            "resume_attempts": recovery_module.MAX_SEAMLESS_RESUME_ATTEMPTS,
+            "task_status": "recovering",
+        },
+        agent_id="search",
+        updated_at=datetime.now(timezone.utc),
+    )
+    storage = _FakeStorage(session)
+    mark_calls: list[dict] = []
+    service = _make_service(storage, mark_calls)
+
+    result = await service.resume_interrupted_run(session, "run-exhausted", "server_restart")
+
+    assert result["success"] is False
+    assert "恢复次数已达上限" in result["message"]
+    assert mark_calls == [
+        {
+            "run_id": "run-exhausted",
+            "reason": f"Resume attempts exhausted ({recovery_module.MAX_SEAMLESS_RESUME_ATTEMPTS})",
+            "recoverable": False,
+        }
+    ]
+
+
+async def _stub(*_args, **_kwargs):
+    return ("", "")
+
+
+async def _noop_mark(*_args, **_kwargs):
+    return None
+
+
+async def _raise_trace_storage_unavailable():
+    raise RuntimeError("trace storage unavailable in test")


### PR DESCRIPTION
Fixes #362

## 问题

生产（k3s 双 Pod）：某 run 自动恢复耗尽次数后，终止路径 `mark_run_failed` 无条件写 `task_recoverable=True + task_error_code=server_restart`——恰好是扫描谓词 `_is_latest_explicit_system_restart_failure` 的完整匹配条件。每轮扫描（约 75s）重新接管→再标记→再写 error 事件，双实例互抢恢复锁，25h 刷 ~1200 轮扫描、~1000 次跨实例冲突、~290 次锁接管与「已达上限」，同一 trace 累积 553 条重复的 `Resume attempts exhausted` error 事件。

## 修复（最小改动）

1. `mark_run_failed` 增加 `recoverable: bool = True`；exhausted 终止路径传 **False**——会话不再满足扫描谓词，风暴闭环根断；
2. exhausted 分支终止时同步释放恢复锁（原先空等 300s TTL，加剧锁乒乓）；
3. 真正的实例中断场景语义不变（默认 True）。

## 测试

- 新增 `tests/infra/task/test_recovery_exhausted_unrecoverable.py`（3 例：默认可恢复语义保持 / recoverable=False 落库 / exhausted 路径回调携带 recoverable=False 且返回「已达上限」）——先红后绿
- 全量后端 3426 passed / 1 skipped；ruff check / ruff format / mypy 全绿（独立 worktree 干净环境）

## 部署提醒（合入 develop 后）

CI 出 develop-\<时间戳\> 镜像后：yang 上 `/data/lambchat-k8s/update-staging.sh` 滚 staging，`ssh -L 8021:127.0.0.1:8021 yang` 隧道验证；OK 后 PR develop→main 晋升，`/data/lambchat-k8s/update.sh` 上生产 + `/root/disttest/run-all.sh` 回归。观察指标：涉事定时任务若再遇上游失败，恢复应在 3 次后彻底停止（无循环日志、每 trace 仅 1 条 Resume attempts exhausted 事件）。