### PR TITLE
fix(agent): 空最终消息不再上抛——流式已交付的场景不判失败

### DIFF
--- a/src/infra/agent/middleware/retry.py
+++ b/src/infra/agent/middleware/retry.py
@@ -25,7 +25,6 @@ from src.infra.agent.middleware.dead_attachment import (
 )
 from src.infra.llm.retry import is_retryable_model_error
 from src.kernel.config import settings
-from src.kernel.errors import AppError, ErrorCode
 
 if TYPE_CHECKING:
     from langchain.agents.middleware.types import ExtendedModelResponse
@@ -156,7 +155,11 @@ class ModelFallbackMiddleware(AgentMiddleware):
         fallback_llm = await self._get_fallback_llm()
         new_request = request.override(model=fallback_llm)
         try:
-            response = await handler(new_request)
+            # 空最终消息不上抛：中间件层没有「流式是否已把正文交付给用户」的
+            # 视野（2026-09-05 13:50 生产 4 例：message:chunk + done 之后才
+            # 追加 error，成功 run 被标失败且重试/降级重复烧钱）。零正文的
+            # 终态判定由 executor 按真实 message:chunk 事件兜底。
+            return await handler(new_request)
         except Exception as fallback_exc:
             logger.error(
                 "[ModelFallback] Fallback model %s also failed: %s",
@@ -164,20 +167,6 @@ class ModelFallbackMiddleware(AgentMiddleware):
                 fallback_exc,
             )
             raise
-        # 防御：兜底结果若仍是空正文（内层 EmptyContentRetry 负责上抛，这里
-        # 兜住中间件栈被重构后的漏网路径），同样按失败上抛，绝不静默放行。
-        fallback_messages = _extract_messages(response)
-        if (
-            fallback_messages
-            and isinstance(fallback_messages[0], AIMessage)
-            and _is_empty_content(fallback_messages[0])
-        ):
-            logger.error(
-                "[ModelFallback] Fallback model %s also returned empty content",
-                self._fallback_model,
-            )
-            raise AppError(ErrorCode.MODEL_EMPTY_RESPONSE)
-        return response
 
     async def awrap_model_call(
         self,
@@ -233,18 +222,11 @@ class EmptyContentRetryMiddleware(AgentMiddleware):
             if attempt < self.max_retries:
                 await asyncio.sleep(self.retry_delay)
 
-        # 重试耗尽仍是空正文（thinking-only / 完全空）→ 按模型调用失败上抛：
-        # 外层 ModelFallback 换兜底模型重放；兜底也空时任务进入 error 终态。
-        # 绝不静默返回空回答把 run 假装 completed（2026-09-05 生产事故：
-        # 续跑后 4 次空正文被放行，done(completed) 但用户拿不到答案）。
-        # 截断启发式命中的半截回答不上抛——部分内容已流出，保留给用户。
-        final_messages = _extract_messages(last_response)
-        if (
-            final_messages
-            and isinstance(final_messages[0], AIMessage)
-            and _is_empty_content(final_messages[0])
-        ):
-            raise AppError(ErrorCode.MODEL_EMPTY_RESPONSE)
+        # 耗尽后返回最后响应（含空最终消息）：本层没有「流式是否已交付正文」
+        # 的视野，无法区分「真空响应」与「已流式交付但最终聚合消息为空」，
+        # 后者上抛会把成功 run 标成失败并重复烧钱（2026-09-05 13:50 生产
+        # 4 例）。零正文的终态判定由 executor 按真实 message:chunk 事件兜底
+        # （tests/infra/task/test_executor_no_output_guard.py）。
         return last_response  # type: ignore[return-value]
 
 

--- a/tests/infra/agent/test_retry_middleware.py
+++ b/tests/infra/agent/test_retry_middleware.py
@@ -3,7 +3,6 @@ import pytest
 from langchain_core.messages import AIMessage
 
 from src.infra.agent.middleware.retry import EmptyContentRetryMiddleware, ModelFallbackMiddleware
-from src.kernel.errors import AppError, ErrorCode
 
 
 class _Request:
@@ -91,11 +90,15 @@ async def test_fallback_runs_when_primary_returns_truncated_content() -> None:
     assert result.content == "fallback answer"
 
 
-async def test_empty_content_retry_raises_when_all_attempts_empty() -> None:
-    """重试耗尽仍是空正文（thinking-only/完全空）必须上抛，禁止静默返回空回答。
+async def test_empty_content_retry_exhausted_returns_last_response_without_raise() -> None:
+    """重试耗尽仍空最终消息时返回最后响应，不上抛。
 
-    2026-09-05 生产事故：无缝续跑后模型连续 4 次只返回 thinking 没有正文，
-    重试与降级耗尽后被静默放行，run 假装 completed 但用户拿不到任何答案。
+    中间件层没有「用户是否已通过流式拿到正文」的视野：2026-09-05 13:50 生产
+    4 例，上游流式已把完整答案交付（message:chunk + done 之后）但最终聚合
+    AIMessage 为空，此处上抛会在 done 后追加 error、把成功 run 标成失败，
+    还触发 210K input 的重试/降级重复烧钱。「零正文」的终态判定权在
+    executor 层（按真实 message:chunk 事件判定，见
+    tests/infra/task/test_executor_no_output_guard.py）。
     """
     middleware = EmptyContentRetryMiddleware(max_retries=1, retry_delay=0)
     calls = 0
@@ -105,10 +108,9 @@ async def test_empty_content_retry_raises_when_all_attempts_empty() -> None:
         calls += 1
         return AIMessage(content="", additional_kwargs={"reasoning_content": "长篇思考"})
 
-    with pytest.raises(AppError) as exc_info:
-        await middleware.awrap_model_call(None, handler)
+    result = await middleware.awrap_model_call(None, handler)
 
-    assert exc_info.value.error_code is ErrorCode.MODEL_EMPTY_RESPONSE
+    assert result.content == ""
     assert calls == 2
 
 
@@ -143,26 +145,8 @@ async def test_tool_call_only_response_returns_without_raise() -> None:
     assert result is message
 
 
-async def test_fallback_re_raises_when_fallback_model_also_empty() -> None:
-    """兜底模型重放后仍空正文（内部 EmptyContentRetry 上抛）必须继续上抛。"""
-    primary_model = object()
-    fallback_model = object()
-    middleware = ModelFallbackMiddleware(fallback_model="openai/fallback-model")
-    middleware._fallback_llm = fallback_model
-
-    async def handler(request):
-        if request.model is primary_model:
-            return AIMessage(content="")
-        raise AppError(ErrorCode.MODEL_EMPTY_RESPONSE)
-
-    with pytest.raises(AppError) as exc_info:
-        await middleware.awrap_model_call(_Request(primary_model), handler)
-
-    assert exc_info.value.error_code is ErrorCode.MODEL_EMPTY_RESPONSE
-
-
-async def test_fallback_empty_response_without_raise_still_escalates() -> None:
-    """防御：兜底结果即使未被内层上抛（如中间件栈被重构），仍按空正文上抛。"""
+async def test_fallback_empty_final_message_returns_response_without_raise() -> None:
+    """兜底模型的最终消息为空时返回该响应，不上抛（同上：流式可能已交付）。"""
     primary_model = object()
     fallback_model = object()
     middleware = ModelFallbackMiddleware(fallback_model="openai/fallback-model")
@@ -173,8 +157,9 @@ async def test_fallback_empty_response_without_raise_still_escalates() -> None:
             return AIMessage(content="")
         return AIMessage(content="", additional_kwargs={"reasoning_content": "兜底也在思考"})
 
-    with pytest.raises(AppError):
-        await middleware.awrap_model_call(_Request(primary_model), handler)
+    result = await middleware.awrap_model_call(_Request(primary_model), handler)
+
+    assert result.content == ""
 
 
 async def test_fallback_model_is_created_with_same_thinking_config(monkeypatch) -> None:


### PR DESCRIPTION
## 问题

2026-09-05 13:50 生产 4 例（用户 clivia.yang 实际对话）：上游流式已把完整答案交付（事件序列为 message:chunk(正文) → token:usage → **done** → **之后才追加 error**），但最终聚合 AIMessage 为空。上一版修复（#397）在中间件层对空最终消息上抛 model_empty_response，导致：

1. 成功 run 在 done 之后被追加 error 事件、trace 标为 error、控制台记 Err（用户看到的对话本身完全正常）；
2. 上抛触发重试 + 降级全量重放，单例重复消耗 ~210K input tokens。

## 根因

中间件层没有「用户是否已通过流式拿到正文」的视野，无法区分「真空响应」与「已流式交付但最终聚合消息为空」（后者是上游/协议转换的已知形态）。

## 修复

回退中间件层两处上抛（EmptyContentRetryMiddleware 耗尽返回最后响应、ModelFallback 兜底结果不再校验上抛）。零正文的终态判定权收归 executor 事件层守卫（#397 已有）：按真实 message:chunk 事件判定——交付过内容即 completed，全程零正文才报 model_empty_response。

## 验证

- 后端全量 pytest 3559 passed；ruff / mypy 通过
- executor 守卫测试不变仍绿（test_executor_no_output_guard.py）