### PR TITLE
fix(memory): 提取 content blocks 兼容 + 记忆 scope（develop → main 晋升）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,8 @@ YubbChat/
 !/scripts/codemod_error_literals.py
 !/scripts/cleanup_junk_memories.py
 !/scripts/sync_error_locales.py
+!/scripts/backfill_memory_scope.py
+!/scripts/benchmark_memory_scope.py
 docs/docs/.vitepress/
 k8s/lambchat-secret.yaml
 k8s/lambchat.yaml

--- a/docs/superpowers/specs/2026-09-04-memory-scope-and-context-design.md
+++ b/docs/superpowers/specs/2026-09-04-memory-scope-and-context-design.md
@@ -1,0 +1,164 @@
+# 记忆作用域（scope）与项目隔离设计
+
+日期：2026-09-04
+状态：已确认，实现中
+前置文档：`2026-08-27-memory-system-enhancement-design.md`（A3a 已把 `context` 启用为检索过滤器；本文把"归属边界"正式化为独立维度，与 `context` 的"内容分类"语义分离）
+
+## 背景
+
+对照 openai/codex（`codex-rs`，commit ec84e69，2026-09-03）的世界状态注入与 memories 两阶段流水线，得到两条核心纪律：
+
+1. **上下文必须类型化且归属于所属结构**：`cwd`/`workspace_roots` 是 `role=user` 的 `environments.environment_context` 片段，AGENTS.md 是 `agents_md.instructions` 片段——每个上下文片段有自己的 `content_item_kind`、role 和 marker，不与用户正文混淆；首次请求注入完整 snapshot，后续 turn 只注入 diff。
+2. **记忆提取按会话独立、全局合并**：Phase 1 对空闲 rollout 做结构化提取（no-op 是合法结局），Phase 2 全局 consolidation；每个 workspace 有稳定基线，通过 diff 识别增删改。
+
+LambChat 已对齐的部分（保持不动）：记忆正文永不进用户消息；导航索引只挂 `memory_recall` 工具描述且有 30 分钟会话快照；`access_count` 不进索引排序（KV 缓存纪律）；`source_refs` 经 `ConversationHistoryService` 授权校验；两阶段提取（extraction.py + compaction_agent）。
+
+**缺口**：记忆只有 `user_id` 一个隔离维度。`project_id` 写进了 `sessions.metadata.project_id`（有索引），但 memory 写入、检索、索引全部无视它——A 项目的部署约束会泄漏进 B 项目的会话；自动提取产出的项目知识没有归属字段，事后无法回填。
+
+## 目标 / 非目标
+
+**目标**
+
+- 同一用户的多项目记忆互不污染：项目记忆只在其归属项目的会话中可检索、可见于索引。
+- 用户级长期偏好跨项目可见（现状保持）。
+- `scope` 成为记忆文档的一等字段，`context` 回归纯内容分类。
+- 索引字节由内容派生 revision，相同数据 → 相同字节（可断言、可观测），会话内前缀稳定性不回退。
+
+**非目标**
+
+- 不迁移存储（仍用现有 collection）；不重写检索算法；不引入 Codex 式本地 memory workspace 文件树。
+- 不给 `memory_recall` 增加"跨项目检索"参数——默认隔离就是产品语义。
+- 不引入独立 revision 计数器 collection（见"revision 设计"）。
+
+## scope 模型
+
+| scope | 语义 | project_id | 检索可见性 |
+|---|---|---|---|
+| `user` | 用户长期偏好、身份、知识 | 空 | 所有会话 |
+| `project` | 项目架构、约束、部署、已确认决策 | 必填 | 仅该项目会话 |
+| `reference` | 外部资料、链接、供应商 | 空（可选） | 所有会话（外部事实无项目边界） |
+
+**关于 session scope 的决策（考虑后不落库）**：会话临时状态（当前分支、当前 bug、打开的文件）已有承载位——`turn_context`/`active_goal` 写时注入且随状态持久化，自动提取模板明确排除临时状态，`is_manual_memory_worthy` 拒绝瞬时内容。为它再加一个持久 scope 存储位会造成双写和边界混淆。Codex 的对应物（`WorldState` 的 snapshot/diff）本质也是"会话态不进持久记忆"。
+
+**scope 与 context 的关系**：`scope` 回答"这条记忆属于谁"（归属边界），`context` 回答"这条记忆是什么类型的内容"（`project_constraint`/`user_identity`/`feedback_rule`…）。推导规则：`scope=project` 的记忆通常 `context` 以 `project_` 开头，但反之不自动成立——归属必须来自可靠的 `project_id`，不猜。
+
+## project_id 传播链路
+
+现状：`request.project_id` → `sessions.metadata.project_id`（`chat.py:235`），**不进入** agent 执行链（`_execute_agent_stream` 签名无此参数）。
+
+设计：**memory 侧用 `session_id` 反查，不改 agent 执行链**。理由：
+
+- agent stream 链路（chat route → task manager → arq 序列化 → agent.stream kwargs → nodes → middleware）穿透改动面大且触碰 arq 任务兼容性；
+- `sessions.metadata.project_id` 是唯一权威源（会话归属可能被用户在会话中途改派，反查天然跟随）；
+- memory 各触点已有 session_id：middleware 有、extraction 有 session_doc、memory tools 可从 `runtime.config.configurable.context`（FastAgentContext）拿。
+
+新增 `src/infra/memory/scope.py`：
+
+```python
+async def resolve_session_project_id(session_id: str | None) -> str | None
+```
+
+- 查 `sessions` collection `metadata.project_id`（投影单字段，命中既有索引 `user_id+metadata.project_id`——按 session_id 反查走 `_id`/`session_id` 索引）。
+- 进程内 TTL 缓存 60s（含负缓存：无 project 的会话也缓存，防止无项目用户每轮 retain/recall 都打 Mongo）。会话中途改派项目的可见性延迟 ≤60s，可接受（索引快照本身 30 分钟）。
+- 任何异常 → 返回 None（降级为无项目行为，绝不阻塞）。
+
+## 各模块变更
+
+### P0 存储与写入（backend.py）
+
+`retain()` 新增可选参数 `scope: str | None`、`project_id: str | None`：
+
+- 校验：`scope` ∈ {user, project, reference}，非法值拒绝。
+- 推导顺序（写入侧绝不猜测归属）：
+  1. 显式 `scope=project` 且无 `project_id` → 拒绝（`success=False`，错误说明需要项目上下文）；
+  2. 显式 `project_id` 无 `scope` → `scope=project`；
+  3. `scope` 未传：`context` 以 `project_` 开头 **且** 能解析到 `project_id` → `project`；否则 `user`。拿不到可靠 `project_id` 时项目类内容降级 `user`（与旧行为一致，不丢数据）。
+- 新字段落库：`scope`、`project_id`（仅 project scope 时非空）。
+- **scope 内去重**：`fetch_recent_memories` / `fetch_semantic_candidates` 增加边界——project 记忆只与同 `(user_id, scope, project_id)` 匹配，跨项目不合并、不互相覆盖。
+- MongoDB 增加索引 `(user_id, scope, project_id)`。
+- `delete` 不变（按 memory_id，与 scope 无关）。
+
+### P1 检索硬过滤（search.py + vector_store.py）
+
+`recall_memories()` 新增 `project_id: str | None`，构造 scope 子句注入**全部四条**查询路径（text_search / keyword_fallback / vector_search Mongo 链路 / recent_context_fallback）：
+
+```python
+def build_scope_clause(project_id: str | None) -> dict:
+    visible = {"$in": [None, "user", "reference"]}
+    if project_id:
+        return {"$or": [{"scope": visible}, {"scope": "project", "project_id": project_id}]}
+    return {"scope": visible}  # 无项目会话：看不到任何 project 记忆
+```
+
+- 无 `scope` 字段的旧数据命中 `None` → user 语义，向后兼容。
+- Qdrant `index_search` payload 增加 `scope`/`project_id`，预过滤同语义。
+- `$vectorSearch` 的 `$match` 与 Python 余弦兜底的 base 查询同步携带子句。
+- `prioritize_sources` 排序键增加 scope 优先级：`project > user/reference`（同 source 同分时当前项目上下文优先）；`format_memory` 返回体新增 `scope`/`project_id` 字段。
+
+### P2 索引与 revision（indexing.py + prompt_injection.py）
+
+`build_memory_index(backend, user_id, project_id=None)`：
+
+- 候选查询带 scope 子句（与 recall 同源函数，避免两处漂移）；Project 区块仅在项目会话出现。
+- 索引头部带内容派生 revision：`compute_index_revision(docs) = sha1(sorted(memory_id + updated_at) + count)[:12]`。相同数据 → 相同 revision → 相同字节；任何写入/删除/合并改变候选集 → revision 变化。**不引入计数器 collection**：计数器需要跨副本原子递增 + 失效广播，而内容 hash 天然满足"相同数据 → 相同字节"，且快照键仍为 `(user_id, session_id)`（session 内 project 不变 → 前缀稳定，30 分钟 TTL 重建时若数据未变字节亦不变，KV 缓存安全）。
+- middleware 构建：`MemoryRecallIndexMiddleware` 增加 `project_id` 参数，三个 agent 构建处经 `resolve_session_project_id(session_id)` 解析（会话内首构建时解析一次并随快照固化）。
+- `<memory_index_context>` 框架文案不变（untrusted 包装保持）。
+
+### P3 自动提取继承（extraction.py + 模板）
+
+- `find_candidate_sessions` 投影增加 `metadata.project_id`。
+- `extract_session_memory`：解析 session 的 `project_id`，retain 时传入；模板新增一节说明：项目相关内容标记归属（输出 `scope` 字段可选），**模板继续禁止**把临时状态存为长期记忆。
+- `_fallback_index_fields` 的 context 兜底保持；scope 推导复用 P0 规则（拿不到 project_id 降级 user）。
+
+### P4 工具层（tools.py + base.py）
+
+- `base.py` 新增 `get_session_id_from_runtime(runtime)`（与 `get_user_id_from_runtime` 同风格，从 `configurable.context.session_id` 提取）。
+- `memory_retain` 新增可选参数 `scope`（描述说明三种取值与默认继承当前会话项目）；retain 前经 `resolve_session_project_id` 补齐 project_id。
+- `memory_recall` 不加新参数——scope 过滤由 runtime session 自动应用（描述更新说明项目隔离语义）。
+
+### P5 迁移（scripts/backfill_memory_scope.py）
+
+- 默认 dry-run：报告无 `scope` 字段的存量记忆分布（按 memory_type 统计、可回填数预估）。
+- `--apply`：所有无 scope 记忆 → `scope=user`（安全默认，无归属猜测）。
+- `--apply --from-source-sessions`：仅对 `source_refs` 能唯一定位到带 `project_id` 会话的记忆回填 `scope=project`（可追溯归属才回填；定位到多个不同项目会话的跳过并列出）。
+
+## 兼容矩阵
+
+| 场景 | 行为 |
+|---|---|
+| 旧记忆（无 scope 字段） | 视同 `user`，所有会话可见（现状） |
+| 无项目会话 recall | 只见 user/reference（含旧数据），见不到任何 project 记忆 |
+| 项目会话 recall | user + reference + 本项目 project |
+| `memory_retain` 旧调用（不传 scope） | 推导：context=project_* 且会话有 project → project；否则 user |
+| `scope=project` 但无 project_id（无项目会话手动指定） | 拒绝并说明原因 |
+| 跨项目语义去重 | 互不匹配（各自演化，合并交给本项目内的 consolidation） |
+
+## KV 缓存与 benchmark 验收
+
+会话内多轮前缀稳定性是硬约束（前置文档 C1）。验收方式：
+
+1. **pytest 钉死**：同 session 两次构建索引（数据未变，绕过快照）字节完全一致；revision 相同；数据变化后 revision 变化、字节变化。`access_count`/`accessed_at` 变化不影响索引字节（现有纪律扩展到 scope 字段）。
+2. **本地 benchmark**（`scripts/benchmark_memory_scope.py`，独立 benchmark 库不碰开发数据）：
+   - **recall 隔离质量**：真实 MongoDB 上构造 3 项目 × N 记忆 + 用户记忆，验证：项目会话内本项目命中率、跨项目泄漏率 = 0、用户记忆跨项目可见率 = 100%。
+   - **多轮 KV 缓存率**：模拟 10 轮对话，每轮序列化 `(system + tools 描述 + 历史消息)` 为字节流，计算相邻轮次最长公共前缀占本轮总字节比例（≈ provider 前缀缓存命中率的下界估计）。对比三组：无记忆用户 / 项目用户稳定数据 / 中途写入记忆（下一 session 才生效——验证会话内快照不被写穿）。
+3. 中途写记忆不破坏当前会话前缀（快照语义），只影响下一会话——benchmark 断言之一。
+
+## 测试清单
+
+- P0：retain scope 校验（非法值 / project 无 pid 拒绝 / context 推导 / 降级 user）；scope 内去重（跨项目不合并）。
+- P1：scope 子句注入四条检索路径（FakeCollection 断言 query）；无项目会话看不到 project 记忆；项目会话可见本项目；`prioritize_sources` 项目优先。
+- P2：索引 scope 过滤；revision 稳定性与敏感性；access stats 不影响索引。
+- P3：extraction 继承 project_id；无项目会话降级。
+- P4：runtime session 提取；retain 工具透传。
+- 兼容：旧 schema 文档流经全链路不报错。
+
+## 回滚
+
+无新开关、纯增量字段：revert 代码即回滚，数据多出的 `scope`/`project_id` 字段对旧代码无害（未知字段忽略）。
+
+## 决策记录
+
+- **反查而非穿透传参**：见"project_id 传播链路"。
+- **内容 hash revision 而非计数器**：见 P2；可观测性目标（"索引是否变了"）用 hash 即可满足，计数器的一致性成本不划算。
+- **session scope 不落库**：见"scope 模型"。
+- **recall 不加跨项目参数**：默认隔离是产品语义；确需跨项目共享的内容应该存为 `user` 或 `reference` scope。

--- a/scripts/backfill_memory_scope.py
+++ b/scripts/backfill_memory_scope.py
@@ -1,0 +1,164 @@
+"""Memory scope backfill — 给存量记忆补 scope/project_id（dry-run 默认）。
+
+设计文档：docs/superpowers/specs/2026-09-04-memory-scope-and-context-design.md
+
+规则（写入侧不猜归属的延续）：
+- 默认（--apply）：所有无 scope 字段的存量记忆 → scope=user（安全默认，
+  与检索侧"legacy 视同 user"一致；回填只是把隐式语义显式化）。
+- --from-source-sessions：仅当记忆的 source_refs 能唯一定位到一个带
+  project_id 的会话时，回填 scope=project + project_id。定位到多个不同
+  项目的会话、或会话无项目归属的，一律跳过并列出（可追溯才回填）。
+
+用法::
+
+    uv run python scripts/backfill_memory_scope.py                      # dry-run 报告
+    uv run python scripts/backfill_memory_scope.py --apply               # 全部 → user
+    uv run python scripts/backfill_memory_scope.py --apply --from-source-sessions
+    uv run python scripts/backfill_memory_scope.py --user <id>           # 限定用户
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+# Support the documented `uv run python scripts/...` invocation from the repo root.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.infra.logging import get_logger
+from src.kernel.config import settings
+
+logger = get_logger(__name__)
+
+
+async def _session_project_map(db, session_ids: set[str]) -> dict[str, str | None]:
+    """session_id → project_id（无项目/不存在 → None）。"""
+    result: dict[str, str | None] = {}
+    ids = sorted(session_ids)
+    for start in range(0, len(ids), 500):
+        chunk = ids[start : start + 500]
+        cursor = db[settings.MONGODB_SESSIONS_COLLECTION].find(
+            {"session_id": {"$in": chunk}}, {"session_id": 1, "metadata.project_id": 1}
+        )
+        async for doc in cursor:
+            pid = str((doc.get("metadata") or {}).get("project_id") or "").strip()
+            result[str(doc["session_id"])] = pid or None
+    for sid in ids:
+        result.setdefault(sid, None)
+    return result
+
+
+async def run(*, apply: bool, from_source_sessions: bool, user_id: str | None) -> dict[str, Any]:
+    from src.infra.storage.mongodb import get_mongo_client
+
+    client = get_mongo_client()
+    db = client[settings.MONGODB_DB]
+    collection = db["native_memories"]
+
+    query: dict[str, Any] = {"scope": {"$exists": False}}
+    if user_id:
+        query["user_id"] = user_id
+
+    cursor = collection.find(
+        query, {"memory_id": 1, "user_id": 1, "memory_type": 1, "source_refs": 1}
+    )
+    docs = [doc async for doc in cursor]
+
+    by_type: dict[str, int] = defaultdict(int)
+    user_fill: list[dict] = []
+    project_fill: list[tuple[dict, str]] = []
+    skipped_ambiguous: list[tuple[dict, str]] = []
+
+    session_ids = {
+        str(ref.get("session_id"))
+        for doc in docs
+        for ref in (doc.get("source_refs") or [])
+        if ref.get("session_id")
+    }
+    session_projects = await _session_project_map(db, session_ids) if session_ids else {}
+
+    for doc in docs:
+        by_type[str(doc.get("memory_type") or "unknown")] += 1
+        if not from_source_sessions:
+            user_fill.append(doc)
+            continue
+        projects = {
+            session_projects[str(ref["session_id"])]
+            for ref in (doc.get("source_refs") or [])
+            if ref.get("session_id") and str(ref["session_id"]) in session_projects
+        }
+        projects.discard(None)
+        if len(projects) == 1:
+            project_fill.append((doc, next(iter(projects))))
+        else:
+            reason = (
+                f"source sessions span {len(projects)} projects"
+                if len(projects) > 1
+                else "no project attributable from source sessions"
+            )
+            if str(doc.get("memory_type")) == "project":
+                skipped_ambiguous.append((doc, reason))
+            else:
+                user_fill.append(doc)
+
+    report: dict[str, Any] = {
+        "total_without_scope": len(docs),
+        "by_memory_type": dict(by_type),
+        "to_user_scope": len(user_fill),
+        "to_project_scope": len(project_fill),
+        "skipped_project_memories": len(skipped_ambiguous),
+        "applied": apply,
+    }
+
+    if apply:
+        for doc in user_fill:
+            await collection.update_one(
+                {"memory_id": doc["memory_id"]},
+                {"$set": {"scope": "user", "project_id": None}},
+            )
+        for doc, pid in project_fill:
+            await collection.update_one(
+                {"memory_id": doc["memory_id"]},
+                {"$set": {"scope": "project", "project_id": pid}},
+            )
+
+    if skipped_ambiguous:
+        report["skipped_details"] = [
+            {
+                "memory_id": doc["memory_id"],
+                "reason": reason,
+            }
+            for doc, reason in skipped_ambiguous[:50]
+        ]
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true", help="执行回填（默认 dry-run）")
+    parser.add_argument(
+        "--from-source-sessions",
+        action="store_true",
+        help="source_refs 可唯一定位项目会话的记忆回填 project scope",
+    )
+    parser.add_argument("--user", default=None, help="限定用户")
+    args = parser.parse_args()
+
+    report = asyncio.run(
+        run(apply=args.apply, from_source_sessions=args.from_source_sessions, user_id=args.user)
+    )
+
+    import json
+
+    print(json.dumps(report, ensure_ascii=False, indent=2, default=str))
+    if not args.apply:
+        print("\n(dry-run：加 --apply 执行回填)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark_memory_scope.py
+++ b/scripts/benchmark_memory_scope.py
@@ -1,0 +1,407 @@
+"""Memory scope benchmark — 检索隔离质量 + 多轮 KV 前缀稳定性。
+
+设计文档：docs/superpowers/specs/2026-09-04-memory-scope-and-context-design.md
+
+Part A（隔离质量，真实 MongoDB 独立 benchmark 库）：
+- 3 个项目 × 主题重叠的项目记忆（部署/数据库/CI 各项目不同事实）+ 用户记忆 + reference
+- 断言：项目会话零跨项目泄漏、无项目会话见不到 project 记忆、user 记忆全项目可见
+
+Part B（KV 缓存前缀稳定性）：
+- 模拟 10 轮对话，序列化 (system + tools 描述 + 历史消息) 为字节流
+- 逐轮计算与上一轮的最长公共前缀占比（≈ provider 前缀缓存命中率的下界估计）
+- 三组：无记忆用户 / 项目用户稳定数据 / 会话中途写入记忆
+
+用法::
+
+    uv run python scripts/benchmark_memory_scope.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+BENCHMARK_DB = "lambchat_benchmark_scope"
+PROJECTS = {
+    "proj-alpha": {
+        "deploy": "k8s rolling updates with auto rollback",
+        "db": "MongoDB 8.2 replica set",
+    },
+    "proj-beta": {"deploy": "docker compose on a single VM", "db": "PostgreSQL 16 with pgvector"},
+    "proj-gamma": {"deploy": "bare metal systemd services", "db": "SQLite with WAL mode"},
+}
+USER_MEMORIES = [
+    ("raw SQL preference", "The user prefers raw SQL over ORMs for analytics workloads."),
+    ("terse replies", "The user prefers terse, evidence-backed replies in Chinese."),
+    ("uv tooling", "The user manages Python dependencies with uv, never pip."),
+]
+REFERENCE_MEMORIES = [
+    ("mongo vector docs", "MongoDB 8.2 community edition ships built-in $vectorSearch."),
+    (
+        "openai prompt caching",
+        "OpenAI prefix caching keys on the leading stable bytes of the request.",
+    ),
+]
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+async def seed_memories(collection) -> dict[str, int]:
+    """直接落库（写入路径已有单测；benchmark 关注检索与索引）。"""
+    now = _now()
+    docs: list[dict[str, Any]] = []
+
+    def doc(memory_id, mtype, content, context, scope, project_id=None, source="manual"):
+        base = {
+            "memory_id": memory_id,
+            "user_id": "bench-user",
+            "title": memory_id[:25],
+            "summary": content[:100],
+            "index_label": f"{memory_id}: {content[:60]}",
+            "memory_type": mtype,
+            "context": context,
+            "tags": [],
+            "scope": scope,
+            "project_id": project_id,
+            "source": source,
+            "embedding": None,
+            "created_at": now - timedelta(days=1),
+            "updated_at": now - timedelta(days=1),
+            "accessed_at": now - timedelta(days=1),
+            "access_count": 0,
+            "source_refs": [],
+            "content": content,
+            "content_storage_mode": "inline",
+            "content_store_key": None,
+        }
+        docs.append(base)
+
+    n = 0
+    for pid, facts in PROJECTS.items():
+        for topic, fact in facts.items():
+            doc(
+                f"m-{pid}-{topic}",
+                "project",
+                f"{pid} {topic}: {fact}",
+                "project_constraint",
+                "project",
+                pid,
+            )
+            n += 1
+        # 每项目再补 6 条噪声项目记忆，检验过滤不靠内容巧合
+        for i in range(6):
+            doc(
+                f"m-{pid}-note{i}",
+                "project",
+                f"{pid} internal note {i}",
+                "project_status",
+                "project",
+                pid,
+            )
+            n += 1
+    for title, content in USER_MEMORIES:
+        doc(f"m-user-{title.replace(' ', '-')[:20]}", "user", content, "user_identity", "user")
+        n += 1
+    for title, content in REFERENCE_MEMORIES:
+        doc(
+            f"m-ref-{title.replace(' ', '-')[:20]}",
+            "reference",
+            content,
+            "reference_link",
+            "reference",
+        )
+        n += 1
+    # legacy：无 scope 字段的旧数据（视同 user）
+    doc("m-legacy-1", "user", "The user's timezone is Asia/Shanghai.", "user_identity", None)
+    docs[-1].pop("scope")
+    docs[-1].pop("project_id")
+    n += 1
+
+    await collection.insert_many(docs)
+    return {
+        "total": n,
+        "projects": len(PROJECTS) * 8,
+        "user": len(USER_MEMORIES) + 1,
+        "reference": len(REFERENCE_MEMORIES),
+    }
+
+
+async def run_isolation_benchmark(backend, collection) -> dict[str, Any]:
+    results: dict[str, Any] = {"cases": [], "violations": []}
+
+    async def recall(query: str, project_id: str | None) -> list[dict]:
+        out = await backend.recall("bench-user", query, max_results=8, project_id=project_id)
+        return out.get("memories") or []
+
+    # 1) 项目会话：部署/数据库查询只见本项目 + user/reference
+    for pid, facts in PROJECTS.items():
+        for topic, fact in facts.items():
+            hits = await recall(topic, pid)
+            hit_ids = {m["memory_id"] for m in hits}
+            foreign = {
+                mid
+                for mid in hit_ids
+                if mid.startswith("m-proj-") and not mid.startswith(f"m-{pid}-")
+            }
+            own = f"m-{pid}-{topic}" in hit_ids
+            user_visible = any(mid.startswith("m-user-") or mid == "m-legacy-1" for mid in hit_ids)
+            if foreign:
+                results["violations"].append(
+                    {"project": pid, "query": topic, "foreign": sorted(foreign)}
+                )
+            results["cases"].append(
+                {
+                    "project": pid,
+                    "query": topic,
+                    "hits": len(hits),
+                    "own_hit": own,
+                    "foreign_leak": len(foreign),
+                }
+            )
+            assert own, f"{pid} {topic}: own project memory not recalled: {sorted(hit_ids)}"
+
+    # 2) 无项目会话：见不到任何 project 记忆
+    for query in ("deploy", "database", "note"):
+        hits = await recall(query, None)
+        leaked = [m["memory_id"] for m in hits if m.get("scope") == "project"]
+        if leaked:
+            results["violations"].append({"no_project_query": query, "leaked": leaked})
+
+    # 3) 用户记忆跨项目可见（宽松验证：任一项目会话可召回 raw SQL）
+    pid = next(iter(PROJECTS))
+    hits = await recall("raw SQL preference", pid)
+    results["user_memory_visible_in_project"] = any(
+        m["memory_id"].startswith("m-user-") for m in hits
+    )
+
+    # 4) legacy 无 scope 文档在项目会话可见（视同 user）
+    hits = await recall("timezone", pid)
+    results["legacy_visible"] = any(m["memory_id"] == "m-legacy-1" for m in hits)
+
+    # 延迟
+    t0 = time.perf_counter()
+    for _ in range(5):
+        await recall("deployment", pid)
+    results["recall_latency_ms_avg"] = round((time.perf_counter() - t0) / 5 * 1000, 2)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Part B：多轮 KV 前缀稳定性
+# ---------------------------------------------------------------------------
+
+
+def serialize_turn(
+    system_prompt: str, tool_descriptions: list[tuple[str, str]], history: list[str]
+) -> bytes:
+    """模拟 provider 请求中参与前缀缓存的字节：system + tools + 消息历史。"""
+    parts = [system_prompt]
+    for name, description in tool_descriptions:
+        parts.append(f"TOOL {name}: {description}")
+    parts.extend(history)
+    return "\x00".join(parts).encode("utf-8")
+
+
+def lcp_bytes(a: bytes, b: bytes) -> int:
+    n = min(len(a), len(b))
+    lo, hi = 0, n
+    while lo < hi:
+        mid = (lo + hi + 1) // 2
+        if a[:mid] == b[:mid]:
+            lo = mid
+        else:
+            hi = mid - 1
+    return lo
+
+
+async def run_kv_benchmark(backend, collection) -> dict[str, Any]:
+    from src.infra.agent.middleware import prompt_injection as pi
+
+    system_prompt = "You are LambChat agent. " * 20  # ~1KB 稳定 system
+    base_tool_descriptions = [
+        ("memory_recall", "base recall description"),
+        ("memory_retain", "base retain description"),
+        ("web_search", "search the web"),
+    ] * 10  # 放大 tools 段占比，贴近真实规模
+
+    async def index_context(user_id: str, session_id: str) -> str:
+        return await pi.build_memory_recall_index_context(user_id, session_id=session_id)
+
+    def turn_bytes(idx_ctx: str, turn: int, middleware_style: str) -> bytes:
+        tools = list(base_tool_descriptions)
+        if middleware_style == "inject":
+            tools[0] = ("memory_recall", f"base recall description\n\n{idx_ctx}")
+        history = [f"user: question {i}\nassistant: answer {i}" for i in range(1, turn + 1)]
+        return serialize_turn(system_prompt, tools, history)
+
+    scenarios: dict[str, Any] = {}
+
+    # 场景 1：无记忆用户（空索引）
+    pi._MEMORY_INDEX_SNAPSHOTS.clear()
+    empty_ctx = await index_context("bench-empty", "s-empty")
+    ratios = []
+    prev = None
+    for turn in range(1, 11):
+        cur = turn_bytes(empty_ctx, turn, "none" if not empty_ctx else "inject")
+        if prev is not None:
+            ratios.append(lcp_bytes(prev, cur) / len(cur))
+        prev = cur
+    scenarios["no_memory_user"] = {
+        "per_turn_prefix_hit": [round(r, 4) for r in ratios],
+        "avg": round(sum(ratios) / len(ratios), 4),
+    }
+
+    # 场景 2：项目用户、数据稳定 —— middleware 实例语义（首构建后冻结）
+    pi._MEMORY_INDEX_SNAPSHOTS.clear()
+    ctx = await index_context("bench-user", "s-stable")
+    assert "<memory_index" in ctx, "expected seeded index"
+    ratios = []
+    prev = None
+    for turn in range(1, 11):
+        cur = turn_bytes(ctx, turn, "inject")
+        if prev is not None:
+            ratios.append(lcp_bytes(prev, cur) / len(cur))
+        prev = cur
+    scenarios["project_user_stable"] = {
+        "per_turn_prefix_hit": [round(r, 4) for r in ratios],
+        "avg": round(sum(ratios) / len(ratios), 4),
+        "index_bytes": len(ctx.encode()),
+    }
+
+    # 场景 3：会话中途写入记忆 → 当前会话前缀不回溯变化（实例快照语义）
+    pi._MEMORY_INDEX_SNAPSHOTS.clear()
+    ctx_v1 = await index_context("bench-user", "s-mid")
+    before = turn_bytes(ctx_v1, 10, "inject")
+    # 中途写入一条新用户记忆 + 失效广播（清模块级快照）
+    await collection.insert_one(
+        {
+            "memory_id": "m-user-new-mid",
+            "user_id": "bench-user",
+            "title": "new preference",
+            "summary": "The user now prefers DuckDB for local analytics.",
+            "index_label": "new preference: DuckDB",
+            "memory_type": "user",
+            "context": "user_identity",
+            "tags": [],
+            "scope": "user",
+            "project_id": None,
+            "source": "manual",
+            "embedding": None,
+            "created_at": _now(),
+            "updated_at": _now(),
+            "accessed_at": _now(),
+            "access_count": 0,
+            "source_refs": [],
+            "content": "The user now prefers DuckDB for local analytics.",
+            "content_storage_mode": "inline",
+            "content_store_key": None,
+        }
+    )
+    pi._MEMORY_INDEX_SNAPSHOTS.clear()
+    # 等价 retain 的失效链路：pi 层经 tools._get_backend() 用的是全局单例，
+    # 失效必须打到同一实例（生产写入走同一单例，无此错位）
+    from src.infra.memory.tools import _get_backend
+
+    singleton = await _get_backend()
+    if singleton is not None:
+        await singleton._invalidate_cache("bench-user")
+    ctx_v2 = await index_context("bench-user", "s-mid-next-session")
+    after_same_session = turn_bytes(ctx_v1, 11, "inject")  # 已加载实例仍用 v1
+    after_new_session = turn_bytes(ctx_v2, 1, "inject")  # 新会话用 v2
+    scenarios["mid_session_write"] = {
+        "current_session_prefix_stable": lcp_bytes(before, after_same_session) == len(before),
+        "index_changed_for_new_session": ctx_v1 != ctx_v2,
+        "new_session_overlap_with_old": round(
+            lcp_bytes(before, after_new_session) / len(after_new_session), 4
+        ),
+    }
+    return scenarios
+
+
+async def main() -> int:
+    from src.kernel.config import settings
+
+    settings.MONGODB_DB = BENCHMARK_DB
+
+    from src.infra.storage.mongodb import get_mongo_client
+
+    client = get_mongo_client()
+    db = client[BENCHMARK_DB]
+    await client.drop_database(BENCHMARK_DB)
+
+    from src.infra.memory.client.native import NativeMemoryBackend
+    from src.infra.memory.client.native.models import COLLECTION_NAME
+
+    backend = NativeMemoryBackend()
+    t0 = time.perf_counter()
+    await backend.initialize()
+    init_s = time.perf_counter() - t0
+
+    collection = db[COLLECTION_NAME]
+    seed = await seed_memories(collection)
+
+    isolation = await run_isolation_benchmark(backend, collection)
+    kv = await run_kv_benchmark(backend, collection)
+
+    # 索引隔离：项目会话的索引不含他项目条目
+    index_proj = await backend.build_memory_index("bench-user", project_id="proj-alpha")
+    index_plain = await backend.build_memory_index("bench-user", project_id=None)
+    index_check = {
+        "alpha_index_contains_beta": "proj-beta" in index_proj,
+        "alpha_index_contains_alpha": "proj-alpha" in index_proj,
+        "plain_index_contains_any_project": "proj-alpha" in index_plain
+        or "proj-beta" in index_plain,
+        "revision_stable": index_proj.count("revision=") == 1,
+    }
+
+    report = {
+        "seed": seed,
+        "backend_init_seconds": round(init_s, 2),
+        "isolation": isolation,
+        "index": index_check,
+        "kv_prefix_stability": kv,
+        "verdict": {
+            "zero_cross_project_leak": not isolation["violations"],
+            "user_memory_cross_project_visible": isolation["user_memory_visible_in_project"],
+            "no_project_session_sees_nothing_project": all(
+                not v.get("leaked") for v in isolation["violations"] if "no_project_query" in v
+            ),
+        },
+    }
+    print(json.dumps(report, ensure_ascii=False, indent=2, default=str))
+
+    await backend.close()
+    await client.drop_database(BENCHMARK_DB)
+
+    ok = (
+        report["verdict"]["zero_cross_project_leak"]
+        and report["verdict"]["user_memory_cross_project_visible"]
+        and not index_check["alpha_index_contains_beta"]
+        and not index_check["plain_index_contains_any_project"]
+        and scenarios_ok(kv)
+    )
+    print("\nBENCHMARK:", "PASS" if ok else "FAIL")
+    return 0 if ok else 1
+
+
+def scenarios_ok(kv: dict[str, Any]) -> bool:
+    stable = kv["project_user_stable"]["avg"]
+    mid = kv["mid_session_write"]
+    return (
+        stable >= 0.97
+        and mid["current_session_prefix_stable"]
+        and mid["index_changed_for_new_session"]
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/scripts/benchmark_memory_scope.py
+++ b/scripts/benchmark_memory_scope.py
@@ -153,7 +153,6 @@ async def run_isolation_benchmark(backend, collection) -> dict[str, Any]:
                 if mid.startswith("m-proj-") and not mid.startswith(f"m-{pid}-")
             }
             own = f"m-{pid}-{topic}" in hit_ids
-            user_visible = any(mid.startswith("m-user-") or mid == "m-legacy-1" for mid in hit_ids)
             if foreign:
                 results["violations"].append(
                     {"project": pid, "query": topic, "foreign": sorted(foreign)}

--- a/scripts/cleanup_junk_memories.py
+++ b/scripts/cleanup_junk_memories.py
@@ -161,6 +161,8 @@ async def judge_memory_durability(model: Any, doc: dict[str, Any]) -> dict[str, 
     """单条 durable 判定；异常时保守 KEEP（清理是删数据，宁可漏删不可误删）。"""
     from langchain_core.messages import HumanMessage, SystemMessage
 
+    from src.infra.memory.extraction import response_text
+
     content = str(doc.get("content") or doc.get("summary") or "")[:4000]
     user_prompt = (
         f"title: {doc.get('title') or ''}\nsummary: {doc.get('summary') or ''}\ncontent: {content}"
@@ -172,7 +174,7 @@ async def judge_memory_durability(model: Any, doc: dict[str, Any]) -> dict[str, 
                 HumanMessage(content=user_prompt),
             ]
         )
-        keep, reason = parse_judge_reply(str(getattr(response, "content", "") or ""))
+        keep, reason = parse_judge_reply(response_text(response))
     except Exception as exc:
         # 只记异常类型：异常原文可能携带用户记忆内容
         logger.warning(

--- a/src/infra/agent/middleware/prompt_injection.py
+++ b/src/infra/agent/middleware/prompt_injection.py
@@ -106,9 +106,15 @@ class MemoryRecallIndexMiddleware(AgentMiddleware):
         handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]],
     ) -> ModelResponse[ResponseT]:
         if not self._loaded:
+            # 项目归属在会话首构建时解析一次并随快照固化：会话内归属不变，
+            # 前缀字节保持稳定（解析本身也受 2s 硬超时保护）
+            from src.infra.memory.scope import resolve_session_project_id
+
+            project_id = await resolve_session_project_id(self._session_id)
             self._index_context = await build_memory_recall_index_context(
                 self._user_id,
                 session_id=self._session_id,
+                project_id=project_id,
             )
             self._loaded = True
         if not self._index_context:
@@ -140,13 +146,16 @@ async def build_memory_recall_index_context(
     user_id: str,
     *,
     session_id: str | None,
+    project_id: str | None = None,
 ) -> str:
     """Build a navigation index for the recall tool without touching user messages."""
     from src.kernel.config import settings
 
     if not user_id or not getattr(settings, "NATIVE_MEMORY_INDEX_ENABLED", True):
         return ""
-    index_str = await _build_memory_index_for_user(user_id, session_id=session_id)
+    index_str = await _build_memory_index_for_user(
+        user_id, session_id=session_id, project_id=project_id
+    )
     if not index_str:
         return ""
     return (
@@ -160,14 +169,19 @@ async def build_memory_recall_index_context(
     )
 
 
-async def _build_memory_index_for_user(user_id: str, *, session_id: str | None = None) -> str:
+async def _build_memory_index_for_user(
+    user_id: str,
+    *,
+    session_id: str | None = None,
+    project_id: str | None = None,
+) -> str:
     """Build memory index string for a user. Returns empty string on any failure.
 
     Session-scoped snapshot (user_id, session_id): consecutive turns on any
     replica get identical bytes for the session lifetime. Empty results are
-    cached with a short TTL. The whole build (user-pref check + Mongo) is
-    hard-capped at 2s — on timeout, degrade to no injection (never block
-    the model call).
+    cached with a short TTL. The whole build (user-pref check + project
+    resolution + Mongo) is hard-capped at 2s — on timeout, degrade to no
+    injection (never block the model call).
     """
     import time as _time
 
@@ -195,7 +209,8 @@ async def _build_memory_index_for_user(user_id: str, *, session_id: str | None =
     # 硬超时：user_pref 检查 + 索引构建全链路 ≤ 2s，超时降级为不注入
     try:
         index = await asyncio.wait_for(
-            _build_memory_index_full(user_id), timeout=_MEMORY_INDEX_BUILD_TIMEOUT_SECONDS
+            _build_memory_index_full(user_id, project_id=project_id),
+            timeout=_MEMORY_INDEX_BUILD_TIMEOUT_SECONDS,
         )
     except (asyncio.TimeoutError, Exception):
         logger.debug("[Memory] Index build timed out/failed for %s, degrading", user_id)
@@ -227,16 +242,16 @@ def _evict_oldest_snapshots() -> None:
             _MEMORY_INDEX_SNAPSHOTS.pop(k, None)
 
 
-async def _build_memory_index_full(user_id: str) -> str:
+async def _build_memory_index_full(user_id: str, *, project_id: str | None = None) -> str:
     """User-pref check + actual index build (called under wait_for)."""
     from src.infra.memory.user_pref import user_memory_enabled
 
     if not await user_memory_enabled(user_id):
         return ""
-    return await _build_memory_index_uncached(user_id)
+    return await _build_memory_index_uncached(user_id, project_id=project_id)
 
 
-async def _build_memory_index_uncached(user_id: str) -> str:
+async def _build_memory_index_uncached(user_id: str, *, project_id: str | None = None) -> str:
     try:
         from src.infra.memory.tools import _get_backend
 
@@ -248,7 +263,7 @@ async def _build_memory_index_uncached(user_id: str) -> str:
 
         if not isinstance(backend, NativeMemoryBackend):
             return ""
-        index = await backend.build_memory_index(user_id)
+        index = await backend.build_memory_index(user_id, project_id=project_id)
         return index if index else ""
     except Exception:
         logger.warning("[Memory] Failed to build memory index for user %s", user_id, exc_info=True)

--- a/src/infra/memory/client/base.py
+++ b/src/infra/memory/client/base.py
@@ -131,6 +131,8 @@ class MemoryBackend(ABC):
         tags: Optional[list[str]] = None,
         existing_memory_id: Optional[str] = None,
         source_refs: Optional[Sequence[ConversationSourceRef | dict[str, str]]] = None,
+        scope: Optional[str] = None,
+        project_id: Optional[str] = None,
     ) -> dict[str, Any]:
         """Store a memory."""
         ...
@@ -143,6 +145,7 @@ class MemoryBackend(ABC):
         max_results: int = 5,
         memory_types: Optional[list[str]] = None,
         context_filter: Optional[str] = None,
+        project_id: Optional[str] = None,
     ) -> dict[str, Any]:
         """Recall memories matching the query."""
         ...
@@ -210,6 +213,29 @@ def get_user_id_from_runtime(runtime: Any) -> Optional[str]:
                 context = configurable.get("context")
                 if context and hasattr(context, "user_id"):
                     return context.user_id
+    except Exception:
+        pass
+    return None
+
+
+def get_session_id_from_runtime(runtime: Any) -> Optional[str]:
+    """Extract session_id from ToolRuntime context (agent context object)."""
+    if not runtime:
+        return None
+    try:
+        if hasattr(runtime, "config"):
+            config = runtime.config
+            if isinstance(config, dict):
+                configurable = config.get("configurable", {})
+                context = configurable.get("context")
+                if context and hasattr(context, "session_id"):
+                    session_id = context.session_id
+                    if session_id:
+                        return str(session_id)
+                # sub-agent / fallback: LangGraph config 自带 session_id
+                session_id = configurable.get("session_id")
+                if session_id:
+                    return str(session_id)
     except Exception:
         pass
     return None

--- a/src/infra/memory/client/native/backend.py
+++ b/src/infra/memory/client/native/backend.py
@@ -67,8 +67,8 @@ class NativeMemoryBackend(MemoryBackend):
         self._httpx_client: Any = None  # keep ref for proper cleanup
         self._store: Any = None
         self._logger = logger
-        # In-memory cache for memory index: {user_id: (built_at, index_str)}
-        self._index_cache: dict[str, tuple[float, str]] = {}
+        # In-memory cache for memory index: {(user_id, project_id): (built_at, index_str)}
+        self._index_cache: dict[tuple[str, str], tuple[float, str]] = {}
 
     @property
     def name(self) -> str:
@@ -80,7 +80,8 @@ class NativeMemoryBackend(MemoryBackend):
 
     async def _invalidate_cache(self, user_id: str) -> None:
         """Invalidate local index cache and publish invalidation to other instances."""
-        self._index_cache.pop(user_id, None)
+        for key in [k for k in self._index_cache if k[0] == user_id]:
+            self._index_cache.pop(key, None)
         try:
             from src.infra.memory.distributed import publish_memory_invalidation
 
@@ -163,6 +164,8 @@ class NativeMemoryBackend(MemoryBackend):
         tags: Optional[list[str]] = None,
         existing_memory_id: Optional[str] = None,
         source_refs: Optional[Sequence[ConversationSourceRef | dict[str, str]]] = None,
+        scope: Optional[str] = None,
+        project_id: Optional[str] = None,
     ) -> dict[str, Any]:
         # --- Validation (relaxed for manual retention — trust user intent) ---
         if len(content.strip()) < 5:
@@ -170,6 +173,13 @@ class NativeMemoryBackend(MemoryBackend):
                 "success": False,
                 "error": "Content too short (minimum 5 characters)",
             }
+
+        from src.infra.memory.scope import ScopeResolutionError, resolve_retain_scope
+
+        try:
+            scope, project_id = resolve_retain_scope(scope=scope, project_id=project_id)
+        except ScopeResolutionError as exc:
+            return {"success": False, "error": str(exc)}
 
         if not is_manual_memory_worthy(content, context):
             return {
@@ -194,10 +204,18 @@ class NativeMemoryBackend(MemoryBackend):
             enriched = await llm_enrich_memory(self, content)
             tags = enriched["tags"]
 
+        from src.infra.memory.scope import build_dedup_scope_clause
+
+        dedup_scope_clause = build_dedup_scope_clause(scope, project_id)
+
         async def fetch_recent_memories(target_user_id: str) -> list[dict[str, Any]]:
             seven_days_ago = utc_now() - timedelta(days=7)
             return await self._collection.find(
-                {"user_id": target_user_id, "updated_at": {"$gte": seven_days_ago}},
+                {
+                    "user_id": target_user_id,
+                    "updated_at": {"$gte": seven_days_ago},
+                    **dedup_scope_clause,
+                },
                 {"summary": 1, "memory_id": 1, "memory_type": 1},
             ).to_list(length=50)
 
@@ -207,6 +225,7 @@ class NativeMemoryBackend(MemoryBackend):
                     "user_id": target_user_id,
                     "embedding": {"$exists": True, "$ne": None},
                     "source": {"$ne": "session_summary"},
+                    **dedup_scope_clause,
                 },
                 {"memory_id": 1, "memory_type": 1, "summary": 1, "embedding": 1},
             ).to_list(length=200)
@@ -290,6 +309,8 @@ class NativeMemoryBackend(MemoryBackend):
                         "index_label": build_index_label(title, summary, content),
                         "context": context,
                         "tags": tags,
+                        "scope": scope,
+                        "project_id": project_id,
                         "embedding": embedding,
                         "updated_at": now,
                         "source_refs": source_ref_docs,
@@ -313,11 +334,15 @@ class NativeMemoryBackend(MemoryBackend):
                 memory_type=memory_type,
                 context=context,
                 updated_at_ts=int(now.timestamp()),
+                scope=scope,
+                project_id=project_id,
             )
             return {
                 "success": True,
                 "memory_id": _existing["memory_id"],
                 "memory_type": memory_type,
+                "scope": scope,
+                "project_id": project_id,
                 "updated_existing": True,
                 "message": "Memory updated successfully",
             }
@@ -331,6 +356,8 @@ class NativeMemoryBackend(MemoryBackend):
             "memory_type": memory_type,
             "context": context,
             "tags": tags,
+            "scope": scope,
+            "project_id": project_id,
             "source": "manual",
             "embedding": embedding,
             "created_at": now,
@@ -353,12 +380,16 @@ class NativeMemoryBackend(MemoryBackend):
             memory_type=memory_type,
             context=context,
             updated_at_ts=int(now.timestamp()),
+            scope=scope,
+            project_id=project_id,
         )
 
         return {
             "success": True,
             "memory_id": memory_id,
             "memory_type": memory_type,
+            "scope": scope,
+            "project_id": project_id,
             "message": "Memory stored successfully",
         }
 
@@ -369,9 +400,16 @@ class NativeMemoryBackend(MemoryBackend):
         max_results: int = 5,
         memory_types: Optional[list[str]] = None,
         context_filter: Optional[str] = None,
+        project_id: Optional[str] = None,
     ) -> dict[str, Any]:
         return await recall_memories(
-            self, user_id, query, max_results, memory_types, context_filter=context_filter
+            self,
+            user_id,
+            query,
+            max_results,
+            memory_types,
+            context_filter=context_filter,
+            project_id=project_id,
         )
 
     async def delete(
@@ -394,8 +432,8 @@ class NativeMemoryBackend(MemoryBackend):
             return {"success": True, "message": f"Memory {memory_id} deleted"}
         return {"success": False, "error": "Memory not found"}
 
-    async def build_memory_index(self, user_id: str) -> str:
-        return await build_memory_index(self, user_id)
+    async def build_memory_index(self, user_id: str, project_id: Optional[str] = None) -> str:
+        return await build_memory_index(self, user_id, project_id=project_id)
 
     async def _update_access_stats(self, memory_ids: list[str], user_id: str = "") -> None:
         query: dict[str, Any] = {"memory_id": {"$in": memory_ids}}
@@ -470,6 +508,13 @@ class NativeMemoryBackend(MemoryBackend):
             )
         except Exception as e:
             logger.warning(f"[NativeMemory] Session context index creation skipped: {e}")
+        try:
+            col.create_index(
+                [("user_id", 1), ("scope", 1), ("project_id", 1)],
+                name="native_mem_scope_idx",
+            )
+        except Exception as e:
+            logger.warning(f"[NativeMemory] Scope index creation skipped: {e}")
 
     async def _maybe_create_vector_index(self) -> None:
         """Best-effort 创建 vectorSearch 索引（MongoDB 8.2+ 社区版内置）。

--- a/src/infra/memory/client/native/indexing.py
+++ b/src/infra/memory/client/native/indexing.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import hashlib
 import time
 from datetime import datetime
-from typing import Any
+from typing import Any, Optional
 
+from src.infra.memory.client.native.search import build_scope_clause
 from src.infra.memory.client.types import MemoryType
 from src.infra.utils.datetime import ensure_utc, utc_now
 from src.kernel.config import settings
@@ -38,7 +40,20 @@ def choose_index_memories(
     return ranked[:per_type_limit]
 
 
-def evict_index_cache(index_cache: dict[str, tuple[float, str]], max_size: int) -> None:
+def compute_index_revision(docs: list[dict[str, Any]]) -> str:
+    """内容派生 revision：相同候选集 → 相同 revision（→ 相同索引字节）。
+
+    不维护计数器：计数器需要跨副本原子递增 + 失效广播，而内容 hash 天然
+    满足"相同数据 → 相同字节"，且可直接观测"索引是否真的变了"。
+    """
+    parts = sorted(
+        f"{doc.get('memory_id', '')}:{ensure_utc(doc.get('updated_at', ensure_utc(utc_now()))).isoformat()}"
+        for doc in docs
+    )
+    return hashlib.sha1("|".join(parts).encode("utf-8")).hexdigest()[:12]
+
+
+def evict_index_cache(index_cache: dict[tuple[str, str], tuple[float, str]], max_size: int) -> None:
     now = time.monotonic()
     cache_ttl = getattr(settings, "NATIVE_MEMORY_INDEX_CACHE_TTL", 300)
     expired = [uid for uid, (t, _) in index_cache.items() if (now - t) >= cache_ttl]
@@ -51,9 +66,10 @@ def evict_index_cache(index_cache: dict[str, tuple[float, str]], max_size: int) 
             del index_cache[uid]
 
 
-async def build_memory_index(backend, user_id: str) -> str:
+async def build_memory_index(backend, user_id: str, project_id: Optional[str] = None) -> str:
+    cache_key = (user_id, project_id or "")
     cache_ttl = getattr(settings, "NATIVE_MEMORY_INDEX_CACHE_TTL", 300)
-    cached = backend._index_cache.get(user_id)
+    cached = backend._index_cache.get(cache_key)
     if cached:
         built_at, cached_str = cached
         if (time.monotonic() - built_at) < cache_ttl:
@@ -68,10 +84,15 @@ async def build_memory_index(backend, user_id: str) -> str:
         "memory_type": 1,
         "source": 1,
         "context": 1,
+        "memory_id": 1,
     }
     docs = (
         await backend._collection.find(
-            {"user_id": user_id, "source": {"$ne": "session_summary"}},
+            {
+                "user_id": user_id,
+                "source": {"$ne": "session_summary"},
+                **build_scope_clause(project_id),
+            },
             projection,
         )
         .sort("updated_at", -1)
@@ -82,6 +103,7 @@ async def build_memory_index(backend, user_id: str) -> str:
     if not docs:
         return ""
 
+    revision = compute_index_revision(docs)
     now = utc_now()
     grouped: dict[str, list[dict[str, Any]]] = {}
     for doc in docs:
@@ -111,7 +133,7 @@ async def build_memory_index(backend, user_id: str) -> str:
     lesson_docs.sort(key=lambda d: str(d.get("updated_at") or ""), reverse=True)
     lesson_docs = lesson_docs[:3]
 
-    lines = ["<memory_index>", "# Cross-Session Memory Index"]
+    lines = [f'<memory_index revision="{revision}">', "# Cross-Session Memory Index"]
     if lesson_docs:
         lesson_lines: list[str] = ["\n## Lessons"]
         for d in lesson_docs:
@@ -146,6 +168,6 @@ async def build_memory_index(backend, user_id: str) -> str:
 
     lines.append("\n</memory_index>")
     result = "\n".join(lines)
-    backend._index_cache[user_id] = (time.monotonic(), result)
+    backend._index_cache[cache_key] = (time.monotonic(), result)
     evict_index_cache(backend._index_cache, backend._INDEX_CACHE_MAX_SIZE)
     return result

--- a/src/infra/memory/client/native/search.py
+++ b/src/infra/memory/client/native/search.py
@@ -44,6 +44,23 @@ def build_context_clause(context_filter: str) -> dict[str, Any]:
     return {"$regex": f"^{re.escape(context_filter.strip())}"}
 
 
+def build_scope_clause(project_id: Optional[str]) -> dict[str, Any]:
+    """scope 硬过滤子句：归属边界先于相关性。
+
+    - 无项目会话：只见 user/reference（含 legacy 无 scope 文档）
+    - 项目会话：user/reference + 本项目 project 记忆；其他项目一律不可见
+    """
+    visible = {"$in": [None, "user", "reference"]}
+    if project_id:
+        return {
+            "$or": [
+                {"scope": visible},
+                {"scope": "project", "project_id": project_id},
+            ]
+        }
+    return {"scope": visible}
+
+
 async def _hydrate_memories_limited(
     backend, memories: list[dict[str, Any]]
 ) -> list[dict[str, Any]]:
@@ -117,6 +134,8 @@ def format_memory(doc: dict, score: float, now: datetime | None = None) -> dict:
         "summary": doc["summary"],
         "title": doc.get("title", ""),
         "type": doc["memory_type"],
+        "scope": doc.get("scope") or "user",
+        "project_id": doc.get("project_id"),
         "source": doc.get("source", "manual"),
         "storage_mode": doc.get("content_storage_mode", "inline"),
         "content_store_key": doc.get("content_store_key"),
@@ -140,10 +159,17 @@ def prioritize_sources(memories: list[dict]) -> list[dict]:
         "consolidated": 2,
         "session_summary": 99,
     }
+    # 同 source 同分时当前项目上下文优先于用户级泛化记忆
+    scope_order = {
+        "project": 0,
+        "user": 1,
+        "reference": 1,
+    }
     return sorted(
         memories,
         key=lambda memory: (
             source_order.get(str(memory.get("source", "")), 50),
+            scope_order.get(str(memory.get("scope") or "user"), 1),
             -float(memory.get("score", 0.0) or 0.0),
         ),
     )
@@ -168,12 +194,14 @@ async def recent_context_fallback(
     limit: int,
     memory_types: Optional[list[str]],
     context_filter: Optional[str] = None,
+    project_id: Optional[str] = None,
 ) -> list[dict]:
     base: dict[str, Any] = {"user_id": user_id, "source": {"$ne": "session_summary"}}
     if memory_types:
         base["memory_type"] = {"$in": memory_types}
     if context_filter:
         base["context"] = build_context_clause(context_filter)
+    base.update(build_scope_clause(project_id))
     cursor = (
         collection.find(
             base,
@@ -207,12 +235,14 @@ async def text_search(
     limit: int,
     memory_types: Optional[list[str]],
     context_filter: Optional[str] = None,
+    project_id: Optional[str] = None,
 ) -> list[dict]:
     base: dict[str, Any] = {"user_id": user_id, "source": {"$ne": "session_summary"}}
     if memory_types:
         base["memory_type"] = {"$in": memory_types}
     if context_filter:
         base["context"] = build_context_clause(context_filter)
+    base.update(build_scope_clause(project_id))
     base["$text"] = {"$search": query}
 
     try:
@@ -225,12 +255,12 @@ async def text_search(
     except Exception:
         logger.debug("[NativeMemory] Text search failed, falling back to keyword match")
         docs = await keyword_fallback(
-            collection, user_id, query, limit, memory_types, context_filter
+            collection, user_id, query, limit, memory_types, context_filter, project_id
         )
     else:
         if not docs:
             docs = await keyword_fallback(
-                collection, user_id, query, limit, memory_types, context_filter
+                collection, user_id, query, limit, memory_types, context_filter, project_id
             )
 
     return [format_memory(doc, doc.get("score", 0)) for doc in docs]
@@ -243,6 +273,7 @@ async def keyword_fallback(
     limit: int,
     memory_types: Optional[list[str]],
     context_filter: Optional[str] = None,
+    project_id: Optional[str] = None,
 ) -> list[dict]:
     clauses = build_keyword_clauses(query)
     if not clauses:
@@ -257,6 +288,11 @@ async def keyword_fallback(
         base["memory_type"] = {"$in": memory_types}
     if context_filter:
         base["context"] = build_context_clause(context_filter)
+    scope_clause = build_scope_clause(project_id)
+    if "$or" in scope_clause:
+        base["$and"] = [scope_clause]
+    else:
+        base.update(scope_clause)
 
     _projection = {
         "memory_id": 1,
@@ -287,6 +323,7 @@ async def vector_search(
     limit: int,
     memory_types: Optional[list[str]],
     context_filter: Optional[str] = None,
+    project_id: Optional[str] = None,
 ) -> list[dict]:
     query_vec = await backend._maybe_embed(query)
     if not query_vec:
@@ -315,6 +352,8 @@ async def vector_search(
 
     qdrant_hits = None
     if not context_prefetch_failed:
+        # scope 过滤不在 Qdrant 下推（旧 point 缺 scope 字段的语义不可靠），
+        # 由下方 Mongo hydration 查询做权威过滤；limit 已放大缓解召回不足
         qdrant_hits = await index_search(
             vector=query_vec,
             user_id=user_id,
@@ -331,6 +370,7 @@ async def vector_search(
                 "user_id": user_id,
                 "memory_id": {"$in": list(order)},
                 "source": {"$ne": "session_summary"},
+                **build_scope_clause(project_id),
             },
             {"embedding": 0},
         )
@@ -347,6 +387,7 @@ async def vector_search(
         base["memory_type"] = {"$in": memory_types}
     if context_filter:
         base["context"] = build_context_clause(context_filter)
+    base.update(build_scope_clause(project_id))
 
     try:
         pipeline = [
@@ -598,6 +639,7 @@ async def recall_memories(
     touch_access: bool = True,
     enable_rerank: bool = True,
     context_filter: Optional[str] = None,
+    project_id: Optional[str] = None,
 ) -> dict[str, Any]:
     max_results = max(1, min(int(max_results or 1), NATIVE_MEMORY_RECALL_MAX_RESULTS))
     query = _clip_recall_query(query)
@@ -609,12 +651,15 @@ async def recall_memories(
         max_results * 2,
         memory_types,
         context_filter,
+        project_id,
     )
 
     if backend._embedding_fn:
         text_results, vector_results = await asyncio.gather(
             text_coro,
-            vector_search(backend, user_id, query, max_results * 2, memory_types, context_filter),
+            vector_search(
+                backend, user_id, query, max_results * 2, memory_types, context_filter, project_id
+            ),
         )
     else:
         text_results = await text_coro
@@ -624,7 +669,7 @@ async def recall_memories(
 
     if not memories and is_context_overview_query(query):
         memories = await recent_context_fallback(
-            backend._collection, user_id, max_results * 2, memory_types, context_filter
+            backend._collection, user_id, max_results * 2, memory_types, context_filter, project_id
         )
 
     # rerank 全池排序（不提前截断），让 min_score 过滤后仍有足额候选回填 top-N

--- a/src/infra/memory/client/native/vector_store.py
+++ b/src/infra/memory/client/native/vector_store.py
@@ -112,6 +112,8 @@ class QdrantVectorIndex:
         memory_type: str,
         context: Optional[str],
         updated_at: int,
+        scope: Optional[str] = None,
+        project_id: Optional[str] = None,
     ) -> bool:
         from qdrant_client.models import PointStruct
 
@@ -128,6 +130,10 @@ class QdrantVectorIndex:
                             "memory_type": memory_type,
                             "context": context,
                             "updated_at": updated_at,
+                            # scope 过滤的权威在 Mongo hydration；payload 携带
+                            # 归属字段供未来精确下推与排查
+                            "scope": scope or "user",
+                            "project_id": project_id,
                         },
                     )
                 ],
@@ -311,6 +317,8 @@ async def index_write_through(
     memory_type: str,
     context: Optional[str],
     updated_at_ts: int,
+    scope: Optional[str] = None,
+    project_id: Optional[str] = None,
 ) -> bool:
     idx = await get_vector_index()
     if idx is None or not embedding:
@@ -322,6 +330,8 @@ async def index_write_through(
         memory_type=memory_type,
         context=context,
         updated_at=updated_at_ts,
+        scope=scope,
+        project_id=project_id,
     )
 
 
@@ -370,6 +380,8 @@ async def backfill_from_mongo(collection, batch_size: int = 100) -> dict:
             "memory_type": 1,
             "context": 1,
             "updated_at": 1,
+            "scope": 1,
+            "project_id": 1,
         },
     )
     batch: list[PointStruct] = []
@@ -387,6 +399,8 @@ async def backfill_from_mongo(collection, batch_size: int = 100) -> dict:
                         if hasattr(doc.get("updated_at"), "timestamp")
                         else (doc.get("updated_at") or 0)
                     ),
+                    "scope": doc.get("scope") or "user",
+                    "project_id": doc.get("project_id"),
                 },
             )
         )

--- a/src/infra/memory/extraction.py
+++ b/src/infra/memory/extraction.py
@@ -119,7 +119,13 @@ async def find_candidate_sessions(db, user_id: str, *, limit: int) -> list[dict[
                 idle_seconds=cfg["idle_seconds"],
                 max_age_days=cfg["max_age_days"],
             ),
-            {"session_id": 1, "name": 1, "updated_at": 1, "metadata.agent_id": 1},
+            {
+                "session_id": 1,
+                "name": 1,
+                "updated_at": 1,
+                "metadata.agent_id": 1,
+                "metadata.project_id": 1,
+            },
         )
         .sort("updated_at", -1)
         .limit(limit)
@@ -386,6 +392,25 @@ def render_stage_one_input(
     return redact_secrets("\n".join(parts))
 
 
+def response_text(response: Any) -> str:
+    """归一化 provider 响应 content 为纯文本。
+
+    Anthropic 协议的 content 是块列表（reasoning/text/tool_use 混排），直接
+    str(list) 会得到 Python repr 导致 JSON 解析 100% 失败（生产 188 个 job
+    全部 unparseable_output 的事故根因）。字符串 content 原样返回。
+    """
+    content = getattr(response, "content", None)
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "".join(
+            str(block.get("text") or "")
+            for block in content
+            if isinstance(block, dict) and block.get("type") == "text"
+        )
+    return ""
+
+
 def parse_stage_one_output(text: str) -> dict[str, Any] | None:
     """解析模型输出：裸 JSON（codex 契约：无 markdown 包装、无 JSON 外散文）。
 
@@ -500,7 +525,7 @@ async def extract_session_memory(
         logger.warning("[MemoryExtraction] LLM call failed for session %s: %s", session_id, exc)
         return ExtractionOutcome("failed", error=str(exc))
 
-    payload = parse_stage_one_output(str(getattr(response, "content", "") or ""))
+    payload = parse_stage_one_output(response_text(response))
     if payload is None:
         return ExtractionOutcome("failed", error="unparseable_output")
     if payload.get("noop"):
@@ -517,6 +542,9 @@ async def extract_session_memory(
     source_refs = [
         {"session_id": session_id, "run_id": turn["run_id"]} for turn in turns if turn.get("run_id")
     ][:20]
+    # 项目归属继承源会话（metadata.project_id）：拿不到可靠归属时 retain 侧
+    # 自动降级 user scope，不猜测
+    session_project_id = str((metadata or {}).get("project_id") or "").strip() or None
     try:
         result = await backend.retain(
             user_id,
@@ -526,6 +554,7 @@ async def extract_session_memory(
             summary=index_fields["summary"],
             tags=index_fields["tags"],
             source_refs=source_refs,
+            project_id=session_project_id,
         )
     except Exception as exc:
         # 只记异常类型：异常原文可能携带用户记忆内容（详细原因进 job.error）

--- a/src/infra/memory/scope.py
+++ b/src/infra/memory/scope.py
@@ -1,0 +1,110 @@
+"""记忆作用域（scope）——归属边界的单一事实源。
+
+scope 回答"这条记忆属于谁"（user / project / reference），与 `context` 的
+内容分类语义分离。项目归属永远来自可靠来源（显式参数或会话元数据），
+写入侧不做任何猜测；拿不到 project_id 的项目类内容降级为 user scope。
+
+设计文档：docs/superpowers/specs/2026-09-04-memory-scope-and-context-design.md
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Optional
+
+from src.infra.logging import get_logger
+
+logger = get_logger(__name__)
+
+MEMORY_SCOPES = ("user", "project", "reference")
+
+# 会话 → 项目解析的进程内缓存 TTL（含负缓存）。索引快照本身 30 分钟，
+# 60s 的归属可见性延迟可接受；会话中途改派项目最多一分钟内跟进。
+_SESSION_PROJECT_TTL_SECONDS = 60.0
+_SESSION_PROJECT_CACHE_MAX_SIZE = 4096
+
+_SESSION_PROJECT_CACHE: dict[str, tuple[float, Optional[str]]] = {}
+
+
+class ScopeResolutionError(ValueError):
+    """retain 的 scope 参数无法解析为合法归属。"""
+
+
+def resolve_retain_scope(
+    *,
+    scope: Optional[str],
+    project_id: Optional[str],
+) -> tuple[str, Optional[str]]:
+    """推导写入时的 (scope, project_id)。
+
+    - 非法 scope / scope=project 无 project_id → ScopeResolutionError
+    - 归属只认 project_id：显式 project_id（无 scope）→ project；
+      拿不到 project_id 的项目类内容降级 user（不猜归属，context 不参与）
+    - 非 project scope 一律清空 project_id
+    """
+    if scope is not None and scope not in MEMORY_SCOPES:
+        raise ScopeResolutionError(
+            f"Invalid scope '{scope}'; expected one of {', '.join(MEMORY_SCOPES)}"
+        )
+    pid = (project_id or "").strip() or None
+    if scope == "project" and pid is None:
+        raise ScopeResolutionError(
+            "scope='project' requires a project_id (no project context on this session)"
+        )
+    if scope is None:
+        scope = "project" if pid is not None else "user"
+    if scope != "project":
+        pid = None
+    return scope, pid
+
+
+def build_dedup_scope_clause(scope: str, project_id: Optional[str]) -> dict[str, Any]:
+    """写入侧语义/摘要去重的候选边界。
+
+    project 记忆只在同一 (scope, project_id) 内匹配——跨项目绝不合并；
+    user/reference 记忆的候选含 legacy 无 scope 文档（视同 user）。
+    """
+    if scope == "project":
+        return {"scope": "project", "project_id": project_id}
+    return {"scope": {"$in": [scope, None]}}
+
+
+def _get_sessions_collection():
+    from src.infra.storage.mongodb import get_mongo_client
+    from src.kernel.config import settings
+
+    client = get_mongo_client()
+    return client[settings.MONGODB_DB][settings.MONGODB_SESSIONS_COLLECTION]
+
+
+async def resolve_session_project_id(session_id: Optional[str]) -> Optional[str]:
+    """反查会话归属项目（sessions.metadata.project_id），带 TTL 缓存与降级。
+
+    任何失败 → None（按无项目行为继续），绝不阻塞调用方。
+    """
+    if not session_id:
+        return None
+    now = time.monotonic()
+    cached = _SESSION_PROJECT_CACHE.get(session_id)
+    if cached is not None and (now - cached[0]) < _SESSION_PROJECT_TTL_SECONDS:
+        return cached[1]
+
+    project_id: Optional[str] = None
+    try:
+        doc = await _get_sessions_collection().find_one(
+            {"session_id": session_id}, {"metadata.project_id": 1}
+        )
+        metadata = (doc or {}).get("metadata") or {}
+        project_id = str(metadata.get("project_id") or "").strip() or None
+    except Exception as exc:
+        logger.debug(
+            "[MemoryScope] session project lookup failed for %s: %s",
+            session_id,
+            type(exc).__name__,
+        )
+        project_id = None
+
+    if len(_SESSION_PROJECT_CACHE) >= _SESSION_PROJECT_CACHE_MAX_SIZE:
+        _SESSION_PROJECT_CACHE.clear()
+    _SESSION_PROJECT_CACHE[session_id] = (now, project_id)
+    return project_id

--- a/src/infra/memory/tools.py
+++ b/src/infra/memory/tools.py
@@ -18,6 +18,7 @@ from src.infra.logging import get_logger
 from src.infra.memory.client.base import (
     MemoryBackend,
     create_memory_backend,
+    get_session_id_from_runtime,
     get_user_id_from_runtime,
 )
 from src.infra.memory.compaction_agent import (
@@ -104,6 +105,13 @@ async def memory_retain(
         Optional[str],
         "Optional existing memory ID to update instead of relying on fuzzy deduplication.",
     ] = None,
+    scope: Annotated[
+        Optional[str],
+        "Ownership scope: 'user' (cross-project personal preference, default), "
+        "'project' (bound to the current session's project), or 'reference' "
+        "(external docs/links). Project ownership is inherited from the current "
+        "session; scope='project' is rejected when the session has no project.",
+    ] = None,
     source_refs: Annotated[
         Optional[list[ConversationSourceRef]],
         "Conversation sources for this memory. Use only session_id/run_id pairs returned by conversation history tools or memory_recall; never invent IDs.",
@@ -120,6 +128,8 @@ async def memory_retain(
     context, feedback, or external references. Use explicit context labels such as
     `user_identity`, `project_constraint`, `project_status`, `feedback_rule`, or
     `reference_link` instead of vague buckets like `user_preferences`.
+    Scope follows ownership: project knowledge is only visible to sessions of that
+    project; cross-project facts belong in 'user' or 'reference' scope.
     When a durable fact came from conversation history, preserve its authorized
     `source_refs`. Later, memory_recall returns these pointers and the SOP is to call
     get_conversation_detail for the original final answer.
@@ -135,6 +145,9 @@ async def memory_retain(
         return await _json_dumps_result({"success": False, "error": "Memory service not available"})
 
     try:
+        from src.infra.memory.scope import resolve_session_project_id
+
+        project_id = await resolve_session_project_id(get_session_id_from_runtime(runtime))
         result = await backend.retain(
             user_id,
             content,
@@ -144,6 +157,8 @@ async def memory_retain(
             tags=tags,
             existing_memory_id=existing_memory_id,
             source_refs=source_refs,
+            scope=scope,
+            project_id=project_id,
         )
         return await _json_dumps_result(result)
     except Exception as e:
@@ -172,6 +187,10 @@ async def memory_recall(
     Memories are not injected into user messages. When prior facts, preferences,
     project state, suppliers, prices, decisions, or corrections may matter, call this tool
     with a focused query instead of guessing from the compact index.
+    Scope isolation is automatic: results include user-level and reference memories
+    plus project memories bound to the current session's project; other projects'
+    memories are never returned. Each result carries a `scope` (and `project_id`
+    when project-scoped) — do not generalize a project constraint to other contexts.
     Each result returns complete `text` whenever storage is available; read it in
     full and do not omit fine-grained facts. `preview` is only a shortened view.
     Check `text_complete`: if false, say the detail is incomplete and search the
@@ -194,7 +213,12 @@ async def memory_recall(
         return await _json_dumps_result({"success": False, "error": "Memory service not available"})
 
     try:
-        result = await backend.recall(user_id, query, max_results, memory_types, context)
+        from src.infra.memory.scope import resolve_session_project_id
+
+        project_id = await resolve_session_project_id(get_session_id_from_runtime(runtime))
+        result = await backend.recall(
+            user_id, query, max_results, memory_types, context, project_id=project_id
+        )
         return await _json_dumps_result(result)
     except Exception as e:
         logger.error(f"[Memory] Failed to recall memories: {e}")

--- a/src/kernel/schemas/usage.py
+++ b/src/kernel/schemas/usage.py
@@ -98,6 +98,7 @@ class UsageDailyPoint(BaseModel):
     failed_requests: int = 0
     tool_calls: int = 0
     input_tokens: int = 0
+    cache_creation_tokens: int = 0
     cache_read_tokens: int = 0
     cache_read_share: float = 0.0
 

--- a/tests/api/routes/test_usage_routes.py
+++ b/tests/api/routes/test_usage_routes.py
@@ -373,6 +373,7 @@ async def test_dashboard_exposes_cache_read_share(monkeypatch) -> None:
                     "failed_requests": 0,
                     "tool_calls": 1,
                     "input_tokens": 300,
+                    "cache_creation_tokens": 50,
                     "cache_read_tokens": 250,
                 }
             ],

--- a/tests/infra/agent/middleware/test_prompt_injection_memory.py
+++ b/tests/infra/agent/middleware/test_prompt_injection_memory.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+import unittest.mock as mock
 
 import pytest
 from langchain_core.messages import HumanMessage
@@ -79,7 +80,9 @@ async def test_memory_recall_index_respects_dedicated_index_switch(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_memory_index_middleware_attaches_index_only_to_recall_tool(monkeypatch):
-    async def fake_index(user_id: str, *, session_id: str | None = None) -> str:
+    async def fake_index(
+        user_id: str, *, session_id: str | None = None, project_id: str | None = None
+    ) -> str:
         assert user_id == "u1"
         assert session_id == "s1"
         return "<memory_index>\n- 皮蛋供应商\n</memory_index>"
@@ -127,7 +130,9 @@ async def test_memory_index_middleware_attaches_index_only_to_recall_tool(monkey
 async def test_memory_index_middleware_is_stable_for_same_session(monkeypatch):
     calls = 0
 
-    async def fake_index(user_id: str, *, session_id: str | None = None) -> str:
+    async def fake_index(
+        user_id: str, *, session_id: str | None = None, project_id: str | None = None
+    ) -> str:
         nonlocal calls
         calls += 1
         return "<memory_index>stable</memory_index>"
@@ -157,3 +162,95 @@ async def test_memory_index_middleware_is_stable_for_same_session(monkeypatch):
 
     assert descriptions[0] == descriptions[1]
     assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_memory_write_does_not_break_current_session_snapshot():
+    """中途写记忆只影响新会话：已加载的 middleware 实例（=当前会话）字节不变。"""
+
+    class FakeRequest:
+        def __init__(self, tools):
+            self.tools = tools
+
+        def override(self, **updates):
+            updated = FakeRequest(self.tools)
+            for key, value in updates.items():
+                setattr(updated, key, value)
+            return updated
+
+    async def run_turn(middleware):
+        request = FakeRequest([_tool("memory_recall", "base")])
+
+        async def handler(updated):
+            return updated.tools[0].description
+
+        return await middleware.awrap_model_call(request, handler)
+
+    async def fake_index_v1(
+        user_id: str, *, session_id: str | None = None, project_id: str | None = None
+    ) -> str:
+        return "<memory_index>v1</memory_index>"
+
+    async def fake_index_v2(
+        user_id: str, *, session_id: str | None = None, project_id: str | None = None
+    ) -> str:
+        return "<memory_index>v2</memory_index>"
+
+    with mock.patch.object(pi, "_build_memory_index_for_user", fake_index_v1):
+        middleware = pi.MemoryRecallIndexMiddleware(user_id="u1", session_id="s-live")
+        first = await run_turn(middleware)
+
+    # 会话中途写入记忆 → 失效广播清空模块级快照 + 新数据
+    pi._MEMORY_INDEX_SNAPSHOTS.clear()
+
+    with mock.patch.object(pi, "_build_memory_index_for_user", fake_index_v2):
+        # 同一会话的下一轮：middleware 已加载，索引字节不变（KV 前缀不击穿）
+        second = await run_turn(middleware)
+        # 新会话：拿到新版本（写入对新会话可见）
+        fresh = await pi.build_memory_recall_index_context("u1", session_id="s-next")
+
+    assert first == second
+    assert "v1" in first
+    assert "v2" in fresh
+
+
+@pytest.mark.asyncio
+async def test_middleware_resolves_project_once_per_session(monkeypatch):
+    """project_id 在会话首构建时解析一次：后续轮次不再反查（字节稳定 + 省 Mongo）。"""
+    from src.infra.memory import scope as scope_module
+
+    resolve_calls: list[str | None] = []
+
+    async def fake_resolve(session_id):
+        resolve_calls.append(session_id)
+        return "proj-1"
+
+    async def fake_index(
+        user_id: str, *, session_id: str | None = None, project_id: str | None = None
+    ) -> str:
+        assert project_id == "proj-1"
+        return "<memory_index>scoped</memory_index>"
+
+    with mock.patch.object(scope_module, "resolve_session_project_id", fake_resolve):
+        with mock.patch.object(pi, "_build_memory_index_for_user", fake_index):
+            middleware = pi.MemoryRecallIndexMiddleware(user_id="u1", session_id="s1")
+
+            class FakeRequest:
+                def __init__(self, tools):
+                    self.tools = tools
+
+                def override(self, **updates):
+                    updated = FakeRequest(self.tools)
+                    for key, value in updates.items():
+                        setattr(updated, key, value)
+                    return updated
+
+            for _ in range(3):
+                request = FakeRequest([_tool("memory_recall", "base")])
+
+                async def handler(updated):
+                    return object()
+
+                await middleware.awrap_model_call(request, handler)
+
+    assert resolve_calls == ["s1"]

--- a/tests/infra/memory/native/test_indexing.py
+++ b/tests/infra/memory/native/test_indexing.py
@@ -2,7 +2,11 @@ from datetime import datetime, timezone
 
 import pytest
 
-from src.infra.memory.client.native.indexing import build_memory_index, choose_index_memories
+from src.infra.memory.client.native.indexing import (
+    build_memory_index,
+    choose_index_memories,
+    compute_index_revision,
+)
 
 
 def test_choose_index_memories_is_deterministic_without_access_count():
@@ -165,8 +169,9 @@ async def test_build_memory_index_renders_markdown_dates_and_summaries_without_i
 
     index = await build_memory_index(FakeBackend(docs), user_id="u1")
 
+    assert index.startswith('<memory_index revision="')
     assert index == (
-        "<memory_index>\n"
+        f'<memory_index revision="{compute_index_revision(docs)}">\n'
         "# Cross-Session Memory Index\n\n"
         "## User\n\n"
         "- **Current preference**\n"

--- a/tests/infra/memory/native/test_scope.py
+++ b/tests/infra/memory/native/test_scope.py
@@ -1,0 +1,659 @@
+"""Scope（归属边界）行为测试：写入推导、检索硬过滤、索引 revision、session 反查。
+
+设计文档：docs/superpowers/specs/2026-09-04-memory-scope-and-context-design.md
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from src.infra.memory.client.native import indexing
+from src.infra.memory.client.native.backend import NativeMemoryBackend
+from src.infra.memory.client.native.search import (
+    build_scope_clause,
+    format_memory,
+    prioritize_sources,
+)
+
+# ---------------------------------------------------------------------------
+# P0 scope 推导（纯函数）
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_retain_scope_rejects_unknown_scope():
+    from src.infra.memory.scope import ScopeResolutionError, resolve_retain_scope
+
+    with pytest.raises(ScopeResolutionError):
+        resolve_retain_scope(scope="global", project_id=None)
+
+
+def test_resolve_retain_scope_rejects_project_scope_without_project_id():
+    from src.infra.memory.scope import ScopeResolutionError, resolve_retain_scope
+
+    with pytest.raises(ScopeResolutionError):
+        resolve_retain_scope(scope="project", project_id=None)
+
+
+def test_resolve_retain_scope_infers_project_from_explicit_project_id():
+    from src.infra.memory.scope import resolve_retain_scope
+
+    scope, project_id = resolve_retain_scope(scope=None, project_id="p1")
+
+    assert scope == "project"
+    assert project_id == "p1"
+
+
+def test_resolve_retain_scope_ignores_project_context_without_project_id():
+    """归属只认 project_id：context=project_* 但无归属证据 → 降级 user，不猜。"""
+    from src.infra.memory.scope import resolve_retain_scope
+
+    scope, project_id = resolve_retain_scope(scope=None, project_id=None)
+
+    assert scope == "user"
+    assert project_id is None
+
+
+def test_resolve_retain_scope_project_context_with_project_id_becomes_project():
+    from src.infra.memory.scope import resolve_retain_scope
+
+    scope, project_id = resolve_retain_scope(scope=None, project_id="p1")
+
+    assert scope == "project"
+    assert project_id == "p1"
+
+
+def test_resolve_retain_scope_clears_project_id_for_user_scope():
+    from src.infra.memory.scope import resolve_retain_scope
+
+    scope, project_id = resolve_retain_scope(scope="user", project_id="p1")
+
+    assert scope == "user"
+    assert project_id is None
+
+
+# ---------------------------------------------------------------------------
+# P0 retain 落库与 scope 内去重
+# ---------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self, docs):
+        self._docs = docs
+
+    async def to_list(self, length):
+        return self._docs[:length]
+
+
+class _ScopeFakeCollection:
+    """按查询形状分流：embedding 键=语义候选；否则=摘要候选。
+
+    同时按查询中的 scope 去重边界过滤候选（模拟 Mongo 行为）：project 写入
+    只见同项目候选，user 写入含 legacy 无 scope 文档。
+    """
+
+    def __init__(self, summary_docs, semantic_docs):
+        self._summary_docs = summary_docs
+        self._semantic_docs = semantic_docs
+        self.find_queries: list[dict] = []
+        self.inserted: list[dict] = []
+        self.updated: list[tuple[dict, dict]] = []
+
+    @staticmethod
+    def _apply_scope_filter(query, docs):
+        scope_cond = query.get("scope")
+        if scope_cond is None:
+            return docs
+        if isinstance(scope_cond, dict) and "$in" in scope_cond:
+            allowed = set(scope_cond["$in"])
+            return [d for d in docs if d.get("scope") in allowed]
+        expected_pid = query.get("project_id")
+        return [
+            d for d in docs if d.get("scope") == "project" and d.get("project_id") == expected_pid
+        ]
+
+    def find(self, query, _projection):
+        self.find_queries.append(query)
+        if "embedding" in query:
+            return _FakeCursor(self._apply_scope_filter(query, self._semantic_docs))
+        return _FakeCursor(self._apply_scope_filter(query, self._summary_docs))
+
+    async def find_one(self, *_args, **_kwargs):
+        return {"content_storage_mode": "inline", "content_store_key": None, "source_refs": []}
+
+    async def update_one(self, query, payload):
+        self.updated.append((query, payload))
+
+    async def insert_one(self, doc):
+        self.inserted.append(doc)
+
+
+def _backend_with(collection) -> NativeMemoryBackend:
+    backend = NativeMemoryBackend()
+
+    async def fake_invalidate(_user_id):
+        return None
+
+    async def fake_embed(_text):
+        return [1.0, 0.0]
+
+    backend._collection = collection
+    backend._invalidate_cache = fake_invalidate  # type: ignore[method-assign]
+    backend._maybe_embed = fake_embed  # type: ignore[method-assign]
+    return backend
+
+
+@pytest.mark.asyncio
+async def test_retain_rejects_project_scope_without_project_id():
+    backend = _backend_with(_ScopeFakeCollection([], []))
+
+    result = await backend.retain(
+        "u1",
+        "The project uses uv for all Python dependency management.",
+        context="project_constraint",
+        scope="project",
+        title="uv deps",
+        summary="Project uses uv for dependency management.",
+        tags=["uv"],
+    )
+
+    assert result["success"] is False
+    assert "project" in str(result.get("error", "")).lower()
+
+
+@pytest.mark.asyncio
+async def test_retain_persists_scope_and_project_id_on_insert():
+    collection = _ScopeFakeCollection([], [])
+    backend = _backend_with(collection)
+
+    result = await backend.retain(
+        "u1",
+        "The LambChat project deploys via k8s with rolling updates and auto rollback.",
+        context="project_constraint",
+        project_id="proj-1",
+        title="k8s deploys",
+        summary="LambChat deploys via k8s with rollback.",
+        tags=["k8s"],
+    )
+
+    assert result["success"] is True
+    doc = collection.inserted[0]
+    assert doc["scope"] == "project"
+    assert doc["project_id"] == "proj-1"
+
+
+@pytest.mark.asyncio
+async def test_retain_defaults_to_user_scope_for_legacy_calls():
+    collection = _ScopeFakeCollection([], [])
+    backend = _backend_with(collection)
+
+    result = await backend.retain(
+        "u1",
+        "The user prefers raw SQL over ORMs for all analytics workloads.",
+        context="user_identity",
+        title="raw SQL",
+        summary="User prefers raw SQL for analytics.",
+        tags=["sql"],
+    )
+
+    assert result["success"] is True
+    doc = collection.inserted[0]
+    assert doc["scope"] == "user"
+    assert doc.get("project_id") is None
+
+
+@pytest.mark.asyncio
+async def test_retain_project_write_dedups_within_same_project_only():
+    """项目记忆的语义去重候选必须限定在同一 project 内。"""
+    now = datetime.now(timezone.utc)
+    other_project = {
+        "memory_id": "m-other",
+        "memory_type": "project",
+        "scope": "project",
+        "project_id": "proj-2",
+        "summary": "Project deploys via k8s.",
+        "embedding": [1.0, 0.0],
+        "updated_at": now,
+    }
+    collection = _ScopeFakeCollection([], [other_project])
+    backend = _backend_with(collection)
+
+    result = await backend.retain(
+        "u1",
+        "The project deploys via k8s with rolling updates.",
+        context="project_constraint",
+        project_id="proj-1",
+        title="k8s deploys",
+        summary="Project deploys via k8s with rollback.",
+        tags=["k8s"],
+    )
+
+    assert result["success"] is True
+    assert collection.inserted, "must NOT merge into another project's memory"
+    assert collection.inserted[0]["memory_id"] != "m-other"
+    semantic_query = next(q for q in collection.find_queries if "embedding" in q)
+    assert semantic_query.get("scope") == "project"
+    assert semantic_query.get("project_id") == "proj-1"
+
+
+@pytest.mark.asyncio
+async def test_retain_user_write_dedups_against_user_scope_and_legacy_docs():
+    """user 写入的摘要候选包含 legacy 无 scope 文档（视同 user）。"""
+    now = datetime.now(timezone.utc)
+    legacy = {
+        "memory_id": "m-legacy",
+        "memory_type": "user",
+        "summary": "Prefers raw SQL for analytics work.",
+        "updated_at": now,
+    }
+    collection = _ScopeFakeCollection([legacy], [])
+    backend = _backend_with(collection)
+
+    result = await backend.retain(
+        "u1",
+        "The user now prefers DuckDB but still raw SQL for analytics queries.",
+        context="user_identity",
+        title="SQL preference",
+        summary="Prefers raw SQL for analytics work.",
+        tags=["sql"],
+    )
+
+    assert result["success"] is True
+    assert result.get("updated_existing") is True
+    summary_query = next(q for q in collection.find_queries if "embedding" not in q)
+    assert summary_query.get("scope") == {"$in": ["user", None]}
+
+
+@pytest.mark.asyncio
+async def test_retain_update_sets_scope_fields_on_existing_memory():
+    now = datetime.now(timezone.utc)
+    existing = {
+        "memory_id": "m1",
+        "memory_type": "project",
+        "summary": "Project deploys via k8s with rollback.",
+        "updated_at": now,
+        "scope": "project",
+        "project_id": "proj-1",
+    }
+    collection = _ScopeFakeCollection([existing], [])
+    backend = _backend_with(collection)
+
+    result = await backend.retain(
+        "u1",
+        "The project deploys via k8s with rolling updates and auto rollback.",
+        context="project_constraint",
+        project_id="proj-1",
+        title="k8s deploys",
+        summary="Project deploys via k8s with rollback.",
+        tags=["k8s"],
+    )
+
+    assert result["success"] is True
+    assert result["updated_existing"] is True
+    _query, payload = collection.updated[0]
+    assert payload["$set"]["scope"] == "project"
+    assert payload["$set"]["project_id"] == "proj-1"
+
+
+# ---------------------------------------------------------------------------
+# P1 检索硬过滤
+# ---------------------------------------------------------------------------
+
+
+def test_build_scope_clause_without_project_hides_project_memories():
+    clause = build_scope_clause(None)
+
+    assert clause == {"scope": {"$in": [None, "user", "reference"]}}
+
+
+def test_build_scope_clause_with_project_includes_only_that_project():
+    clause = build_scope_clause("proj-1")
+
+    assert clause == {
+        "$or": [
+            {"scope": {"$in": [None, "user", "reference"]}},
+            {"scope": "project", "project_id": "proj-1"},
+        ]
+    }
+
+
+def test_prioritize_sources_prefers_current_project_scope():
+    memories = [
+        {"memory_id": "m-user", "source": "manual", "score": 0.9, "scope": "user"},
+        {
+            "memory_id": "m-proj",
+            "source": "manual",
+            "score": 0.5,
+            "scope": "project",
+            "project_id": "proj-1",
+        },
+    ]
+
+    ranked = prioritize_sources(memories)
+
+    assert ranked[0]["memory_id"] == "m-proj"
+
+
+def test_format_memory_exposes_scope_fields():
+    doc = {
+        "memory_id": "m1",
+        "user_id": "u1",
+        "content": "Project uses uv.",
+        "summary": "Project uses uv.",
+        "title": "uv",
+        "memory_type": "project",
+        "source": "manual",
+        "scope": "project",
+        "project_id": "proj-1",
+        "content_storage_mode": "inline",
+        "created_at": datetime(2026, 9, 1, tzinfo=timezone.utc),
+        "updated_at": datetime(2026, 9, 1, tzinfo=timezone.utc),
+    }
+
+    memory = format_memory(doc, score=1.0, now=datetime(2026, 9, 2, tzinfo=timezone.utc))
+
+    assert memory["scope"] == "project"
+    assert memory["project_id"] == "proj-1"
+
+
+@pytest.mark.asyncio
+async def test_text_search_threads_scope_clause():
+    from src.infra.memory.client.native import search as search_module
+
+    queries: list[dict] = []
+
+    class FakeCursor:
+        def sort(self, *_a, **_k):
+            return self
+
+        def limit(self, *_a, **_k):
+            return self
+
+        async def to_list(self, length):
+            # 非空结果：避免触发 keyword fallback 覆盖断言目标
+            return [
+                {
+                    "memory_id": "m1",
+                    "user_id": "u1",
+                    "content": "k8s rollback",
+                    "summary": "k8s rollback",
+                    "title": "k8s",
+                    "memory_type": "project",
+                    "scope": "project",
+                    "project_id": "proj-1",
+                    "source": "manual",
+                    "content_storage_mode": "inline",
+                    "created_at": datetime(2026, 9, 1, tzinfo=timezone.utc),
+                    "updated_at": datetime(2026, 9, 1, tzinfo=timezone.utc),
+                }
+            ]
+
+    class FakeCollection:
+        def find(self, query, *_a, **_k):
+            queries.append(query)
+            return FakeCursor()
+
+    await search_module.text_search(
+        collection=FakeCollection(),
+        logger=object(),
+        user_id="u1",
+        query="k8s rollback",
+        limit=5,
+        memory_types=None,
+        project_id="proj-1",
+    )
+
+    text_query = queries[0]
+    assert "$text" in text_query
+    assert text_query["$or"][1] == {"scope": "project", "project_id": "proj-1"}
+
+
+@pytest.mark.asyncio
+async def test_recall_memories_threads_project_id_to_all_paths(monkeypatch):
+    from src.infra.memory.client.native import search as search_module
+
+    seen: dict[str, object] = {}
+
+    async def fake_text_search(
+        collection,
+        logger,
+        user_id,
+        query,
+        limit,
+        memory_types,
+        context_filter=None,
+        project_id=None,
+    ):
+        seen["text_project_id"] = project_id
+        return []
+
+    async def fake_vector_search(
+        backend, user_id, query, limit, memory_types, context_filter=None, project_id=None
+    ):
+        seen["vector_project_id"] = project_id
+        return []
+
+    async def fake_fallback(
+        collection, user_id, limit, memory_types, context_filter=None, project_id=None
+    ):
+        seen["fallback_project_id"] = project_id
+        return []
+
+    monkeypatch.setattr(search_module, "text_search", fake_text_search)
+    monkeypatch.setattr(search_module, "vector_search", fake_vector_search)
+    monkeypatch.setattr(search_module, "recent_context_fallback", fake_fallback)
+
+    class FakeBackend:
+        _embedding_fn = object()  # truthy：gather 同时走 vector_search 路径
+        _logger = object()
+        _collection = object()
+
+        async def _update_access_stats(self, *_a, **_k):
+            return None
+
+    await search_module.recall_memories(
+        FakeBackend(),  # type: ignore[arg-type]
+        "u1",
+        "project context overview",
+        max_results=5,
+        project_id="proj-1",
+    )
+
+    assert seen["text_project_id"] == "proj-1"
+    assert seen["vector_project_id"] == "proj-1"
+    assert seen["fallback_project_id"] == "proj-1"
+
+
+# ---------------------------------------------------------------------------
+# P2 索引 scope 过滤与 revision
+# ---------------------------------------------------------------------------
+
+
+def _index_doc(mid: str, mtype: str = "project", updated: datetime | None = None, **extra):
+    doc = {
+        "memory_id": mid,
+        "title": f"title-{mid}",
+        "index_label": f"label-{mid}",
+        "summary": f"summary-{mid}",
+        "updated_at": updated or datetime(2026, 9, 1, tzinfo=timezone.utc),
+        "memory_type": mtype,
+        "source": "manual",
+        "context": "project_constraint",
+    }
+    doc.update(extra)
+    return doc
+
+
+def test_compute_index_revision_is_stable_and_sensitive():
+    docs = [_index_doc("m1"), _index_doc("m2")]
+
+    rev_same = indexing.compute_index_revision(docs)
+    rev_shuffled = indexing.compute_index_revision(list(reversed(docs)))
+    rev_changed = indexing.compute_index_revision(
+        [_index_doc("m1"), _index_doc("m2", updated=datetime(2026, 9, 3, tzinfo=timezone.utc))]
+    )
+
+    assert rev_same == rev_shuffled
+    assert rev_same != rev_changed
+    assert len(rev_same) == 12
+
+
+@pytest.mark.asyncio
+async def test_build_memory_index_filters_by_scope_and_carries_revision():
+    project_doc = _index_doc("m-proj", scope="project", project_id="proj-1")
+    other_project_doc = _index_doc("m-other", scope="project", project_id="proj-2")
+    user_doc = _index_doc("m-user", mtype="user", scope="user", context="user_identity")
+    docs = [project_doc, other_project_doc, user_doc]
+
+    seen: dict[str, object] = {}
+
+    class FakeCursor:
+        def __init__(self, result_docs):
+            self._docs = result_docs
+
+        def sort(self, *_a, **_k):
+            return self
+
+        def limit(self, *_a, **_k):
+            return self
+
+        async def to_list(self, length):
+            return self._docs
+
+    class FakeCollection:
+        def find(self, query, _projection):
+            seen["query"] = query
+            scope_clause = query.get("$or")
+            if scope_clause:
+                allowed_project = scope_clause[1]["project_id"]
+                docs_visible = [
+                    d
+                    for d in docs
+                    if d.get("scope") in (None, "user", "reference")
+                    or (d.get("scope") == "project" and d.get("project_id") == allowed_project)
+                ]
+            else:
+                docs_visible = docs
+            return FakeCursor(docs_visible)
+
+    class FakeBackend:
+        _collection = FakeCollection()
+        _index_cache: dict = {}
+        _INDEX_CACHE_MAX_SIZE = 1000
+
+    result = await indexing.build_memory_index(FakeBackend(), "u1", project_id="proj-1")  # type: ignore[arg-type]
+
+    assert "m-proj" in result or "label-m-proj" in result
+    assert "m-other" not in result and "label-m-other" not in result
+    assert "label-m-user" in result
+    assert 'revision="' in result
+    assert "$or" in seen["query"]
+
+
+@pytest.mark.asyncio
+async def test_build_memory_index_bytes_stable_across_rebuilds_with_same_data():
+    """数据未变时两次构建（绕过缓存）字节一致——KV 缓存前缀纪律。"""
+    docs = [
+        _index_doc("m-proj", scope="project", project_id="proj-1"),
+        _index_doc("m-user", mtype="user", scope="user", context="user_identity"),
+    ]
+
+    class FakeCursor:
+        def __init__(self, result_docs):
+            self._docs = result_docs
+
+        def sort(self, *_a, **_k):
+            return self
+
+        def limit(self, *_a, **_k):
+            return self
+
+        async def to_list(self, length):
+            return self._docs
+
+    class FakeCollection:
+        def find(self, *_a, **_k):
+            return FakeCursor(docs)
+
+    class FakeBackend:
+        _collection = FakeCollection()
+        _index_cache: dict = {}
+        _INDEX_CACHE_MAX_SIZE = 1000
+
+    first = await indexing.build_memory_index(FakeBackend(), "u1", project_id="proj-1")  # type: ignore[arg-type]
+    second = await indexing.build_memory_index(FakeBackend(), "u1", project_id="proj-1")  # type: ignore[arg-type]
+
+    assert first == second
+
+
+# ---------------------------------------------------------------------------
+# session → project 反查（scope.py）
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_session_project_id_returns_metadata_project(monkeypatch):
+    from src.infra.memory import scope as scope_module
+
+    class FakeSessions:
+        async def find_one(self, query, projection):
+            assert query == {"session_id": "s1"}
+            return {"metadata": {"project_id": "proj-1"}}
+
+    class FakeDB:
+        def __getitem__(self, _name):
+            return FakeSessions()
+
+    class FakeClient:
+        def __getitem__(self, _name):
+            return FakeDB()
+
+    monkeypatch.setattr(scope_module, "_get_sessions_collection", lambda: FakeSessions())
+    scope_module._SESSION_PROJECT_CACHE.clear()
+
+    project_id = await scope_module.resolve_session_project_id("s1")
+
+    assert project_id == "proj-1"
+    assert "s1" in scope_module._SESSION_PROJECT_CACHE
+
+
+@pytest.mark.asyncio
+async def test_resolve_session_project_id_degrades_to_none_on_error(monkeypatch):
+    from src.infra.memory import scope as scope_module
+
+    class BrokenSessions:
+        async def find_one(self, *_a, **_k):
+            raise RuntimeError("mongo down")
+
+    monkeypatch.setattr(scope_module, "_get_sessions_collection", lambda: BrokenSessions())
+    scope_module._SESSION_PROJECT_CACHE.clear()
+
+    assert await scope_module.resolve_session_project_id("s-broken") is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_session_project_id_caches_within_ttl(monkeypatch):
+    from src.infra.memory import scope as scope_module
+
+    calls: list[str] = []
+
+    class FakeSessions:
+        async def find_one(self, query, projection):
+            calls.append(str(query))
+            return None
+
+    monkeypatch.setattr(scope_module, "_get_sessions_collection", lambda: FakeSessions())
+    scope_module._SESSION_PROJECT_CACHE.clear()
+
+    await scope_module.resolve_session_project_id("s-cache")
+    await scope_module.resolve_session_project_id("s-cache")
+
+    assert len(calls) == 1
+    scope_module._SESSION_PROJECT_CACHE.clear()
+
+
+@pytest.mark.asyncio
+async def test_resolve_session_project_id_none_for_empty_session():
+    from src.infra.memory import scope as scope_module
+
+    assert await scope_module.resolve_session_project_id(None) is None
+    assert await scope_module.resolve_session_project_id("") is None

--- a/tests/infra/memory/native/test_search.py
+++ b/tests/infra/memory/native/test_search.py
@@ -148,16 +148,27 @@ async def test_recall_memories_threads_context_filter(monkeypatch):
     captured = {}
 
     async def fake_text_search(
-        collection, logger, user_id, query, limit, memory_types, context_filter=None
+        collection,
+        logger,
+        user_id,
+        query,
+        limit,
+        memory_types,
+        context_filter=None,
+        project_id=None,
     ):
         captured["text"] = context_filter
         return []
 
-    async def fake_vector_search(backend, user_id, query, limit, memory_types, context_filter=None):
+    async def fake_vector_search(
+        backend, user_id, query, limit, memory_types, context_filter=None, project_id=None
+    ):
         captured["vector"] = context_filter
         return []
 
-    async def fake_fallback(collection, user_id, limit, memory_types, context_filter=None):
+    async def fake_fallback(
+        collection, user_id, limit, memory_types, context_filter=None, project_id=None
+    ):
         captured["fallback"] = context_filter
         return []
 
@@ -471,15 +482,24 @@ async def test_recall_memories_filters_min_score_before_truncation(monkeypatch):
     from src.infra.memory.client.native.search import recall_memories
 
     async def fake_text_search(
-        collection, logger, user_id, query, limit, memory_types, context_filter=None
+        collection,
+        logger,
+        user_id,
+        query,
+        limit,
+        memory_types,
+        context_filter=None,
+        project_id=None,
     ):
         return []
 
-    async def fake_vector_search(backend, user_id, query, limit, memory_types, context_filter=None):
+    async def fake_vector_search(
+        backend, user_id, query, limit, memory_types, context_filter=None, project_id=None
+    ):
         return []
 
     async def fake_recent_context_fallback(
-        collection, user_id, limit, memory_types, context_filter=None
+        collection, user_id, limit, memory_types, context_filter=None, project_id=None
     ):
         return []
 

--- a/tests/infra/memory/native/test_search_candidates.py
+++ b/tests/infra/memory/native/test_search_candidates.py
@@ -292,7 +292,14 @@ async def test_recall_memories_caps_requested_max_results(monkeypatch):
     seen: dict[str, int] = {}
 
     async def fake_text_search(
-        _collection, _logger, _user_id, _query, limit, _memory_types, context_filter=None
+        _collection,
+        _logger,
+        _user_id,
+        _query,
+        limit,
+        _memory_types,
+        context_filter=None,
+        project_id=None,
     ):
         seen["text_limit"] = limit
         return [
@@ -342,13 +349,20 @@ async def test_recall_memories_clips_oversized_query_before_search(monkeypatch):
     seen: dict[str, str] = {}
 
     async def fake_text_search(
-        _collection, _logger, _user_id, query, _limit, _memory_types, context_filter=None
+        _collection,
+        _logger,
+        _user_id,
+        query,
+        _limit,
+        _memory_types,
+        context_filter=None,
+        project_id=None,
     ):
         seen["text_query"] = query
         return []
 
     async def fake_vector_search(
-        _backend, _user_id, query, _limit, _memory_types, context_filter=None
+        _backend, _user_id, query, _limit, _memory_types, context_filter=None, project_id=None
     ):
         seen["vector_query"] = query
         return []

--- a/tests/infra/memory/test_extraction.py
+++ b/tests/infra/memory/test_extraction.py
@@ -1171,3 +1171,141 @@ def test_start_memory_extraction_agent_registers_even_when_memory_disabled(monke
     # job 无条件注册：热开启 ENABLE_MEMORY 后由 enabled lambda 动态放行
     assert len(recorded) == 1
     assert recorded[0].id == "memory.extraction"
+
+
+# ---------------------------------------------------------------------------
+# provider content blocks 归一化（Anthropic 协议 content 是块列表而非字符串）
+# ---------------------------------------------------------------------------
+
+
+def test_response_text_joins_text_blocks_and_skips_reasoning():
+    from src.infra.memory.extraction import response_text
+
+    blocks = [
+        {"type": "reasoning", "content": [], "encrypted_content": "gAAAA"},
+        {"type": "text", "text": '{"raw_memory":"皮蛋丁九只鸭15元/kg"'},
+        {"type": "text", "text": ',"rollout_summary":"汇报"}'},
+        {"type": "tool_use", "name": "x"},
+    ]
+    assert response_text(type("R", (), {"content": blocks})()) == (
+        '{"raw_memory":"皮蛋丁九只鸭15元/kg","rollout_summary":"汇报"}'
+    )
+    # 字符串 content 透传；空/异常 content 返回空串
+    assert response_text(type("R", (), {"content": "plain"})()) == "plain"
+    assert response_text(type("R", (), {"content": []})()) == ""
+    assert response_text(type("R", (), {"content": None})()) == ""
+
+
+@pytest.mark.asyncio
+async def test_extract_session_memory_parses_anthropic_content_blocks(monkeypatch):
+    """生产事故：提取模型 content 为块列表，str(list) 后 100% unparseable_output。"""
+
+    async def fake_model():
+        return object()
+
+    class FakeResponse:
+        content = [
+            {"type": "reasoning", "encrypted_content": "gAAAA", "content": []},
+            {
+                "type": "text",
+                "text": '{"raw_memory":"卤蛋现用旭日16元/kg","rollout_summary":"报价汇报",'
+                '"rollout_slug":"ludan","title":"卤蛋报价","summary":"旭日16元/kg",'
+                '"tags":["卤蛋"],"context":"project"}',
+            },
+        ]
+
+    async def fake_ainvoke(model, messages, operation=None):
+        return FakeResponse()
+
+    monkeypatch.setattr(extraction, "_get_extraction_model", fake_model)
+    import src.infra.llm.retry as retry_module
+
+    monkeypatch.setattr(retry_module, "ainvoke_with_retry", fake_ainvoke)
+
+    outcome = await extract_session_memory(
+        FakeBackend(),
+        _fake_db([_trace_doc("run-1", "卤蛋报价多少", "旭日16元/kg")]),
+        "u1",
+        {"session_id": "s1", "metadata": {}},
+    )
+
+    assert outcome.status == "succeeded"
+    assert outcome.memory_id == "m-1"
+
+
+@pytest.mark.asyncio
+async def test_extract_session_memory_inherits_session_project_id(monkeypatch):
+    """提取的项目知识继承源会话的 metadata.project_id。"""
+    base = _now()
+    trace_docs = [
+        _started_trace("run-1", base, "LambChat 部署方式是什么？", "k8s 滚动更新，失败自动回滚。")
+    ]
+
+    async def fake_model():
+        return object()
+
+    class FakeResponse:
+        content = (
+            '{"raw_memory":"LambChat 生产部署走 k8s，滚动失败自动回滚。",'
+            '"rollout_summary":"部署方式问询","rollout_slug":"lambchat-deploy",'
+            '"title":"k8s 部署","summary":"k8s 滚动+自动回滚",'
+            '"tags":["k8s","deploy"],"context":"project"}'
+        )
+
+    async def fake_ainvoke(model, messages, operation=None):
+        return FakeResponse()
+
+    monkeypatch.setattr(extraction, "_get_extraction_model", fake_model)
+    import src.infra.llm.retry as retry_module
+
+    monkeypatch.setattr(retry_module, "ainvoke_with_retry", fake_ainvoke)
+
+    backend = FakeBackend()
+    outcome = await extract_session_memory(
+        backend,
+        _fake_db(trace_docs),
+        "u1",
+        {"session_id": "s1", "name": "部署", "metadata": {"project_id": "proj-9"}},
+    )
+
+    assert outcome.status == "succeeded"
+    call = backend.retain_calls[0]
+    assert call["project_id"] == "proj-9"
+
+
+@pytest.mark.asyncio
+async def test_extract_session_memory_degrades_to_user_without_project(monkeypatch):
+    """无项目归属的会话：project_id=None 传入，由 retain 侧降级 user scope。"""
+    base = _now()
+    trace_docs = [_started_trace("run-1", base, "我喜欢什么样的回复风格？", "简洁、直接、带证据。")]
+
+    async def fake_model():
+        return object()
+
+    class FakeResponse:
+        content = (
+            '{"raw_memory":"用户偏好简洁直接带证据的回复。",'
+            '"rollout_summary":"风格偏好","rollout_slug":"reply-style",'
+            '"title":"回复风格","summary":"简洁直接带证据",'
+            '"tags":["style"],"context":"user"}'
+        )
+
+    async def fake_ainvoke(model, messages, operation=None):
+        return FakeResponse()
+
+    monkeypatch.setattr(extraction, "_get_extraction_model", fake_model)
+    import src.infra.llm.retry as retry_module
+
+    monkeypatch.setattr(retry_module, "ainvoke_with_retry", fake_ainvoke)
+
+    backend = FakeBackend()
+    outcome = await extract_session_memory(
+        backend,
+        _fake_db(trace_docs),
+        "u1",
+        {"session_id": "s2", "name": "风格", "metadata": {}},
+    )
+
+    assert outcome.status == "succeeded"
+    call = backend.retain_calls[0]
+    assert call["project_id"] is None

--- a/tests/infra/memory/test_tools.py
+++ b/tests/infra/memory/test_tools.py
@@ -6,8 +6,10 @@ import pytest
 
 
 class _Runtime:
-    def __init__(self, user_id: str | None) -> None:
-        context = SimpleNamespace(user_id=user_id) if user_id is not None else None
+    def __init__(self, user_id: str | None, session_id: str | None = None) -> None:
+        context = (
+            SimpleNamespace(user_id=user_id, session_id=session_id) if user_id is not None else None
+        )
         self.config = {"configurable": {"context": context}}
 
 
@@ -105,7 +107,13 @@ async def test_memory_recall_offloads_result_json(monkeypatch):
 
     class FakeBackend:
         async def recall(
-            self, user_id: str, query: str, max_results: int, memory_types, context_filter=None
+            self,
+            user_id: str,
+            query: str,
+            max_results: int,
+            memory_types,
+            context_filter=None,
+            project_id=None,
         ):
             assert user_id == "u1"
             assert query == "project"
@@ -376,3 +384,127 @@ def test_get_memory_guide_lists_delete_inline_when_deferred_loading_disabled(mon
     guide = subagent_prompts.get_memory_guide()
     assert "search_tools" not in guide
     assert "`memory_delete` (remove)" in guide
+
+
+@pytest.mark.asyncio
+async def test_memory_retain_resolves_project_from_runtime_session(monkeypatch):
+    """retain 工具经 runtime session 反查 project_id 并透传 scope。"""
+    from src.infra.memory import scope as scope_module
+    from src.infra.memory import tools as memory_tools
+
+    seen = {}
+
+    class FakeBackend:
+        async def retain(self, *args, **kwargs):
+            seen["args"] = args
+            seen["kwargs"] = kwargs
+            return {"success": True}
+
+    async def fake_get_backend():
+        return FakeBackend()
+
+    async def fake_resolve(session_id):
+        seen["resolved_session"] = session_id
+        return "proj-1"
+
+    monkeypatch.setattr(memory_tools, "_get_backend", fake_get_backend)
+    monkeypatch.setattr(scope_module, "resolve_session_project_id", fake_resolve)
+
+    result = json.loads(
+        await memory_tools.memory_retain.coroutine(
+            "The LambChat project deploys via k8s with auto rollback.",
+            scope="project",
+            runtime=_Runtime("u1", session_id="sess-1"),
+        )
+    )
+
+    assert result == {"success": True}
+    assert seen["resolved_session"] == "sess-1"
+    assert seen["kwargs"]["scope"] == "project"
+    assert seen["kwargs"]["project_id"] == "proj-1"
+
+
+@pytest.mark.asyncio
+async def test_memory_recall_applies_session_project_scope(monkeypatch):
+    """recall 工具把 session 归属项目作为硬过滤参数传入 backend。"""
+    from src.infra.memory import scope as scope_module
+    from src.infra.memory import tools as memory_tools
+
+    seen = {}
+
+    class FakeBackend:
+        async def recall(self, *args, **kwargs):
+            seen["args"] = args
+            seen["kwargs"] = kwargs
+            return {"success": True, "memories": []}
+
+    async def fake_get_backend():
+        return FakeBackend()
+
+    async def fake_resolve(session_id):
+        seen["resolved_session"] = session_id
+        return "proj-2"
+
+    monkeypatch.setattr(memory_tools, "_get_backend", fake_get_backend)
+    monkeypatch.setattr(scope_module, "resolve_session_project_id", fake_resolve)
+
+    result = json.loads(
+        await memory_tools.memory_recall.coroutine(
+            "k8s rollback policy",
+            runtime=_Runtime("u1", session_id="sess-2"),
+        )
+    )
+
+    assert result["success"] is True
+    assert seen["resolved_session"] == "sess-2"
+    assert seen["kwargs"]["project_id"] == "proj-2"
+
+
+@pytest.mark.asyncio
+async def test_memory_recall_without_session_uses_user_scope(monkeypatch):
+    """无 session 上下文（sub-agent 无 context 等）→ project_id=None，全用户域检索。"""
+    from src.infra.memory import scope as scope_module
+    from src.infra.memory import tools as memory_tools
+
+    seen = {}
+
+    class FakeBackend:
+        async def recall(self, *args, **kwargs):
+            seen["kwargs"] = kwargs
+            return {"success": True, "memories": []}
+
+    async def fake_get_backend():
+        return FakeBackend()
+
+    async def fake_resolve(session_id):
+        return None
+
+    monkeypatch.setattr(memory_tools, "_get_backend", fake_get_backend)
+    monkeypatch.setattr(scope_module, "resolve_session_project_id", fake_resolve)
+
+    result = json.loads(
+        await memory_tools.memory_recall.coroutine(
+            "user preferences",
+            runtime=_Runtime("u1"),
+        )
+    )
+
+    assert result["success"] is True
+    assert seen["kwargs"]["project_id"] is None
+
+
+def test_memory_retain_scope_param_documents_ownership_semantics():
+    from src.infra.memory.tools import memory_retain
+
+    scope_description = str(memory_retain.args["scope"].get("description") or "")
+    assert "project" in scope_description
+    assert "user" in scope_description
+    assert "reference" in scope_description
+
+
+def test_memory_recall_description_documents_scope_isolation():
+    from src.infra.memory.tools import memory_recall
+
+    description = memory_recall.description
+    assert "Scope isolation" in description
+    assert "never returned" in description


### PR DESCRIPTION
## 晋升内容（自 #384）

1. **#385 fix(memory): 提取输出兼容 content blocks + daily cw 透传 + 记忆 scope**
   - 生产提取 100% unparseable_output 根因修复（response_text 归一化）
   - UsageDailyPoint 补 cache_creation_tokens 声明
   - 会话级记忆 scope（user/project/reference，spec 齐全）
2. **#386 fix(ci): benchmark 脚本 F841 清理**

## staging 验证（develop-20260904-015516）

- 提取端到端：succeeded，落库记忆含三家供应商全部报价细节 + 5 个 run 出处绑定
- dashboard daily cache_creation_tokens：None → 0（透传修复生效）
- 缓存率串行复测：95.6% / 96.3% / 96.6%（scope 改动未引入前缀不稳）
- CI 全绿（Ruff/MyPy/后端 3512/前端/双架构镜像）