### PR TITLE
fix(ci): benchmark 脚本清理未使用变量（Ruff F841 补漏）

### DIFF
--- a/scripts/benchmark_memory_scope.py
+++ b/scripts/benchmark_memory_scope.py
@@ -153,7 +153,6 @@ async def run_isolation_benchmark(backend, collection) -> dict[str, Any]:
                 if mid.startswith("m-proj-") and not mid.startswith(f"m-{pid}-")
             }
             own = f"m-{pid}-{topic}" in hit_ids
-            user_visible = any(mid.startswith("m-user-") or mid == "m-legacy-1" for mid in hit_ids)
             if foreign:
                 results["violations"].append(
                     {"project": pid, "query": topic, "foreign": sorted(foreign)}


### PR DESCRIPTION
## 概述

PR #385 的 CI Ruff 检查失败补漏：`scripts/benchmark_memory_scope.py` 存在未使用局部变量 `user_visible`（F841）。该变量在 `ruff format` 重排脚本后提交前未重跑 `ruff check`，导致漏网。

## 变更

- 删除未使用的 `user_visible` 赋值（其语义已由后续 `user_memory_visible_in_project` 独立查询覆盖）

## 验证

- `uv run ruff check .` → All checks passed
- `uv run ruff format --check .` → 1100 files already formatted
- `uv run python scripts/benchmark_memory_scope.py` → BENCHMARK: PASS（隔离与 KV 前缀指标不受影响）