### PR TITLE
fix(memory): 自进化管线加固——扫描锁续期、教训防压缩改写、反思输入净化

### DIFF
--- a/src/infra/memory/compaction_agent.py
+++ b/src/infra/memory/compaction_agent.py
@@ -36,6 +36,16 @@ _LOCAL_ATTEMPT_CACHE_LIMIT = 500
 _COMPACTION_INVENTORY_MAX_CHARS = 80_000
 COMPACTION_SCAN_CANDIDATE_LIMIT = 100
 
+# 教训（self_evolved）有 rule:/why:/how_to_apply 固定 schema，写入时经形状校验；
+# 压缩改写会破坏形状且校验不会重跑——与 manual 同级保护，不参与压缩计数与清单。
+_COMPACTION_EXCLUDED_SOURCES = ["manual", "self_evolved"]
+
+
+def _compaction_candidate_query(user_id: str) -> dict[str, Any]:
+    """压缩候选查询（按用户）——排除 manual 与 self_evolved。"""
+    return {"user_id": user_id, "source": {"$nin": _COMPACTION_EXCLUDED_SOURCES}}
+
+
 _COMPACTION_SYSTEM_PROMPT = (
     "You are a dedicated memory compaction agent for LambChat.\n"
     "Your job is to organize automatic cross-session memories for one user into concise, "
@@ -50,11 +60,13 @@ _COMPACTION_SYSTEM_PROMPT = (
     "- memory_compaction_update: update one existing automatic memory. Arguments: "
     "memory_id, content, optional title, summary, tags, context. "
     'tags MUST be a JSON array of strings (e.g. [\\"a\\", \\"b\\"]), never a plain string. '
+    "Never use it on self-evolved lessons. "
     "Use it on the canonical "
     "memory after merging durable facts; metadata is optional; omitted fields are filled "
     "automatically.\n"
     "- memory_compaction_delete: delete one redundant or low-value automatic memory. "
-    "Arguments: memory_id. Never use it on manual memories.\n\n"
+    "Arguments: memory_id. Never use it on manual memories or self-evolved lessons "
+    "(context=feedback_rule, fixed rule:/why:/how_to_apply shape).\n\n"
     "Follow these steps:\n\n"
     "Step 1 — Candidate selection (from the inventory below):\n"
     "- First scan titles, summaries, tags, context, updated_at, access_count, and content "
@@ -80,7 +92,8 @@ _COMPACTION_SYSTEM_PROMPT = (
     "- Delete ONLY after durable facts are preserved in the canonical memory, or the memory "
     "is confirmed vague/stale/temporary/contradicted.\n"
     "- Prefer reducing total memory count when facts are already represented elsewhere. "
-    "NEVER delete manual memories. NEVER delete a unique durable fact.\n\n"
+    "NEVER delete manual memories. NEVER delete self-evolved lessons. "
+    "NEVER delete a unique durable fact.\n\n"
     "Step 4 — Finish:\n"
     "- When done, respond with a summary: checked count, updated count, deleted count, "
     "merged topics, unchanged items.\n"
@@ -179,9 +192,7 @@ class MemoryCompactionAgent:
             )
             return {"triggered": False, "reason": "unsupported_backend"}
 
-        count = await backend._collection.count_documents(
-            {"user_id": user_id, "source": {"$ne": "manual"}}
-        )
+        count = await backend._collection.count_documents(_compaction_candidate_query(user_id))
         if count < self.threshold:
             logger.info(
                 "[MemoryCompactionAgent] after-write skipped for %s: count=%s threshold=%s",
@@ -309,7 +320,7 @@ class MemoryCompactionAgent:
 
         try:
             memory_count = await backend._collection.count_documents(
-                {"user_id": user_id, "source": {"$ne": "manual"}}
+                _compaction_candidate_query(user_id)
             )
             if memory_count < 3:
                 return {"agent": "deepagent", "checked": memory_count, "skipped": True}
@@ -389,7 +400,7 @@ class MemoryCompactionAgent:
 
         cursor = backend._collection.aggregate(
             [
-                {"$match": {"source": {"$ne": "manual"}}},
+                {"$match": {"source": {"$nin": _COMPACTION_EXCLUDED_SOURCES}}},
                 {"$group": {"_id": "$user_id", "count": {"$sum": 1}}},
                 {"$match": {"count": {"$gte": self.threshold}}},
                 {"$sort": {"count": -1}},
@@ -454,6 +465,8 @@ class MemoryCompactionAgent:
                 return {"success": False, "error": "memory_not_found"}
             if existing.get("source") == "manual":
                 return {"success": False, "error": "manual_memory_protected"}
+            if existing.get("source") == "self_evolved":
+                return {"success": False, "error": "self_evolved_memory_protected"}
             filled_title, filled_summary, filled_tags = self._fill_compaction_metadata(
                 content=content,
                 existing=existing,
@@ -476,7 +489,7 @@ class MemoryCompactionAgent:
 
         @tool
         async def memory_compaction_delete(
-            memory_id: Annotated[str, "Existing non-manual memory id to delete"],
+            memory_id: Annotated[str, "Existing non-manual memory to delete"],
         ) -> dict[str, Any]:
             """Delete one redundant automatic memory after its facts were preserved elsewhere."""
             existing = await backend._collection.find_one(
@@ -487,6 +500,8 @@ class MemoryCompactionAgent:
                 return {"success": False, "error": "memory_not_found"}
             if existing.get("source") == "manual":
                 return {"success": False, "error": "manual_memory_protected"}
+            if existing.get("source") == "self_evolved":
+                return {"success": False, "error": "self_evolved_memory_protected"}
             result = await backend.delete(user_id, memory_id)
             if result.get("success"):
                 tool_metrics["deleted"] += 1
@@ -572,7 +587,7 @@ class MemoryCompactionAgent:
             "content_store_key": 1,
         }
         cursor = backend._collection.find(
-            {"user_id": user_id, "source": {"$ne": "manual"}},
+            _compaction_candidate_query(user_id),
             projection,
         ).sort("updated_at", 1)
         result: list[dict[str, Any]] = []

--- a/src/infra/memory/evolution/reflector.py
+++ b/src/infra/memory/evolution/reflector.py
@@ -42,6 +42,10 @@ _SECRET_PATTERNS = [
     re.compile(r"((?:api[_-]?key|token|secret|password)\s*[:=]\s*\S{8,})", re.I),
 ]
 
+# 写时注入到用户消息的系统块（memory_context/turn_context）——反思输入须剥离，
+# 只留用户真实表达：既是降噪，也防教训提炼到注入块上。
+_INJECTED_BLOCK_RE = re.compile(r"\s*<(memory_context|turn_context)>.*?</\1>\s*", re.S)
+
 
 @dataclass(frozen=True)
 class SignalRun:
@@ -49,6 +53,13 @@ class SignalRun:
     session_id: str
     kind: str  # "down" | "failed" | "up"
     comment: Optional[str] = None
+
+
+def _strip_injected_blocks(text: str) -> str:
+    """剥离写时注入的 <memory_context>/<turn_context> 系统块，保留用户真实表达。"""
+    if not text:
+        return text
+    return _INJECTED_BLOCK_RE.sub("", text).strip()
 
 
 def _validate_and_sanitize_lesson(content: str) -> Optional[str]:
@@ -304,25 +315,34 @@ async def _increment_daily_quota(user_id: str, stored: int) -> None:
         logger.debug("[MemoryEvolution] quota increment failed: %s", e)
 
 
-async def _load_exchange(run_id: str, session_id: str = "") -> tuple[str, str]:
-    """从 trace 取该 run 的用户消息与最终助手回复（累积合并 chunk）。"""
+async def _load_exchange(run_id: str, session_id: str = "", user_id: str = "") -> tuple[str, str]:
+    """从 trace 取该 run 的用户消息与最终助手回复（累积合并 chunk）。
+
+    查询带 user_id 过滤（防御性隔离：run_id 不作为唯一凭证）；
+    用户消息剥离注入块后再裁剪——剥离释放的预算留给真实内容。
+    """
     from src.infra.storage.mongodb import get_mongo_client
 
     client = get_mongo_client()
     db = client[settings.MONGODB_DB]
 
-    query: dict[str, Any] = {"run_id": run_id}
+    def _scope(query: dict[str, Any]) -> dict[str, Any]:
+        if user_id:
+            query["user_id"] = user_id
+        return query
+
+    query = _scope({"run_id": run_id})
     if session_id:
-        query = {"session_id": session_id, "run_id": run_id}
+        query["session_id"] = session_id
 
     events: list[dict[str, Any]] = []
     trace = await db[settings.MONGODB_TRACES_COLLECTION].find_one(query, {"events": 1})
     if trace:
         events = trace.get("events") or []
     if not events:
-        chunks_query: dict[str, Any] = {"run_id": run_id}
+        chunks_query = _scope({"run_id": run_id})
         if session_id:
-            chunks_query = {"session_id": session_id, "run_id": run_id}
+            chunks_query["session_id"] = session_id
         chunks = (
             await db[settings.MONGODB_TRACE_EVENT_CHUNKS_COLLECTION]
             .find(chunks_query, {"events": 1})
@@ -359,7 +379,9 @@ async def _load_exchange(run_id: str, session_id: str = "") -> tuple[str, str]:
         if total_len >= EXCHANGE_CLIP_CHARS:
             break
     assistant_msg = "\n".join(reversed(parts))
-    return user_msg[:EXCHANGE_CLIP_CHARS], assistant_msg[:EXCHANGE_CLIP_CHARS]
+    return _strip_injected_blocks(user_msg)[:EXCHANGE_CLIP_CHARS], assistant_msg[
+        :EXCHANGE_CLIP_CHARS
+    ]
 
 
 REFLECT_SYSTEM_PROMPT = """You are an offline reflection engine distilling behavioral lessons \
@@ -390,7 +412,7 @@ If nothing worth extracting, call no tool."""
 async def reflect_on_run(backend, user_id: str, signal: SignalRun) -> dict:
     """对单个信号 run 跑反思 LLM，产出教训则 retain（至多 1 条）。"""
     try:
-        user_msg, assistant_msg = await _load_exchange(signal.run_id, signal.session_id)
+        user_msg, assistant_msg = await _load_exchange(signal.run_id, signal.session_id, user_id)
     except Exception as e:
         logger.info("[MemoryEvolution] exchange load failed for %s: %s", signal.run_id, e)
         return {"stored": 0, "skipped": True}

--- a/src/infra/memory/evolution/scheduler.py
+++ b/src/infra/memory/evolution/scheduler.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import uuid
 from datetime import datetime, timedelta, timezone
-from typing import Optional
+from typing import Any, Optional
 
 from src.kernel.config import settings
 
@@ -20,6 +20,11 @@ EVOLUTION_SCAN_LOCK_TTL = 600  # 10 分钟（远小于调度间隔，防死锁�
 _RELEASE_LOCK_LUA = (
     "if redis.call('get', KEYS[1]) == ARGV[1] then "
     "return redis.call('del', KEYS[1]) else return 0 end"
+)
+
+_REFRESH_LOCK_LUA = (
+    "if redis.call('get', KEYS[1]) == ARGV[1] then "
+    "return redis.call('expire', KEYS[1], ARGV[2]) else return 0 end"
 )
 
 
@@ -54,6 +59,27 @@ async def _release_scan_lock(token: str) -> None:
         )
     except Exception:
         pass
+
+
+async def _refresh_scan_lock(token: str) -> bool:
+    """Token-checked TTL 续期——单轮扫描最坏可跑远超锁 TTL（50 用户 × 多次
+    反思 LLM 调用），运行中逐用户续期防止锁过期后被其他副本并发抢占。
+
+    返回 False 仅当 Redis 明确表示锁已易主（调用方应立即中止扫描）；
+    Redis 故障时 fail-open 返回 True——无法证伪所有权，不误杀进行中的长任务。
+    """
+    if not token:
+        return False
+    try:
+        from src.infra.storage.redis import get_redis_client
+
+        result: Any = await get_redis_client().eval(  # type: ignore[misc]
+            _REFRESH_LOCK_LUA, 1, EVOLUTION_SCAN_LOCK_KEY, token, str(EVOLUTION_SCAN_LOCK_TTL)
+        )
+        return bool(int(result))
+    except Exception as e:
+        logger.warning("[MemoryEvolution] scan lock refresh failed (fail-open): %s", e)
+        return True
 
 
 async def _collect_signal_user_ids(cutoff: datetime) -> list[str]:
@@ -142,6 +168,12 @@ async def run_scheduled_evolution() -> dict:
         total = 0
         users_processed = 0
         for uid in user_ids:
+            if not await _refresh_scan_lock(lock_token):
+                logger.warning(
+                    "[MemoryEvolution] scan lock lost mid-scan (users_done=%d), aborting",
+                    users_processed,
+                )
+                return {"skipped": "scan_lock_lost"}
             try:
                 r = await evolve_user(backend, uid)
                 stored = int(r.get("stored") or 0)

--- a/tests/infra/memory/evolution/test_reflector.py
+++ b/tests/infra/memory/evolution/test_reflector.py
@@ -8,6 +8,10 @@ import pytest
 
 from src.infra.memory.evolution import reflector
 
+# autouse 的 _exchange_stub 会替换模块函数——直测 _load_exchange 的用例
+# 需要这份 import 期捕获的真实引用来还原。
+_REAL_LOAD_EXCHANGE = reflector._load_exchange
+
 
 def _dt(**kw):
     return datetime.now(timezone.utc) - timedelta(**kw)
@@ -54,7 +58,7 @@ class _FakeTracesCol:
 
 @pytest.fixture(autouse=True)
 def _exchange_stub(monkeypatch):
-    async def fake_load(run_id, session_id=""):
+    async def fake_load(run_id, session_id="", user_id=""):
         if run_id == "r-down":
             return "帮我写个部署脚本", "好的，这是一个 3000 字的详细教程……（非常啰嗦）"
         if run_id == "r-fail":
@@ -181,6 +185,114 @@ async def test_reflect_no_tool_call_skips(monkeypatch):
     FakeBackend._get_memory_model = staticmethod(lambda: FakeModel())
     sig = reflector.SignalRun(run_id="r-ok", session_id="s1", kind="down", comment=None)
     assert await reflector.reflect_on_run(FakeBackend(), "u1", sig) == {"stored": 0}
+
+
+@pytest.mark.asyncio
+async def test_strip_injected_blocks_removes_system_context():
+    """反思输入须剥离写时注入的上下文块，只留用户真实表达。"""
+    raw = (
+        "帮我优化这个查询\n\n"
+        "<memory_context>\n"
+        "System-injected relevant memories. Not authored by the user; ...\n"
+        "- [user|2026-08-30] 标题 — 摘要\n"
+        "</memory_context>\n\n"
+        "<turn_context>\n"
+        "System-injected context. Not authored by the user; ...\n"
+        "（目标/自动模式内容）\n"
+        "</turn_context>"
+    )
+    assert reflector._strip_injected_blocks(raw) == "帮我优化这个查询"
+    # 无注入块时原样返回
+    assert reflector._strip_injected_blocks("普通消息") == "普通消息"
+
+
+@pytest.mark.asyncio
+async def test_load_exchange_scopes_queries_by_user_id(monkeypatch):
+    """trace/chunks 查询必须带 user_id——防御性隔离，run_id 不可信任为唯一凭证。"""
+    seen_queries: list[dict] = []
+
+    class _FakeTraceCol:
+        async def find_one(self, query, *_a, **_k):
+            seen_queries.append(("trace", dict(query)))
+            return None
+
+    class _FakeChunksCol:
+        def find(self, query, *_a, **_k):
+            seen_queries.append(("chunks", dict(query)))
+            return _FakeFind([])
+
+    class _FakeDB:
+        def __init__(self, cols):
+            self._cols = cols
+
+        def __getitem__(self, name):
+            return self._cols[name]
+
+    class _FakeClient:
+        def __init__(self, cols):
+            self._db = _FakeDB(cols)
+
+        def __getitem__(self, _db_name):
+            return self._db
+
+    import src.infra.memory.evolution.reflector as r
+
+    monkeypatch.setattr(r, "_load_exchange", _REAL_LOAD_EXCHANGE)
+    monkeypatch.setattr(r.settings, "MONGODB_DB", "testdb", raising=False)
+    monkeypatch.setattr(r.settings, "MONGODB_TRACES_COLLECTION", "traces", raising=False)
+    monkeypatch.setattr(
+        r.settings,
+        "MONGODB_TRACE_EVENT_CHUNKS_COLLECTION",
+        "trace_event_chunks",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "src.infra.storage.mongodb.get_mongo_client",
+        lambda: _FakeClient({"traces": _FakeTraceCol(), "trace_event_chunks": _FakeChunksCol()}),
+    )
+    await r._load_exchange("run-1", "sess-1", "u1")
+    assert seen_queries, "应发出 trace 查询"
+    for _, q in seen_queries:
+        assert q.get("user_id") == "u1"
+        assert q.get("run_id") == "run-1"
+
+
+@pytest.mark.asyncio
+async def test_load_exchange_strips_injected_blocks_before_clip(monkeypatch):
+    """注入块剥离应在裁剪之前——剥离释放的预算留给真实内容。"""
+    long_tail = "真实诉求" * 600
+
+    class _FakeTraceCol:
+        async def find_one(self, _query, *_a, **_k):
+            return {
+                "events": [
+                    {
+                        "event_type": "user:message",
+                        "data": {
+                            "content": "<memory_context>\n被注入的块\n</memory_context>\n\n"
+                            + long_tail
+                        },
+                    }
+                ]
+            }
+
+    class _FakeDB:
+        def __getitem__(self, _name):
+            return _FakeTraceCol()
+
+    class _FakeClient:
+        def __getitem__(self, _db_name):
+            return _FakeDB()
+
+    monkeypatch.setattr("src.infra.storage.mongodb.get_mongo_client", lambda: _FakeClient())
+    import src.infra.memory.evolution.reflector as r
+
+    monkeypatch.setattr(r, "_load_exchange", _REAL_LOAD_EXCHANGE)
+    monkeypatch.setattr(r.settings, "MONGODB_TRACES_COLLECTION", "traces", raising=False)
+    user_msg, _assistant = await r._load_exchange("run-1", "", "u1")
+    assert "<memory_context>" not in user_msg
+    assert user_msg.startswith("真实诉求")
+    assert len(user_msg) == r.EXCHANGE_CLIP_CHARS
 
 
 @pytest.mark.asyncio

--- a/tests/infra/memory/evolution/test_scheduler.py
+++ b/tests/infra/memory/evolution/test_scheduler.py
@@ -13,6 +13,9 @@ class _FakeRedis:
     def __init__(self, initial: dict | None = None):
         self.store: dict = dict(initial or {})
         self.eval_calls: list = []
+        self.expire_calls: list = []
+        # eval 脚本行为开关：release 删 key，refresh 只续期
+        self.eval_mode: str = "release"
 
     async def set(self, key, value, nx=False, ex=None):
         if nx and key in self.store:
@@ -20,10 +23,18 @@ class _FakeRedis:
         self.store[key] = value
         return True
 
-    async def eval(self, _script, _numkeys, key, token):
+    async def eval(self, _script, _numkeys, key, token, *_rest):
         self.eval_calls.append((key, token))
-        if self.store.get(key) == token:
-            self.store.pop(key)
+        if self.store.get(key) != token:
+            return 0
+        if self.eval_mode == "refresh":
+            return 1
+        self.store.pop(key)
+        return 1
+
+    async def expire(self, key, ttl):
+        self.expire_calls.append((key, ttl))
+        return key in self.store
 
 
 @pytest.mark.asyncio
@@ -69,6 +80,115 @@ async def test_release_empty_token_is_noop(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_refresh_scan_lock_extends_ttl_for_owner(monkeypatch):
+    fake = _FakeRedis({scheduler.EVOLUTION_SCAN_LOCK_KEY: "tok-1"})
+    fake.eval_mode = "refresh"
+    monkeypatch.setattr("src.infra.storage.redis.get_redis_client", lambda: fake)
+    assert await scheduler._refresh_scan_lock("tok-1") is True
+    assert fake.eval_calls == [(scheduler.EVOLUTION_SCAN_LOCK_KEY, "tok-1")]
+    # 续期不删锁
+    assert fake.store.get(scheduler.EVOLUTION_SCAN_LOCK_KEY) == "tok-1"
+
+
+@pytest.mark.asyncio
+async def test_refresh_scan_lock_rejects_foreign_token(monkeypatch):
+    fake = _FakeRedis({scheduler.EVOLUTION_SCAN_LOCK_KEY: "tok-real"})
+    fake.eval_mode = "refresh"
+    monkeypatch.setattr("src.infra.storage.redis.get_redis_client", lambda: fake)
+    assert await scheduler._refresh_scan_lock("tok-stale") is False
+    assert fake.store.get(scheduler.EVOLUTION_SCAN_LOCK_KEY) == "tok-real"
+
+
+@pytest.mark.asyncio
+async def test_refresh_scan_lock_redis_error_fails_open(monkeypatch):
+    class _BrokenRedis:
+        async def eval(self, *_a, **_k):
+            raise ConnectionError("redis down")
+
+    monkeypatch.setattr("src.infra.storage.redis.get_redis_client", lambda: _BrokenRedis())
+    # Redis 故障无法证伪所有权——延续当前扫描（fail-open），不误杀长任务
+    assert await scheduler._refresh_scan_lock("tok-1") is True
+
+
+@pytest.mark.asyncio
+async def test_refresh_scan_lock_empty_token_is_noop(monkeypatch):
+    def _boom():
+        raise AssertionError("eval must not be called for empty token")
+
+    monkeypatch.setattr("src.infra.storage.redis.get_redis_client", _boom)
+    assert await scheduler._refresh_scan_lock("") is False
+
+
+@pytest.mark.asyncio
+async def test_run_scheduled_evolution_refreshes_lock_per_user(monkeypatch):
+    fake = _FakeRedis()
+    fake.eval_mode = "refresh"
+    monkeypatch.setattr("src.infra.storage.redis.get_redis_client", lambda: fake)
+    monkeypatch.setattr(scheduler.settings, "ENABLE_MEMORY", True)
+    monkeypatch.setattr(scheduler.settings, "NATIVE_MEMORY_SELF_EVOLVE_ENABLED", True)
+
+    async def fake_collect(_cutoff):
+        return ["u1", "u2"]
+
+    monkeypatch.setattr(scheduler, "_collect_signal_user_ids", fake_collect)
+
+    async def fake_backend():
+        return SimpleNamespace()
+
+    monkeypatch.setattr("src.infra.memory.tools._get_backend", fake_backend)
+
+    async def fake_evolve(_backend, uid):
+        return {"stored": 1}
+
+    monkeypatch.setattr("src.infra.memory.evolution.reflector.evolve_user", fake_evolve)
+
+    result = await scheduler.run_scheduled_evolution()
+    assert result == {"users": 2, "users_evolved": 2, "stored": 2}
+    # eval 序列：2 次逐用户续期 + 1 次最终释放；token 全部一致（本次持有者）
+    assert len(fake.eval_calls) == 3
+    tokens = {t for _, t in fake.eval_calls}
+    assert len(tokens) == 1 and tokens.pop()  # 同一 token：续期与释放均为持有者
+
+
+@pytest.mark.asyncio
+async def test_run_scheduled_evolution_aborts_when_lock_lost(monkeypatch):
+    fake = _FakeRedis()
+    fake.eval_mode = "refresh_lost"  # eval 一律返回 0：锁已易主
+
+    async def eval_override(_script, _numkeys, key, token, *_rest):
+        fake.eval_calls.append((key, token))
+        return 0
+
+    fake.eval = eval_override  # type: ignore[method-assign]
+    monkeypatch.setattr("src.infra.storage.redis.get_redis_client", lambda: fake)
+    monkeypatch.setattr(scheduler.settings, "ENABLE_MEMORY", True)
+    monkeypatch.setattr(scheduler.settings, "NATIVE_MEMORY_SELF_EVOLVE_ENABLED", True)
+
+    async def fake_collect(_cutoff):
+        return ["u1", "u2"]
+
+    monkeypatch.setattr(scheduler, "_collect_signal_user_ids", fake_collect)
+
+    async def fake_backend():
+        return SimpleNamespace()
+
+    monkeypatch.setattr("src.infra.memory.tools._get_backend", fake_backend)
+
+    evolved = []
+
+    async def fake_evolve(_backend, uid):
+        evolved.append(uid)
+        return {"stored": 1}
+
+    monkeypatch.setattr("src.infra.memory.evolution.reflector.evolve_user", fake_evolve)
+
+    result = await scheduler.run_scheduled_evolution()
+    # 锁确认易主后立即中止，不再处理后续用户（防双副本并发反思）
+    assert evolved == []
+    assert result["skipped"] == "scan_lock_lost"
+
+
+@pytest.mark.asyncio
 async def test_run_scheduled_evolution_releases_own_token(monkeypatch):
     fake = _FakeRedis()
     monkeypatch.setattr("src.infra.storage.redis.get_redis_client", lambda: fake)
@@ -92,7 +212,8 @@ async def test_run_scheduled_evolution_releases_own_token(monkeypatch):
 
     result = await scheduler.run_scheduled_evolution()
     assert result == {"users": 1, "users_evolved": 1, "stored": 1}
-    # 释放的 token 与获取时写入的一致（token-checked 释放）
-    assert len(fake.eval_calls) == 1
-    released_token = fake.eval_calls[0][1]
-    assert released_token  # 用的是本次持有者 token（而非全局残留）
+    # eval 序列：1 次续期（单用户）+ 1 次释放；两者 token 一致且为本次持有者
+    assert len(fake.eval_calls) == 2
+    refresh_token = fake.eval_calls[0][1]
+    release_token = fake.eval_calls[1][1]
+    assert refresh_token == release_token and release_token

--- a/tests/infra/memory/native/test_backend_lifecycle.py
+++ b/tests/infra/memory/native/test_backend_lifecycle.py
@@ -118,6 +118,8 @@ async def test_get_memory_model_uses_native_model_id(monkeypatch: pytest.MonkeyP
         fake_resolve_model_reference,
     )
     monkeypatch.setattr(backend_module.settings, "NATIVE_MEMORY_MODEL", "memory-model-id")
+    # 钉住 max_tokens——测试不得依赖开发者本地 .env 的覆盖值
+    monkeypatch.setattr(backend_module.settings, "NATIVE_MEMORY_MAX_TOKENS", 2000)
     monkeypatch.setattr(backend_module.settings, "NATIVE_MEMORY_API_BASE", "https://unused.test/v1")
     monkeypatch.setattr(backend_module.settings, "NATIVE_MEMORY_API_KEY", "unused-key")
 
@@ -151,6 +153,7 @@ async def test_get_memory_model_uses_default_model_when_native_model_empty(
         fake_resolve_model_reference,
     )
     monkeypatch.setattr(backend_module.settings, "NATIVE_MEMORY_MODEL", "")
+    monkeypatch.setattr(backend_module.settings, "NATIVE_MEMORY_MAX_TOKENS", 2000)
 
     await NativeMemoryBackend._get_memory_model()
 

--- a/tests/infra/memory/test_compaction_agent.py
+++ b/tests/infra/memory/test_compaction_agent.py
@@ -150,7 +150,8 @@ async def test_maybe_compact_after_write_skips_below_threshold():
 
 
 @pytest.mark.asyncio
-async def test_maybe_compact_after_write_counts_only_non_manual_memories():
+async def test_maybe_compact_after_write_counts_only_compactable_memories():
+    """manual 与 self_evolved（教训）都不参与压缩计数——教训有固定 schema，不允许被改写。"""
     backend = _Backend({"u1": 49})
     agent = MemoryCompactionAgent(enabled=True, threshold=50)
 
@@ -158,7 +159,7 @@ async def test_maybe_compact_after_write_counts_only_non_manual_memories():
 
     assert backend._collection.last_count_query == {
         "user_id": "u1",
-        "source": {"$ne": "manual"},
+        "source": {"$nin": ["manual", "self_evolved"]},
     }
 
 
@@ -1441,3 +1442,108 @@ async def test_run_periodic_once_skips_when_scan_lock_not_acquired(monkeypatch):
         "reason": "scan_lock_not_acquired",
     }
     assert [event[0] for event in events] == ["acquire_scan"]
+
+
+# ---------------------------------------------------------------------------
+# self_evolved（自进化教训）保护——教训有 rule:/why:/how_to_apply 固定 schema，
+# 压缩改写会破坏形状且写入时校验不会重跑，故与 manual 同级保护。
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_compaction_update_rejects_self_evolved_memory():
+    backend = _Backend(
+        {"u1": 80},
+        docs=[
+            {
+                "memory_id": "m-lesson",
+                "user_id": "u1",
+                "content": "rule: 保持简洁\nwhy: 差评\nhow_to_apply: 回复时",
+                "source": "self_evolved",
+            }
+        ],
+    )
+
+    async def fail_retain(*_a, **_k):
+        raise AssertionError("self_evolved 记忆不得被压缩改写")
+
+    backend.retain = fail_retain  # type: ignore[method-assign]
+    tools = MemoryCompactionAgent()._build_compaction_tools(backend, "u1")
+    tool_by_name = {tool.name: tool for tool in tools}
+
+    result = await tool_by_name["memory_compaction_update"].ainvoke(
+        {"memory_id": "m-lesson", "content": "合并后的简洁版教训"}
+    )
+    assert result == {"success": False, "error": "self_evolved_memory_protected"}
+
+
+@pytest.mark.asyncio
+async def test_compaction_delete_rejects_self_evolved_memory():
+    backend = _Backend(
+        {"u1": 80},
+        docs=[
+            {
+                "memory_id": "m-lesson",
+                "user_id": "u1",
+                "content": "rule: 保持简洁",
+                "source": "self_evolved",
+            }
+        ],
+    )
+
+    async def fail_delete(*_a, **_k):
+        raise AssertionError("self_evolved 记忆不得被压缩删除")
+
+    backend.delete = fail_delete  # type: ignore[method-assign]
+    tools = MemoryCompactionAgent()._build_compaction_tools(backend, "u1")
+    tool_by_name = {tool.name: tool for tool in tools}
+
+    result = await tool_by_name["memory_compaction_delete"].ainvoke({"memory_id": "m-lesson"})
+    assert result == {"success": False, "error": "self_evolved_memory_protected"}
+
+
+@pytest.mark.asyncio
+async def test_build_inventory_excludes_self_evolved_memories():
+    class QueryCaptureCollection(_Collection):
+        def __init__(self):
+            super().__init__({})
+            self.find_query = None
+
+        def find(self, query, projection):
+            self.find_query = dict(query)
+            return _CountCursor([])
+
+    backend = _Backend({"u1": 3})
+    backend._collection = QueryCaptureCollection()
+
+    await MemoryCompactionAgent._build_inventory(backend, "u1")
+
+    assert backend._collection.find_query == {
+        "user_id": "u1",
+        "source": {"$nin": ["manual", "self_evolved"]},
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_periodic_once_scan_excludes_self_evolved(monkeypatch):
+    from src.infra.memory import compaction_agent as compaction_module
+
+    backend = _Backend({"u1": 40})
+    agent = MemoryCompactionAgent(enabled=True, threshold=20)
+
+    async def fake_acquire(_iid, ttl_seconds=None):
+        return "acquired"
+
+    monkeypatch.setattr(compaction_module, "acquire_compaction_scan_lock", fake_acquire)
+
+    async def fake_compact(_backend, user_id):
+        return {"agent": "deepagent", "checked": 1}
+
+    agent.compact_user_memories = fake_compact  # type: ignore[method-assign]
+
+    await agent.run_periodic_once(backend)
+
+    pipelines = backend._collection.aggregate_pipelines
+    assert pipelines, "应发出聚合扫描"
+    match_stage = pipelines[0][0]["$match"]
+    assert match_stage["source"] == {"$nin": ["manual", "self_evolved"]}


### PR DESCRIPTION
## 背景

自进化记忆（`src/infra/memory/evolution/`）在生产排查中发现三处代码级问题 + 一处测试坏味道，本 PR 全部修复。

## 修复内容

| # | 问题 | 修复 |
|---|------|------|
| 1 | 扫描锁 TTL（600s）撑不住最坏运行时长（50 用户 × 多次反思 LLM），过期后另一副本可并发进入，同一批未打标信号被重复反思 | `_refresh_scan_lock`：token 校验 Lua 续期，逐用户续期；锁确认易主立即中止（`scan_lock_lost`）；Redis 故障 fail-open |
| 2 | compaction 会把 self_evolved 教训改写成简洁版，破坏 `rule:/why:/how_to_apply` 固定形状（写入时校验不会重跑） | 教训与 manual 同级保护：排除出压缩计数/清单/聚合扫描，update/delete 工具拒写 `self_evolved_memory_protected`，系统提示词同步 |
| 3 | `_load_exchange` 按 run_id 查 trace 无 user_id 过滤 | trace/chunks 查询带 `user_id` 域 |
| 4 | 反思输入含写时注入的 `<memory_context>`/`<turn_context>` 块，教训可能提炼到注入块上 | `_strip_injected_blocks` 剥离后再裁剪（释放的预算留给真实内容） |
| 5 | `test_backend_lifecycle` 两个用例读本地 `.env` 的 `NATIVE_MEMORY_MAX_TOKENS`，环境一改就挂 | 测试内钉住固定值 |

## 验证

- TDD：先 RED（15 个新用例失败）后 GREEN
- `uv run pytest tests/infra`：**2473 passed, 1 skipped**
- `make lint` / mypy：通过
- 端到端实测（真实 Redis + Mongo + LLM）：锁生命周期（acquire/续期 TTL 实际拉长/拒易主/释放）✓；注入块剥离 + user_id 隔离 ✓；完整 `evolve_user` 产出 2 条合规教训、第二轮防重 stored=0 ✓

## 未包含

信号源扩展（差评为 0、仅失败 run 喂信号）为产品决策，另行讨论。