### PR TITLE
fix(task): 零正文守卫误判修复——正文事件直发路径绕过 executor 循环（生产事故 hotfix）

### DIFF
--- a/src/infra/task/executor.py
+++ b/src/infra/task/executor.py
@@ -285,9 +285,14 @@ class TaskExecutor:
                 )
                 return True
 
-            # 兜底守卫：run 正常走到终点却没有任何主代理正文（中间件空正文静默
-            # 放行的漏网路径）→ 按 error 终结，绝不假装 completed 让用户对着
-            # 空气泡（2026-09-05 生产事故：续跑后 done(completed) 无答案）。
+            # 兜底守卫：run 正常走到终点却没有任何主代理正文 → 按 error 终结，
+            # 绝不假装 completed 让用户对着空气泡。判定信号有两个来源：
+            # ① 本循环里流过的事件；② presenter.produced_main_text——
+            # AgentEventProcessor 的缓冲 flush 走 presenter.emit 直连路径，
+            # message:chunk 往往不经过本循环（2026-09-05 生产事故教训），
+            # 两条路径都在 presenter.save_event 汇聚并统一标记。
+            if not produced_main_text and presenter is not None:
+                produced_main_text = bool(getattr(presenter, "produced_main_text", False))
             if not produced_main_text:
                 raise AppError(ErrorCode.MODEL_EMPTY_RESPONSE)
 

--- a/src/infra/writer/present.py
+++ b/src/infra/writer/present.py
@@ -103,6 +103,11 @@ class Presenter(EventPresenterMixin, StoragePresenterMixin):
         self._done_recorded: bool = False
         self._goal_end_recorded: bool = False
         self._recommend_questions_recorded: bool = False
+        # 主代理（depth=0）非空 message:chunk 是否经本 presenter 交付过。
+        # 事件有两条入口：executor 循环的 save_event、AgentEventProcessor
+        # 缓冲 flush 的 emit——两者都汇聚到 save_event，在此统一标记，
+        # 供 executor 零正文守卫判定 run 是否真的交付过答案。
+        self.produced_main_text: bool = False
 
     @property
     def trace_id(self) -> str:

--- a/src/infra/writer/presenter_storage.py
+++ b/src/infra/writer/presenter_storage.py
@@ -367,6 +367,20 @@ class StoragePresenterMixin:
         Args:
             event: SSE 事件字典，包含 event 和 data 字段
         """
+        # 主代理正文追踪放在最前（enable_storage=False 时也要标记）：
+        # message:chunk 可能经两条路径进入（executor 循环、处理器缓冲 flush
+        # 的 emit），executor 零正文守卫依赖本标记判定 run 是否交付过答案。
+        _event_type = event.get("event", "unknown")
+        _data = event.get("data")
+        if (
+            _event_type == "message:chunk"
+            and isinstance(_data, dict)
+            and not (isinstance(_data.get("depth"), int) and _data["depth"] > 0)
+            and isinstance(_data.get("content"), str)
+            and _data["content"].strip()
+        ):
+            self.produced_main_text = True
+
         if not self.config.enable_storage:
             return
 

--- a/tests/infra/task/test_executor_no_output_guard.py
+++ b/tests/infra/task/test_executor_no_output_guard.py
@@ -150,6 +150,36 @@ async def test_run_without_assistant_text_fails_instead_of_completing(
     assert error_events[0]["data"]["code"] == "model_empty_response"
 
 
+async def test_run_with_presenter_delivered_text_completes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """处理器直发路径回归（2026-09-05 生产事故）：正文经 presenter.emit 落库、
+    不经过 executor 事件循环，守卫必须读 presenter.produced_main_text 判定，
+    不得把交付过内容的 run 误判失败。"""
+    executor, writer, holder, status_updates = _executor_fixture(monkeypatch)
+
+    async def _stream_with_direct_delivery(*_args, **kwargs):
+        # 模拟 AgentEventProcessor 缓冲 flush：正文直发 presenter，循环里看不到
+        kwargs["presenter"].produced_main_text = True
+        yield {"event": "thinking", "data": {"content": "思考"}}
+        yield {"event": "done", "data": {"status": "completed"}}
+
+    result = await executor.run_task(
+        session_id="session-1",
+        run_id="run-1",
+        agent_id="fast",
+        message="hi",
+        user_id="user-1",
+        executor=_stream_with_direct_delivery,
+        user_message_written=True,
+    )
+
+    assert result is False  # completed path
+    assert holder["presenter"].completions == ["completed"]
+    assert "completed" in status_updates
+    assert [e for e in writer.written if e.get("event_type") == "error"] == []
+
+
 async def test_run_with_main_agent_text_completes(monkeypatch: pytest.MonkeyPatch) -> None:
     """有主代理 message:chunk 的 run 保持原行为：completed。"""
     executor, writer, holder, status_updates = _executor_fixture(monkeypatch)

--- a/tests/infra/writer/test_presenter_main_text.py
+++ b/tests/infra/writer/test_presenter_main_text.py
@@ -43,9 +43,7 @@ async def test_save_event_main_text_chunk_marks_produced() -> None:
 async def test_subagent_chunk_does_not_mark() -> None:
     presenter = _presenter()
 
-    await presenter.emit(
-        {"event": "message:chunk", "data": {"content": "子代理输出", "depth": 1}}
-    )
+    await presenter.emit({"event": "message:chunk", "data": {"content": "子代理输出", "depth": 1}})
 
     assert presenter.produced_main_text is False
 

--- a/tests/infra/writer/test_presenter_main_text.py
+++ b/tests/infra/writer/test_presenter_main_text.py
@@ -1,0 +1,67 @@
+"""Presenter 主代理正文追踪契约。
+
+message:chunk 有两条入口（executor 循环的 save_event、AgentEventProcessor
+缓冲 flush 的 emit 直连），必须都汇聚标记 produced_main_text——executor 的
+零正文守卫依赖它判定 run 是否真的交付过答案（2026-09-05 生产事故：直发
+路径绕过 executor 循环，导致交付过内容的 run 被误判失败）。
+"""
+
+from __future__ import annotations
+
+from src.infra.writer.present import Presenter, PresenterConfig
+
+
+def _presenter() -> Presenter:
+    # enable_storage=False：只验证追踪契约本身，不触达 dual writer
+    return Presenter(
+        PresenterConfig(
+            session_id="session-1",
+            agent_id="fast",
+            run_id="run-1",
+            enable_storage=False,
+        )
+    )
+
+
+async def test_emit_main_text_chunk_marks_produced() -> None:
+    presenter = _presenter()
+
+    assert presenter.produced_main_text is False
+    await presenter.emit({"event": "message:chunk", "data": {"content": "最终回答"}})
+
+    assert presenter.produced_main_text is True
+
+
+async def test_save_event_main_text_chunk_marks_produced() -> None:
+    presenter = _presenter()
+
+    await presenter.save_event({"event": "message:chunk", "data": {"content": "最终回答"}})
+
+    assert presenter.produced_main_text is True
+
+
+async def test_subagent_chunk_does_not_mark() -> None:
+    presenter = _presenter()
+
+    await presenter.emit(
+        {"event": "message:chunk", "data": {"content": "子代理输出", "depth": 1}}
+    )
+
+    assert presenter.produced_main_text is False
+
+
+async def test_blank_chunk_does_not_mark() -> None:
+    presenter = _presenter()
+
+    await presenter.emit({"event": "message:chunk", "data": {"content": "   "}})
+
+    assert presenter.produced_main_text is False
+
+
+async def test_other_event_types_do_not_mark() -> None:
+    presenter = _presenter()
+
+    await presenter.emit({"event": "thinking", "data": {"content": "长篇思考"}})
+    await presenter.emit({"event": "tool:start", "data": {"tool": "web_search"}})
+
+    assert presenter.produced_main_text is False


### PR DESCRIPTION
## 事故（当前生产 main-20260905-061515 存在，需尽快晋升部署）

上一提交回退了中间件上抛，但生产验证发现 executor 零正文守卫本身有缺陷：message:chunk 事件大量走 AgentEventProcessor 缓冲 flush 的 presenter.emit **直连路径**，不经过 executor 事件循环——守卫只盯循环内事件，导致**交付过完整回答的 run 也被误标 model_empty_response**（2026-09-05 14:22 生产 3 例，全部 hasText=true 仍失败）。当前生产所有对话都会失败，需紧急晋升。

## 修复

- Presenter.save_event 顶部统一标记 produced_main_text（两条事件路径都汇聚于此；enable_storage=False 也生效）
- executor 守卫兜底读取 presenter 标记，循环内追踪保留双保险
- 新增 Presenter 追踪契约测试（emit/save_event/depth>0/空白）+ executor 直发路径回归测试

## 验证

- 后端全量 pytest 通过（3560+）；ruff / mypy 通过