### PR TITLE
fix(prompt): 补 lazy 沙箱文件工具与 shell 的路径桥接规则

### DIFF
--- a/src/agents/core/prompt_policy.py
+++ b/src/agents/core/prompt_policy.py
@@ -21,7 +21,13 @@ LAZY_SANDBOX_RUNTIME_POLICY = """## Sandbox Runtime
 
 Logical file-tool alias (not a shell path): `{work_dir}`
 
-Use this alias only with file tools and uploads. For shell commands, use relative paths or `$LAMBCHAT_WORKSPACE`. Never paste `{work_dir}` into a shell command. Never guess or repeat a provider filesystem path. The backend resolves the alias after the sandbox starts. Do not persist either path in durable documents unless requested."""
+Use this alias only with file tools and uploads. For shell commands, use relative paths or `$LAMBCHAT_WORKSPACE`. Never paste `{work_dir}` into a shell command. Never guess or repeat a provider filesystem path. The backend resolves the alias after the sandbox starts. Do not persist either path in durable documents unless requested.
+
+### File/Shell Path Bridging
+- File tools and shell share one sandbox filesystem. `{work_dir}/<name>` and `$LAMBCHAT_WORKSPACE/<name>` are the same directory: file-tool writes appear in the shell, and shell-created files are readable by file tools at `{work_dir}/<name>` — never at a guessed `/workspace/<name>`.
+- Absolute paths outside `{work_dir}` (e.g. `/workspace/<name>`) sit outside the work directory; the shell reaches them only by that exact absolute path, never via `$LAMBCHAT_WORKSPACE` or relative paths. Keep working files under `{work_dir}` / `$LAMBCHAT_WORKSPACE`.
+- `/skills/` and `/memories/` exist only for file tools. To run skill scripts in the shell, `transfer_path` them with target prefix `{work_dir}/` first.
+- `upload_url_to_sandbox` downloads inside the sandbox; pass `{work_dir}/<name>` as the target so the file lands in `$LAMBCHAT_WORKSPACE` for later shell commands."""
 
 WORKSPACE_POLICY = """### Workspace Boundaries
 Check whether a target exists before creating it. Modify an existing project only when requested or relevant; otherwise use a named directory in the current session workspace."""

--- a/tests/agents/core/test_subagent_prompts.py
+++ b/tests/agents/core/test_subagent_prompts.py
@@ -113,6 +113,42 @@ def test_search_lazy_runtime_distinguishes_file_and_shell_workspace_paths() -> N
     )
 
 
+def test_search_lazy_runtime_documents_file_tool_shell_bridging() -> None:
+    rendered = SANDBOX_RUNTIME_SECTION.format(work_dir="/workspace/session-1")
+
+    # 文件工具与 shell 共享同一沙箱文件系统：alias 与 $LAMBCHAT_WORKSPACE 互为映射
+    _assert_markers(
+        rendered,
+        (
+            "same directory",
+            "file-tool writes appear in the shell",
+            "shell-created files are readable by file tools at `/workspace/session-1/<name>`",
+            "outside the work directory",
+            "never at a guessed `/workspace/<name>`",
+        ),
+    )
+    # /skills 与 /memories 是文件工具专属的虚拟存储，进 shell 必须先 transfer_path 进工作目录
+    _assert_markers(
+        rendered,
+        (
+            "exist only for file tools",
+            "transfer_path",
+            "target prefix `/workspace/session-1/`",
+        ),
+    )
+    # URL 下载要落到工作目录 alias，后续 shell 命令才能用
+    _assert_markers(
+        rendered,
+        (
+            "upload_url_to_sandbox",
+            "pass `/workspace/session-1/<name>` as the target",
+            "$LAMBCHAT_WORKSPACE",
+        ),
+    )
+    # 桥接规则属于系统提示词，保持紧凑预算
+    assert len(LAZY_SANDBOX_RUNTIME_POLICY) <= 1700
+
+
 def test_team_runtime_keeps_eager_real_work_dir_semantics() -> None:
     real_work_dir = "/home/user/sessions/session-1"
     rendered = TEAM_SANDBOX_RUNTIME_SECTION.format(work_dir=real_work_dir)


### PR DESCRIPTION
## 背景

排查生产会话（🐞Bug清单汇总）首轮跑偏：agent 因不掌握文件工具别名与 `$LAMBCHAT_WORKSPACE` 的映射，三次踩坑（transfer_path 落点、截图回读 404、xlsx 下载后 shell 不可见），HITL 前多耗费约 28 万 input tokens。详见分析：文件工具与 shell 实际共享同一容器文件系统（`CompositeBackend` default=LazySandboxBackend），问题全在「会话工作目录别名」与「容器裸 `/workspace` 路径」的前缀错位，而提示词只说了「alias 不是 shell 路径」，没教互通规则。

## 改动

- `LAZY_SANDBOX_RUNTIME_POLICY` 新增 **File/Shell Path Bridging** 一节，四条规则：
  1. `{work_dir}/<name>` ≡ `$LAMBCHAT_WORKSPACE/<name>`，双向互通（含「不要猜裸 /workspace/<name>」）
  2. `{work_dir}` 之外的绝对路径不在工作目录内，shell 仅能按精确路径访问
  3. `/skills/`、`/memories/` 仅文件工具可见；进 shell 先 `transfer_path` 到 `{work_dir}/`
  4. `upload_url_to_sandbox` 目标传 `{work_dir}/<name>` 才落到工作目录
- 新增测试 `test_search_lazy_runtime_documents_file_tool_shell_bridging`（RED→GREEN），并加 ≤1700 字符预算（当前 1310）

## 验证

- `tests/agents/`：218 passed
- `tests/infra/backend/`：171 passed, 1 skipped
- `make lint` / `make typecheck`：通过