### PR TITLE
fix(memory): 修复记忆检索加载行渲染条件恒假

### DIFF
--- a/frontend/src/components/layout/AppContent/ChatView.tsx
+++ b/frontend/src/components/layout/AppContent/ChatView.tsx
@@ -602,7 +602,7 @@ export function ChatView({
   const virtuosoFooterComponent = useCallback(
     () => (
       <>
-        {isRecallingMemory && !hasVisibleStreamingMessage && (
+        {isRecallingMemory && (
           <div className="flex items-center gap-2 px-4 py-2 text-xs text-[var(--theme-text-tertiary)]">
             <Loader2 size={14} className="animate-spin" />
             {t("chat.memoryRecalling")}
@@ -619,7 +619,7 @@ export function ChatView({
         />
       </>
     ),
-    [isRecallingMemory, hasVisibleStreamingMessage, showStreamingFooterSkeleton, isMobileViewport, messagesEndRef, t],
+    [isRecallingMemory, showStreamingFooterSkeleton, isMobileViewport, messagesEndRef, t],
   );
 
   const virtuosoHeaderComponent = useCallback(() => {


### PR DESCRIPTION
## 问题

#368 的界面内加载行在 staging 实测不渲染：status 事件已到达（trace 可见）、`setIsRecallingMemory(true)` 已执行，但行不出现。

**根因**：`createOptimisticMessagesForSend` 在发送瞬间就创建 `isStreaming: true` 的空助手消息，原渲染条件 `isRecallingMemory && !hasVisibleStreamingMessage` 永不成立。

## 修复

去掉 `hasVisibleStreamingMessage` 门——加载行直接随 `isRecallingMemory` 显示：助手气泡自带 spinner（既有行为），footer 行标注当前阶段（"正在检索相关记忆…"），metadata 到达即收起。

## 验证

- AppContent 测试 344 passed；ESLint / build 通过
- staging 部署后浏览器实测（见后续）