### PR TITLE
fix(scheduled_task): 定时任务确认卡片渲染与 ask_human pill 永久加载（develop → main 晋升）

### DIFF
--- a/frontend/src/components/panels/ScheduledTaskApprovalContent.tsx
+++ b/frontend/src/components/panels/ScheduledTaskApprovalContent.tsx
@@ -83,7 +83,7 @@ export function ScheduledTaskApprovalContent({
       <p>
         <strong>{t("approvals.scheduledTask.promptSent")}</strong>
       </p>
-      <pre>
+      <pre className="max-h-48 overflow-y-auto whitespace-pre-wrap break-words">
         <code>{preview.message}</code>
       </pre>
     </div>

--- a/frontend/src/components/panels/__tests__/askHumanLayout.test.ts
+++ b/frontend/src/components/panels/__tests__/askHumanLayout.test.ts
@@ -165,7 +165,6 @@ test("aligns the ask-human title group on one vertically centered row", () => {
 
 test("keeps approval text readable without truncation", () => {
   expect(approvalSource).not.toMatch(/approval-summary block truncate/);
-  expect(approvalCss).not.toMatch(/text-overflow:\s*ellipsis;/);
   expect(approvalCss).not.toMatch(
     /\.approval-ask-human-question\s*\{[^}]*white-space:\s*nowrap;/,
   );
@@ -174,6 +173,14 @@ test("keeps approval text readable without truncation", () => {
   );
   expect(approvalCss).toMatch(
     /\.approval-form--ask-human \.approval-input[\s\S]*?font-size:\s*1rem;/,
+  );
+});
+
+test("clamps the collapsed approval summary to two lines", () => {
+  // 折叠态摘要把整段确认文案压成一行且不截断，长消息（如定时任务确认）
+  // 会撑爆卡片；限制为两行省略。
+  expect(approvalCss).toMatch(
+    /\.approval-summary\s*\{[\s\S]*?-webkit-line-clamp:\s*2;[\s\S]*?overflow:\s*hidden;/,
   );
 });
 

--- a/frontend/src/hooks/useAgent.ts
+++ b/frontend/src/hooks/useAgent.ts
@@ -26,6 +26,7 @@ import {
   prepareMessagesForRunningRun,
   extractGoalFromEvents,
   extractGoalsByRunFromEvents,
+  createScheduledTaskApprovalLookup,
 } from "./useAgent/historyLoader";
 import { clearAllLoadingStates } from "./useAgent/messageParts";
 import { type EventHandlerContext } from "./useAgent/eventHandlers";
@@ -165,6 +166,10 @@ export function useAgent(options?: UseAgentOptions): UseAgentReturn {
     messagesRef.current = messages;
   }, [messages]);
 
+  // 历史回放查到已决的 scheduled-task 审批时，补收尾对应 ask_human pill（详见 historyLoader）
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- 工厂仅依赖 useState 的稳定 setter
+  const onApprovalLookup = useCallback(createScheduledTaskApprovalLookup(setMessages), []);
+
   // History trace-window pagination (older pages prepend on scroll)
   const {
     hasMoreHistoryTraces,
@@ -182,6 +187,7 @@ export function useAgent(options?: UseAgentOptions): UseAgentReturn {
     streamingMessageIdRef,
     setMessages,
     setGoalsByRunId,
+    onApprovalLookup,
   });
 
   // Create event handler context
@@ -355,7 +361,11 @@ export function useAgent(options?: UseAgentOptions): UseAgentReturn {
           let reconstructedMessages = reconstructMessagesFromEvents(
             historyEvents,
             processedEventIdsRef.current,
-            { options, activeSubagentStack: activeSubagentStackRef.current },
+            {
+              options,
+              activeSubagentStack: activeSubagentStackRef.current,
+              onApprovalLookup,
+            },
           );
           const lastTimestamp = getLastEventTimestamp(historyEvents);
           lastHistoryTimestampRef.current = lastTimestamp;

--- a/frontend/src/hooks/useAgent/__tests__/historyLoader.test.ts
+++ b/frontend/src/hooks/useAgent/__tests__/historyLoader.test.ts
@@ -2,7 +2,9 @@ import {
   normalizeEventRunIds,
   prepareMessagesForRunningRun,
   reconstructMessagesFromEvents,
+  resolveLegacyScheduledTaskApproval,
 } from "../historyLoader.ts";
+import { vi } from "vitest";
 import type { Message } from "../../../types";
 import type { HistoryEvent } from "../types.ts";
 
@@ -1482,4 +1484,164 @@ test("restores run modes on user messages from history events", () => {
 
   expect(messages.length).toBe(1);
   expect(messages[0]?.runModes).toEqual(["auto", "goal"]);
+});
+
+test("resolves a scheduled-task approval pill from an approval_resolved event without tool_call_id", () => {
+  const messages = reconstructMessagesFromEvents(
+    [
+      {
+        event_type: "user:message",
+        run_id: "run-st-confirm",
+        timestamp: "2026-09-01T00:00:00.000Z",
+        data: { content: "创建定时任务", message_id: "run-st-confirm:user" },
+      },
+      {
+        event_type: "approval_required",
+        run_id: "run-st-confirm",
+        timestamp: "2026-09-01T00:00:01.000Z",
+        data: {
+          id: "approval-st-1",
+          message: "Please confirm creation of this scheduled task.",
+          type: "confirm",
+          fields: [],
+          timeout: 300,
+        },
+      },
+      {
+        event_type: "approval_resolved",
+        run_id: "run-st-confirm",
+        timestamp: "2026-09-01T00:00:02.000Z",
+        data: {
+          id: "approval-st-1",
+          approval_id: "approval-st-1",
+          status: "approved",
+          success: true,
+          result: { status: "success", message: "ok", values: {} },
+        },
+      },
+    ] satisfies HistoryEvent[],
+    new Set<string>(),
+    { activeSubagentStack: [] },
+  );
+
+  const askHuman = messages[1]?.parts?.find(
+    (part) => part.type === "tool" && part.name === "ask_human",
+  );
+  expect(askHuman).toMatchObject({ isPending: false, success: true });
+});
+
+test("reports fetched scheduled-task approvals via onApprovalLookup", async () => {
+  const onApprovalLookup = vi.fn();
+  vi.stubGlobal("localStorage", {
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+  });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "approval-legacy-1",
+          status: "approved",
+          message: "Please confirm creation of this scheduled task.",
+          type: "confirm",
+          fields: [],
+          metadata: { approval_type: "scheduled_task_create" },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    ),
+  );
+
+  const messages = reconstructMessagesFromEvents(
+    [
+      {
+        event_type: "approval_required",
+        run_id: "run-legacy",
+        timestamp: "2026-09-01T00:00:00.000Z",
+        data: {
+          id: "approval-legacy-1",
+          message: "Please confirm creation of this scheduled task.",
+          type: "confirm",
+          fields: [],
+          timeout: 300,
+        },
+      } satisfies HistoryEvent,
+    ],
+    new Set<string>(),
+    { activeSubagentStack: [], onApprovalLookup },
+  );
+
+  // 事件本身不带 metadata（旧版后端），先按 pending 重建 pill
+  expect(messages[0]?.parts?.[0]).toMatchObject({
+    type: "tool",
+    name: "ask_human",
+    id: "approval-legacy-1",
+    isPending: true,
+  });
+
+  await vi.waitFor(() => expect(onApprovalLookup).toHaveBeenCalled());
+  const approval = onApprovalLookup.mock.calls[0]?.[0] as {
+    id: string;
+    status: string;
+    metadata?: Record<string, unknown>;
+  };
+
+  const resolved = resolveLegacyScheduledTaskApproval(messages, approval);
+  expect(resolved[0]?.parts?.[0]).toMatchObject({
+    isPending: false,
+    success: true,
+  });
+  vi.unstubAllGlobals();
+});
+
+test("resolveLegacyScheduledTaskApproval only touches terminal scheduled-task approvals", () => {
+  const buildMessages = () => [
+    {
+      id: "m1",
+      role: "assistant" as const,
+      content: "",
+      timestamp: new Date(),
+      parts: [
+        {
+          type: "tool" as const,
+          name: "ask_human",
+          id: "approval-x",
+          args: { message: "confirm?", fields: [] },
+          isPending: true,
+          depth: 0,
+        },
+      ],
+    },
+  ];
+
+  // pending 审批不动（卡片还要继续交互）
+  expect(
+    resolveLegacyScheduledTaskApproval(buildMessages(), {
+      id: "approval-x",
+      status: "pending",
+      metadata: { approval_type: "scheduled_task_create" },
+    })[0]?.parts?.[0],
+  ).toMatchObject({ isPending: true });
+
+  // 非 scheduled-task 审批不动（真实 ask_human 走 interrupt 恢复路径）
+  const untouched = buildMessages();
+  const result = resolveLegacyScheduledTaskApproval(untouched, {
+    id: "approval-x",
+    status: "approved",
+    metadata: { mode: "interrupt" },
+  });
+  expect(result[0]?.parts?.[0]).toMatchObject({ isPending: true });
+
+  // scheduled-task 已决审批：补收尾，避免幽灵 pill 永远转圈
+  const resolved = resolveLegacyScheduledTaskApproval(buildMessages(), {
+    id: "approval-x",
+    status: "rejected",
+    metadata: { approval_type: "scheduled_task_create" },
+  });
+  expect(resolved[0]?.parts?.[0]).toMatchObject({
+    isPending: false,
+    success: false,
+  });
 });

--- a/frontend/src/hooks/useAgent/historyLoader.ts
+++ b/frontend/src/hooks/useAgent/historyLoader.ts
@@ -46,6 +46,12 @@ interface ProcessHistoryOptions {
       metadata?: Record<string, unknown>;
     }) => void;
   };
+  /** 审批状态查询回调：无论 pending 与否都会收到，用于补收尾历史幽灵 pill。 */
+  onApprovalLookup?: (approval: {
+    id: string;
+    status: string;
+    metadata?: Record<string, unknown> | null;
+  }) => void;
   activeSubagentStack: SubagentStackItem[];
 }
 
@@ -210,8 +216,12 @@ function processHistoryEvent(
         ],
       };
     }
-    if (approvalData.id && opts.options?.onApprovalRequired) {
+    if (
+      approvalData.id &&
+      (opts.options?.onApprovalRequired || opts.onApprovalLookup)
+    ) {
       authFetch<{
+        id?: string;
         status: string;
         message?: string;
         type?: string;
@@ -220,6 +230,15 @@ function processHistoryEvent(
       }>(buildApiUrl(`/human/${approvalData.id}`))
         .then((data) => data ?? null)
         .then((approval) => {
+          if (approval?.id) {
+            // 无论 pending 与否都上报：已决的 scheduled-task 审批要在此
+            // 补收尾历史幽灵 pill（旧版事件没有 approval_resolved 可回放）
+            opts.onApprovalLookup?.({
+              id: approval.id,
+              status: approval.status,
+              metadata: approval.metadata ?? null,
+            });
+          }
           if (approval?.status === "pending") {
             opts.options?.onApprovalRequired?.({
               id: approvalData.id!,
@@ -839,4 +858,79 @@ export function extractGoalsByRunFromEvents(
   }
 
   return goalsByRunId;
+}
+
+/**
+ * 补收尾历史幽灵 ask_human pill：scheduled_task_create 的确认审批
+ * （approval_required 事件）会生成 ask_human pill，但工具结果带的是
+ * scheduled_task_create 自己的 tool_call_id，pill 永远停在「加载中」。
+ * 新版后端会写 approval_resolved 事件；旧数据靠审批终态查询在此兜底。
+ */
+export function resolveLegacyScheduledTaskApproval(
+  messages: Message[],
+  approval: {
+    id: string;
+    status: string;
+    metadata?: Record<string, unknown> | null;
+  },
+): Message[] {
+  if (
+    !approval?.id ||
+    approval.status === "pending" ||
+    approval.metadata?.approval_type !== "scheduled_task_create"
+  ) {
+    return messages;
+  }
+
+  const approved = approval.status === "approved";
+  const resultStatus = approved
+    ? "success"
+    : approval.status === "expired" || approval.status === "timeout"
+      ? "timeout"
+      : "rejected";
+
+  let changed = false;
+  const next = messages.map((message) => {
+    const hasPhantom = message.parts?.some(
+      (part) =>
+        part.type === "tool" &&
+        part.name === "ask_human" &&
+        part.id === approval.id &&
+        part.isPending,
+    );
+    if (!hasPhantom) return message;
+    changed = true;
+    return {
+      ...message,
+      parts: message.parts?.map((part) =>
+        part.type === "tool" &&
+        part.name === "ask_human" &&
+        part.id === approval.id &&
+        part.isPending
+          ? {
+              ...part,
+              isPending: false,
+              success: approved,
+              result: {
+                status: resultStatus,
+                message: `Scheduled task creation ${approval.status}.`,
+                values: {},
+              },
+            }
+          : part,
+      ),
+    };
+  });
+  return changed ? next : messages;
+}
+
+/** 构造 onApprovalLookup 回调：查到已决 scheduled-task 审批时补收尾幽灵 pill。 */
+export function createScheduledTaskApprovalLookup(
+  setMessages: (updater: (previous: Message[]) => Message[]) => void,
+) {
+  return (approval: {
+    id: string;
+    status: string;
+    metadata?: Record<string, unknown> | null;
+  }) => setMessages((previous) => resolveLegacyScheduledTaskApproval(previous, approval));
 }

--- a/frontend/src/hooks/useAgent/historyTracePagination.ts
+++ b/frontend/src/hooks/useAgent/historyTracePagination.ts
@@ -32,6 +32,11 @@ interface HistoryTracePaginationDeps {
   streamingMessageIdRef: RefObject<string | null>;
   setMessages: Dispatch<SetStateAction<Message[]>>;
   setGoalsByRunId: Dispatch<SetStateAction<Record<string, ActiveGoalSpec>>>;
+  onApprovalLookup?: (approval: {
+    id: string;
+    status: string;
+    metadata?: Record<string, unknown> | null;
+  }) => void;
 }
 
 export function useHistoryTracePagination(deps: HistoryTracePaginationDeps) {
@@ -44,6 +49,7 @@ export function useHistoryTracePagination(deps: HistoryTracePaginationDeps) {
     streamingMessageIdRef,
     setMessages,
     setGoalsByRunId,
+    onApprovalLookup,
   } = deps;
 
   const [hasMoreHistoryTraces, setHasMoreHistoryTraces] = useState(false);
@@ -141,7 +147,7 @@ export function useHistoryTracePagination(deps: HistoryTracePaginationDeps) {
       let reconstructedMessages = reconstructMessagesFromEvents(
         mergedEvents,
         processedEventIdsRef.current,
-        { options, activeSubagentStack: [] },
+        { options, activeSubagentStack: [], onApprovalLookup },
       );
       const streamingRunId =
         messagesRef.current.find(
@@ -183,6 +189,7 @@ export function useHistoryTracePagination(deps: HistoryTracePaginationDeps) {
     streamingMessageIdRef,
     setMessages,
     setGoalsByRunId,
+    onApprovalLookup,
   ]);
 
   return {

--- a/frontend/src/styles/approval.css
+++ b/frontend/src/styles/approval.css
@@ -484,6 +484,11 @@
   color: var(--approval-text-dim);
   font-size: 0.75rem;
   line-height: 1.25;
+  /* 折叠态摘要最多两行：长确认文案（如定时任务创建）不再撑爆卡片 */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
 }
 
 .approval-expand-icon {

--- a/src/infra/tool/scheduled_task/approval.py
+++ b/src/infra/tool/scheduled_task/approval.py
@@ -125,10 +125,26 @@ async def _send_scheduled_task_approval_event(
     run_id: str | None,
     timeout: int,
     trace_id: str | None = None,
+    preview: dict[str, Any] | None = None,
 ) -> None:
     if not session_id:
         logger.warning("[ScheduledTask] Cannot send approval event: no session_id")
         return
+
+    data: dict[str, Any] = {
+        "id": approval_id,
+        "message": message,
+        "type": "confirm",
+        "fields": [],
+        "timeout": timeout,
+    }
+    if preview is not None:
+        # 前端实时路径只从事件 data 取 metadata；缺失会退回通用 Markdown
+        # 渲染，把确认文案（表格/代码块标记）整段平铺出来。
+        data["metadata"] = {
+            "approval_type": "scheduled_task_create",
+            "preview": preview,
+        }
 
     try:
         from src.infra.session.dual_writer import get_dual_writer
@@ -136,18 +152,56 @@ async def _send_scheduled_task_approval_event(
         await get_dual_writer().write_event(
             session_id=session_id,
             event_type="approval_required",
-            data={
-                "id": approval_id,
-                "message": message,
-                "type": "confirm",
-                "fields": [],
-                "timeout": timeout,
-            },
+            data=data,
             run_id=run_id,
             trace_id=trace_id,
         )
     except Exception as e:
         logger.error("[ScheduledTask] Failed to send approval event: %s", e, exc_info=True)
+
+
+async def _send_scheduled_task_resolved_event(
+    *,
+    approval_id: str,
+    status: str,
+    session_id: str | None,
+    run_id: str | None,
+    trace_id: str | None = None,
+) -> None:
+    """确认结束后写 approval_resolved，收尾前端 approval_required 生成的 ask_human pill。
+
+    scheduled_task_create 的 tool:result 与该 pill 的 id（审批 id）对不上，
+    没有这个事件 pill 会永远停在「加载中」。
+    """
+    if not session_id:
+        return
+
+    success = status == "approved"
+    result_status = "success" if success else ("timeout" if status == "timeout" else "rejected")
+    try:
+        from src.infra.session.dual_writer import get_dual_writer
+        from src.infra.utils.datetime import utc_now_iso
+
+        await get_dual_writer().write_event(
+            session_id=session_id,
+            event_type="approval_resolved",
+            data={
+                "id": approval_id,
+                "approval_id": approval_id,
+                "status": status,
+                "success": success,
+                "result": {
+                    "status": result_status,
+                    "message": f"Scheduled task creation {status}.",
+                    "values": {},
+                },
+                "timestamp": utc_now_iso(),
+            },
+            run_id=run_id,
+            trace_id=trace_id,
+        )
+    except Exception as e:
+        logger.error("[ScheduledTask] Failed to send approval resolved event: %s", e, exc_info=True)
 
 
 async def _confirm_scheduled_task_creation(
@@ -200,10 +254,18 @@ async def _confirm_scheduled_task_creation(
         run_id=ctx.run_id or None,
         timeout=timeout,
         trace_id=ctx.trace_id,
+        preview=preview,
     )
 
     response = await wait_for_response(approval.id, timeout=timeout)
     if response is None:
+        await _send_scheduled_task_resolved_event(
+            approval_id=approval.id,
+            status="timeout",
+            session_id=ctx.session_id or None,
+            run_id=ctx.run_id or None,
+            trace_id=ctx.trace_id,
+        )
         return {
             "approved": False,
             "status": "timeout",
@@ -211,12 +273,26 @@ async def _confirm_scheduled_task_creation(
             "message": f"Scheduled task creation timed out waiting for user confirmation ({timeout}s).",
         }
     if not response.approved:
+        await _send_scheduled_task_resolved_event(
+            approval_id=approval.id,
+            status="rejected",
+            session_id=ctx.session_id or None,
+            run_id=ctx.run_id or None,
+            trace_id=ctx.trace_id,
+        )
         return {
             "approved": False,
             "status": "rejected",
             "approval_id": approval.id,
             "message": "User rejected scheduled task creation.",
         }
+    await _send_scheduled_task_resolved_event(
+        approval_id=approval.id,
+        status="approved",
+        session_id=ctx.session_id or None,
+        run_id=ctx.run_id or None,
+        trace_id=ctx.trace_id,
+    )
     return {
         "approved": True,
         "status": "approved",

--- a/src/infra/tool/scheduled_task/helpers.py
+++ b/src/infra/tool/scheduled_task/helpers.py
@@ -182,7 +182,7 @@ def _build_task_preview(
         "run_on_start": run_on_start,
         "effect": (
             f"After creation, agent '{agent_id}' will run on {schedule}. "
-            f"Each run will start a new session and send this prompt to the agent: {message!r}."
+            "Each run will start a new session and send the prompt listed below to the agent."
             + (" The task will also run immediately after creation." if run_on_start else "")
         ),
     }

--- a/tests/infra/tool/test_scheduled_task_approval.py
+++ b/tests/infra/tool/test_scheduled_task_approval.py
@@ -61,15 +61,21 @@ async def test_confirm_scheduled_task_creation_proceeds_in_interactive_session(
     async def fake_create(*args, **kwargs):
         return _FakeApproval()
 
-    async def fake_send(*, approval_id, message, session_id, run_id, timeout, trace_id=None):
+    async def fake_send(
+        *, approval_id, message, session_id, run_id, timeout, trace_id=None, preview=None
+    ):
         nonlocal send_called
         send_called = True
 
     async def fake_wait(*args, **kwargs):
         return None  # timeout path
 
+    async def fake_send_resolved(**kwargs):
+        pass
+
     monkeypatch.setattr(approval, "create_approval", fake_create)
     monkeypatch.setattr(approval, "_send_scheduled_task_approval_event", fake_send)
+    monkeypatch.setattr(approval, "_send_scheduled_task_resolved_event", fake_send_resolved)
     monkeypatch.setattr(approval, "wait_for_response", fake_wait)
 
     result = await approval._confirm_scheduled_task_creation(
@@ -79,6 +85,183 @@ async def test_confirm_scheduled_task_creation_proceeds_in_interactive_session(
     assert send_called is True
     assert result["approved"] is False
     assert result["status"] == "timeout"
+
+
+@pytest.mark.asyncio
+async def test_scheduled_task_approval_event_includes_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """approval_required 事件必须带 approval_type + preview metadata。
+
+    前端实时路径只从事件 data 取 metadata；缺失时会退回通用 Markdown
+    渲染，把确认文案（表格/代码块标记）整段平铺出来。
+    """
+    from src.infra.session.dual_writer import DualEventWriter  # noqa: F401
+    from src.infra.tool.scheduled_task import approval
+
+    write_calls: list[dict] = []
+
+    async def fake_write_event(**kwargs):
+        write_calls.append(kwargs)
+        return True
+
+    fake_dual_writer = SimpleNamespace(write_event=fake_write_event)
+    monkeypatch.setattr("src.infra.session.dual_writer.get_dual_writer", lambda: fake_dual_writer)
+
+    preview = {"name": "t", "message": "run-me"}
+    await approval._send_scheduled_task_approval_event(
+        approval_id="ap-1",
+        message="msg",
+        session_id="session-1",
+        run_id="run-1",
+        timeout=300,
+        trace_id="trace-1",
+        preview=preview,
+    )
+
+    assert len(write_calls) == 1
+    data = write_calls[0]["data"]
+    assert data["metadata"]["approval_type"] == "scheduled_task_create"
+    assert data["metadata"]["preview"] == preview
+
+
+@pytest.mark.asyncio
+async def test_confirm_scheduled_task_writes_approval_resolved_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """确认响应（批准/拒绝/超时）后必须写 approval_resolved 事件。
+
+    前端 approval_required 会生成 ask_human pill；scheduled_task_create 的
+    tool:result 与该 pill id 对不上，没有 approval_resolved 会永远转圈。
+    """
+    from src.infra.logging.context import TraceContext
+    from src.infra.session.dual_writer import DualEventWriter  # noqa: F401
+    from src.infra.tool.scheduled_task import approval
+
+    monkeypatch.setattr(
+        TraceContext,
+        "get_request_context",
+        lambda: SimpleNamespace(
+            session_id="interactive-1", run_id="r1", user_id="u1", trace_id="trace-ctx"
+        ),
+    )
+    monkeypatch.setattr(approval, "_format_approval_message", lambda _preview: "msg")
+
+    class _FakeApproval:
+        id = "ap-1"
+
+    async def fake_create(*args, **kwargs):
+        return _FakeApproval()
+
+    async def fake_send_required(**kwargs):
+        pass
+
+    response = SimpleNamespace(approved=True)
+
+    async def fake_wait(*args, **kwargs):
+        return response
+
+    write_calls: list[dict] = []
+
+    async def fake_write_event(**kwargs):
+        write_calls.append(kwargs)
+        return True
+
+    fake_dual_writer = SimpleNamespace(write_event=fake_write_event)
+    monkeypatch.setattr("src.infra.session.dual_writer.get_dual_writer", lambda: fake_dual_writer)
+    monkeypatch.setattr(approval, "create_approval", fake_create)
+    monkeypatch.setattr(approval, "_send_scheduled_task_approval_event", fake_send_required)
+    monkeypatch.setattr(approval, "wait_for_response", fake_wait)
+
+    result = await approval._confirm_scheduled_task_creation(preview={"name": "t"}, user_id="u1")
+
+    assert result["approved"] is True
+    resolved = [c for c in write_calls if c["event_type"] == "approval_resolved"]
+    assert len(resolved) == 1
+    assert resolved[0]["session_id"] == "interactive-1"
+    assert resolved[0]["run_id"] == "r1"
+    assert resolved[0]["trace_id"] == "trace-ctx"
+    data = resolved[0]["data"]
+    assert data["approval_id"] == "ap-1"
+    assert data["success"] is True
+    assert data["result"]["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_confirm_scheduled_task_writes_approval_resolved_on_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """超时路径同样要写 approval_resolved（status=timeout），否则 pill 永远转圈。"""
+    from src.infra.logging.context import TraceContext
+    from src.infra.session.dual_writer import DualEventWriter  # noqa: F401
+    from src.infra.tool.scheduled_task import approval
+
+    monkeypatch.setattr(
+        TraceContext,
+        "get_request_context",
+        lambda: SimpleNamespace(
+            session_id="interactive-1", run_id="r1", user_id="u1", trace_id=None
+        ),
+    )
+    monkeypatch.setattr(approval, "_format_approval_message", lambda _preview: "msg")
+
+    class _FakeApproval:
+        id = "ap-1"
+
+    async def fake_create(*args, **kwargs):
+        return _FakeApproval()
+
+    async def fake_send_required(**kwargs):
+        pass
+
+    async def fake_wait(*args, **kwargs):
+        return None  # timeout
+
+    write_calls: list[dict] = []
+
+    async def fake_write_event(**kwargs):
+        write_calls.append(kwargs)
+        return True
+
+    fake_dual_writer = SimpleNamespace(write_event=fake_write_event)
+    monkeypatch.setattr("src.infra.session.dual_writer.get_dual_writer", lambda: fake_dual_writer)
+    monkeypatch.setattr(approval, "create_approval", fake_create)
+    monkeypatch.setattr(approval, "_send_scheduled_task_approval_event", fake_send_required)
+    monkeypatch.setattr(approval, "wait_for_response", fake_wait)
+
+    result = await approval._confirm_scheduled_task_creation(preview={"name": "t"}, user_id="u1")
+
+    assert result["approved"] is False
+    assert result["status"] == "timeout"
+    resolved = [c for c in write_calls if c["event_type"] == "approval_resolved"]
+    assert len(resolved) == 1
+    assert resolved[0]["data"]["result"]["status"] == "timeout"
+    assert resolved[0]["data"]["success"] is False
+
+
+def test_approval_message_contains_prompt_exactly_once() -> None:
+    """确认文案中完整 prompt 只出现一次（```text 代码块），effect 不再内联。"""
+    from src.infra.tool.scheduled_task.approval import _format_approval_message
+    from src.infra.tool.scheduled_task.helpers import _build_task_preview
+    from src.kernel.schemas.scheduled_task import TriggerType
+
+    prompt = "每天早上 7:30 提醒我记录供应商账，用中文，包含昨日新增条目数"
+    preview = _build_task_preview(
+        name="每天记供应商账提醒",
+        message=prompt,
+        trigger_type=TriggerType.CRON,
+        trigger_config={"hour": "7", "minute": "30"},
+        timezone_name="Asia/Shanghai",
+        agent_id="fast",
+        description=None,
+        timeout_seconds=3600,
+        run_on_start=False,
+    )
+
+    assert prompt not in preview["effect"]
+
+    message = _format_approval_message(preview)
+    assert message.count(prompt) == 1
 
 
 @pytest.mark.asyncio
@@ -139,14 +322,20 @@ async def test_confirm_scheduled_task_forwards_request_trace_id(
     async def fake_create(*args, **kwargs):
         return _FakeApproval()
 
-    async def fake_send(*, approval_id, message, session_id, run_id, timeout, trace_id=None):
+    async def fake_send(
+        *, approval_id, message, session_id, run_id, timeout, trace_id=None, preview=None
+    ):
         captured.append({"trace_id": trace_id})
 
     async def fake_wait(*args, **kwargs):
         return None
 
+    async def fake_send_resolved(**kwargs):
+        pass
+
     monkeypatch.setattr(approval, "create_approval", fake_create)
     monkeypatch.setattr(approval, "_send_scheduled_task_approval_event", fake_send)
+    monkeypatch.setattr(approval, "_send_scheduled_task_resolved_event", fake_send_resolved)
     monkeypatch.setattr(approval, "wait_for_response", fake_wait)
 
     await approval._confirm_scheduled_task_creation(preview={"name": "t"}, user_id="u1")

--- a/tests/infra/tool/test_scheduled_task_tool.py
+++ b/tests/infra/tool/test_scheduled_task_tool.py
@@ -215,7 +215,9 @@ async def test_create_interval_task(monkeypatch: pytest.MonkeyPatch) -> None:
     assert result["approved"] is True
     assert result["status"] == "approved"
     assert result["preview"]["schedule"] == "every 5 minute(s)"
-    assert "Clean up expired cache entries" in result["preview"]["effect"]
+    # effect 不再内联完整 prompt（确认文案里 prompt 只在代码块出现一次）
+    assert "Clean up expired cache entries" in result["preview"]["message"]
+    assert "Clean up expired cache entries" not in result["preview"]["effect"]
 
     # Verify service was called with correct trigger config
     request = create_mock.call_args.kwargs.get("request") or create_mock.call_args[0][0]
@@ -862,6 +864,7 @@ async def test_create_confirmation_shows_preview_and_waits(monkeypatch: pytest.M
         run_id="run-1",
         timeout=120,
         trace_id=None,
+        preview=preview,
     )
     wait_for_response.assert_awaited_once_with("approval-3", timeout=120)
 


### PR DESCRIPTION
## 晋升内容

develop 领先 main 一个提交（PR #391）：

- **fix(scheduled_task): 修复创建任务确认卡片渲染与 ask_human pill 永久加载**

## 修复摘要

1. `approval_required` 事件补发 `metadata`（approval_type + preview），前端实时路径走 `ScheduledTaskApprovalContent` 专属表格渲染，不再平铺原始 Markdown（表格符号/代码块标记裸露）
2. 确认结束（批准/拒绝/超时）写 `approval_resolved` 事件，收尾 ask_human pill，修复点击确认后 pill 永久转圈
3. `effect` 不再内联完整 prompt，确认文案中 prompt 只出现一次
4. 历史回放查到已决 scheduled-task 审批时补收尾幽灵 pill（兼容存量旧事件数据）
5. 折叠态摘要两行截断；prompt 代码块限高滚动

## 验证

- CI 全绿（Ruff / MyPy / ESLint / 前后端测试 / Large File Check / 双架构镜像构建）
- staging 已滚动到 `develop-20260904-050645`：Pod 1/1 Running，`/ready` 200，前端 200
- 后端 776 tests passed；前端 2131 tests passed