### PR TITLE
fix(memory): 首轮记忆检索进度反馈 + 思考文案平滑流出（develop → main 晋升）

### DIFF
--- a/frontend/src/components/chat/ChatMessage/ThinkingBlock.tsx
+++ b/frontend/src/components/chat/ChatMessage/ThinkingBlock.tsx
@@ -10,6 +10,7 @@ import {
 } from "./items/persistentToolPanelState";
 import { SidebarMarkdownContent } from "./SidebarMarkdownContent";
 import { buildStreamingThinkingPreview } from "./thinkingPreview";
+import { useSmoothStreamText } from "./useSmoothStreamText";
 
 export function ThinkingBlock({
   content,
@@ -24,6 +25,9 @@ export function ThinkingBlock({
 
   const status: CollapsibleStatus = isStreaming ? "loading" : "success";
 
+  // 思考文案平滑流出：片段到达后打字机式渐显，而非整块蹦出；历史回放全量
+  const displayContent = useSmoothStreamText(content, !!isStreaming);
+
   useEffect(() => {
     if (!isPersistentToolPanelOpen(panelKey)) return;
     updatePersistentToolPanel(
@@ -33,7 +37,7 @@ export function ThinkingBlock({
         children: (
           <div className="p-3 sm:p-4 [&_.markdown-preview]:thinking-content">
             <SidebarMarkdownContent
-              content={content}
+              content={displayContent}
               isStreaming={isStreaming}
             />
           </div>
@@ -41,15 +45,15 @@ export function ThinkingBlock({
       }),
       panelKey,
     );
-  }, [content, isStreaming, panelKey, status]);
+  }, [displayContent, isStreaming, panelKey, status]);
 
   // Show a brief preview of the reasoning content in the pill label
   const preview = useMemo(() => {
-    if (!content) return "";
-    if (isStreaming) return buildStreamingThinkingPreview(content);
-    const text = content.replace(/\n+/g, " ").trim();
+    if (!displayContent) return "";
+    if (isStreaming) return buildStreamingThinkingPreview(displayContent);
+    const text = displayContent.replace(/\n+/g, " ").trim();
     return text.length > 80 ? text.slice(0, 80) + "…" : text;
-  }, [content, isStreaming]);
+  }, [displayContent, isStreaming]);
 
   const label = isStreaming
     ? preview
@@ -75,7 +79,7 @@ export function ThinkingBlock({
           children: (
             <div className="p-3 sm:p-4 [&_.markdown-preview]:thinking-content">
               <SidebarMarkdownContent
-                content={content}
+                content={displayContent}
                 isStreaming={isStreaming}
               />
             </div>

--- a/frontend/src/components/chat/ChatMessage/__tests__/sidebarLongTextPerformanceSource.test.ts
+++ b/frontend/src/components/chat/ChatMessage/__tests__/sidebarLongTextPerformanceSource.test.ts
@@ -24,7 +24,7 @@ test("thinking and subagent sidebars use a lightweight renderer for long or stre
   expect(sidebarSource).not.toMatch(/<pre className=/);
 
   expect(thinkingSource).toMatch(
-    /<SidebarMarkdownContent\s+content=\{content\}/,
+    /<SidebarMarkdownContent\s+content=\{displayContent\}/,
   );
   expect(panelSource).toMatch(
     /<SidebarMarkdownContent\s+content=\{data\.input\}/,

--- a/frontend/src/components/chat/ChatMessage/__tests__/thinkingPreviewSource.test.ts
+++ b/frontend/src/components/chat/ChatMessage/__tests__/thinkingPreviewSource.test.ts
@@ -7,7 +7,7 @@ test("ThinkingBlock appends the live tail preview to the streaming label", () =>
   );
 
   // 流式分支用尾部预览而非空串，保证标签随 delta 动态更新
-  expect(source).toMatch(/if \(isStreaming\) return buildStreamingThinkingPreview\(content\);/);
+  expect(source).toMatch(/if \(isStreaming\) return buildStreamingThinkingPreview\(displayContent\);/);
   // 标签拼上「思考中」前缀
   expect(source).toMatch(/`\$\{t\("chat\.message\.thinking"\)\} \$\{preview\}`/);
 });

--- a/frontend/src/components/chat/ChatMessage/__tests__/useSmoothStreamText.test.ts
+++ b/frontend/src/components/chat/ChatMessage/__tests__/useSmoothStreamText.test.ts
@@ -1,0 +1,129 @@
+/** @vitest-environment jsdom */
+/**
+ * useSmoothStreamText——流式文案平滑展示：片段到达后逐帧流出（打字机效果），
+ * 而非整块蹦出；非流式（历史回放/已完成）直接全量。
+ */
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { useSmoothStreamText } from "../useSmoothStreamText";
+
+let frames: FrameRequestCallback[] = [];
+
+beforeEach(() => {
+  frames = [];
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    frames.push(cb);
+    return frames.length;
+  });
+  vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+    void id;
+  });
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** 推进 n 帧：执行已排队的所有 rAF 回调 */
+function tick(n = 1) {
+  for (let i = 0; i < n; i++) {
+    const cbs = frames.splice(0);
+    for (const cb of cbs) cb(0);
+  }
+}
+
+describe("useSmoothStreamText", () => {
+  test("非流式（历史回放/已完成）直接全量展示", () => {
+    const { result } = renderHook(() =>
+      useSmoothStreamText("整段已完成的内容", false),
+    );
+    expect(result.current).toBe("整段已完成的内容");
+  });
+
+  test("流式：片段到达后逐帧流出，最终追平目标", () => {
+    const { result, rerender } = renderHook(
+      ({ text, streaming }: { text: string; streaming: boolean }) =>
+        useSmoothStreamText(text, streaming),
+      { initialProps: { text: "", streaming: true } },
+    );
+
+    act(() => {
+      rerender({ text: "0123456789", streaming: true });
+    });
+    act(() => {
+      tick(1);
+    });
+    // 首帧只流出一部分——不是整块蹦出
+    expect(result.current.length).toBeGreaterThanOrEqual(1);
+    expect(result.current.length).toBeLessThan(10);
+
+    act(() => {
+      tick(30);
+    });
+    expect(result.current).toBe("0123456789");
+  });
+
+  test("流式结束（isStreaming→false）立即展示全量", () => {
+    const { result, rerender } = renderHook(
+      ({ text, streaming }: { text: string; streaming: boolean }) =>
+        useSmoothStreamText(text, streaming),
+      { initialProps: { text: "", streaming: true } },
+    );
+
+    act(() => {
+      rerender({ text: "未追平就结束了", streaming: true });
+    });
+    act(() => {
+      rerender({ text: "未追平就结束了", streaming: false });
+    });
+    expect(result.current).toBe("未追平就结束了");
+  });
+
+  test("动画进行中新片段到达：从已展示长度继续，不重放", () => {
+    const { result, rerender } = renderHook(
+      ({ text, streaming }: { text: string; streaming: boolean }) =>
+        useSmoothStreamText(text, streaming),
+      { initialProps: { text: "", streaming: true } },
+    );
+
+    act(() => {
+      rerender({ text: "第一段", streaming: true });
+    });
+    act(() => {
+      tick(1);
+    });
+    const shownAfterFirst = result.current;
+    expect(shownAfterFirst.length).toBeGreaterThan(0);
+    expect(shownAfterFirst.length).toBeLessThan(3);
+
+    act(() => {
+      rerender({ text: "第一段+第二段", streaming: true });
+    });
+    act(() => {
+      tick(30);
+    });
+    // 前缀保持连续：已流出的部分不变，只是继续向后追
+    expect(result.current.startsWith(shownAfterFirst)).toBe(true);
+    expect(result.current).toBe("第一段+第二段");
+  });
+
+  test("目标变短（内容重置）时立即对齐", () => {
+    const { result, rerender } = renderHook(
+      ({ text, streaming }: { text: string; streaming: boolean }) =>
+        useSmoothStreamText(text, streaming),
+      { initialProps: { text: "", streaming: true } },
+    );
+
+    act(() => {
+      rerender({ text: "旧内容比较长", streaming: true });
+    });
+    act(() => {
+      tick(30); // 旧内容已全量流出
+    });
+    expect(result.current).toBe("旧内容比较长");
+
+    act(() => {
+      rerender({ text: "新", streaming: true });
+    });
+    expect(result.current).toBe("新"); // 变短立即对齐，不逐帧回退
+  });
+});

--- a/frontend/src/components/chat/ChatMessage/useSmoothStreamText.ts
+++ b/frontend/src/components/chat/ChatMessage/useSmoothStreamText.ts
@@ -1,0 +1,45 @@
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * 流式文案平滑展示：片段（chunk）到达后逐帧流出，呈现打字机效果而非整块
+ * 蹦出。每帧流出量随积压量按比例增长（backlog/divisor，下限 2 字），任何
+ * 大小的片段都约 12 帧（~200ms）追平——平滑但不拖尾。
+ *
+ * 非流式（历史回放/已完成）直接全量展示，不做动画。
+ */
+const BACKLOG_DIVISOR = 12;
+const MIN_CHARS_PER_FRAME = 2;
+
+export function useSmoothStreamText(target: string, isStreaming: boolean) {
+  const [shown, setShown] = useState(() => (isStreaming ? "" : target));
+  const shownRef = useRef(shown);
+
+  useEffect(() => {
+    if (!isStreaming || target.length < shownRef.current.length) {
+      // 非流式 / 内容重置：立即对齐
+      shownRef.current = target;
+      setShown(target);
+      return;
+    }
+    if (target.length === shownRef.current.length) return;
+
+    let raf = 0;
+    const step = () => {
+      const backlog = target.length - shownRef.current.length;
+      if (backlog <= 0) return;
+      const advance = Math.max(
+        MIN_CHARS_PER_FRAME,
+        Math.ceil(backlog / BACKLOG_DIVISOR),
+      );
+      shownRef.current = target.slice(0, shownRef.current.length + advance);
+      setShown(shownRef.current);
+      if (shownRef.current.length < target.length) {
+        raf = requestAnimationFrame(step);
+      }
+    };
+    raf = requestAnimationFrame(step);
+    return () => cancelAnimationFrame(raf);
+  }, [target, isStreaming]);
+
+  return isStreaming ? shown : target;
+}

--- a/frontend/src/components/layout/AppContent/ChatView.tsx
+++ b/frontend/src/components/layout/AppContent/ChatView.tsx
@@ -603,8 +603,8 @@ export function ChatView({
     () => (
       <>
         {isRecallingMemory && (
-          <div className="flex items-center gap-2 px-4 py-2 text-xs text-[var(--theme-text-tertiary)]">
-            <Loader2 size={14} className="animate-spin" />
+          <div className="animate-in fade-in duration-300 flex items-center gap-2 px-4 py-2 text-xs font-medium text-amber-600/90 dark:text-amber-400/90 select-none">
+            <Loader2 size={12} className="shrink-0 animate-spin text-amber-500 dark:text-amber-400" />
             {t("chat.memoryRecalling")}
           </div>
         )}

--- a/frontend/src/hooks/useAgent/__tests__/eventHandlers.memoryStatus.test.ts
+++ b/frontend/src/hooks/useAgent/__tests__/eventHandlers.memoryStatus.test.ts
@@ -1,4 +1,10 @@
-/** status(memory) 事件——后台记忆注入的界面内加载状态（提交与召回解耦后）。 */
+/** status(memory/memory_done) 事件——首轮记忆装配的开始/完成事件。
+
+对齐沙箱初始化（starting/ready）的两段式生命周期：开始亮行、完成收起，
+且带最短展示保护——SSE 重放时 start/done 可能同批毫秒级到达，React 合并
+渲染会吞掉行，固定延迟收起保证用户总能看见。
+*/
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Message } from "../../../types";
 import { handleStreamEvent } from "../eventHandlers.ts";
 import type { EventHandlerContext } from "../eventHandlers.ts";
@@ -40,16 +46,46 @@ function event(name: string, payload: unknown, id: string): StreamEvent {
 }
 
 describe("memory recall status event", () => {
-  it("sets recall state on status stage=memory and clears on metadata", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows row on start and collapses on memory_done after min display", () => {
     const { ctx, recallStates } = createContext();
     handleStreamEvent(event("status", { stage: "memory" }, "e1"), "m1", "e1", undefined, ctx);
-    handleStreamEvent(event("metadata", {}, "e2"), "m1", "e2", undefined, ctx);
+    expect(recallStates).toEqual([true]);
+    handleStreamEvent(event("status", { stage: "memory_done" }, "e2"), "m1", "e2", undefined, ctx);
+    // 召回刚完成：未到最短展示时长，不立即收起（防 SSE 重放同批吞行）
+    expect(recallStates).toEqual([true]);
+    vi.advanceTimersByTime(600);
+    expect(recallStates).toEqual([true, false]);
+  });
+
+  it("collapses promptly on memory_done when recall was slow", () => {
+    const { ctx, recallStates } = createContext();
+    handleStreamEvent(event("status", { stage: "memory" }, "e3"), "m1", "e3", undefined, ctx);
+    vi.advanceTimersByTime(2000); // 召回耗时 2s，早已满足最短展示
+    handleStreamEvent(event("status", { stage: "memory_done" }, "e4"), "m1", "e4", undefined, ctx);
+    expect(recallStates).toEqual([true]); // 收起仍走异步任务
+    vi.advanceTimersByTime(0);
+    expect(recallStates).toEqual([true, false]);
+  });
+
+  it("metadata also collapses the row (fallback, min display applies)", () => {
+    const { ctx, recallStates } = createContext();
+    handleStreamEvent(event("status", { stage: "memory" }, "e5"), "m1", "e5", undefined, ctx);
+    handleStreamEvent(event("metadata", {}, "e6"), "m1", "e6", undefined, ctx);
+    expect(recallStates).toEqual([true]);
+    vi.advanceTimersByTime(600);
     expect(recallStates).toEqual([true, false]);
   });
 
   it("ignores other status stages", () => {
     const { ctx, recallStates } = createContext();
-    handleStreamEvent(event("status", { stage: "other" }, "e3"), "m1", "e3", undefined, ctx);
+    handleStreamEvent(event("status", { stage: "other" }, "e7"), "m1", "e7", undefined, ctx);
     expect(recallStates).toEqual([]);
   });
 });

--- a/frontend/src/hooks/useAgent/eventHandlers.ts
+++ b/frontend/src/hooks/useAgent/eventHandlers.ts
@@ -25,6 +25,21 @@ import { convertAttachments, processMessageEvent } from "./eventProcessor";
 import { dispatchToolMutationRefresh } from "../../components/chat/ChatMessage/items/toolMutationEvents";
 
 /**
+ * 首轮记忆装配进度行的两段式生命周期（对齐 sandbox:starting/ready）：
+ * status{stage:memory} 亮行 → status{stage:memory_done} 收起，metadata 兜底。
+ * 最短展示保护：SSE 重放时 start/done 可能同批毫秒级到达，React 合并渲染
+ * 会吞掉整段行——收起一律走延迟任务（不足最短展示则补足），保证可见。
+ */
+const MEMORY_RECALL_MIN_DISPLAY_MS = 600;
+let memoryRecallShownAt = 0;
+
+function scheduleMemoryRecallCollapse(ctx: EventHandlerContext) {
+  const elapsed = Date.now() - memoryRecallShownAt;
+  const delay = Math.max(0, MEMORY_RECALL_MIN_DISPLAY_MS - elapsed);
+  setTimeout(() => ctx.setIsRecallingMemory(false), delay);
+}
+
+/**
  * Context passed to event handler
  */
 export interface EventHandlerContext {
@@ -141,15 +156,19 @@ export function handleStreamEvent(
       ) {
         ctx.setSessionId(data.session_id);
       }
-      // Agent 已开跑——收掉记忆检索的界面内加载状态（如果还挂着）
-      ctx.setIsRecallingMemory(false);
+      // Agent 已开跑——收掉记忆检索的界面内加载状态（如果还挂着，兜底；
+      // 正常由 memory_done 收起）
+      scheduleMemoryRecallCollapse(ctx);
       return;
     }
 
     case "status": {
-      // 后台记忆注入开始：立刻给用户进度反馈（提交与召回已解耦）
+      // 首轮记忆装配：开始亮行（记录展示起点），完成收起（带最短展示保护）
       if (data.stage === "memory") {
+        memoryRecallShownAt = Date.now();
         ctx.setIsRecallingMemory(true);
+      } else if (data.stage === "memory_done") {
+        scheduleMemoryRecallCollapse(ctx);
       }
       return;
     }

--- a/src/api/routes/chat.py
+++ b/src/api/routes/chat.py
@@ -31,6 +31,7 @@ from src.infra.chat.session_baseline import (
     _time_report_due,
     _turn_context_signature,
     assemble_first_turn_message,
+    inject_session_memory,
 )
 from src.infra.goal import GoalSpec, coerce_goal_spec
 from src.infra.logging import get_logger
@@ -301,8 +302,18 @@ async def _execute_agent_stream(
                 "data": {"goal": active_goal, "started_at": started_at},
             }
 
-    # 记忆注入已收敛为 Codex 式会话基线（POST 仅在会话首轮注入一次）：
-    # 逐轮注入的变量块会击穿 provider 前缀缓存（生产实测），executor 不再注入。
+    # 首轮记忆装配在 executor 后台执行（POST 不再做首轮判定与召回，提交零
+    # 记忆成本）：executor 判首轮（traces 计数排除本 run 已写入的用户消息
+    # trace），首轮先发 status 事件让前端立刻出加载行（沙箱初始化式）再注入
+    # ——字节顺序与 POST 侧装配完全一致（基线置头、快照置尾），前缀缓存
+    # append-only 语义不变。HITL 恢复轮跳过（恢复语义不重注入）。
+    if hitl_resume is None and await _should_inject_session_memory(
+        session_id, exclude_run_id=run_id
+    ):
+        yield {"event": "status", "data": {"stage": "memory"}}
+        message = await inject_session_memory(
+            message, user_id=user_id, raw_query=recommendation_input
+        )
 
     try:
         agent = await AgentFactory.get(agent_id)
@@ -422,11 +433,10 @@ async def chat_stream(
     apply_response_language(request.agent_options, http_request.headers.get("accept-language"))
 
     # Codex 式装配（稳定在前、变化在后，全部写时一次性）：
-    # - 记忆索引基线：仅会话首轮，置于消息头部（同用户跨会话字节稳定，
-    #   公共前缀延伸到索引末尾）
+    # - 记忆索引基线 + 相关记忆快照：仅会话首轮，装配在 executor 后台执行
+    #   （status 事件实时反馈进度，提交延迟与召回解耦），字节顺序不变
     # - 报时漂移：首轮或超阈值才带时间戳
     # - goal/自动模式签名去重：目标未变不重复注入
-    include_memory = await _should_inject_session_memory(request.session_id)
     time_due = _time_report_due(existing_metadata)
     tc_signature = _turn_context_signature(active_goal, request.auto_mode)
 
@@ -437,7 +447,6 @@ async def chat_stream(
         active_goal=active_goal,
         auto_mode=request.auto_mode,
         user_id=user.sub,
-        include_memory=include_memory,
         include_timestamp=time_due,
         last_tc_signature=(existing_metadata or {}).get("prompt_turn_context_signature"),
     )

--- a/src/api/routes/chat.py
+++ b/src/api/routes/chat.py
@@ -304,7 +304,8 @@ async def _execute_agent_stream(
 
     # 首轮记忆装配在 executor 后台执行（POST 不再做首轮判定与召回，提交零
     # 记忆成本）：executor 判首轮（traces 计数排除本 run 已写入的用户消息
-    # trace），首轮先发 status 事件让前端立刻出加载行（沙箱初始化式）再注入
+    # trace），首轮先发 status 事件让前端立刻出加载行（沙箱初始化式）再注入，
+    # 注入完成补发 memory_done（对齐 sandbox:starting/ready 两段式生命周期）
     # ——字节顺序与 POST 侧装配完全一致（基线置头、快照置尾），前缀缓存
     # append-only 语义不变。HITL 恢复轮跳过（恢复语义不重注入）。
     if hitl_resume is None and await _should_inject_session_memory(
@@ -314,6 +315,7 @@ async def _execute_agent_stream(
         message = await inject_session_memory(
             message, user_id=user_id, raw_query=recommendation_input
         )
+        yield {"event": "status", "data": {"stage": "memory_done"}}
 
     try:
         agent = await AgentFactory.get(agent_id)

--- a/src/infra/chat/session_baseline.py
+++ b/src/infra/chat/session_baseline.py
@@ -10,9 +10,7 @@ from src.infra.chat.model_facing import build_model_facing_message
 from src.kernel.config import settings
 
 
-async def session_has_prior_messages(
-    session_id: str, *, exclude_run_id: str | None = None
-) -> bool:
+async def session_has_prior_messages(session_id: str, *, exclude_run_id: str | None = None) -> bool:
     """会话是否已有历史消息（按 traces 计数）。exclude_run_id 用于 executor
     侧判定首轮：本 run 的用户消息 trace 在 executor 开跑前已写入，需排除。"""
     from src.infra.storage.mongodb import get_mongo_client
@@ -101,9 +99,7 @@ async def assemble_first_turn_message(
     return formatted, inject_turn_context
 
 
-async def inject_session_memory(
-    message: str, *, user_id: str, raw_query: str | None
-) -> str:
+async def inject_session_memory(message: str, *, user_id: str, raw_query: str | None) -> str:
     """首轮记忆装配（executor 后台）：索引基线置头、相关记忆快照置尾。
 
     字节顺序与 POST 侧装配完全一致（基线 → 报时/技能/目标 → 快照），仅

--- a/src/infra/chat/session_baseline.py
+++ b/src/infra/chat/session_baseline.py
@@ -10,13 +10,19 @@ from src.infra.chat.model_facing import build_model_facing_message
 from src.kernel.config import settings
 
 
-async def session_has_prior_messages(session_id: str) -> bool:
-    """会话是否已有历史消息（按 traces 计数）。"""
+async def session_has_prior_messages(
+    session_id: str, *, exclude_run_id: str | None = None
+) -> bool:
+    """会话是否已有历史消息（按 traces 计数）。exclude_run_id 用于 executor
+    侧判定首轮：本 run 的用户消息 trace 在 executor 开跑前已写入，需排除。"""
     from src.infra.storage.mongodb import get_mongo_client
 
     client = get_mongo_client()
+    query: dict = {"session_id": session_id}
+    if exclude_run_id:
+        query["run_id"] = {"$ne": exclude_run_id}
     count = await client[settings.MONGODB_DB][settings.MONGODB_TRACES_COLLECTION].count_documents(
-        {"session_id": session_id}
+        query
     )
     return count > 0
 
@@ -49,7 +55,9 @@ def _time_report_due(existing_metadata: dict | None) -> bool:
         return True
 
 
-async def _should_inject_session_memory(session_id: str | None) -> bool:
+async def _should_inject_session_memory(
+    session_id: str | None, *, exclude_run_id: str | None = None
+) -> bool:
     """Codex 式会话基线：记忆块只在会话首轮注入一次，之后 append-only——
     逐轮注入的内容各异的块会击穿 provider 前缀缓存（生产实测）。
     开关关闭时零查询成本。"""
@@ -59,7 +67,7 @@ async def _should_inject_session_memory(session_id: str | None) -> bool:
         return False
     if not session_id:
         return True  # 全新会话，必为首轮
-    return not await session_has_prior_messages(session_id)
+    return not await session_has_prior_messages(session_id, exclude_run_id=exclude_run_id)
 
 
 async def assemble_first_turn_message(
@@ -70,12 +78,12 @@ async def assemble_first_turn_message(
     active_goal,
     auto_mode: bool,
     user_id: str,
-    include_memory: bool,
     include_timestamp: bool,
     last_tc_signature: str | None,
 ) -> tuple[str, bool]:
-    """Codex 式首条/当轮消息装配：稳定内容在前（记忆索引基线 → 报时 →
-    技能 → 目标块），query 相关记忆快照在尾部。返回 (消息, 是否注入了目标块)。"""
+    """POST 侧只做零成本本地格式化（报时 → 技能 → 目标块）；首轮记忆装配
+    （索引基线 + 相关记忆快照）移至 executor 后台执行，提交延迟与召回解耦。
+    返回 (消息, 是否注入了目标块)。"""
     tc_signature = _turn_context_signature(active_goal, auto_mode)
     inject_turn_context = tc_signature is not None and tc_signature != last_tc_signature
 
@@ -86,14 +94,25 @@ async def assemble_first_turn_message(
         active_goal,
         auto_mode,
         user_id,
-        include_memory=include_memory,
+        include_memory=False,
         include_timestamp=include_timestamp,
         include_turn_context=inject_turn_context,
     )
-    if include_memory:
-        from src.infra.agent.middleware.prompt_injection import build_session_memory_baseline
-
-        baseline = await build_session_memory_baseline(user_id)
-        if baseline:
-            formatted = f"{baseline}\n\n{formatted}"
     return formatted, inject_turn_context
+
+
+async def inject_session_memory(
+    message: str, *, user_id: str, raw_query: str | None
+) -> str:
+    """首轮记忆装配（executor 后台）：索引基线置头、相关记忆快照置尾。
+
+    字节顺序与 POST 侧装配完全一致（基线 → 报时/技能/目标 → 快照），仅
+    执行时机移出提交关键路径——持久化与发送字节不变，前缀缓存语义不变。
+    一切失败静默降级为不注入（由底层 best-effort 保证）。"""
+    from src.infra.agent.middleware.prompt_injection import build_session_memory_baseline
+    from src.infra.chat.memory_context import append_memory_context
+
+    baseline = await build_session_memory_baseline(user_id)
+    if baseline:
+        message = f"{baseline}\n\n{message}"
+    return await append_memory_context(message, user_id, raw_query=raw_query)

--- a/tests/api/routes/test_chat_goal.py
+++ b/tests/api/routes/test_chat_goal.py
@@ -201,6 +201,11 @@ async def test_execute_agent_stream_runs_agent_when_active_goal_is_supplied(
 
     monkeypatch.setattr("src.api.routes.chat.AgentFactory.get", _get)
 
+    async def _no_memory(session_id, *, exclude_run_id=None):
+        return False
+
+    monkeypatch.setattr("src.api.routes.chat._should_inject_session_memory", _no_memory)
+
     events = [
         event
         async for event in _execute_agent_stream(
@@ -243,6 +248,11 @@ async def test_execute_agent_stream_passes_auto_mode_to_agent(
         return agent
 
     monkeypatch.setattr("src.api.routes.chat.AgentFactory.get", _get)
+
+    async def _no_memory(session_id, *, exclude_run_id=None):
+        return False
+
+    monkeypatch.setattr("src.api.routes.chat._should_inject_session_memory", _no_memory)
 
     events = [
         event

--- a/tests/api/routes/test_chat_memory_context.py
+++ b/tests/api/routes/test_chat_memory_context.py
@@ -216,6 +216,7 @@ async def test_execute_agent_stream_emits_status_then_injects_first_round_memory
         events.append(ev)
 
     assert events[0] == {"event": "status", "data": {"stage": "memory"}}
+    assert events[1] == {"event": "status", "data": {"stage": "memory_done"}}
     assert injected["args"] == ("u1", "原始问题")
     assert captured["message"].endswith("</memory_context>"), "agent 收到的必须是注入后的消息"
 

--- a/tests/api/routes/test_chat_memory_context.py
+++ b/tests/api/routes/test_chat_memory_context.py
@@ -156,13 +156,8 @@ async def test_model_facing_message_skips_memory_when_deferred(
     assert "<memory_context>" not in message
 
 
-@pytest.mark.asyncio
-async def test_execute_agent_stream_never_injects_memory(monkeypatch: pytest.MonkeyPatch):
-    """Codex 式会话基线：注入只在 POST 首轮发生，executor 逐轮注入已移除
-    （逐轮变化块是前缀缓存杀手——生产实测确认）。"""
-    from src.api.routes import chat as chat_route
-
-    captured = {}
+def _fake_agent_factory(captured: dict, monkeypatch: pytest.MonkeyPatch) -> None:
+    """FakeAgent：捕获 executor 实际喂给 agent.stream 的最终消息。"""
 
     class FakeAgent:
         def stream(self, message, *a, **kw):
@@ -178,9 +173,35 @@ async def test_execute_agent_stream_never_injects_memory(monkeypatch: pytest.Mon
 
     monkeypatch.setattr("src.agents.core.AgentFactory.get", fake_get)
 
-    class FakePresenter:
-        run_id = "run-test"
-        hitl_suspended = False
+
+class _FakePresenter:
+    run_id = "run-test"
+    hitl_suspended = False
+
+
+@pytest.mark.asyncio
+async def test_execute_agent_stream_emits_status_then_injects_first_round_memory(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """首轮记忆装配移回 executor 后台：先发 status{stage:memory} 让前端出
+    加载行（沙箱初始化式），注入完成才开跑 agent——提交延迟与召回解耦。"""
+    from src.api.routes import chat as chat_route
+
+    captured = {}
+    _fake_agent_factory(captured, monkeypatch)
+
+    async def fake_first_round(session_id, *, exclude_run_id=None):
+        return True
+
+    monkeypatch.setattr(chat_route, "_should_inject_session_memory", fake_first_round)
+
+    injected = {}
+
+    async def fake_inject(message: str, *, user_id: str, raw_query: str | None) -> str:
+        injected["args"] = (user_id, raw_query)
+        return f"{message}\n\n<memory_context>注入块</memory_context>"
+
+    monkeypatch.setattr(chat_route, "inject_session_memory", fake_inject)
 
     events = []
     gen = chat_route._execute_agent_stream(
@@ -188,7 +209,45 @@ async def test_execute_agent_stream_never_injects_memory(monkeypatch: pytest.Mon
         agent_id="fast_agent",
         message="base message",
         user_id="u1",
-        presenter=FakePresenter(),
+        presenter=_FakePresenter(),
+        recommendation_input="原始问题",
+    )
+    async for ev in gen:
+        events.append(ev)
+
+    assert events[0] == {"event": "status", "data": {"stage": "memory"}}
+    assert injected["args"] == ("u1", "原始问题")
+    assert captured["message"].endswith("</memory_context>"), "agent 收到的必须是注入后的消息"
+
+
+@pytest.mark.asyncio
+async def test_execute_agent_stream_no_status_or_injection_when_not_first_round(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """非首轮：不发 status、不注入，消息原样透传——前缀缓存 append-only
+    语义不变。"""
+    from src.api.routes import chat as chat_route
+
+    captured = {}
+    _fake_agent_factory(captured, monkeypatch)
+
+    async def fake_not_first_round(session_id, *, exclude_run_id=None):
+        return False
+
+    monkeypatch.setattr(chat_route, "_should_inject_session_memory", fake_not_first_round)
+
+    async def unexpected_inject(message: str, *, user_id: str, raw_query: str | None) -> str:
+        raise AssertionError("非首轮不应触发记忆注入")
+
+    monkeypatch.setattr(chat_route, "inject_session_memory", unexpected_inject)
+
+    events = []
+    gen = chat_route._execute_agent_stream(
+        session_id="s1",
+        agent_id="fast_agent",
+        message="base message",
+        user_id="u1",
+        presenter=_FakePresenter(),
         recommendation_input="原始问题",
     )
     async for ev in gen:
@@ -196,6 +255,43 @@ async def test_execute_agent_stream_never_injects_memory(monkeypatch: pytest.Mon
 
     assert all(ev.get("event") != "status" for ev in events)
     assert captured["message"] == "base message", "executor 必须原样透传消息"
+
+
+@pytest.mark.asyncio
+async def test_execute_agent_stream_skips_memory_injection_on_hitl_resume(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """HITL 恢复轮跳过注入（恢复语义不重注入），即使判定为首轮。"""
+    from src.api.routes import chat as chat_route
+
+    captured = {}
+    _fake_agent_factory(captured, monkeypatch)
+
+    async def fake_first_round(session_id, *, exclude_run_id=None):
+        return True
+
+    monkeypatch.setattr(chat_route, "_should_inject_session_memory", fake_first_round)
+
+    async def unexpected_inject(message: str, *, user_id: str, raw_query: str | None) -> str:
+        raise AssertionError("HITL 恢复轮不应触发记忆注入")
+
+    monkeypatch.setattr(chat_route, "inject_session_memory", unexpected_inject)
+
+    events = []
+    gen = chat_route._execute_agent_stream(
+        session_id="s1",
+        agent_id="fast_agent",
+        message="base message",
+        user_id="u1",
+        presenter=_FakePresenter(),
+        recommendation_input="原始问题",
+        hitl_resume={"goal_started_at": "2026-09-03T00:00:00+00:00"},
+    )
+    async for ev in gen:
+        events.append(ev)
+
+    assert all(ev.get("event") != "status" for ev in events)
+    assert captured["message"] == "base message"
 
 
 @pytest.mark.asyncio
@@ -228,13 +324,33 @@ async def test_session_memory_baseline_only_first_turn(monkeypatch: pytest.Monke
     assert counts["called_with"] == [{"session_id": "s1"}]
     counts["ret"] = 3
     assert await session_has_prior_messages("s1") is True
+    # executor 侧判定：排除本 run 已写入的用户消息 trace
+    await session_has_prior_messages("s1", exclude_run_id="run-current")
+    assert counts["called_with"][-1] == {
+        "session_id": "s1",
+        "run_id": {"$ne": "run-current"},
+    }
+    await session_has_prior_messages("s1", exclude_run_id=None)
+    assert counts["called_with"][-1] == {"session_id": "s1"}  # None 时不排除
 
 
 @pytest.mark.asyncio
-async def test_session_baseline_prepended_at_message_head(monkeypatch: pytest.MonkeyPatch):
-    """Codex input[1]：记忆索引基线置于首条消息头部——稳定内容在时间戳等
-    变化内容之前，同用户跨会话公共前缀延伸到索引末尾。"""
-    from src.api.routes import chat as chat_route
+async def test_inject_session_memory_baseline_head_snapshot_tail(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """executor 侧首轮装配的字节顺序与原 POST 侧完全一致：索引基线置头、
+    相关记忆快照置尾——持久化与发送字节不变，前缀缓存语义不变。"""
+    from src.infra.chat.session_baseline import inject_session_memory
+
+    monkeypatch.setattr(memory_context.settings, "ENABLE_MEMORY", True)
+    monkeypatch.setattr(memory_context.settings, "NATIVE_MEMORY_QUERY_CONTEXT_ENABLED", True)
+    seen = {}
+
+    async def fake_recall(user_id: str, query: str) -> list[dict]:
+        seen["query"] = query
+        return [_memory()]
+
+    monkeypatch.setattr(memory_context, "_recall_memories_raw", fake_recall)
 
     async def fake_baseline(user_id):
         return "<memory_index_context>\n- 记忆索引行\n</memory_index_context>"
@@ -244,6 +360,45 @@ async def test_session_baseline_prepended_at_message_head(monkeypatch: pytest.Mo
         fake_baseline,
     )
 
+    out = await inject_session_memory(
+        "[User message sent at 09:00+08:00]\n\n帮我总结项目进度",
+        user_id="u1",
+        raw_query="帮我总结项目进度",
+    )
+
+    assert seen["query"] == "帮我总结项目进度"  # 检索用原始消息，不用带时间戳文本
+    assert (
+        out.index("<memory_index_context>")
+        < out.index("[User message sent at")
+        < out.index("<memory_context>")
+    )
+    assert out.endswith("</memory_context>")  # 快照在尾部——前缀缓存安全位置
+
+
+@pytest.mark.asyncio
+async def test_assemble_first_turn_message_skips_memory_recall(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """POST 装配只做零成本本地格式化：即使开关全开也不触发召回与基线构建
+    （昂贵部分移至 executor，提交延迟与召回解耦）。"""
+    from src.api.routes import chat as chat_route
+
+    monkeypatch.setattr(memory_context.settings, "ENABLE_MEMORY", True)
+    monkeypatch.setattr(memory_context.settings, "NATIVE_MEMORY_QUERY_CONTEXT_ENABLED", True)
+
+    async def unexpected_recall(user_id: str, query: str) -> list[dict]:
+        raise AssertionError("POST 装配不应触发记忆召回")
+
+    monkeypatch.setattr(memory_context, "_recall_memories_raw", unexpected_recall)
+
+    async def unexpected_baseline(user_id):
+        raise AssertionError("POST 装配不应触发基线构建")
+
+    monkeypatch.setattr(
+        "src.infra.agent.middleware.prompt_injection.build_session_memory_baseline",
+        unexpected_baseline,
+    )
+
     msg, _tc = await chat_route.assemble_first_turn_message(
         raw_message="你好",
         user_timezone="Asia/Shanghai",
@@ -251,13 +406,13 @@ async def test_session_baseline_prepended_at_message_head(monkeypatch: pytest.Mo
         active_goal=None,
         auto_mode=False,
         user_id="u1",
-        include_memory=True,
         include_timestamp=True,
         last_tc_signature=None,
     )
 
-    assert msg.startswith("<memory_index_context>")
-    assert msg.index("<memory_index_context>") < msg.index("[User message sent at")
+    assert msg.startswith("[User message sent at")
+    assert "<memory_context>" not in msg
+    assert "<memory_index_context>" not in msg
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 内容

- PR #378：首轮记忆装配移回 executor 后台（POST 零记忆成本、字节序与前缀缓存语义不变）、status{stage:memory_done} 两段式事件、600ms 最短展示保护、加载行 amber 视觉、思考文案 useSmoothStreamText 打字机式渐显
- PR #379：ruff format 修复

## 验证

- develop CI 全绿（Ruff / MyPy / 前后端测试 / 双架构镜像）
- staging develop-20260903-121307 滚动成功、pod 健康