### PR TITLE
fix(frontend): 插话补发前探测会话运行状态，运行中暂缓避免同会话并发 run

### DIFF
--- a/frontend/src/hooks/useAgent.ts
+++ b/frontend/src/hooks/useAgent.ts
@@ -39,9 +39,8 @@ import {
 import { createOptimisticMessagesForSend } from "./useAgent/optimisticMessages";
 import { startQueuePositionPolling } from "./useAgent/queuePolling";
 import {
-  promoteSteerFollowUps,
-  selectSteersForFollowUp,
   useSteerQueue,
+  useSteerFollowUpPromotion,
 } from "./useAgent/steerQueue";
 import { getValidAccessToken } from "../services/api/tokenManager";
 import { resolveRunEnabledSkills } from "./useAgent/runSkillOverrides";
@@ -790,37 +789,18 @@ export function useAgent(options?: UseAgentOptions): UseAgentReturn {
 
   // If the run finishes after the API accepted a steer but before the next
   // model boundary, promote it to a normal follow-up instead of leaving it
-  // stranded above the composer.
-  useEffect(() => {
-    if (isLoading || isSendingRef.current) return;
-    const followUps = selectSteersForFollowUp(steerQueue.steerMessages).filter(
-      (item) => !followUpSteerIdsRef.current.has(item.id),
-    );
-    if (followUps.length === 0) return;
-    for (const item of followUps) {
-      followUpSteerIdsRef.current.add(item.id);
-    }
-    let cancelled = false;
-    const timer = window.setTimeout(() => {
-      // 先取消后端队列中的残留项再补发，否则新 run 的首次模型调用会把
-      // 同一条插话再次注入（同内容投递两次）。FIFO 逐条等待补发，避免
-      // 单 run 守卫丢弃后续条目。
-      void promoteSteerFollowUps(followUps, {
-        sessionId: sessionIdRef.current,
-        cancelSteer: (sessionId, content, messageId) =>
-          sessionApi.cancelSteer(sessionId, content, messageId),
-        sendMessage: async (content, attachments) => {
-          await sendMessageRef.current?.(content, attachments);
-        },
-        isCancelled: (id) => cancelled || cancelledSteerIdsRef.current.has(id),
-        clearSteer,
-      });
-    }, 0);
-    return () => {
-      cancelled = true;
-      window.clearTimeout(timer);
-    };
-  }, [clearSteer, isLoading, steerQueue.steerMessages]);
+  // stranded above the composer.（运行中探测/重试在 hook 内部，见
+  // useSteerFollowUpPromotion）
+  useSteerFollowUpPromotion({
+    isLoading,
+    isSendingRef,
+    steerMessages: steerQueue.steerMessages,
+    clearSteer,
+    cancelledSteerIdsRef,
+    followUpSteerIdsRef,
+    sessionIdRef,
+    sendMessageRef,
+  });
 
   const stopGeneration = useCallback(async () => {
     isSendingRef.current = false;

--- a/frontend/src/hooks/useAgent/__tests__/steerQueue.test.ts
+++ b/frontend/src/hooks/useAgent/__tests__/steerQueue.test.ts
@@ -129,6 +129,62 @@ describe("promoteSteerFollowUps", () => {
     expect(sent).toEqual(["保留"]);
   });
 
+  test("holds promotion while the session still has an active run", async () => {
+    // 重进/断连恢复时插话可能仍在原 run 的队列里等注入：
+    // 会话还在运行就补发会造出同会话并发 run，历史交错不可读
+    const calls: string[] = [];
+    const result = await promoteSteerFollowUps([item("s1", "要多点中国的")], {
+      sessionId: "session-1",
+      cancelSteer: async () => {
+        calls.push("cancel");
+      },
+      sendMessage: async () => {
+        calls.push("send");
+      },
+      clearSteer: () => {
+        calls.push("clear");
+      },
+      isSessionActive: async () => true,
+    });
+
+    expect(calls).toEqual([]);
+    expect(result).toEqual({ promoted: 0, skippedActive: 1 });
+  });
+
+  test("status probe failure is treated as active (never double-send blind)", async () => {
+    const sent: string[] = [];
+    const result = await promoteSteerFollowUps([item("s1", "插话")], {
+      sessionId: "session-1",
+      cancelSteer: async () => {},
+      sendMessage: async (content) => {
+        sent.push(content);
+      },
+      isSessionActive: async () => {
+        throw new Error("probe failed");
+      },
+    });
+
+    expect(sent).toEqual([]);
+    expect(result.skippedActive).toBe(1);
+  });
+
+  test("promotes as before when the session is idle", async () => {
+    const calls: string[] = [];
+    const result = await promoteSteerFollowUps([item("s1", "插话")], {
+      sessionId: "session-1",
+      cancelSteer: async () => {
+        calls.push("cancel");
+      },
+      sendMessage: async () => {
+        calls.push("send");
+      },
+      isSessionActive: async () => false,
+    });
+
+    expect(calls).toEqual(["cancel", "send"]);
+    expect(result).toEqual({ promoted: 1, skippedActive: 0 });
+  });
+
   test("clears local state first so the promotion effect does not retrigger", async () => {
     const cleared: Array<[string, string]> = [];
     const calls: string[] = [];

--- a/frontend/src/hooks/useAgent/steerQueue.ts
+++ b/frontend/src/hooks/useAgent/steerQueue.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { RefObject } from "react";
 
 import { sessionApi } from "../../services/api";
@@ -42,6 +42,14 @@ export interface PromoteSteerFollowUpsDeps {
   sendMessage: (content: string, attachments?: MessageAttachment[]) => Promise<unknown>;
   isCancelled?: (messageId: string) => boolean;
   clearSteer?: (content: string, messageId: string) => void;
+  /** 会话仍有运行中的 run 时返回 true：插话留在队列等注入，不补发 */
+  isSessionActive?: () => Promise<boolean>;
+}
+
+export interface PromoteSteerFollowUpsResult {
+  promoted: number;
+  /** 因会话仍在运行而暂缓补发的条数（调用方稍后重试） */
+  skippedActive: number;
 }
 
 /**
@@ -51,13 +59,33 @@ export interface PromoteSteerFollowUpsDeps {
  * 后端队列按会话共享，若只补发不取消，新 run 的首次模型调用会把同
  * 一条插话再次注入（同内容投递两次）。取消失败不阻塞补发——后端在
  * 新 run 提交时也会兜底清空残留队列。
+ *
+ * 补发前先探测会话是否仍在运行（重进/断连恢复场景）：运行中的 run
+ * 仍可能在下一次模型调用注入这条插话，此时补发会造出同会话并发 run
+ * （两路事件按时间交错落库，历史不可读）。探测失败按运行中处理——
+ * 宁可让补发稍后再试，也不冒双发并发 run 的险。
  */
 export async function promoteSteerFollowUps(
   items: SteerItem[],
   deps: PromoteSteerFollowUpsDeps,
-): Promise<void> {
+): Promise<PromoteSteerFollowUpsResult> {
   const { sessionId } = deps;
-  if (!sessionId) return;
+  if (!sessionId) return { promoted: 0, skippedActive: 0 };
+  if (deps.isSessionActive) {
+    let active = true;
+    try {
+      active = await deps.isSessionActive();
+    } catch {
+      active = true;
+    }
+    if (active) {
+      const skippedActive = items.filter(
+        (item) => !deps.isCancelled?.(item.id),
+      ).length;
+      return { promoted: 0, skippedActive };
+    }
+  }
+  let promoted = 0;
   for (const item of items) {
     if (deps.isCancelled?.(item.id)) continue;
     deps.clearSteer?.(item.content, item.id);
@@ -67,7 +95,114 @@ export async function promoteSteerFollowUps(
       // 取消失败继续补发；新 run 提交时的后端兜底清理会移除残留项
     }
     await deps.sendMessage(item.content, item.attachments);
+    promoted += 1;
   }
+  return { promoted, skippedActive: 0 };
+}
+
+/** 补发插话前视为「会话仍在运行」的任务状态（终态之外的都算） */
+const ACTIVE_RUN_STATUSES = new Set([
+  "pending",
+  "queued",
+  "starting",
+  "running",
+  "cancelling",
+  "waiting_human",
+  "recovering",
+]);
+
+const PROMOTE_RETRY_INTERVAL_MS = 5000;
+
+export interface SteerFollowUpPromotionOptions {
+  isLoading: boolean;
+  isSendingRef: RefObject<boolean>;
+  steerMessages: SteerItem[];
+  clearSteer: (content: string, messageId?: string) => void;
+  cancelledSteerIdsRef: RefObject<Set<string>>;
+  followUpSteerIdsRef: RefObject<Set<string>>;
+  sessionIdRef: RefObject<string | null>;
+  sendMessageRef: RefObject<
+    ((content: string, attachments?: MessageAttachment[]) => Promise<void>) | null
+  >;
+}
+
+/**
+ * 未送达插话的自动补发（run 结束后转为普通消息）。
+ *
+ * 触发条件只看本地发送态——重进/断连恢复时它恒为 false，因此补发前
+ * 必须探测会话实际状态：运行中则插话留在原 run 队列等注入，稍后重试
+ * （避免补发造出同会话并发 run、两路事件按时间交错落库）。
+ */
+export function useSteerFollowUpPromotion(
+  options: SteerFollowUpPromotionOptions,
+): void {
+  const {
+    isLoading,
+    isSendingRef,
+    steerMessages,
+    clearSteer,
+    cancelledSteerIdsRef,
+    followUpSteerIdsRef,
+    sessionIdRef,
+    sendMessageRef,
+  } = options;
+  // 重试时校验插话是否仍在队列（已被注入/送达的不重发，防同内容双投）
+  const steerMessagesRef = useRef(steerMessages);
+  useEffect(() => {
+    steerMessagesRef.current = steerMessages;
+  }, [steerMessages]);
+
+  useEffect(() => {
+    if (isLoading || isSendingRef.current) return;
+    const followUps = selectSteersForFollowUp(steerMessages).filter(
+      (item) => !followUpSteerIdsRef.current.has(item.id),
+    );
+    if (followUps.length === 0) return;
+    for (const item of followUps) {
+      followUpSteerIdsRef.current.add(item.id);
+    }
+    let cancelled = false;
+    let retryTimer: number | undefined;
+    const promote = async () => {
+      // 先取消后端队列中的残留项再补发，否则新 run 的首次模型调用会把
+      // 同一条插话再次注入（同内容投递两次）。FIFO 逐条等待补发，避免
+      // 单 run 守卫丢弃后续条目。
+      const result = await promoteSteerFollowUps(followUps, {
+        sessionId: sessionIdRef.current,
+        cancelSteer: (sessionId, content, messageId) =>
+          sessionApi.cancelSteer(sessionId, content, messageId),
+        sendMessage: async (content, attachments) => {
+          await sendMessageRef.current?.(content, attachments);
+        },
+        // cancelled：effect 卸载或用户撤销；不在队列：已被注入/送达
+        isCancelled: (id) =>
+          cancelled ||
+          cancelledSteerIdsRef.current.has(id) ||
+          !steerMessagesRef.current.some((item) => item.id === id),
+        clearSteer,
+        isSessionActive: async () => {
+          const sessionId = sessionIdRef.current;
+          if (!sessionId) return false;
+          const { status } = await sessionApi.getStatus(sessionId);
+          return ACTIVE_RUN_STATUSES.has(status);
+        },
+      });
+      // 会话仍在运行：插话留在原 run 队列等注入，稍后再探测
+      if (result.skippedActive > 0 && !cancelled) {
+        retryTimer = window.setTimeout(() => {
+          void promote();
+        }, PROMOTE_RETRY_INTERVAL_MS);
+      }
+    };
+    const timer = window.setTimeout(() => {
+      void promote();
+    }, 0);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+      if (retryTimer !== undefined) window.clearTimeout(retryTimer);
+    };
+  }, [clearSteer, isLoading, isSendingRef, steerMessages, cancelledSteerIdsRef, followUpSteerIdsRef, sessionIdRef, sendMessageRef]);
 }
 
 export interface PendingSteerSnapshot {


### PR DESCRIPTION
## 事故（生产 main-20260905-143248）

会话 https://lambchat.com/chat/b22fc71c-8667-4104-b200-fe882840210e：用户 steer「要多点中国的」成功入队（200）→ 退出重进 → 前端恢复未送达插话并**立即补发为普通消息**（新 run）→ 原 run 仍在执行 → 同会话两个并发 run，事件按时间交错落库，历史错乱。

根因是 9de30727 引入的「未送达插话自动补发」机制：触发条件只看本地 isLoading，未校验会话实际运行状态。重进/断连恢复时 isLoading 恒为 false，补发即刻触发。

## 修复（最小改动，3 个文件）

- `promoteSteerFollowUps` 补发前探测会话状态（新增 `isSessionActive` 依赖）：运行中（pending/queued/starting/running/cancelling/waiting_human/recovering）则**不补发**，插话留在原 run 队列等注入；探测失败按运行中处理——宁可补发滞后，不冒双发并发 run 的险。
- useAgent 接线：GET `/sessions/{id}/status`，暂缓后每 5s 重试直至空闲；重试期间补验插话仍在本地队列（已被注入送达的不再重发，防同内容双投）。
- 返回值 `{promoted, skippedActive}`，新增 4 个测试用例。

## 验证

- `pnpm test`：2144 通过（474 文件，新增 4 例）
- `pnpm run build` + `pnpm run lint`：通过（0 error）
- 后端不受影响（pytest 15 通过）