### PR TITLE
fix(prompt): 补 lazy 沙箱文件工具与 shell 的路径桥接规则（develop → main 晋升）

### DIFF
--- a/src/agents/core/prompt_policy.py
+++ b/src/agents/core/prompt_policy.py
@@ -21,7 +21,13 @@ LAZY_SANDBOX_RUNTIME_POLICY = """## Sandbox Runtime
 
 Logical file-tool alias (not a shell path): `{work_dir}`
 
-Use this alias only with file tools and uploads. For shell commands, use relative paths or `$LAMBCHAT_WORKSPACE`. Never paste `{work_dir}` into a shell command. Never guess or repeat a provider filesystem path. The backend resolves the alias after the sandbox starts. Do not persist either path in durable documents unless requested."""
+Use this alias only with file tools and uploads. For shell commands, use relative paths or `$LAMBCHAT_WORKSPACE`. Never paste `{work_dir}` into a shell command. Never guess or repeat a provider filesystem path. The backend resolves the alias after the sandbox starts. Do not persist either path in durable documents unless requested.
+
+### File/Shell Path Bridging
+- File tools and shell share one sandbox filesystem. `{work_dir}/<name>` and `$LAMBCHAT_WORKSPACE/<name>` are the same directory: file-tool writes appear in the shell, and shell-created files are readable by file tools at `{work_dir}/<name>` — never at a guessed `/workspace/<name>`.
+- Absolute paths outside `{work_dir}` (e.g. `/workspace/<name>`) sit outside the work directory; the shell reaches them only by that exact absolute path, never via `$LAMBCHAT_WORKSPACE` or relative paths. Keep working files under `{work_dir}` / `$LAMBCHAT_WORKSPACE`.
+- `/skills/` and `/memories/` exist only for file tools. To run skill scripts in the shell, `transfer_path` them with target prefix `{work_dir}/` first.
+- `upload_url_to_sandbox` downloads inside the sandbox; pass `{work_dir}/<name>` as the target so the file lands in `$LAMBCHAT_WORKSPACE` for later shell commands."""
 
 WORKSPACE_POLICY = """### Workspace Boundaries
 Check whether a target exists before creating it. Modify an existing project only when requested or relevant; otherwise use a named directory in the current session workspace."""

--- a/tests/agents/core/test_subagent_prompts.py
+++ b/tests/agents/core/test_subagent_prompts.py
@@ -113,6 +113,42 @@ def test_search_lazy_runtime_distinguishes_file_and_shell_workspace_paths() -> N
     )
 
 
+def test_search_lazy_runtime_documents_file_tool_shell_bridging() -> None:
+    rendered = SANDBOX_RUNTIME_SECTION.format(work_dir="/workspace/session-1")
+
+    # 文件工具与 shell 共享同一沙箱文件系统：alias 与 $LAMBCHAT_WORKSPACE 互为映射
+    _assert_markers(
+        rendered,
+        (
+            "same directory",
+            "file-tool writes appear in the shell",
+            "shell-created files are readable by file tools at `/workspace/session-1/<name>`",
+            "outside the work directory",
+            "never at a guessed `/workspace/<name>`",
+        ),
+    )
+    # /skills 与 /memories 是文件工具专属的虚拟存储，进 shell 必须先 transfer_path 进工作目录
+    _assert_markers(
+        rendered,
+        (
+            "exist only for file tools",
+            "transfer_path",
+            "target prefix `/workspace/session-1/`",
+        ),
+    )
+    # URL 下载要落到工作目录 alias，后续 shell 命令才能用
+    _assert_markers(
+        rendered,
+        (
+            "upload_url_to_sandbox",
+            "pass `/workspace/session-1/<name>` as the target",
+            "$LAMBCHAT_WORKSPACE",
+        ),
+    )
+    # 桥接规则属于系统提示词，保持紧凑预算
+    assert len(LAZY_SANDBOX_RUNTIME_POLICY) <= 1700
+
+
 def test_team_runtime_keeps_eager_real_work_dir_semantics() -> None:
     real_work_dir = "/home/user/sessions/session-1"
     rendered = TEAM_SANDBOX_RUNTIME_SECTION.format(work_dir=real_work_dir)


### PR DESCRIPTION
## 晋级内容

- PR #376：LAZY_SANDBOX_RUNTIME_POLICY 新增 File/Shell Path Bridging 四条规则（{work_dir} ↔ $LAMBCHAT_WORKSPACE 同目录映射、容器裸路径边界、/skills 与 /memories 进 shell 需 transfer_path、upload_url_to_sandbox 落点），含测试与预算约束。

## 验证

- PR #376 CI 全绿（Ruff / MyPy / 前后端测试 / 双架构镜像构建）
- staging 已滚至 develop-20260903-072304：健康检查 200，pod 内已确认新提示词文件
- 改动为系统提示词文本，无接口/存储变更