### PR TITLE
fix(memory): 无项目会话 memory_retain scope=project 降级 user 不再报错

### DIFF
--- a/docs/superpowers/specs/2026-09-04-memory-scope-and-context-design.md
+++ b/docs/superpowers/specs/2026-09-04-memory-scope-and-context-design.md
@@ -70,7 +70,7 @@ async def resolve_session_project_id(session_id: str | None) -> str | None
 
 - 校验：`scope` ∈ {user, project, reference}，非法值拒绝。
 - 推导顺序（写入侧绝不猜测归属）：
-  1. 显式 `scope=project` 且无 `project_id` → 拒绝（`success=False`，错误说明需要项目上下文）；
+  1. 显式 `scope=project` 且无 `project_id` → backend 拒绝（`success=False`，错误说明需要项目上下文）；`memory_retain` 工具层在此基础上先降级——无项目会话直接按自动推导存储（→ `user`）并在结果 note 里说明，避免 LLM 误传导致前端报错（2026-09-04 生产回归）；
   2. 显式 `project_id` 无 `scope` → `scope=project`；
   3. `scope` 未传：`context` 以 `project_` 开头 **且** 能解析到 `project_id` → `project`；否则 `user`。拿不到可靠 `project_id` 时项目类内容降级 `user`（与旧行为一致，不丢数据）。
 - 新字段落库：`scope`、`project_id`（仅 project scope 时非空）。
@@ -130,7 +130,7 @@ def build_scope_clause(project_id: str | None) -> dict:
 | 无项目会话 recall | 只见 user/reference（含旧数据），见不到任何 project 记忆 |
 | 项目会话 recall | user + reference + 本项目 project |
 | `memory_retain` 旧调用（不传 scope） | 推导：context=project_* 且会话有 project → project；否则 user |
-| `scope=project` 但无 project_id（无项目会话手动指定） | 拒绝并说明原因 |
+| `scope=project` 但无 project_id（无项目会话手动指定） | 工具层降级存为 `user` 并带 note；backend 直连调用仍拒绝并说明原因 |
 | 跨项目语义去重 | 互不匹配（各自演化，合并交给本项目内的 consolidation） |
 
 ## KV 缓存与 benchmark 验收

--- a/src/infra/memory/tools.py
+++ b/src/infra/memory/tools.py
@@ -110,7 +110,8 @@ async def memory_retain(
         "Ownership scope: 'user' (cross-project personal preference, default), "
         "'project' (bound to the current session's project), or 'reference' "
         "(external docs/links). Project ownership is inherited from the current "
-        "session; scope='project' is rejected when the session has no project.",
+        "session; when the session has no project, project-scoped content is "
+        "automatically stored as 'user' scope (see result note).",
     ] = None,
     source_refs: Annotated[
         Optional[list[ConversationSourceRef]],
@@ -148,6 +149,10 @@ async def memory_retain(
         from src.infra.memory.scope import resolve_session_project_id
 
         project_id = await resolve_session_project_id(get_session_id_from_runtime(runtime))
+        # 无项目会话里 LLM 显式要 scope='project'：backend 会硬拒绝（生产上
+        # 表现为前端红色报错 + agent 重试一轮）。工具层先降级为自动推导
+        # （无归属 → user），不丢数据；结果里带 note 告知实际归属。
+        scope_downgraded = scope == "project" and not project_id
         result = await backend.retain(
             user_id,
             content,
@@ -157,9 +162,15 @@ async def memory_retain(
             tags=tags,
             existing_memory_id=existing_memory_id,
             source_refs=source_refs,
-            scope=scope,
+            scope=None if scope_downgraded else scope,
             project_id=project_id,
         )
+        if scope_downgraded and isinstance(result, dict) and result.get("success"):
+            result.setdefault("scope", "user")
+            result["note"] = (
+                "session has no project context; stored as 'user' scope "
+                "(assign the session to a project to keep it project-scoped)"
+            )
         return await _json_dumps_result(result)
     except Exception as e:
         logger.error(f"[Memory] Failed to retain memory: {e}")

--- a/tests/infra/memory/test_tools.py
+++ b/tests/infra/memory/test_tools.py
@@ -493,6 +493,88 @@ async def test_memory_recall_without_session_uses_user_scope(monkeypatch):
     assert seen["kwargs"]["project_id"] is None
 
 
+@pytest.mark.asyncio
+async def test_memory_retain_degrades_project_scope_without_project_context(monkeypatch):
+    """无项目会话中 agent 显式 scope='project' → 降级 user 存储，不再硬拒绝。
+
+    生产回归（2026-09-04）：LLM 在无项目会话里传 scope='project'，backend
+    拒绝导致工具返回 success=false，前端渲染红色错误。工具层先解析项目上下文，
+    拿不到就把归属降级为 user（写入侧不猜归属、不丢数据），并在结果里说明。
+    """
+    from src.infra.memory import scope as scope_module
+    from src.infra.memory import tools as memory_tools
+
+    seen = {}
+
+    class FakeBackend:
+        async def retain(self, *args, **kwargs):
+            seen["kwargs"] = kwargs
+            return {"success": True, "scope": kwargs.get("scope") or "user"}
+
+    async def fake_get_backend():
+        return FakeBackend()
+
+    async def fake_resolve(session_id):
+        seen["resolved_session"] = session_id
+        return None
+
+    monkeypatch.setattr(memory_tools, "_get_backend", fake_get_backend)
+    monkeypatch.setattr(scope_module, "resolve_session_project_id", fake_resolve)
+
+    result = json.loads(
+        await memory_tools.memory_retain.coroutine(
+            "The daily news digest job pushes at 08:00 every morning.",
+            scope="project",
+            runtime=_Runtime("u1", session_id="sess-no-proj"),
+        )
+    )
+
+    assert result["success"] is True
+    assert "error" not in result
+    assert seen["resolved_session"] == "sess-no-proj"
+    # 不能把 scope='project' 原样传给 backend（backend 会拒绝）
+    assert seen["kwargs"].get("scope") != "project"
+    # 结果必须告知 LLM 实际归属与原因
+    assert result.get("scope") == "user"
+    assert "user" in str(result.get("note", "")).lower()
+
+
+@pytest.mark.asyncio
+async def test_memory_retain_keeps_project_scope_when_session_has_project(monkeypatch):
+    """有项目会话中 scope='project' 原样透传，不降级。"""
+    from src.infra.memory import scope as scope_module
+    from src.infra.memory import tools as memory_tools
+
+    seen = {}
+
+    class FakeBackend:
+        async def retain(self, *args, **kwargs):
+            seen["kwargs"] = kwargs
+            return {"success": True, "scope": "project"}
+
+    async def fake_get_backend():
+        return FakeBackend()
+
+    async def fake_resolve(_session_id):
+        return "proj-1"
+
+    monkeypatch.setattr(memory_tools, "_get_backend", fake_get_backend)
+    monkeypatch.setattr(scope_module, "resolve_session_project_id", fake_resolve)
+
+    result = json.loads(
+        await memory_tools.memory_retain.coroutine(
+            "The project deploys via k8s.",
+            scope="project",
+            runtime=_Runtime("u1", session_id="sess-proj"),
+        )
+    )
+
+    assert result["success"] is True
+    assert seen["kwargs"]["scope"] == "project"
+    assert seen["kwargs"]["project_id"] == "proj-1"
+    assert "note" not in result
+
+
 def test_memory_retain_scope_param_documents_ownership_semantics():
     from src.infra.memory.tools import memory_retain
 


### PR DESCRIPTION
## 问题

生产回归（2026-09-04，scope 功能上线当天）：agent 在**无项目会话**里调 `memory_retain` 时显式传 `scope='project'`，`resolve_retain_scope` 硬拒绝，工具返回 `success=false`，前端 `MemoryStoreItem` 渲染红色错误框；agent 虽会换 user scope 重试成功，但报错已展示给用户。

生产证据（trace 事件扫描，83 次 memory_retain 结果）：该错误今日出现 2 次，全部为上述模式。

## 修复

`memory_retain` 工具层在调 backend 前先解析会话项目上下文，`scope='project'` 且无项目时**自动降级**为自动推导（→ user）存储，成功结果带 `note` 告知 LLM 实际归属与原因。不报错、不丢数据、省一轮重试。

- backend 层严格拒绝契约保留（保护程序化调用方），仅 LLM-facing 工具层降级——与 `scope.py` 模块哲学一致："拿不到 project_id 的项目类内容降级为 user scope（不丢数据）"
- 工具 `scope` 参数描述同步改为降级语义
- 设计文档兼容矩阵同步更新

## 测试

- 新增 TDD 测试：无项目降级不报错（含 note）/ 有项目原样透传不降级
- `tests/infra/memory/` 全量 252 通过；关联 scope/deferred 测试 38 通过
- ruff / mypy 全绿