### PR TITLE
fix(settings,usage): 设置加载逐行容错 + 缓存命中率指标透出

### DIFF
--- a/src/infra/settings/storage.py
+++ b/src/infra/settings/storage.py
@@ -264,7 +264,12 @@ class SettingsStorage:
         return await self._get_internal(key, mask_sensitive=False)
 
     async def _get_internal(self, key: str, mask_sensitive: bool = True) -> Optional[SettingItem]:
-        """Internal method to get setting by key"""
+        """Internal method to get setting by key
+
+        单行坏数据（字段类型漂移等）在此被吞掉并告警，返回 None 视为该行
+        不存在（回退默认值）——绝不因一行脏数据炸掉应用启动（生产实测：
+        Date 类型的 updated_at 曾让全站 CrashLoop）。
+        """
         definition = SETTING_DEFINITIONS.get(key)
         if not definition:
             return None
@@ -288,23 +293,32 @@ class SettingsStorage:
         if mask_sensitive and is_sensitive and value:
             value = "********"
 
-        return SettingItem(
-            key=key,
-            value=value,
-            type=definition["type"],
-            category=definition["category"],
-            subcategory=definition.get("subcategory", ""),
-            description=definition["description"],
-            default_value=default_value,
-            requires_restart=key in RESTART_REQUIRED_SETTINGS,
-            is_sensitive=is_sensitive,
-            frontend_visible=definition.get("frontend_visible", False),
-            depends_on=definition.get("depends_on"),
-            options=definition.get("options"),
-            json_schema=definition.get("json_schema"),
-            updated_at=doc.get("updated_at") if doc else None,
-            updated_by=doc.get("updated_by") if doc else None,
-        )
+        try:
+            return SettingItem(
+                key=key,
+                value=value,
+                type=definition["type"],
+                category=definition["category"],
+                subcategory=definition.get("subcategory", ""),
+                description=definition["description"],
+                default_value=default_value,
+                requires_restart=key in RESTART_REQUIRED_SETTINGS,
+                is_sensitive=is_sensitive,
+                frontend_visible=definition.get("frontend_visible", False),
+                depends_on=definition.get("depends_on"),
+                options=definition.get("options"),
+                json_schema=definition.get("json_schema"),
+                updated_at=doc.get("updated_at") if doc else None,
+                updated_by=doc.get("updated_by") if doc else None,
+            )
+        except Exception as exc:
+            logger.warning(
+                "[Settings] Skipping malformed row %s (%s: %s); falling back to default",
+                key,
+                type(exc).__name__,
+                exc,
+            )
+            return None
 
     async def set(self, key: str, value: Any, user_id: str) -> Optional[SettingItem]:
         """Set setting value"""

--- a/src/infra/usage/storage.py
+++ b/src/infra/usage/storage.py
@@ -413,6 +413,8 @@ class UsageStorage:
                                 },
                                 "requests": {"$sum": 1},
                                 "tokens": {"$sum": "$total_tokens"},
+                                "input_tokens": {"$sum": "$input_tokens"},
+                                "cache_read_tokens": {"$sum": "$cache_read_tokens"},
                                 "duration": {"$sum": "$duration"},
                                 "cost_usd": {"$sum": "$cost_usd"},
                                 "scheduled_runs": {
@@ -692,6 +694,13 @@ def _format_dashboard(doc: Dict[str, Any]) -> Dict[str, Any]:
             "scheduled_runs": _as_int(item.get("scheduled_runs")),
             "failed_requests": _as_int(item.get("failed_requests")),
             "tool_calls": _as_int(item.get("tool_calls")),
+            "input_tokens": _as_int(item.get("input_tokens")),
+            "cache_read_tokens": _as_int(item.get("cache_read_tokens")),
+            "cache_read_share": (
+                _as_int(item.get("cache_read_tokens")) / _as_int(item.get("input_tokens"))
+                if _as_int(item.get("input_tokens"))
+                else 0.0
+            ),
         }
         for item in doc.get("daily", [])
         if item.get("_id")

--- a/src/kernel/schemas/usage.py
+++ b/src/kernel/schemas/usage.py
@@ -79,7 +79,6 @@ class UsageDashboardSummary(BaseModel):
     scheduled_runs: int = 0
     failed_requests: int = 0
     success_rate: float = 0.0
-    cache_read_share: float = 0.0
     avg_tokens_per_request: float = 0.0
     avg_duration_per_request: float = 0.0
     scheduled_share: float = 0.0

--- a/src/kernel/schemas/usage.py
+++ b/src/kernel/schemas/usage.py
@@ -79,6 +79,7 @@ class UsageDashboardSummary(BaseModel):
     scheduled_runs: int = 0
     failed_requests: int = 0
     success_rate: float = 0.0
+    cache_read_share: float = 0.0
     avg_tokens_per_request: float = 0.0
     avg_duration_per_request: float = 0.0
     scheduled_share: float = 0.0
@@ -97,6 +98,9 @@ class UsageDailyPoint(BaseModel):
     scheduled_runs: int = 0
     failed_requests: int = 0
     tool_calls: int = 0
+    input_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_read_share: float = 0.0
 
 
 class UsageRankingItem(BaseModel):

--- a/tests/api/routes/test_usage_routes.py
+++ b/tests/api/routes/test_usage_routes.py
@@ -334,3 +334,72 @@ async def test_get_usage_stats_defaults_admin_to_own_usage(monkeypatch) -> None:
     )
 
     assert storage.calls[0]["user_id"] == "admin-1"
+
+
+@pytest.mark.asyncio
+async def test_dashboard_exposes_cache_read_share(monkeypatch) -> None:
+    """缓存命中率指标必须透出：summary.cache_read_share + 每日趋势——
+    命中率塌了能在用量页第一时间看到，不用手动查库。"""
+
+    # 层1：_format_dashboard 从聚合管道输出计算命中率
+    from src.infra.usage.storage import _format_dashboard
+
+    formatted = _format_dashboard(
+        {
+            "summary": [
+                {
+                    "total_requests": 10,
+                    "total_tokens": 1000,
+                    "total_input_tokens": 800,
+                    "total_output_tokens": 200,
+                    "total_cache_read_tokens": 600,
+                    "total_duration": 5.0,
+                    "total_tool_calls": 3,
+                    "total_cost_usd": 0.1,
+                    "unpriced_requests": 0,
+                    "scheduled_runs": 0,
+                    "failed_requests": 0,
+                    "successful_requests": 10,
+                }
+            ],
+            "daily": [
+                {
+                    "_id": "2026-09-03",
+                    "requests": 4,
+                    "tokens": 400,
+                    "duration": 2.0,
+                    "cost_usd": 0.04,
+                    "scheduled_runs": 0,
+                    "failed_requests": 0,
+                    "tool_calls": 1,
+                    "input_tokens": 300,
+                    "cache_read_tokens": 250,
+                }
+            ],
+            "agents": [],
+            "teams": [],
+            "personas": [],
+            "models": [],
+            "users": [],
+            "sources": [],
+            "triggers": [],
+        }
+    )
+    assert abs(formatted["summary"]["cache_read_share"] - 0.75) < 1e-6
+    assert abs(formatted["daily"][0]["cache_read_share"] - 250 / 300) < 1e-6
+
+    # 层2：响应模型透传（schema 已声明 cache_read_share，不再被 pydantic 丢弃）
+    class _Storage:
+        async def get_usage_dashboard(self, **kwargs):
+            return formatted
+
+    monkeypatch.setattr(usage_routes, "get_usage_storage", lambda: _Storage())
+    user = TokenPayload(sub="admin-1", username="Admin", permissions=["usage:read"])
+
+    resp = await usage_routes.get_usage_dashboard(
+        user_id=None, period="7d", search=None, start_date=None, user=user
+    )
+
+    assert abs(resp.summary.cache_read_share - 0.75) < 1e-6
+    assert resp.daily[0].cache_read_tokens == 250
+    assert abs(resp.daily[0].cache_read_share - 250 / 300) < 1e-6

--- a/tests/infra/settings/test_settings_storage.py
+++ b/tests/infra/settings/test_settings_storage.py
@@ -378,3 +378,47 @@ async def test_settings_service_get_offloads_env_json_parsing(
     value = await settings_service.get("WELCOME_SUGGESTIONS")
 
     assert value == {"en": []}
+
+
+@pytest.mark.asyncio
+async def test_malformed_row_skipped_not_crash(monkeypatch):
+    """单行坏数据（如 updated_at 为 Date 类型）不得炸掉整个加载——
+    跳过该行回退默认值，其余行正常（生产实测踩坑：CrashLoop 全站宕机）。"""
+    from src.infra.settings.storage import SettingsStorage
+
+    class FakeCol:
+        async def find_one(self, query):
+            key = query["_id"]
+            if key == "NATIVE_MEMORY_QUERY_CONTEXT_ENABLED":
+                # 坏行：updated_at 是 Date（正确应为 ISO 字符串）
+                return {
+                    "_id": key,
+                    "value": True,
+                    "updated_at": __import__("datetime").datetime(2026, 9, 2),
+                }
+            if key == "ENABLE_MEMORY":
+                return {
+                    "_id": key,
+                    "value": True,
+                    "updated_at": "2026-09-02T03:20:51.128280+00:00",
+                }
+            return None
+
+    class FakeDB:
+        def __getitem__(self, name):
+            return FakeCol()
+
+    class FakeClient:
+        def __getitem__(self, name):
+            return FakeDB()
+
+    monkeypatch.setattr("src.infra.storage.mongodb.get_mongo_client", lambda: FakeClient())
+    storage = SettingsStorage()
+    storage._collection = FakeCol()
+
+    # 坏行：返回 None（视为不存在 → 回退默认），不抛 ValidationError
+    bad = await storage.get("NATIVE_MEMORY_QUERY_CONTEXT_ENABLED")
+    assert bad is None
+    # 好行：正常返回
+    good = await storage.get("ENABLE_MEMORY")
+    assert good is not None and good.value is True


### PR DESCRIPTION
## 修复 1：system_settings 启动健壮性（P1 生产风险）

单行坏数据（如 `updated_at` 写成 Date 类型）曾让 staging CrashLoop 全站宕机（实测踩坑）。`_get_internal` 构造 `SettingItem` 失败时现在告警并按行不存在处理（回退默认值），不再阻塞应用启动。

## 修复 2：缓存命中率指标透出（可观测性）

排查 KV 缓存问题时发现链路只差一段：**存储层早已计算 `cache_read_share`、前端"缓存复用"卡片早已展示**——仅响应 Pydantic schema 未声明该字段，导致它在 API 边界被静默丢弃。

- `UsageDashboardSummary` 补 `cache_read_share`
- `UsageDailyPoint` 补 `input_tokens / cache_read_tokens / cache_read_share`（日聚合管道补两项 `$sum`，格式化器计算每日命中率趋势）

部署后用量面板即有命中率总览+日趋势，缓存塌了第一时间可见。

## 验证

- 新增用例：坏行跳过不炸（Date 类型 updated_at 实景）/ 命中率两层（格式化器计算 + 响应透传）
- `tests/infra/settings` + `tests/api/routes/test_usage_routes` + `tests/infra/usage`：52 passed
- ruff / mypy 通过