### PR TITLE
fix(memory): rrf_merge 双路命中保留高分字典，修复召回随机失效

### DIFF
--- a/src/infra/memory/client/native/search.py
+++ b/src/infra/memory/client/native/search.py
@@ -478,6 +478,13 @@ async def rerank_candidates(query: str, candidates: list[dict], max_results: int
     return ranked[:max_results] if ranked else local_rerank(query, candidates, max_results)
 
 
+def _memory_score(memory: dict) -> float:
+    try:
+        return float(memory.get("score", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
 def rrf_merge(
     text_results: list[dict], vector_results: list[dict], max_results: int, k: int = 60
 ) -> list[dict]:
@@ -493,6 +500,10 @@ def rrf_merge(
         mid = item["memory_id"]
         if mid not in scores:
             scores[mid] = {"data": item, "rrf_score": 0.0}
+        elif _memory_score(item) > _memory_score(scores[mid]["data"]):
+            # 同一记忆双路命中时保留高分字典：文本 keyword 兜底命中 score=0，
+            # 若任其覆盖向量相似度，会被下游 min_score 阈值整体滤除
+            scores[mid]["data"] = item
         scores[mid]["rrf_score"] += 1.0 / (k + rank + 1)
 
     merged = sorted(scores.values(), key=lambda x: x["rrf_score"], reverse=True)

--- a/tests/infra/memory/native/test_search.py
+++ b/tests/infra/memory/native/test_search.py
@@ -309,3 +309,30 @@ async def test_vector_search_qdrant_none_falls_back_to_cosine(monkeypatch):
     assert out[0]["score"] == pytest.approx(1.0)
     assert out[1]["score"] == pytest.approx(0.0)
     assert col.find_queries  # 走了 Mongo find 兜底
+
+
+def test_rrf_merge_keeps_higher_score_dict_for_same_memory():
+    """同一记忆被文本(keyword 兜底 score=0)与向量(cosine 0.6)同时命中时，
+    合并结果必须保留高分字典——否则 0 分被下游 min_score(0.3) 全部过滤，
+    召回凭查询措辞随机失效（staging 实测定位）。"""
+    from src.infra.memory.client.native.search import rrf_merge
+
+    text_hit = {"memory_id": "m1", "title": "t", "score": 0.0}
+    vector_hit = {"memory_id": "m1", "title": "t", "score": 0.602}
+    other = {"memory_id": "m2", "title": "o", "score": 0.5}
+
+    merged = rrf_merge([text_hit], [vector_hit, other], max_results=5)
+
+    by_id = {m["memory_id"]: m for m in merged}
+    assert by_id["m1"]["score"] == 0.602, "文本兜底的 0 分不得覆盖向量相似度"
+
+
+def test_rrf_merge_text_score_beats_zero_vector_keeps_text():
+    from src.infra.memory.client.native.search import rrf_merge
+
+    text_hit = {"memory_id": "m1", "score": 1.2}
+    vector_hit = {"memory_id": "m1", "score": 0.4}
+
+    merged = rrf_merge([text_hit], [vector_hit], max_results=5)
+
+    assert merged[0]["score"] == 1.2


### PR DESCRIPTION
## 背景

staging 实测注入链路时定位到的召回 bug：**同一条记忆能否被召回取决于查询措辞，随机失效**。

**定位链**（staging 实测）：
- `index_search` 直接命中：score=0.602 ✓
- `recall_memories` 同参数：n=0 ✗
- 分步插桩：text_search n=1（keyword 兜底，score=0）→ vector n=1（qdrant，score=0.602）→ rrf_merge 后 score=0 → 被 `RECALL_MIN_SCORE=0.3` 滤除

**根因**：`rrf_merge` 对同一 memory_id 先到先得保留 text 路字典。当文本索引缺失走 keyword 兜底（score=0）时，文本命中覆盖向量 cosine 分，下游 min_score 阈值把结果整体清零。查询措辞恰好触发文本命中 → 该记忆消失。

## 修复

`rrf_merge` 双路命中同一记忆时保留**高分**字典（RRF 排序不变，只修正呈现分）。

## 影响

`memory_recall` 工具与 `<memory_context>` 注入共用此链路，修复后召回稳定性恢复。

## 验证

- 新增 2 个 rrf_merge 用例（先 RED 后 GREEN）；`tests/infra/memory` **184 passed**
- ruff / mypy 通过
- staging 部署后复测注入（见后续）

## 关联

- #364 自进化加固 / #365 注入提速——本 PR 是同一轮 staging 实测挖出的第三个问题