### PR TITLE
fix(api): HITL 审批四端点补归属校验，非本人审批按不存在处理

### DIFF
--- a/src/api/routes/human.py
+++ b/src/api/routes/human.py
@@ -21,6 +21,7 @@ from fastapi import APIRouter, Depends, Query
 from src.api.deps import require_permissions
 from src.infra.async_utils import run_blocking_io
 from src.infra.logging import get_logger
+from src.infra.session.manager import SessionManager
 from src.infra.storage.mongodb import (
     APPROVAL_TTL,
     ApprovalResponse,
@@ -250,6 +251,26 @@ def _cleanup_approval(approval_id: str) -> None:
     _local_events.pop(approval_id, None)
 
 
+async def resolve_approval_owner_id(approval: PendingApproval) -> Optional[str]:
+    """解析审批记录归属：优先 user_id，缺失时回退会话属主，皆缺返回 None。"""
+    owner_id = getattr(approval, "user_id", None)
+    if owner_id:
+        return owner_id
+    session_id = getattr(approval, "session_id", None)
+    if session_id:
+        session = await SessionManager().get_session(session_id)
+        if session is not None:
+            return getattr(session, "user_id", None)
+    return None
+
+
+async def _ensure_approval_access(approval: PendingApproval, user: TokenPayload) -> None:
+    """审批归属校验：非本人的审批一律按不存在处理（404 语义，避免存在性枚举）。"""
+    owner_id = await resolve_approval_owner_id(approval)
+    if owner_id is None or owner_id != user.sub:
+        raise AppError(ErrorCode.APPROVAL_NOT_FOUND)
+
+
 def _cleanup_stale_events(max_age: float = 3600) -> int:
     """清理超时的本地 Event（防止遗弃的审批泄漏内存）"""
     now = time.time()
@@ -279,11 +300,12 @@ async def get_pending_approvals(
     return {"approvals": [a.model_dump() for a in pending], "count": len(pending)}
 
 
-@router.post("/{approval_id}/respond", dependencies=[Depends(require_permissions("chat:write"))])
+@router.post("/{approval_id}/respond")
 async def respond_to_approval(
     approval_id: str,
     approved: bool = Query(..., description="是否批准"),
     response: str = Query("{}", description="响应数据（JSON 字符串）"),
+    user: TokenPayload = Depends(require_permissions("chat:write")),
 ):
     """
     响应审批请求
@@ -298,6 +320,7 @@ async def respond_to_approval(
     approval = await _approval_storage.get(approval_id)
     if not approval:
         raise AppError(ErrorCode.APPROVAL_NOT_FOUND)
+    await _ensure_approval_access(approval, user)
 
     if approval.status != "pending":
         logger.info(
@@ -402,10 +425,11 @@ async def respond_to_approval(
     return result
 
 
-@router.post("/{approval_id}/extend", dependencies=[Depends(require_permissions("chat:write"))])
+@router.post("/{approval_id}/extend")
 async def extend_approval_timeout(
     approval_id: str,
     extra_seconds: int = Query(60, ge=10, le=300, description="延长的秒数"),
+    user: TokenPayload = Depends(require_permissions("chat:write")),
 ):
     """
     延长审批超时时间（用户交互时触发，支持分布式）
@@ -414,8 +438,10 @@ async def extend_approval_timeout(
     对无截止时间的审批不生效）。
     """
     approval = await _approval_storage.get(approval_id)
-    if approval and (getattr(approval, "metadata", None) or {}).get("mode") == "interrupt":
-        return {"status": "success", "expires_at": None}
+    if approval:
+        await _ensure_approval_access(approval, user)
+        if (getattr(approval, "metadata", None) or {}).get("mode") == "interrupt":
+            return {"status": "success", "expires_at": None}
 
     new_expires = await _approval_storage.extend_expires_at(
         approval_id,
@@ -430,8 +456,10 @@ async def extend_approval_timeout(
     }
 
 
-@router.get("/{approval_id}", dependencies=[Depends(require_permissions("chat:write"))])
-async def get_approval(approval_id: str):
+@router.get("/{approval_id}")
+async def get_approval(
+    approval_id: str, user: TokenPayload = Depends(require_permissions("chat:write"))
+):
     """获取单个审批详情"""
     approval = await _approval_storage.get(approval_id)
     if not approval:
@@ -439,15 +467,24 @@ async def get_approval(approval_id: str):
         # 这样前端处理更简洁，不需要 catch 404 错误
         return {"id": approval_id, "status": "not_found"}
 
+    # 非本人审批与"不存在"同形返回，避免存在性枚举
+    try:
+        await _ensure_approval_access(approval, user)
+    except AppError:
+        return {"id": approval_id, "status": "not_found"}
+
     return approval.model_dump()
 
 
-@router.delete("/{approval_id}", dependencies=[Depends(require_permissions("chat:write"))])
-async def cancel_approval(approval_id: str):
+@router.delete("/{approval_id}")
+async def cancel_approval(
+    approval_id: str, user: TokenPayload = Depends(require_permissions("chat:write"))
+):
     """取消审批请求"""
     approval = await _approval_storage.get(approval_id)
     if not approval:
         raise AppError(ErrorCode.APPROVAL_NOT_FOUND)
+    await _ensure_approval_access(approval, user)
 
     # 删除 MongoDB 记录
     await _approval_storage.delete(approval_id)

--- a/src/infra/channel/feishu/approval.py
+++ b/src/infra/channel/feishu/approval.py
@@ -82,12 +82,22 @@ async def _get_existing_approval_status(approval_id: str) -> str:
 
 
 async def _respond_to_human_approval(approval_id: str, *, approved: bool) -> None:
-    from src.api.routes.human import respond_to_approval
+    """以审批属主身份代答（飞书卡片点击在其自身信任域内完成授权）。"""
+    from src.api.routes.human import resolve_approval_owner_id, respond_to_approval
+    from src.infra.storage.mongodb import get_approval_storage
+    from src.kernel.errors import AppError, ErrorCode
+    from src.kernel.schemas.user import TokenPayload
+
+    approval = await get_approval_storage().get(approval_id)
+    owner_id = await resolve_approval_owner_id(approval) if approval is not None else None
+    if not owner_id:
+        raise AppError(ErrorCode.APPROVAL_NOT_FOUND)
 
     await respond_to_approval(
         approval_id,
         approved=approved,
         response="{}",
+        user=TokenPayload(sub=owner_id, username="feishu-channel"),
     )
 
 

--- a/tests/api/routes/test_human_approval_ownership.py
+++ b/tests/api/routes/test_human_approval_ownership.py
@@ -1,0 +1,256 @@
+"""HITL 审批路由归属校验测试
+
+respond/extend/get/delete 四个端点操作具体审批记录，必须校验记录归属：
+非本人的审批一律按不存在处理（404 语义，避免存在性枚举）；
+user_id 缺失的旧记录回退会话归属校验；两者皆缺则拒绝。
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.api.deps import TokenPayload
+from src.api.routes import human as human_routes
+from src.infra.storage.mongodb import PendingApproval
+from src.kernel.errors import AppError, ErrorCode
+
+
+def _make_user(user_id: str = "user-1") -> TokenPayload:
+    return TokenPayload(sub=user_id, username="tester", exp=9999999999)
+
+
+def _make_approval(**overrides) -> PendingApproval:
+    defaults = {
+        "id": "approval-1",
+        "message": "请确认",
+        "type": "form",
+        "fields": [],
+        "status": "pending",
+        "session_id": "session-1",
+        "user_id": "user-1",
+        "created_at": datetime(2026, 9, 1, 12, 0, 0),
+        "metadata": None,
+    }
+    defaults.update(overrides)
+    return PendingApproval(**defaults)
+
+
+def _make_storage(approval: PendingApproval | None, **methods) -> MagicMock:
+    storage = MagicMock()
+    storage.get = AsyncMock(return_value=approval)
+    for name, mock in methods.items():
+        setattr(storage, name, mock)
+    return storage
+
+
+def _find_route(method: str, suffix: str):
+    for route in human_routes.router.routes:
+        if (
+            hasattr(route, "path")
+            and route.path.endswith(suffix)
+            and hasattr(route, "methods")
+            and method in route.methods
+        ):
+            return route.endpoint
+    return None
+
+
+# ---------------------------------------------------------------------------
+# respond
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_respond_rejects_other_users_approval():
+    approval = _make_approval(user_id="user-2")
+    storage = _make_storage(approval, respond_if_pending=AsyncMock())
+
+    with patch.object(human_routes, "_approval_storage", storage):
+        handler = _find_route("POST", "/respond")
+        assert handler is not None, "respond 路由未注册"
+        with pytest.raises(AppError) as exc_info:
+            await handler("approval-1", approved=True, response="{}", user=_make_user())
+
+    assert exc_info.value.error_code is ErrorCode.APPROVAL_NOT_FOUND
+    storage.respond_if_pending.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_respond_allows_owner():
+    approval = _make_approval()
+    updated = _make_approval(status="approved")
+    storage = _make_storage(
+        approval,
+        respond_if_pending=AsyncMock(return_value=updated),
+        expire_after=AsyncMock(),
+    )
+
+    with (
+        patch.object(human_routes, "_approval_storage", storage),
+        patch.object(human_routes, "notify_approval_response", AsyncMock()),
+    ):
+        handler = _find_route("POST", "/respond")
+        result = await handler("approval-1", approved=True, response="{}", user=_make_user())
+
+    assert result["status"] == "success"
+    assert result["approved"] is True
+    storage.respond_if_pending.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# extend
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_extend_rejects_other_users_approval():
+    approval = _make_approval(user_id="user-2")
+    storage = _make_storage(approval, extend_expires_at=AsyncMock())
+
+    with patch.object(human_routes, "_approval_storage", storage):
+        handler = _find_route("POST", "/extend")
+        with pytest.raises(AppError) as exc_info:
+            await handler("approval-1", extra_seconds=60, user=_make_user())
+
+    assert exc_info.value.error_code is ErrorCode.APPROVAL_NOT_FOUND
+    storage.extend_expires_at.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_extend_allows_owner():
+    approval = _make_approval()
+    new_expires = datetime(2026, 9, 1, 13, 0, 0, tzinfo=timezone.utc)
+    storage = _make_storage(approval, extend_expires_at=AsyncMock(return_value=new_expires))
+
+    with patch.object(human_routes, "_approval_storage", storage):
+        handler = _find_route("POST", "/extend")
+        result = await handler("approval-1", extra_seconds=60, user=_make_user())
+
+    assert result["status"] == "success"
+    assert result["expires_at"] == new_expires.isoformat()
+
+
+# ---------------------------------------------------------------------------
+# get
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_returns_not_found_shape_for_other_users_approval():
+    approval = _make_approval(user_id="user-2")
+    storage = _make_storage(approval)
+
+    with patch.object(human_routes, "_approval_storage", storage):
+        handler = _find_route("GET", "/{approval_id}")
+        result = await handler("approval-1", user=_make_user())
+
+    # 与"审批不存在"同形返回，避免存在性枚举
+    assert result == {"id": "approval-1", "status": "not_found"}
+
+
+@pytest.mark.asyncio
+async def test_get_allows_owner():
+    approval = _make_approval()
+    storage = _make_storage(approval)
+
+    with patch.object(human_routes, "_approval_storage", storage):
+        handler = _find_route("GET", "/{approval_id}")
+        result = await handler("approval-1", user=_make_user())
+
+    assert result["id"] == "approval-1"
+    assert result["status"] == "pending"
+
+
+# ---------------------------------------------------------------------------
+# delete
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_rejects_other_users_approval():
+    approval = _make_approval(user_id="user-2")
+    storage = _make_storage(approval, delete=AsyncMock())
+
+    with patch.object(human_routes, "_approval_storage", storage):
+        handler = _find_route("DELETE", "/{approval_id}")
+        with pytest.raises(AppError) as exc_info:
+            await handler("approval-1", user=_make_user())
+
+    assert exc_info.value.error_code is ErrorCode.APPROVAL_NOT_FOUND
+    storage.delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delete_allows_owner():
+    approval = _make_approval()
+    storage = _make_storage(approval, delete=AsyncMock())
+
+    with patch.object(human_routes, "_approval_storage", storage):
+        handler = _find_route("DELETE", "/{approval_id}")
+        result = await handler("approval-1", user=_make_user())
+
+    assert result == {"status": "cancelled"}
+    storage.delete.assert_awaited_once_with("approval-1")
+
+
+# ---------------------------------------------------------------------------
+# user_id 缺失时的会话归属回退
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_user_id_falls_back_to_session_ownership_allows_owner():
+    approval = _make_approval(user_id=None, session_id="session-1")
+    session = MagicMock()
+    session.user_id = "user-1"
+    storage = _make_storage(approval, delete=AsyncMock())
+
+    with (
+        patch.object(human_routes, "_approval_storage", storage),
+        patch(
+            "src.api.routes.human.SessionManager",
+            return_value=MagicMock(get_session=AsyncMock(return_value=session)),
+        ),
+    ):
+        handler = _find_route("DELETE", "/{approval_id}")
+        result = await handler("approval-1", user=_make_user())
+
+    assert result == {"status": "cancelled"}
+    storage.delete.assert_awaited_once_with("approval-1")
+
+
+@pytest.mark.asyncio
+async def test_missing_user_id_falls_back_to_session_ownership_denies_stranger():
+    approval = _make_approval(user_id=None, session_id="session-1")
+    session = MagicMock()
+    session.user_id = "user-2"
+    storage = _make_storage(approval, delete=AsyncMock())
+
+    with (
+        patch.object(human_routes, "_approval_storage", storage),
+        patch(
+            "src.api.routes.human.SessionManager",
+            return_value=MagicMock(get_session=AsyncMock(return_value=session)),
+        ),
+    ):
+        handler = _find_route("DELETE", "/{approval_id}")
+        with pytest.raises(AppError) as exc_info:
+            await handler("approval-1", user=_make_user())
+
+    assert exc_info.value.error_code is ErrorCode.APPROVAL_NOT_FOUND
+    storage.delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_approval_without_owner_or_session_denied():
+    approval = _make_approval(user_id=None, session_id=None)
+    storage = _make_storage(approval, delete=AsyncMock())
+
+    with patch.object(human_routes, "_approval_storage", storage):
+        handler = _find_route("DELETE", "/{approval_id}")
+        with pytest.raises(AppError) as exc_info:
+            await handler("approval-1", user=_make_user())
+
+    assert exc_info.value.error_code is ErrorCode.APPROVAL_NOT_FOUND
+    storage.delete.assert_not_awaited()

--- a/tests/api/routes/test_human_wait.py
+++ b/tests/api/routes/test_human_wait.py
@@ -5,9 +5,14 @@ import json
 
 import pytest
 
+from src.api.deps import TokenPayload
 from src.api.routes import human
 from src.infra.storage.mongodb import ApprovalResponse
 from src.kernel.errors import AppError
+
+
+def _make_user(user_id: str = "user-1") -> TokenPayload:
+    return TokenPayload(sub=user_id, username="tester", exp=None)
 
 
 @pytest.mark.asyncio
@@ -72,6 +77,7 @@ async def test_respond_to_approval_offloads_response_json_parse(
 
     class _FakeApproval:
         status = "pending"
+        user_id = "user-1"
 
     class _FakeApprovalStorage:
         async def get(self, approval_id: str):
@@ -101,6 +107,7 @@ async def test_respond_to_approval_offloads_response_json_parse(
         "approval-1",
         approved=True,
         response='{"note": "ok"}',
+        user=_make_user(),
     )
 
     assert calls == [json.loads]
@@ -117,6 +124,7 @@ async def test_respond_to_approval_uses_atomic_pending_update(
 
     class _FakeApproval:
         status = "pending"
+        user_id = "user-1"
 
     class _FakeApprovalStorage:
         async def get(self, approval_id: str):
@@ -145,6 +153,7 @@ async def test_respond_to_approval_uses_atomic_pending_update(
             "approval-1",
             approved=True,
             response="{}",
+            user=_make_user(),
         )
 
     assert exc.value.error_code.code == "approval_already_handled"
@@ -162,6 +171,7 @@ async def test_interrupt_resume_failure_restores_pending_approval(
         id = "approval-1"
         status = "pending"
         session_id = "session-1"
+        user_id = "user-1"
         metadata = {"mode": "interrupt", "interrupt_id": "interrupt-a"}
 
     class _FakeApprovalStorage:
@@ -187,7 +197,12 @@ async def test_interrupt_resume_failure_restores_pending_approval(
     monkeypatch.setattr("src.infra.task.hitl.submit_hitl_resume_run", fake_submit)
 
     with pytest.raises(AppError) as exc:
-        await human.respond_to_approval("approval-1", approved=True, response="{}")
+        await human.respond_to_approval(
+            "approval-1",
+            approved=True,
+            response="{}",
+            user=_make_user(),
+        )
 
     assert exc.value.error_code.code == "human_resume_submit_failed"
     assert exc.value.http_status == 503
@@ -204,6 +219,7 @@ async def test_interrupt_resume_success_skips_blocking_waiter_notification(
         id = "approval-1"
         status = "pending"
         session_id = "session-1"
+        user_id = "user-1"
         metadata = {"mode": "interrupt", "interrupt_id": "interrupt-a"}
 
     class _FakeApprovalStorage:
@@ -228,7 +244,9 @@ async def test_interrupt_resume_success_skips_blocking_waiter_notification(
     monkeypatch.setattr("src.infra.task.hitl.submit_hitl_resume_run", fake_submit)
     monkeypatch.setattr("src.infra.task.hitl.settings.HITL_MODE", "blocking")
 
-    result = await human.respond_to_approval("approval-1", approved=True, response="{}")
+    result = await human.respond_to_approval(
+        "approval-1", approved=True, response="{}", user=_make_user()
+    )
 
     assert result["hitl_resume"]["submitted"] is True
     assert notified is False
@@ -244,6 +262,7 @@ async def test_arq_interrupt_prepares_before_atomic_response_and_activates(
         id = "approval-1"
         status = "pending"
         session_id = "session-1"
+        user_id = "user-1"
         metadata = {"mode": "interrupt", "run_id": "run-1", "trace_id": "trace-1"}
 
     class _FakeApprovalStorage:
@@ -280,7 +299,9 @@ async def test_arq_interrupt_prepares_before_atomic_response_and_activates(
     monkeypatch.setattr("src.infra.task.hitl.activate_hitl_resume_attempt", fake_activate)
     monkeypatch.setattr("src.infra.task.hitl.settings.TASK_BACKEND", "arq")
 
-    result = await human.respond_to_approval("approval-1", approved=True, response="{}")
+    result = await human.respond_to_approval(
+        "approval-1", approved=True, response="{}", user=_make_user()
+    )
 
     assert result["hitl_resume"]["run_id"] == "run-1"
     assert order == ["prepare", "claim", "activate"]
@@ -294,6 +315,7 @@ async def test_concurrent_arq_responses_activate_only_the_atomic_winner(
         id = "approval-1"
         status = "pending"
         session_id = "session-1"
+        user_id = "user-1"
         metadata = {"mode": "interrupt", "run_id": "run-1", "trace_id": "trace-1"}
 
     class _FakeApprovalStorage:
@@ -342,8 +364,10 @@ async def test_concurrent_arq_responses_activate_only_the_atomic_winner(
     monkeypatch.setattr("src.infra.task.hitl.settings.TASK_BACKEND", "arq")
 
     results = await asyncio.gather(
-        human.respond_to_approval("approval-1", approved=True, response='{"choice":"a"}'),
-        human.respond_to_approval("approval-1", approved=False, response="{}"),
+        human.respond_to_approval(
+            "approval-1", approved=True, response='{"choice":"a"}', user=_make_user()
+        ),
+        human.respond_to_approval("approval-1", approved=False, response="{}", user=_make_user()),
         return_exceptions=True,
     )
 


### PR DESCRIPTION
## 问题

`src/api/routes/human.py` 中操作具体审批记录的四个端点（`POST /{id}/respond`、`POST /{id}/extend`、`GET /{id}`、`DELETE /{id}`）此前只校验 `chat:write` 权限位，未比对审批记录归属。任何持该权限的登录用户在得知他人 `approval_id` 的前提下，可读取审批载荷、取消他人挂起的审批，甚至代替他人提交审批结果并触发其 HITL 恢复运行。

缓解因素：`approval_id` 为 UUIDv4 不可枚举，且仅经 SSE 推送给会话归属者，实际可利用性低（Low）；但与仓库其余面向用户资源（session / bookmark / queue）一律归属校验的约定不一致，属应修复的访问控制缺口。

## 修复

- 新增 `resolve_approval_owner_id`：`user_id` 优先，缺失回退会话属主（`SessionManager`），两者皆缺视为无主。
- 新增 `_ensure_approval_access`：非本人一律 `APPROVAL_NOT_FOUND`（404 语义，避免存在性枚举）；`GET /{id}` 与"不存在"同形返回 `{"status": "not_found"}`，前端无需改动。
- 飞书卡片代答（`_respond_to_human_approval`）改为先解析审批属主、以属主身份调用 `respond_to_approval`，保持渠道原行为且不留免检旁路。

## 兼容性

- 正常前端流程不受影响（own approval_id 经归属者 SSE 获得）。
- `user_id` 缺失的存量记录走会话属主回退，归属可解析即可访问。
- `GET /pending` 原本就按 `user.sub` 过滤，无变化。

## 测试

- 新增 `tests/api/routes/test_human_approval_ownership.py`：11 个越权回归测试（四端点非本人拒绝 / 属主放行 / user_id 缺失回退 / 无主拒绝）。
- 更新 `test_human_wait.py` 既有 6 个 `respond_to_approval` 测试适配新签名（fake 审批补 `user_id`、调用传 `user`）。
- 本地验证：相关 pytest 全绿、ruff check / format、mypy 通过。