### PR TITLE
fix(chat): 修复取消 WAITING_HUMAN 会话后审批卡死锁并优化 ask_human 交互

### DIFF
--- a/frontend/src/components/chat/ChatMessage/ToolCallItem.tsx
+++ b/frontend/src/components/chat/ChatMessage/ToolCallItem.tsx
@@ -163,38 +163,43 @@ function ToolCallPanelContent({ toolCallId }: { toolCallId: string }) {
   const hasArgs = Object.keys(data.args).length > 0;
 
   return (
-    <div className="space-y-3 max-h-full overflow-y-auto p-2 sm:p-4 [&_pre]:!text-sm">
-      {hasArgs && (
-        <CollapsibleSection title={t("chat.message.args")}>
-          <ToolArgsDisplay args={data.args} />
-        </CollapsibleSection>
-      )}
+    <div className="relative flex h-full min-h-0 flex-col overflow-y-auto p-2 sm:p-4 [&_pre]:!text-sm [&_pre]:!max-h-none">
+      <div className="flex min-h-0 flex-1 flex-col space-y-3">
+        {hasArgs && (
+          <CollapsibleSection title={t("chat.message.args")}>
+            <ToolArgsDisplay args={data.args} />
+          </CollapsibleSection>
+        )}
 
-      {data.result !== undefined && (
-        <CollapsibleSection
-          title={t("chat.message.result")}
-          action={
-            <CopyButton
-              text={
-                typeof data.result === "string"
-                  ? data.result
-                  : JSON.stringify(data.result, null, 2)
-              }
-              size={12}
-            />
-          }
-        >
-          <ToolResultContent result={data.result} hideCopyButton />
-        </CollapsibleSection>
-      )}
+        {data.result !== undefined && (
+          <CollapsibleSection
+            title={t("chat.message.result")}
+            action={
+              <CopyButton
+                text={
+                  typeof data.result === "string"
+                    ? data.result
+                    : JSON.stringify(data.result, null, 2)
+                }
+                size={12}
+              />
+            }
+            expandedClassName="flex min-h-0 flex-col grow shrink-0"
+          >
+            <ToolResultContent result={data.result} hideCopyButton />
+          </CollapsibleSection>
+        )}
 
-      {data.isPending && (
-        <div className="flex items-center gap-2 text-xs text-amber-600 dark:text-amber-400">
-          <LoadingSpinner size="xs" />
-          <span>{t("chat.message.running")}</span>
-          <span className="tabular-nums">{formatElapsed(elapsedSeconds)}</span>
-        </div>
-      )}
+        {data.isPending && (
+          <div className="flex items-center gap-2 text-xs text-amber-600 dark:text-amber-400">
+            <LoadingSpinner size="xs" />
+            <span>{t("chat.message.running")}</span>
+            <span className="tabular-nums">
+              {formatElapsed(elapsedSeconds)}
+            </span>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/chat/ChatMessage/__tests__/collapsibleSectionSource.test.ts
+++ b/frontend/src/components/chat/ChatMessage/__tests__/collapsibleSectionSource.test.ts
@@ -49,3 +49,63 @@ test("expanded collapsible section cards fill the available panel height", () =>
     /title=\{t\("chat\.message\.result"\)\}[\s\S]*?expandedClassName="flex min-h-0 flex-col grow shrink-0"/,
   );
 });
+
+test("generic tool call panel stretches the result card to fill remaining height", () => {
+  const toolCallItemSource = readFileSync(
+    new URL("../ToolCallItem.tsx", import.meta.url),
+    "utf8",
+  );
+
+  // 面板根节点：占满 panel-body 并自身兜底滚动
+  expect(toolCallItemSource).toMatch(
+    /className="relative flex h-full min-h-0 flex-col overflow-y-auto p-2 sm:p-4 \[&_pre\]:!text-sm \[&_pre\]:!max-h-none"/,
+  );
+  // 内层 flex 列承载小节，result 卡片展开时吃掉剩余空间
+  expect(toolCallItemSource).toMatch(
+    /className="flex min-h-0 flex-1 flex-col space-y-3"/,
+  );
+  expect(toolCallItemSource).toMatch(
+    /title=\{t\("chat\.message\.result"\)\}[\s\S]*?expandedClassName="flex min-h-0 flex-col grow shrink-0"/,
+  );
+});
+
+test("tool live panel details fill the panel height while inline previews keep their caps", () => {
+  const itemsDir = new URL("../items/", import.meta.url);
+  const panelDetailItems = [
+    "ToolSearchItem",
+    "TransferItem",
+    "UploadUrlToSandboxItem",
+    "SkillSearchItem",
+    "ConversationHistoryItem",
+  ];
+
+  for (const item of panelDetailItems) {
+    const source = readFileSync(new URL(`${item}.tsx`, itemsDir), "utf8");
+    // 面板详情根节点铺满 panel-body，自身兜底滚动
+    expect(
+      source,
+      `${item} panel detail root should fill the panel height`,
+    ).toMatch(
+      /className="flex h-full min-h-0 flex-col space-y-3 overflow-y-auto p-2 sm:p-4 \[&_pre\]:!max-h-none"/,
+    );
+    expect(
+      source,
+      `${item} should not keep the old shrink-to-fit panel detail root`,
+    ).not.toMatch(/space-y-3 max-h-full overflow-y-auto p-2 sm:p-4/);
+  }
+
+  // 结果区直接可滚动的三个面板：result 区块伸展吃掉剩余空间
+  for (const item of [
+    "ToolSearchItem",
+    "TransferItem",
+    "UploadUrlToSandboxItem",
+  ]) {
+    const source = readFileSync(new URL(`${item}.tsx`, itemsDir), "utf8");
+    expect(
+      source,
+      `${item} panel result block should stretch to fill remaining height`,
+    ).toMatch(
+      /group\/result relative flex-1 min-h-0 text-xs text-theme-text-secondary overflow-y-auto min-w-0/,
+    );
+  }
+});

--- a/frontend/src/components/chat/ChatMessage/items/ConversationHistoryItem.tsx
+++ b/frontend/src/components/chat/ChatMessage/items/ConversationHistoryItem.tsx
@@ -1,11 +1,5 @@
 import { memo, useMemo } from "react";
-import {
-  History,
-  Search,
-  User,
-  MessageSquareText,
-  Clock,
-} from "lucide-react";
+import { History, Search, User, MessageSquareText, Clock } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { CollapsiblePill } from "../../../common";
 import { extractText } from "./toolUtils";
@@ -89,7 +83,8 @@ function matchSourceLabel(
   t: (key: string) => string,
 ): string | null {
   if (source === "user") return t("chat.message.toolHistoryMatchUser");
-  if (source === "assistant") return t("chat.message.toolHistoryMatchAssistant");
+  if (source === "assistant")
+    return t("chat.message.toolHistoryMatchAssistant");
   if (source === "both") return t("chat.message.toolHistoryMatchBoth");
   return null;
 }
@@ -115,9 +110,15 @@ function HistoryQueryChip({
   return (
     <ToolArgsBlock size={size}>
       {isSearch ? (
-        <Search size={size === "detail" ? 14 : 12} className="shrink-0 text-sky-500 dark:text-sky-400" />
+        <Search
+          size={size === "detail" ? 14 : 12}
+          className="shrink-0 text-sky-500 dark:text-sky-400"
+        />
       ) : (
-        <History size={size === "detail" ? 14 : 12} className="shrink-0 text-sky-500 dark:text-sky-400" />
+        <History
+          size={size === "detail" ? 14 : 12}
+          className="shrink-0 text-sky-500 dark:text-sky-400"
+        />
       )}
       <span className="text-sky-600 dark:text-sky-400 font-mono font-medium min-w-0 truncate">
         {isSearch ? truncate(value, 80) : truncate(value, 36)}
@@ -162,7 +163,7 @@ function ConversationHistoryDetail({
   const hasRawFallback = !!result && !parsed;
 
   return (
-    <div className="space-y-3 max-h-full overflow-y-auto p-2 sm:p-4">
+    <div className="flex h-full min-h-0 flex-col space-y-3 overflow-y-auto p-2 sm:p-4 [&_pre]:!max-h-none">
       <HistoryQueryChip toolName={toolName} args={args} size="detail" />
 
       {parsed?.kind === "search" && parsed.items && parsed.items.length > 0 && (
@@ -299,7 +300,8 @@ const ConversationHistoryItem = memo(function ConversationHistoryItem({
   const titleLabel = isSearch
     ? t("chat.message.toolHistorySearch")
     : t("chat.message.toolHistoryDetail");
-  const sessionName = parsed?.kind === "detail" ? parsed.sessionName : undefined;
+  const sessionName =
+    parsed?.kind === "detail" ? parsed.sessionName : undefined;
 
   const pillLabel = isSearch
     ? `${titleLabel} ${query ? `"${truncate(query, 24)}"` : ""}${

--- a/frontend/src/components/chat/ChatMessage/items/SkillSearchItem.tsx
+++ b/frontend/src/components/chat/ChatMessage/items/SkillSearchItem.tsx
@@ -68,7 +68,7 @@ function SkillSearchDetail({ args, result }: ToolDetailProps) {
   const hasRawFallback = !!result && matches.length === 0;
 
   return (
-    <div className="space-y-3 max-h-full overflow-y-auto p-2 sm:p-4">
+    <div className="flex h-full min-h-0 flex-col space-y-3 overflow-y-auto p-2 sm:p-4 [&_pre]:!max-h-none">
       {query && (
         <ToolArgsBlock size="detail">
           <Search

--- a/frontend/src/components/chat/ChatMessage/items/ToolSearchItem.tsx
+++ b/frontend/src/components/chat/ChatMessage/items/ToolSearchItem.tsx
@@ -25,7 +25,7 @@ function ToolSearchDetail({ args, result }: ToolDetailProps) {
     : "";
 
   return (
-    <div className="space-y-3 max-h-full overflow-y-auto p-2 sm:p-4">
+    <div className="flex h-full min-h-0 flex-col space-y-3 overflow-y-auto p-2 sm:p-4 [&_pre]:!max-h-none">
       {query && (
         <ToolArgsBlock size="detail">
           <Search
@@ -38,7 +38,7 @@ function ToolSearchDetail({ args, result }: ToolDetailProps) {
         </ToolArgsBlock>
       )}
       {hasResult && (
-        <div className="group/result relative text-xs text-theme-text-secondary overflow-y-auto min-w-0">
+        <div className="group/result relative flex-1 min-h-0 text-xs text-theme-text-secondary overflow-y-auto min-w-0">
           <ToolHoverCopyButton
             text={resultText}
             position="resultCompact"

--- a/frontend/src/components/chat/ChatMessage/items/TransferItem.tsx
+++ b/frontend/src/components/chat/ChatMessage/items/TransferItem.tsx
@@ -40,7 +40,7 @@ function TransferDetail({
   const resultText = stringifyResult(result);
 
   return (
-    <div className="space-y-3 max-h-full overflow-y-auto p-2 sm:p-4">
+    <div className="flex h-full min-h-0 flex-col space-y-3 overflow-y-auto p-2 sm:p-4 [&_pre]:!max-h-none">
       {source && (
         <ToolArgsBlock size="detail" wrap>
           <FolderOutput
@@ -60,7 +60,7 @@ function TransferDetail({
         </ToolArgsBlock>
       )}
       {hasResult && (
-        <div className="group/result relative text-xs text-theme-text-secondary overflow-y-auto min-w-0">
+        <div className="group/result relative flex-1 min-h-0 text-xs text-theme-text-secondary overflow-y-auto min-w-0">
           <ToolHoverCopyButton
             text={resultText}
             position="resultCompact"

--- a/frontend/src/components/chat/ChatMessage/items/UploadUrlToSandboxItem.tsx
+++ b/frontend/src/components/chat/ChatMessage/items/UploadUrlToSandboxItem.tsx
@@ -31,7 +31,7 @@ function UploadUrlToSandboxDetail({ args, result }: ToolDetailProps) {
   const resultText = stringifyResult(result);
 
   return (
-    <div className="space-y-3 max-h-full overflow-y-auto p-2 sm:p-4">
+    <div className="flex h-full min-h-0 flex-col space-y-3 overflow-y-auto p-2 sm:p-4 [&_pre]:!max-h-none">
       {url && (
         <ToolArgsBlock size="detail" wrap>
           <LinkIcon
@@ -51,7 +51,7 @@ function UploadUrlToSandboxDetail({ args, result }: ToolDetailProps) {
         </ToolArgsBlock>
       )}
       {hasResult && (
-        <div className="group/result relative text-xs text-theme-text-secondary overflow-y-auto min-w-0">
+        <div className="group/result relative flex-1 min-h-0 text-xs text-theme-text-secondary overflow-y-auto min-w-0">
           <ToolHoverCopyButton
             text={resultText}
             position="resultCompact"
@@ -146,9 +146,7 @@ const UploadUrlToSandboxItem = memo(function UploadUrlToSandboxItem({
           subtitle: filePath || url || undefined,
           fallback: detailContent || undefined,
           buildDetail: (data) => (
-            <UploadUrlToSandboxDetail
-              {...toolDetailPropsFromPanelData(data)}
-            />
+            <UploadUrlToSandboxDetail {...toolDetailPropsFromPanelData(data)} />
           ),
           footer: durationFooter,
         });

--- a/frontend/src/components/common/Tooltip.tsx
+++ b/frontend/src/components/common/Tooltip.tsx
@@ -18,6 +18,8 @@ interface TooltipProps {
   className?: string;
   /** z-index for the tooltip (default: 60) */
   zIndex?: number;
+  /** Force the bubble visible (e.g. driven by a parent's touch state); hover/long-press still work when not forced */
+  open?: boolean;
 }
 
 /** Long press duration (ms) before tooltip appears on touch */
@@ -31,6 +33,7 @@ export function Tooltip({
   children,
   className,
   zIndex = 60,
+  open,
 }: TooltipProps) {
   const [show, setShow] = useState(false);
   const hoverTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
@@ -132,7 +135,10 @@ export function Tooltip({
     };
   }, []);
 
-  const tipStyle = useStickyDropdownPosition(childElRef, show, (rect) => {
+  // Forced-open (touch-driven) shows the bubble on top of the internal hover/long-press state
+  const visible = open === true || show;
+
+  const tipStyle = useStickyDropdownPosition(childElRef, visible, (rect) => {
     const textLen =
       typeof content === "string"
         ? content.length
@@ -167,7 +173,7 @@ export function Tooltip({
         {children}
       </span>
 
-      {show &&
+      {visible &&
         createPortal(
           <span
             className={`fixed max-w-[240px] w-max rounded-lg bg-stone-700 dark:bg-stone-900 px-2.5 py-1.5 text-xs leading-relaxed text-white shadow-lg whitespace-normal pointer-events-none ${

--- a/frontend/src/components/common/__tests__/tooltipControlledOpen.test.tsx
+++ b/frontend/src/components/common/__tests__/tooltipControlledOpen.test.tsx
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { fireEvent, render, within } from "@testing-library/react";
+import { Tooltip } from "../Tooltip";
+
+describe("Tooltip controlled open", () => {
+  it("shows the bubble immediately when open is true", () => {
+    render(
+      <Tooltip content="运行中" open>
+        <span data-testid="icon" />
+      </Tooltip>,
+    );
+    const bubble = within(document.body).getByText("运行中");
+    expect(bubble).toHaveClass("fixed", "pointer-events-none");
+  });
+
+  it("does not suppress hover behavior when open is false", () => {
+    const view = render(
+      <Tooltip content="运行中" open={false}>
+        <span data-testid="icon" />
+      </Tooltip>,
+    );
+    expect(within(document.body).queryByText("运行中")).not.toBeInTheDocument();
+    fireEvent.mouseEnter(view.getByTestId("icon"));
+    expect(within(document.body).getByText("运行中")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/panels/ApprovalPanel.tsx
+++ b/frontend/src/components/panels/ApprovalPanel.tsx
@@ -28,6 +28,7 @@ import { parseDate } from "../../utils/datetime";
 import {
   isFormFieldsValid,
   toggleMultiSelectValue,
+  toggleSingleSelectValue,
 } from "./approvalFormValidation";
 
 interface ApprovalPanelProps {
@@ -238,15 +239,13 @@ function AskHumanChoiceList({
   field,
   value,
   disabled,
-  selectedIndex,
   onSelect,
   onInteract,
 }: {
   field: FormField;
   value: unknown;
   disabled: boolean;
-  selectedIndex: number;
-  onSelect: (option: string, index: number) => void;
+  onSelect: (option: string) => void;
   onInteract: () => void;
 }) {
   const { t } = useTranslation();
@@ -281,11 +280,10 @@ function AskHumanChoiceList({
               className={clsx(
                 "approval-ask-human-option",
                 selected && "approval-ask-human-option--selected",
-                selectedIndex === index && "approval-ask-human-option--focused",
               )}
               onClick={() => {
                 onInteract();
-                onSelect(option, index);
+                onSelect(option);
               }}
             >
               <span
@@ -311,14 +309,12 @@ export function ApprovalPanel({
   const { t } = useTranslation();
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isExpanded, setIsExpanded] = useState(false);
-  const [askHumanSelectedIndex, setAskHumanSelectedIndex] = useState(0);
   const [formValues, setFormValues] = useState<
     Record<string, Record<string, unknown>>
   >({});
 
   // Countdown state: map of approval id -> remaining seconds
   const [remaining, setRemaining] = useState<Record<string, number>>({});
-  const currentApprovalId = approvals[currentIndex]?.id;
   // Track expiry deadlines so we can update them on extend
   const deadlinesRef = useRef<Record<string, number>>({});
   // Debounce extend calls (per approval)
@@ -369,10 +365,6 @@ export function ApprovalPanel({
       }
     }
   }, [approvals]);
-
-  useEffect(() => {
-    setAskHumanSelectedIndex(0);
-  }, [currentApprovalId]);
 
   // Countdown tick
   useEffect(() => {
@@ -555,7 +547,6 @@ export function ApprovalPanel({
       field.type === "multi_select" ||
       field.type === "select",
   );
-  const askHumanKeyboardField = askHumanChoiceFields[0];
   const askHumanQuestion = approvalSummary;
   const isSubmitDisabled =
     isLoading || !isFormFieldsValid(currentApproval.fields, currentFormValues);
@@ -607,53 +598,13 @@ export function ApprovalPanel({
           }`}
           key={currentApproval.id}
           onKeyDown={(event) => {
-            // 卡片内文本控件（如“其他”自由填写）优先走原生输入，快捷键让位
+            // 唯一快捷键：Enter 提交。文本控件内走原生（换行），按钮上走原生激活，
+            // 其余数字键/方向键一律不劫持，避免选中乱跳的高亮
             if (isEditableEventTarget(event.target)) return;
-            if (!isAskHuman || !askHumanKeyboardField?.options?.length) return;
-            const count = askHumanKeyboardField.options.length;
-            if (event.key === "ArrowDown" || event.key === "Tab") {
-              event.preventDefault();
-              setAskHumanSelectedIndex((index) => (index + 1) % count);
-            } else if (event.key === "ArrowUp") {
-              event.preventDefault();
-              setAskHumanSelectedIndex((index) => (index - 1 + count) % count);
-            } else if (event.key === "Enter" || event.key === " ") {
-              event.preventDefault();
-              const option =
-                askHumanKeyboardField.options[askHumanSelectedIndex];
-              if (option) {
-                handleFieldChange(
-                  askHumanKeyboardField.name,
-                  askHumanKeyboardField.type === "multi_select"
-                    ? toggleMultiSelectValue(
-                        currentFormValues[askHumanKeyboardField.name],
-                        option,
-                      )
-                    : option,
-                );
-              }
-            } else if (
-              event.key >= "1" &&
-              event.key <= "9" &&
-              Number(event.key) <= count
-            ) {
-              // 数字键快捷选择对应序号的选项
-              event.preventDefault();
-              const option =
-                askHumanKeyboardField.options[Number(event.key) - 1];
-              if (option) {
-                setAskHumanSelectedIndex(Number(event.key) - 1);
-                handleFieldChange(
-                  askHumanKeyboardField.name,
-                  askHumanKeyboardField.type === "multi_select"
-                    ? toggleMultiSelectValue(
-                        currentFormValues[askHumanKeyboardField.name],
-                        option,
-                      )
-                    : option,
-                );
-              }
-            }
+            if (event.target instanceof HTMLButtonElement) return;
+            if (!isAskHuman || event.key !== "Enter") return;
+            event.preventDefault();
+            handleSubmit();
           }}
           tabIndex={isAskHuman ? 0 : undefined}
         >
@@ -698,10 +649,7 @@ export function ApprovalPanel({
             </button>
           ) : (
             <div className="approval-ask-human-header">
-              <div className="approval-ask-human-title-row">
-                <span className="approval-ask-human-badge">
-                  {t("approvals.mainGoal")}
-                </span>
+              <div className="approval-ask-human-title-row font-serif">
                 <span className="approval-ask-human-question">
                   {askHumanQuestion}
                 </span>
@@ -770,16 +718,9 @@ export function ApprovalPanel({
                               field={field}
                               value={currentFormValues[field.name]}
                               disabled={isLoading}
-                              selectedIndex={
-                                field === askHumanKeyboardField
-                                  ? askHumanSelectedIndex
-                                  : -1
-                              }
                               onInteract={handleInteract(currentApproval.id)}
-                              onSelect={(option, index) => {
-                                if (field === askHumanKeyboardField) {
-                                  setAskHumanSelectedIndex(index);
-                                }
+                              onSelect={(option) => {
+                                // 鼠标点击：单选再点同一项取消，多选增删
                                 handleFieldChange(
                                   field.name,
                                   field.type === "multi_select"
@@ -787,7 +728,10 @@ export function ApprovalPanel({
                                         currentFormValues[field.name],
                                         option,
                                       )
-                                    : option,
+                                    : toggleSingleSelectValue(
+                                        currentFormValues[field.name],
+                                        option,
+                                      ),
                                 );
                               }}
                             />
@@ -865,11 +809,11 @@ export function ApprovalPanel({
                 )}
               </div>
               <div
-                className={`approval-actions ${
+                className={`approval-actions font-serif ${
                   isAskHuman ? "approval-ask-human-footer" : ""
                 }`}
               >
-                {isAskHuman && askHumanChoiceFields.length > 0 && (
+                {isAskHuman && (
                   <span
                     className="approval-ask-human-shortcut-hint hidden sm:inline-flex"
                     aria-hidden="true"
@@ -887,7 +831,7 @@ export function ApprovalPanel({
                     title={
                       isAskHuman ? t("approvals.ignore") : t("approvals.cancel")
                     }
-                    className="approval-btn-cancel flex-1 flex items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-sm transition-all duration-200 active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed"
+                    className="approval-btn-cancel flex-1 flex items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs transition-all duration-200 active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed"
                   >
                     <X size={14} />
                     <span>
@@ -901,7 +845,7 @@ export function ApprovalPanel({
                     disabled={isSubmitDisabled}
                     aria-label={t("approvals.submit")}
                     title={t("approvals.submit")}
-                    className="approval-btn-submit flex-1 flex items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-sm transition-all duration-200 active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed"
+                    className="approval-btn-submit flex-1 flex items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs transition-all duration-200 active:scale-[0.97] disabled:opacity-40 disabled:cursor-not-allowed"
                   >
                     <Send size={14} />
                     <span>{t("approvals.submit")}</span>

--- a/frontend/src/components/panels/SidebarParts/SessionListContent.tsx
+++ b/frontend/src/components/panels/SidebarParts/SessionListContent.tsx
@@ -19,6 +19,7 @@ import { useNavigate } from "react-router-dom";
 import { useAuth } from "../../../hooks/useAuth";
 import { Permission } from "../../../types/auth";
 import { LoadingSpinner } from "../../common/LoadingSpinner";
+import { Tooltip } from "../../common/Tooltip";
 import { SkeletonList } from "../../skeletons";
 import { BrandWordmark } from "../../common/BrandWordmark";
 import { BrandLogo } from "../../common/BrandLogo";
@@ -348,25 +349,27 @@ export function SessionListContent({
             <BrandWordmark decorative className="size-7 w-auto mb-1" />
           </a>
         </div>
-        <button
-          onClick={onCollapse}
-          className="flex size-8 items-center justify-center rounded-lg text-stone-600 hover:bg-stone-100 dark:text-stone-400 dark:hover:bg-stone-800/60 transition-colors cursor-w-resize rtl:cursor-e-resize"
-          title={t("sidebar.collapseSidebar")}
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            className="size-5 text-stone-600 dark:text-stone-300"
+        <Tooltip content={t("sidebar.collapseSidebar")}>
+          <button
+            onClick={onCollapse}
+            className="flex size-8 items-center justify-center rounded-lg text-stone-600 hover:bg-stone-100 dark:text-stone-400 dark:hover:bg-stone-800/60 transition-colors cursor-w-resize rtl:cursor-e-resize"
+            aria-label={t("sidebar.collapseSidebar")}
           >
-            <path
-              fillRule="evenodd"
-              clipRule="evenodd"
-              d="M8.85719 3H15.1428C16.2266 2.99999 17.1007 2.99998 17.8086 3.05782C18.5375 3.11737 19.1777 3.24318 19.77 3.54497C20.7108 4.02433 21.4757 4.78924 21.955 5.73005C22.2568 6.32234 22.3826 6.96253 22.4422 7.69138C22.5 8.39925 22.5 9.27339 22.5 10.3572V13.6428C22.5 14.7266 22.5 15.6008 22.4422 16.3086C22.3826 17.0375 22.2568 17.6777 21.955 18.27C21.4757 19.2108 20.7108 19.9757 19.77 20.455C19.1777 20.7568 18.5375 20.8826 17.8086 20.9422C17.1008 21 16.2266 21 15.1428 21H8.85717C7.77339 21 6.89925 21 6.19138 20.9422C5.46253 20.8826 4.82234 20.7568 4.23005 20.455C3.28924 19.9757 2.52433 19.2108 2.04497 18.27C1.74318 17.6777 1.61737 17.0375 1.55782 16.3086C1.49998 15.6007 1.49999 14.7266 1.5 13.6428V10.3572C1.49999 9.27341 1.49998 8.39926 1.55782 7.69138C1.61737 6.96253 1.74318 6.32234 2.04497 5.73005C2.52433 4.78924 3.28924 4.02433 4.23005 3.54497C4.82234 3.24318 5.46253 3.11737 6.19138 3.05782C6.89926 2.99998 7.77341 2.99999 8.85719 3ZM6.35424 5.05118C5.74907 5.10062 5.40138 5.19279 5.13803 5.32698C4.57354 5.6146 4.1146 6.07354 3.82698 6.63803C3.69279 6.90138 3.60062 7.24907 3.55118 7.85424C3.50078 8.47108 3.5 9.26339 3.5 10.4V13.6C3.5 14.7366 3.50078 15.5289 3.55118 16.1458C3.60062 16.7509 3.69279 17.0986 3.82698 17.362C4.1146 17.9265 4.57354 18.3854 5.13803 18.673C5.40138 18.8072 5.74907 18.8994 6.35424 18.9488C6.97108 18.9992 7.76339 19 8.9 19H9.5V5H8.9C7.76339 5 6.97108 5.00078 6.35424 5.05118ZM11.5 5V19H15.1C16.2366 19 17.0289 18.9992 17.6458 18.9488C18.2509 18.8994 18.5986 18.8072 18.862 18.673C19.4265 18.3854 19.8854 17.9265 20.173 17.362C20.3072 17.0986 20.3994 16.7509 20.4488 16.1458C20.4992 15.5289 20.5 14.7366 20.5 13.6V10.4C20.5 9.26339 20.4992 8.47108 20.4488 7.85424C20.3994 7.24907 20.3072 6.90138 20.173 6.63803C19.8854 6.57354 19.4265 6.1146 18.862 5.32698C18.5986 5.19279 18.2509 5.10062 17.6458 5.05118C17.0289 5.00078 16.2366 5 15.1 5H11.5ZM5 8.5C5 7.94772 5.44772 7.5 6 7.5H7C7.55229 7.5 8 7.94772 8 8.5C8 9.05229 7.55229 9.5 7 9.5H6C5.44772 9.5 5 9.05229 5 8.5ZM5 12C5 11.4477 5.44772 11 6 11H7C7.55229 11 8 11.4477 8 12C8 12.5523 7.55229 13 7 13H6C5.44772 13 5 12.4477 5 12Z"
-              fill="currentColor"
-            />
-          </svg>
-        </button>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              className="size-5 text-stone-600 dark:text-stone-300"
+            >
+              <path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M8.85719 3H15.1428C16.2266 2.99999 17.1007 2.99998 17.8086 3.05782C18.5375 3.11737 19.1777 3.24318 19.77 3.54497C20.7108 4.02433 21.4757 4.78924 21.955 5.73005C22.2568 6.32234 22.3826 6.96253 22.4422 7.69138C22.5 8.39925 22.5 9.27339 22.5 10.3572V13.6428C22.5 14.7266 22.5 15.6008 22.4422 16.3086C22.3826 17.0375 22.2568 17.6777 21.955 18.27C21.4757 19.2108 20.7108 19.9757 19.77 20.455C19.1777 20.7568 18.5375 20.8826 17.8086 20.9422C17.1008 21 16.2266 21 15.1428 21H8.85717C7.77339 21 6.89925 21 6.19138 20.9422C5.46253 20.8826 4.82234 20.7568 4.23005 20.455C3.28924 19.9757 2.52433 19.2108 2.04497 18.27C1.74318 17.6777 1.61737 17.0375 1.55782 16.3086C1.49998 15.6007 1.49999 14.7266 1.5 13.6428V10.3572C1.49999 9.27341 1.49998 8.39926 1.55782 7.69138C1.61737 6.96253 1.74318 6.32234 2.04497 5.73005C2.52433 4.78924 3.28924 4.02433 4.23005 3.54497C4.82234 3.24318 5.46253 3.11737 6.19138 3.05782C6.89926 2.99998 7.77341 2.99999 8.85719 3ZM6.35424 5.05118C5.74907 5.10062 5.40138 5.19279 5.13803 5.32698C4.57354 5.6146 4.1146 6.07354 3.82698 6.63803C3.69279 6.90138 3.60062 7.24907 3.55118 7.85424C3.50078 8.47108 3.5 9.26339 3.5 10.4V13.6C3.5 14.7366 3.50078 15.5289 3.55118 16.1458C3.60062 16.7509 3.69279 17.0986 3.82698 17.362C4.1146 17.9265 4.57354 18.3854 5.13803 18.673C5.40138 18.8072 5.74907 18.8994 6.35424 18.9488C6.97108 18.9992 7.76339 19 8.9 19H9.5V5H8.9C7.76339 5 6.97108 5.00078 6.35424 5.05118ZM11.5 5V19H15.1C16.2366 19 17.0289 18.9992 17.6458 18.9488C18.2509 18.8994 18.5986 18.8072 18.862 18.673C19.4265 18.3854 19.8854 17.9265 20.173 17.362C20.3072 17.0986 20.3994 16.7509 20.4488 16.1458C20.4992 15.5289 20.5 14.7366 20.5 13.6V10.4C20.5 9.26339 20.4992 8.47108 20.4488 7.85424C20.3994 7.24907 20.3072 6.90138 20.173 6.63803C19.8854 6.57354 19.4265 6.1146 18.862 5.32698C18.5986 5.19279 18.2509 5.10062 17.6458 5.05118C17.0289 5.00078 16.2366 5 15.1 5H11.5ZM5 8.5C5 7.94772 5.44772 7.5 6 7.5H7C7.55229 7.5 8 7.94772 8 8.5C8 9.05229 7.55229 9.5 7 9.5H6C5.44772 9.5 5 9.05229 5 8.5ZM5 12C5 11.4477 5.44772 11 6 11H7C7.55229 11 8 11.4477 8 12C8 12.5523 7.55229 13 7 13H6C5.44772 13 5 12.4477 5 12Z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </Tooltip>
       </div>
 
       {/* Action buttons */}
@@ -646,7 +649,7 @@ export function SessionListContent({
                       badgeId="all"
                       markingReadId={markingReadId}
                       onMarkAllRead={() => onMarkAllRead()}
-                      title={t("sidebar.markAllRead")}
+                      tooltip={t("sidebar.markAllRead")}
                     />
                   )}
                 </div>
@@ -824,34 +827,38 @@ export function SessionListContent({
                 })}
               </div>
               <div className="flex shrink-0 items-center gap-1.5">
-                <button
-                  type="button"
-                  disabled={selectedCount === 0}
-                  onClick={() => setIsProjectPickerOpen((value) => !value)}
-                  className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-stone-600 transition hover:bg-white/70 hover:text-stone-900 disabled:cursor-not-allowed disabled:opacity-45 dark:text-stone-300 dark:hover:bg-stone-900/45 dark:hover:text-stone-50"
-                  title={t("sidebar.moveSelectedToProject")}
-                  aria-label={t("sidebar.moveSelectedToProject")}
-                >
-                  <FolderInput size={14} />
-                </button>
-                <button
-                  type="button"
-                  disabled={selectedCount === 0}
-                  onClick={handleRequestDeleteSelected}
-                  className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-red-600 transition hover:bg-red-50 hover:text-red-700 disabled:cursor-not-allowed disabled:opacity-45 dark:text-red-400 dark:hover:bg-red-950/40 dark:hover:text-red-300"
-                  title={t("sidebar.deleteSelected")}
-                  aria-label={t("sidebar.deleteSelected")}
-                >
-                  <Trash2 size={14} />
-                </button>
-                <button
-                  type="button"
-                  onClick={onClearSelection}
-                  className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-stone-500 transition hover:bg-white/70 hover:text-stone-800 dark:text-stone-400 dark:hover:bg-stone-900/45 dark:hover:text-stone-100"
-                  title={t("common.cancel")}
-                >
-                  <X size={15} />
-                </button>
+                <Tooltip content={t("sidebar.moveSelectedToProject")}>
+                  <button
+                    type="button"
+                    disabled={selectedCount === 0}
+                    onClick={() => setIsProjectPickerOpen((value) => !value)}
+                    aria-label={t("sidebar.moveSelectedToProject")}
+                    className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-stone-600 transition hover:bg-white/70 hover:text-stone-900 disabled:cursor-not-allowed disabled:opacity-45 dark:text-stone-300 dark:hover:bg-stone-900/45 dark:hover:text-stone-50"
+                  >
+                    <FolderInput size={14} />
+                  </button>
+                </Tooltip>
+                <Tooltip content={t("sidebar.deleteSelected")}>
+                  <button
+                    type="button"
+                    disabled={selectedCount === 0}
+                    onClick={handleRequestDeleteSelected}
+                    aria-label={t("sidebar.deleteSelected")}
+                    className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-red-600 transition hover:bg-red-50 hover:text-red-700 disabled:cursor-not-allowed disabled:opacity-45 dark:text-red-400 dark:hover:bg-red-950/40 dark:hover:text-red-300"
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                </Tooltip>
+                <Tooltip content={t("common.cancel")}>
+                  <button
+                    type="button"
+                    onClick={onClearSelection}
+                    aria-label={t("common.cancel")}
+                    className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-stone-500 transition hover:bg-white/70 hover:text-stone-800 dark:text-stone-400 dark:hover:bg-stone-900/45 dark:hover:text-stone-100"
+                  >
+                    <X size={15} />
+                  </button>
+                </Tooltip>
               </div>
             </div>
           </div>

--- a/frontend/src/components/panels/SidebarParts/SidebarRail.tsx
+++ b/frontend/src/components/panels/SidebarParts/SidebarRail.tsx
@@ -13,6 +13,7 @@ import { Permission } from "../../../types/auth";
 import { getFullUrl } from "../../../services/api";
 import { APP_NAME } from "../../../constants";
 import { BrandLogo } from "../../common/BrandLogo";
+import { Tooltip } from "../../common/Tooltip";
 import { ImageWithSkeleton } from "../../chat/ChatMessage/ImageWithSkeleton";
 
 const railBtn =
@@ -70,26 +71,28 @@ export function SidebarRail({
     >
       {/* Expand button — default: app icon, hover: expand icon */}
       <div className="flex items-center justify-center w-full pt-3">
-        <button
-          onClick={onExpand}
-          className={`${railBtn} group cursor-e-resize rtl:cursor-w-resize`}
-          aria-label={t("sidebar.expandSidebar")}
-        >
-          <BrandLogo alt={APP_NAME} className="size-7 group-hover:hidden" />
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            className="size-5 hidden group-hover:block"
+        <Tooltip content={t("sidebar.expandSidebar")}>
+          <button
+            onClick={onExpand}
+            className={`${railBtn} group cursor-e-resize rtl:cursor-w-resize`}
+            aria-label={t("sidebar.expandSidebar")}
           >
-            <path
-              fillRule="evenodd"
-              clipRule="evenodd"
-              d="M8.85719 3H15.1428C16.2266 2.99999 17.1007 2.99998 17.8086 3.05782C18.5375 3.11737 19.1777 3.24318 19.77 3.54497C20.7108 4.02433 21.4757 4.78924 21.955 5.73005C22.2568 6.32234 22.3826 6.96253 22.4422 7.69138C22.5 8.39925 22.5 9.27339 22.5 10.3572V13.6428C22.5 14.7266 22.5 15.6008 22.4422 16.3086C22.3826 17.0375 22.2568 17.6777 21.955 18.27C21.4757 19.2108 20.7108 19.9757 19.77 20.455C19.1777 20.7568 18.5375 20.8826 17.8086 20.9422C17.1008 21 16.2266 21 15.1428 21H8.85717C7.77339 21 6.89925 21 6.19138 20.9422C5.46253 20.8826 4.82234 20.7568 4.23005 20.455C3.28924 19.9757 2.52433 19.2108 2.04497 18.27C1.74318 17.6777 1.61737 17.0375 1.55782 16.3086C1.49998 15.6007 1.49999 14.7266 1.5 13.6428V10.3572C1.49999 9.27341 1.49998 8.39926 1.55782 7.69138C1.61737 6.96253 1.74318 6.32234 2.04497 5.73005C2.52433 4.78924 2.52433 4.02433 4.23005 3.54497C4.82234 3.24318 5.46253 3.11737 6.19138 3.05782C6.89926 2.99998 7.77341 2.99999 8.85719 3ZM6.35424 5.05118C5.74907 5.10062 5.40138 5.19279 5.13803 5.32698C4.57354 5.6146 4.1146 6.07354 3.82698 6.63803C3.69279 6.90138 3.60062 7.24907 3.55118 7.85424C3.50078 8.47108 3.5 9.26339 3.5 10.4V13.6C3.5 14.7366 3.50078 15.5289 3.55118 16.1458C3.60062 16.7509 3.69279 17.0986 3.82698 17.362C4.1146 17.9265 4.57354 18.3854 5.13803 18.673C5.40138 18.8072 5.74907 18.8994 6.35424 18.9488C6.97108 18.9992 7.76339 19 8.9 19H9.5V5H8.9C7.76339 5 6.97108 5.00078 6.35424 5.05118ZM11.5 5V19H15.1C16.2366 19 17.0289 18.9992 17.6458 18.9488C18.2509 18.8994 18.5986 18.8072 18.862 18.673C19.4265 18.3854 19.8854 17.9265 20.173 17.362C20.3072 17.0986 20.3994 16.7509 20.4488 16.1458C20.4992 15.5289 20.5 14.7366 20.5 13.6V10.4C20.5 9.26339 20.4992 8.47108 20.4488 7.85424C20.3994 7.24907 20.3072 6.40138 20.173 6.63803C19.8854 6.57354 19.4265 6.1146 18.862 5.32698C18.5986 5.19279 18.2509 5.10062 17.6458 5.05118C17.0289 5.00078 16.2366 5 15.1 5H11.5ZM5 8.5C5 7.94772 5.44772 7.5 6 7.5H7C7.55229 7.5 8 7.94772 8 8.5C8 9.05229 7.55229 9.5 7 9.5H6C5.44772 9.5 5 9.05229 5 8.5ZM5 12C5 11.4477 5.44772 11 6 11H7C7.55229 11 8 11.4477 8 12C8 12.5523 7.55229 13 7 13H6C5.44772 13 5 12.5527 5 12Z"
-              fill="currentColor"
-            />
-          </svg>
-        </button>
+            <BrandLogo alt={APP_NAME} className="size-7 group-hover:hidden" />
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              className="size-5 hidden group-hover:block"
+            >
+              <path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M8.85719 3H15.1428C16.2266 2.99999 17.1007 2.99998 17.8086 3.05782C18.5375 3.11737 19.1777 3.24318 19.77 3.54497C20.7108 4.02433 21.4757 4.78924 21.955 5.73005C22.2568 6.32234 22.3826 6.96253 22.4422 7.69138C22.5 8.39925 22.5 9.27339 22.5 10.3572V13.6428C22.5 14.7266 22.5 15.6008 22.4422 16.3086C22.3826 17.0375 22.2568 17.6777 21.955 18.27C21.4757 19.2108 20.7108 19.9757 19.77 20.455C19.1777 20.7568 18.5375 20.8826 17.8086 20.9422C17.1008 21 16.2266 21 15.1428 21H8.85717C7.77339 21 6.89925 21 6.19138 20.9422C5.46253 20.8826 4.82234 20.7568 4.23005 20.455C3.28924 19.9757 2.52433 19.2108 2.04497 18.27C1.74318 17.6777 1.61737 17.0375 1.55782 16.3086C1.49998 15.6007 1.49999 14.7266 1.5 13.6428V10.3572C1.49999 9.27341 1.49998 8.39926 1.55782 7.69138C1.61737 6.96253 1.74318 6.32234 2.04497 5.73005C2.52433 4.78924 2.52433 4.02433 4.23005 3.54497C4.82234 3.24318 5.46253 3.11737 6.19138 3.05782C6.89926 2.99998 7.77341 2.99999 8.85719 3ZM6.35424 5.05118C5.74907 5.10062 5.40138 5.19279 5.13803 5.32698C4.57354 5.6146 4.1146 6.07354 3.82698 6.63803C3.69279 6.90138 3.60062 7.24907 3.55118 7.85424C3.50078 8.47108 3.5 9.26339 3.5 10.4V13.6C3.5 14.7366 3.50078 15.5289 3.55118 16.1458C3.60062 16.7509 3.69279 17.0986 3.82698 17.362C4.1146 17.9265 4.57354 18.3854 5.13803 18.673C5.40138 18.8072 5.74907 18.8994 6.35424 18.9488C6.97108 18.9992 7.76339 19 8.9 19H9.5V5H8.9C7.76339 5 6.97108 5.00078 6.35424 5.05118ZM11.5 5V19H15.1C16.2366 19 17.0289 18.9992 17.6458 18.9488C18.2509 18.8994 18.5986 18.8072 18.862 18.673C19.4265 18.3854 19.8854 17.9265 20.173 17.362C20.3072 17.0986 20.3994 16.7509 20.4488 16.1458C20.4992 15.5289 20.5 14.7366 20.5 13.6V10.4C20.5 9.26339 20.4992 8.47108 20.4488 7.85424C20.3994 7.24907 20.3072 6.40138 20.173 6.63803C19.8854 6.57354 19.4265 6.1146 18.862 5.32698C18.5986 5.19279 18.2509 5.10062 17.6458 5.05118C17.0289 5.00078 16.2366 5 15.1 5H11.5ZM5 8.5C5 7.94772 5.44772 7.5 6 7.5H7C7.55229 7.5 8 7.94772 8 8.5C8 9.05229 7.55229 9.5 7 9.5H6C5.44772 9.5 5 9.05229 5 8.5ZM5 12C5 11.4477 5.44772 11 6 11H7C7.55229 11 8 11.4477 8 12C8 12.5523 7.55229 13 7 13H6C5.44772 13 5 12.5527 5 12Z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </Tooltip>
       </div>
 
       {/* Action icons — scrollable when overflowing, no scrollbar */}
@@ -97,83 +100,90 @@ export function SidebarRail({
         className="mt-3 flex-1 min-h-0 overflow-y-auto overflow-x-hidden flex flex-col items-center w-full space-y-1"
         style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
       >
-        <button
-          type="button"
-          onClick={onNewSession}
-          className={railBtn}
-          title={t("sidebar.newChat")}
-          aria-label={t("sidebar.newChat")}
-        >
-          <MessageSquarePlus size={20} />
-        </button>
-        <button
-          type="button"
-          onClick={onOpenSearch}
-          className={railBtn}
-          title={t("sidebar.searchSessions")}
-          aria-label={t("sidebar.searchSessions")}
-        >
-          <Search size={20} />
-        </button>
+        <Tooltip content={t("sidebar.newChat")}>
+          <button
+            type="button"
+            onClick={onNewSession}
+            className={railBtn}
+            aria-label={t("sidebar.newChat")}
+          >
+            <MessageSquarePlus size={20} />
+          </button>
+        </Tooltip>
+        <Tooltip content={t("sidebar.searchSessions")}>
+          <button
+            type="button"
+            onClick={onOpenSearch}
+            className={railBtn}
+            aria-label={t("sidebar.searchSessions")}
+          >
+            <Search size={20} />
+          </button>
+        </Tooltip>
         {canReadScheduledTasks && (
-          <button
-            type="button"
-            onClick={onOpenScheduledTasks}
-            className={railBtn}
-            title={t("nav.scheduled-tasks")}
-            aria-label={t("nav.scheduled-tasks")}
-          >
-            <CalendarClock size={20} />
-          </button>
-        )}
-        <button
-          type="button"
-          onClick={onOpenFileLibrary}
-          className={railBtn}
-          title={t("fileLibrary.title")}
-          aria-label={t("fileLibrary.title")}
-        >
-          <FolderOpen size={20} />
-        </button>
-        <button
-          type="button"
-          onClick={onOpenBookmarks}
-          className={railBtn}
-          title={t("bookmarks.title")}
-          aria-label={t("bookmarks.title")}
-        >
-          <Bookmark size={20} />
-        </button>
-        <button
-          type="button"
-          ref={recentChatsBtnRef}
-          onClick={onOpenRecentChats}
-          className={`${railBtn} relative`}
-          title={t("sidebar.recentChats")}
-          aria-label={t("sidebar.recentChats")}
-        >
-          <History size={20} />
-          {unreadCount > 0 && (
-            <span
-              className={`absolute -top-0 right-0 flex items-center justify-center rounded-full bg-gradient-to-br from-red-400 to-rose-500 text-9 font-bold leading-none text-white shadow-[0_1px_3px_rgba(239,68,68,0.4)] ring-1 ring-white/20 ${
-                unreadCount <= 9 ? "w-3.5 h-3.5" : "h-3.5 min-w-[18px] px-1"
-              }`}
+          <Tooltip content={t("nav.scheduled-tasks")}>
+            <button
+              type="button"
+              onClick={onOpenScheduledTasks}
+              className={railBtn}
+              aria-label={t("nav.scheduled-tasks")}
             >
-              {unreadCount > 99 ? "99+" : unreadCount}
-            </span>
-          )}
-        </button>
-        {hasMoreMenuItems && (
+              <CalendarClock size={20} />
+            </button>
+          </Tooltip>
+        )}
+        <Tooltip content={t("fileLibrary.title")}>
           <button
             type="button"
-            ref={moreMenuBtnRef}
-            onClick={onToggleMoreMenu}
+            onClick={onOpenFileLibrary}
             className={railBtn}
-            title={t("nav.more", "更多")}
-            aria-label={t("nav.more", "更多")}
+            aria-label={t("fileLibrary.title")}
           >
-            <MoreHorizontal size={20} />
+            <FolderOpen size={20} />
           </button>
+        </Tooltip>
+        <Tooltip content={t("bookmarks.title")}>
+          <button
+            type="button"
+            onClick={onOpenBookmarks}
+            className={railBtn}
+            aria-label={t("bookmarks.title")}
+          >
+            <Bookmark size={20} />
+          </button>
+        </Tooltip>
+        <Tooltip content={t("sidebar.recentChats")}>
+          <button
+            type="button"
+            ref={recentChatsBtnRef}
+            onClick={onOpenRecentChats}
+            className={`${railBtn} relative`}
+            aria-label={t("sidebar.recentChats")}
+          >
+            <History size={20} />
+            {unreadCount > 0 && (
+              <span
+                className={`absolute -top-0 right-0 flex items-center justify-center rounded-full bg-gradient-to-br from-red-400 to-rose-500 text-9 font-bold leading-none text-white shadow-[0_1px_3px_rgba(239,68,68,0.4)] ring-1 ring-white/20 ${
+                  unreadCount <= 9 ? "w-3.5 h-3.5" : "h-3.5 min-w-[18px] px-1"
+                }`}
+              >
+                {unreadCount > 99 ? "99+" : unreadCount}
+              </span>
+            )}
+          </button>
+        </Tooltip>
+        {hasMoreMenuItems && (
+          <Tooltip content={t("nav.more", "更多")}>
+            <button
+              type="button"
+              ref={moreMenuBtnRef}
+              onClick={onToggleMoreMenu}
+              className={railBtn}
+              aria-label={t("nav.more", "更多")}
+            >
+              <MoreHorizontal size={20} />
+            </button>
+          </Tooltip>
         )}
       </div>
 
@@ -182,40 +192,42 @@ export function SidebarRail({
         className="shrink-0 py-4 border-t flex flex-col items-center w-full"
         style={{ borderColor: "var(--theme-border)" }}
       >
-        <button
-          onClick={onShowProfile}
-          className={`${railBtn} rounded-full transition cursor-pointer`}
-          aria-label={t("sidebar.expandSidebar")}
-        >
-          <div
-            className="shrink-0 w-8 h-8 rounded-full overflow-hidden transition"
-            style={{ boxShadow: "0 0 0 1px var(--theme-border)" }}
+        <Tooltip content={t("sidebar.expandSidebar")}>
+          <button
+            onClick={onShowProfile}
+            className={`${railBtn} rounded-full transition cursor-pointer`}
+            aria-label={t("sidebar.expandSidebar")}
           >
-            {user?.avatar_url && !imgError ? (
-              <ImageWithSkeleton
-                src={getFullUrl(user.avatar_url) ?? user.avatar_url}
-                alt={user?.username || t("common.user")}
-                skipUrlResolve
-                inline
-                className="w-full h-full object-cover rounded-full"
-                style={{ borderRadius: "50%" }}
-                errorFallback={
-                  <div className="flex w-full h-full items-center justify-center bg-gradient-to-br from-amber-400 to-orange-500 rounded-full">
-                    <span className="text-xs font-semibold text-white font-serif">
-                      {user?.username?.charAt(0).toUpperCase() || "U"}
-                    </span>
-                  </div>
-                }
-              />
-            ) : (
-              <div className="flex w-full h-full items-center justify-center bg-gradient-to-br from-amber-400 to-orange-500 rounded-full">
-                <span className="text-xs font-semibold text-white font-serif">
-                  {user?.username?.charAt(0).toUpperCase() || "U"}
-                </span>
-              </div>
-            )}
-          </div>
-        </button>
+            <div
+              className="shrink-0 w-8 h-8 rounded-full overflow-hidden transition"
+              style={{ boxShadow: "0 0 0 1px var(--theme-border)" }}
+            >
+              {user?.avatar_url && !imgError ? (
+                <ImageWithSkeleton
+                  src={getFullUrl(user.avatar_url) ?? user.avatar_url}
+                  alt={user?.username || t("common.user")}
+                  skipUrlResolve
+                  inline
+                  className="w-full h-full object-cover rounded-full"
+                  style={{ borderRadius: "50%" }}
+                  errorFallback={
+                    <div className="flex w-full h-full items-center justify-center bg-gradient-to-br from-amber-400 to-orange-500 rounded-full">
+                      <span className="text-xs font-semibold text-white font-serif">
+                        {user?.username?.charAt(0).toUpperCase() || "U"}
+                      </span>
+                    </div>
+                  }
+                />
+              ) : (
+                <div className="flex w-full h-full items-center justify-center bg-gradient-to-br from-amber-400 to-orange-500 rounded-full">
+                  <span className="text-xs font-semibold text-white font-serif">
+                    {user?.username?.charAt(0).toUpperCase() || "U"}
+                  </span>
+                </div>
+              )}
+            </div>
+          </button>
+        </Tooltip>
       </div>
     </nav>
   );

--- a/frontend/src/components/panels/__tests__/approvalFormValidation.test.ts
+++ b/frontend/src/components/panels/__tests__/approvalFormValidation.test.ts
@@ -3,6 +3,7 @@ import {
   isFieldValueFilled,
   isFormFieldsValid,
   toggleMultiSelectValue,
+  toggleSingleSelectValue,
 } from "../approvalFormValidation";
 import type { FormField } from "../../../types";
 
@@ -63,5 +64,17 @@ describe("toggleMultiSelectValue", () => {
 
   test("removes an option when already selected", () => {
     expect(toggleMultiSelectValue(["a", "b"], "a")).toEqual(["b"]);
+  });
+});
+
+describe("toggleSingleSelectValue", () => {
+  test("selects an option when nothing or something else is selected", () => {
+    expect(toggleSingleSelectValue("", "a")).toBe("a");
+    expect(toggleSingleSelectValue("b", "a")).toBe("a");
+    expect(toggleSingleSelectValue(null, "a")).toBe("a");
+  });
+
+  test("deselects the option when clicking it again", () => {
+    expect(toggleSingleSelectValue("a", "a")).toBe("");
   });
 });

--- a/frontend/src/components/panels/__tests__/askHumanLayout.test.ts
+++ b/frontend/src/components/panels/__tests__/askHumanLayout.test.ts
@@ -27,7 +27,9 @@ test("places the ignore action before submit in the approval footer", () => {
 });
 
 test("localizes ask-human labels and keeps one final submit action", () => {
-  expect(approvalSource).toMatch(/approvals\.mainGoal/);
+  // 「主要目标」徽标与问题语义无关，头部只渲染问题本身
+  expect(approvalSource).not.toMatch(/approvals\.mainGoal/);
+  expect(approvalSource).not.toMatch(/approval-ask-human-badge/);
   expect(approvalSource).not.toMatch(/aria-label="上一项"/);
   expect(approvalSource).not.toMatch(/aria-label="下一项"/);
   expect(approvalSource).not.toMatch(
@@ -150,7 +152,7 @@ test("pins approval actions to the right with a clear button group", () => {
 test("uses a compact spacing rhythm for ask-human fields", () => {
   expect(approvalSource).toMatch(/approval-form--ask-human/);
   expect(approvalCss).toMatch(
-    /\.approval-form--ask-human\s*\{[\s\S]*?gap:\s*0\.75rem;/,
+    /\.approval-form--ask-human\s*\{[\s\S]*?gap:\s*1rem;/,
   );
   expect(approvalCss).toMatch(
     /\.approval-form--ask-human > div \+ div[\s\S]*?padding-top:\s*0;/,
@@ -169,10 +171,17 @@ test("keeps approval text readable without truncation", () => {
     /\.approval-ask-human-question\s*\{[^}]*white-space:\s*nowrap;/,
   );
   expect(approvalCss).toMatch(
-    /\.approval-form--ask-human > div > label[\s\S]*?font-size:\s*1rem;/,
+    /\.approval-form--ask-human > div > label[\s\S]*?font-size:\s*0\.8125rem;/,
   );
   expect(approvalCss).toMatch(
-    /\.approval-form--ask-human \.approval-input[\s\S]*?font-size:\s*1rem;/,
+    /\.approval-form--ask-human \.approval-input[\s\S]*?font-size:\s*0\.8125rem;/,
+  );
+});
+
+test("renders ask-human questions bold for clearer scanning", () => {
+  // 问题标签加粗，与选项内容拉开层级
+  expect(approvalCss).toMatch(
+    /\.approval-form--ask-human > div > label[\s\S]*?font-weight:\s*600;/,
   );
 });
 
@@ -225,19 +234,23 @@ test("aligns ask-human options to the same content start as labels and inputs", 
     /\.approval-ask-human-option\s*\{[\s\S]*?display:\s*grid;[\s\S]*?grid-template-columns:\s*1\.65rem minmax\(0, 1fr\);/,
   );
   expect(approvalCss).toMatch(
-    /\.approval-ask-human-option\s*\{[\s\S]*?font-size:\s*1rem;[\s\S]*?line-height:\s*1\.5;/,
+    /\.approval-ask-human-option\s*\{[\s\S]*?font-size:\s*0\.8125rem;[\s\S]*?line-height:\s*1\.5;/,
   );
   expect(approvalCss).toMatch(
     /@media \(max-width: 640px\)[\s\S]*?\.approval-ask-human-options[\s\S]*?padding:\s*0\.1rem 0 0\.25rem;/,
   );
 });
 
-test("uses the same readable body line-height for question and options", () => {
+test("keeps ask-human form text one step smaller than the question", () => {
+  // 表单区（标签/选项/输入框）比头部问题再小一档，行高保持一致的可读节奏
   expect(approvalCss).toMatch(
-    /\.approval-ask-human-question\s*\{[^}]*?font-size:\s*1rem;[^}]*?line-height:\s*1\.5;/,
+    /\.approval-ask-human-question\s*\{[^}]*?font-size:\s*0\.875rem;/,
   );
   expect(approvalCss).toMatch(
-    /\.approval-ask-human-option\s*\{[^}]*?font-size:\s*1rem;[^}]*?line-height:\s*1\.5;/,
+    /\.approval-ask-human-option\s*\{[^}]*?font-size:\s*0\.8125rem;[^}]*?line-height:\s*1\.5;/,
+  );
+  expect(approvalCss).toMatch(
+    /\.approval-ask-human-option\s*\{[^}]*?min-height:\s*2\.5rem;/,
   );
 });
 
@@ -245,14 +258,14 @@ test("keeps hover, keyboard focus, and selected states visually distinct", () =>
   expect(approvalCss).toMatch(
     /\.approval-ask-human-option:hover:not\(\.approval-ask-human-option--selected\)/,
   );
+  // 自定义键盘光标高亮已整体移除，只剩原生 :focus-visible 焦点可访问性
+  expect(approvalCss).not.toMatch(/approval-ask-human-option--focused/);
+  // 选中态靠边框+浅底+加粗区分，不靠投影光晕
   expect(approvalCss).toMatch(
-    /\.approval-ask-human-option--focused:not\(\.approval-ask-human-option--selected\)[\s\S]*?box-shadow:/,
-  );
-  expect(approvalCss).toMatch(
-    /\.approval-ask-human-option--selected\s*\{[^}]*?box-shadow:[\s\S]*?0 3px 12px -9px/,
+    /\.approval-ask-human-option--selected\s*\{[^}]*?font-weight:\s*500;/,
   );
   expect(approvalCss).not.toMatch(
-    /\.approval-ask-human-option--selected\s*\{[^}]*?inset/,
+    /\.approval-ask-human-option--selected\s*\{[^}]*?box-shadow/,
   );
   expect(approvalCss).toMatch(
     /\.approval-ask-human-option:focus-visible\s*\{[^}]*?outline:\s*2px/,
@@ -261,7 +274,7 @@ test("keeps hover, keyboard focus, and selected states visually distinct", () =>
 
 test("keeps the ask-human shortcut hint readable beside the actions", () => {
   expect(approvalCss).toMatch(
-    /\.approval-ask-human-shortcut-hint\s*\{[^}]*?font-size:\s*0\.875rem;[^}]*?line-height:\s*1\.5;/,
+    /\.approval-ask-human-shortcut-hint\s*\{[^}]*?font-size:\s*0\.8125rem;[^}]*?line-height:\s*1\.5;/,
   );
 });
 
@@ -271,13 +284,13 @@ test("announces multi-select choices with an accessible reminder", () => {
   expect(approvalSource).toMatch(/approval-ask-human-multi-select-hint/);
   expect(approvalSource).toMatch(/approvals\.multiSelectHint/);
   expect(approvalCss).toMatch(
-    /\.approval-ask-human-multi-select-hint\s*\{[^}]*?font-size:\s*0\.8125rem;[^}]*?line-height:\s*1\.4;/,
+    /\.approval-ask-human-multi-select-hint\s*\{[^}]*?font-size:\s*0\.6875rem;[^}]*?line-height:\s*1\.4;/,
   );
 });
 
 test("keeps the multi-select reminder visually secondary", () => {
   expect(approvalCss).toMatch(
-    /\.approval-ask-human-multi-select-hint\s*\{[^}]*?font-size:\s*0\.8125rem;[^}]*?opacity:\s*0\.82;/,
+    /\.approval-ask-human-multi-select-hint\s*\{[^}]*?font-size:\s*0\.6875rem;[^}]*?opacity:\s*0\.82;/,
   );
   expect(approvalCss).toMatch(
     /\.approval-ask-human-multi-select-hint::before\s*\{[^}]*?background:\s*var\(--approval-text-dim\);[^}]*?box-shadow:\s*none;/,
@@ -286,10 +299,10 @@ test("keeps the multi-select reminder visually secondary", () => {
 
 test("uses one vertical rhythm across ask-human fields", () => {
   expect(approvalCss).toMatch(
-    /\.approval-form--ask-human\s*\{[^}]*?gap:\s*0\.75rem;/,
+    /\.approval-form--ask-human\s*\{[^}]*?gap:\s*1rem;/,
   );
   expect(approvalCss).toMatch(
-    /\.approval-form--ask-human > div\s*\{[^}]*?display:\s*flex;[^}]*?gap:\s*0\.45rem;/,
+    /\.approval-form--ask-human > div\s*\{[^}]*?display:\s*flex;[^}]*?gap:\s*0\.6rem;/,
   );
   expect(approvalCss).toMatch(
     /\.approval-form--ask-human > div\.space-y-1 > \* \+ \*\s*\{[^}]*?margin-top:\s*0;/,
@@ -298,11 +311,18 @@ test("uses one vertical rhythm across ask-human fields", () => {
 
 test("keeps selected and hover accents restrained", () => {
   expect(approvalCss).toMatch(
-    /\.approval-ask-human-option:hover:not\(\.approval-ask-human-option--selected\)[\s\S]*?background:[\s\S]*?12%/,
+    /\.approval-ask-human-option:hover:not\(\.approval-ask-human-option--selected\)[\s\S]*?background:[\s\S]*?8%/,
   );
   expect(approvalCss).toMatch(
-    /\.approval-ask-human-option--selected\s*\{[\s\S]*?background:[\s\S]*?18%/,
+    /\.approval-ask-human-option--selected\s*\{[\s\S]*?background:[\s\S]*?14%/,
   );
+});
+
+test("only mouse clicks toggle single-select choices", () => {
+  // toggle 只存在于鼠标点击路径（再点取消）；键盘层已移除，不存在快捷键误取消
+  expect(
+    (approvalSource.match(/toggleSingleSelectValue\(/g) ?? []).length,
+  ).toBe(1);
 });
 
 test("keeps the approval card surfaces visually quiet", () => {
@@ -324,12 +344,26 @@ test("shows desktop-only keyboard shortcut hint for ask-human choices", () => {
   expect(approvalSource).toMatch(/hidden sm:inline-flex/);
 });
 
-test("supports number-key selection for ask-human choices", () => {
-  expect(approvalSource).toMatch(/event\.key >= "1"/);
+test("skips the enter shortcut while typing inside card text controls", () => {
+  expect(approvalSource).toMatch(
+    /isEditableEventTarget\(event\.target\)[\s\S]*?event\.key !== "Enter"/,
+  );
 });
 
-test("skips ask-human shortcuts while typing inside card text controls", () => {
-  expect(approvalSource).toMatch(
-    /isEditableEventTarget\(event\.target\)[\s\S]*?event\.key >= "1"/,
-  );
+test("lets a single-select choice be deselected by clicking it again", () => {
+  // 单选再点同一项应取消选择（toggle），而不是只能换选
+  expect(approvalSource).toMatch(/toggleSingleSelectValue\(/);
+});
+
+test("ask-human options carry no custom keyboard cursor highlight", () => {
+  // 数字键/↑↓/光标高亮整套自定义键盘层已移除：不再有任何"乱 hover"高亮源
+  expect(approvalSource).not.toMatch(/askHumanSelectedIndex/);
+  expect(approvalSource).not.toMatch(/approval-ask-human-option--focused/);
+  expect(approvalCss).not.toMatch(/approval-ask-human-option--focused/);
+});
+
+test("enter submits the ask-human answer from anywhere on the card", () => {
+  // 唯一保留的快捷键：Enter 提交（文本框内换行、按钮上原生激活除外）
+  expect(approvalSource).toMatch(/event\.key !== "Enter"/);
+  expect(approvalSource).toMatch(/handleSubmit\(\);/);
 });

--- a/frontend/src/components/panels/approvalFormValidation.ts
+++ b/frontend/src/components/panels/approvalFormValidation.ts
@@ -33,3 +33,11 @@ export function toggleMultiSelectValue(
     ? list.filter((v) => v !== option)
     : [...list, option];
 }
+
+/** radio 单选点选行为：点已选项取消选择（回到空串），点其他项换选。 */
+export function toggleSingleSelectValue(
+  current: unknown,
+  option: string,
+): string {
+  return current === option ? "" : option;
+}

--- a/frontend/src/components/sidebar/MarkAllReadBadge.tsx
+++ b/frontend/src/components/sidebar/MarkAllReadBadge.tsx
@@ -1,5 +1,6 @@
 import { useCallback, type KeyboardEvent, type MouseEvent } from "react";
 import { formatUnreadCount } from "./unreadCounts";
+import { Tooltip } from "../common/Tooltip";
 
 interface MarkAllReadBadgeProps {
   /** Current unread count to display. */
@@ -10,8 +11,8 @@ interface MarkAllReadBadgeProps {
   markingReadId: string | null;
   /** Callback invoked when the user clicks or presses Enter/Space. */
   onMarkAllRead: () => void;
-  /** Tooltip text shown on hover. */
-  title: string;
+  /** Tooltip text shown on hover (desktop) or long press (touch). */
+  tooltip: string;
 }
 
 /**
@@ -24,7 +25,7 @@ export function MarkAllReadBadge({
   badgeId,
   markingReadId,
   onMarkAllRead,
-  title,
+  tooltip,
 }: MarkAllReadBadgeProps) {
   const isLoading = markingReadId === badgeId;
   const isSingleDigit = count >= 1 && count <= 9;
@@ -53,26 +54,28 @@ export function MarkAllReadBadge({
   if (count <= 0 && !isLoading) return null;
 
   return (
-    <span
-      role="button"
-      tabIndex={0}
-      onClick={handleClick}
-      onKeyDown={handleKeyDown}
-      title={title}
-      className={[
-        "inline-flex items-center justify-center rounded-full bg-red-500 text-10 font-medium leading-none text-white cursor-pointer select-none",
-        isLoading
-          ? "w-4 h-4 badge-scale"
-          : isSingleDigit
-            ? "w-4 h-4 hover:opacity-70 transition-opacity"
-            : "h-4 min-w-[20px] px-1.5 hover:opacity-70 transition-opacity",
-      ].join(" ")}
-    >
-      {isLoading ? (
-        <span className="badge-spinner" />
-      ) : (
-        formatUnreadCount(count)
-      )}
-    </span>
+    <Tooltip content={tooltip}>
+      <span
+        role="button"
+        tabIndex={0}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        aria-label={tooltip}
+        className={[
+          "inline-flex items-center justify-center rounded-full bg-red-500 text-10 font-medium leading-none text-white cursor-pointer select-none",
+          isLoading
+            ? "w-4 h-4 badge-scale"
+            : isSingleDigit
+              ? "w-4 h-4 hover:opacity-70 transition-opacity"
+              : "h-4 min-w-[20px] px-1.5 hover:opacity-70 transition-opacity",
+        ].join(" ")}
+      >
+        {isLoading ? (
+          <span className="badge-spinner" />
+        ) : (
+          formatUnreadCount(count)
+        )}
+      </span>
+    </Tooltip>
   );
 }

--- a/frontend/src/components/sidebar/ProjectItem.tsx
+++ b/frontend/src/components/sidebar/ProjectItem.tsx
@@ -20,6 +20,7 @@ import { useFilteredSessionList } from "../../hooks/useSession";
 import { SessionItem } from "./SessionItem";
 import { ProjectMenu } from "./ProjectMenu";
 import { LoadingSpinner } from "../common/LoadingSpinner";
+import { Tooltip } from "../common/Tooltip";
 import { DynamicIcon } from "../common/DynamicIcon";
 import { isSessionFavorite } from "./sessionFavorites";
 import { isSessionPinned } from "./sessionPin";
@@ -338,17 +339,19 @@ export const ProjectItem = forwardRef<ProjectItemHandle, ProjectItemProps>(
               autoFocus
             />
           ) : (
-            <button
-              onClick={handleStartIconEdit}
-              className="flex-shrink-0 hover:opacity-70 transition-opacity"
-              title={t("sidebar.clickToEditIcon")}
-            >
-              <DynamicIcon
-                name={project.icon}
-                size={20}
-                className="text-primary text-20"
-              />
-            </button>
+            <Tooltip content={t("sidebar.clickToEditIcon")}>
+              <button
+                onClick={handleStartIconEdit}
+                aria-label={t("sidebar.clickToEditIcon")}
+                className="flex-shrink-0 hover:opacity-70 transition-opacity"
+              >
+                <DynamicIcon
+                  name={project.icon}
+                  size={20}
+                  className="text-primary text-20"
+                />
+              </button>
+            </Tooltip>
           )}
 
           {/* Project name - editable or display */}
@@ -378,24 +381,29 @@ export const ProjectItem = forwardRef<ProjectItemHandle, ProjectItemProps>(
               badgeId={`project-${project.id}`}
               markingReadId={markingReadId ?? null}
               onMarkAllRead={() => onMarkAllRead?.({ projectId: project.id })}
-              title={t("sidebar.markAllRead")}
+              tooltip={t("sidebar.markAllRead")}
             />
           )}
 
           {/* Menu button - only for custom projects */}
           {!isFavorites && !isEditing && (
-            <button
-              ref={menuButtonRef}
-              onClick={handleMenuClick}
-              className="flex-shrink-0 rounded p-0.5 hover:bg-stone-200/60 dark:hover:bg-stone-700/60 transition-all opacity-0 group-hover:opacity-100 [&:not(:placeholder-shown)]:opacity-100"
-              style={isTouched ? { opacity: 1 } : undefined}
-              title={t("sidebar.moreOptions")}
+            <Tooltip
+              content={t("sidebar.moreOptions")}
+              open={isTouched && !isMenuOpen}
             >
-              <MoreHorizontal
-                size={14}
-                className="text-stone-400 hover:text-stone-600 dark:text-stone-500 dark:hover:text-stone-300"
-              />
-            </button>
+              <button
+                ref={menuButtonRef}
+                onClick={handleMenuClick}
+                aria-label={t("sidebar.moreOptions")}
+                className="flex-shrink-0 rounded p-0.5 hover:bg-stone-200/60 dark:hover:bg-stone-700/60 transition-all opacity-0 group-hover:opacity-100 [&:not(:placeholder-shown)]:opacity-100"
+                style={isTouched ? { opacity: 1 } : undefined}
+              >
+                <MoreHorizontal
+                  size={14}
+                  className="text-stone-400 hover:text-stone-600 dark:text-stone-500 dark:hover:text-stone-300"
+                />
+              </button>
+            </Tooltip>
           )}
         </div>
 

--- a/frontend/src/components/sidebar/RecentChatsDialog.tsx
+++ b/frontend/src/components/sidebar/RecentChatsDialog.tsx
@@ -14,6 +14,7 @@ import {
   type RecentChatsPaginationState,
 } from "./recentChatsPagination";
 import { MarkAllReadBadge } from "./MarkAllReadBadge";
+import { Tooltip } from "../common/Tooltip";
 import { AlertCircle } from "lucide-react";
 
 interface RecentChatsDialogProps {
@@ -54,6 +55,11 @@ export function RecentChatsDialog({
   const [isLoading, setIsLoading] = useState(false);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [scrollRoot, setScrollRoot] = useState<HTMLDivElement | null>(null);
+  // Row whose status tooltip is shown after a touch (auto-hides after 3s)
+  const [touchedSessionId, setTouchedSessionId] = useState<string | null>(null);
+  const touchStatusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
   const anchorRef = useRef(anchorEl);
   anchorRef.current = anchorEl;
   const isOpenRef = useRef(isOpen);
@@ -135,6 +141,23 @@ export function RecentChatsDialog({
     applyPaginationState(initialPaginationState);
     void loadSessions(true);
   }, [applyPaginationState, loadSessions]);
+
+  // Touch: show the row's status tooltip, auto-hide after 3s
+  const handleRowTouchStart = useCallback((sessionId: string) => {
+    if (touchStatusTimerRef.current) clearTimeout(touchStatusTimerRef.current);
+    setTouchedSessionId(sessionId);
+    touchStatusTimerRef.current = setTimeout(
+      () => setTouchedSessionId(null),
+      3000,
+    );
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (touchStatusTimerRef.current)
+        clearTimeout(touchStatusTimerRef.current);
+    };
+  }, []);
 
   useEffect(() => {
     if (isOpen) resetSessions();
@@ -230,7 +253,7 @@ export function RecentChatsDialog({
             badgeId="all"
             markingReadId={markingReadId ?? null}
             onMarkAllRead={() => onMarkAllRead?.()}
-            title={t("sidebar.markAllRead")}
+            tooltip={t("sidebar.markAllRead")}
           />
         )}
       </div>
@@ -250,6 +273,15 @@ export function RecentChatsDialog({
               const isWaitingForHuman = taskStatus === "waiting_human";
               const isGenerating =
                 taskStatus === "running" || taskStatus === "pending";
+              const statusTooltipOpen = touchedSessionId === session.id;
+              const runningLabel = isGenerating
+                ? t(
+                    taskStatus === "pending"
+                      ? "sidebar.pendingStatus"
+                      : "sidebar.runningStatus",
+                    taskStatus === "pending" ? "等待中" : "运行中",
+                  )
+                : null;
 
               return (
                 <button
@@ -258,6 +290,7 @@ export function RecentChatsDialog({
                     onSelectSession(session.id);
                     onClose();
                   }}
+                  onTouchStart={() => handleRowTouchStart(session.id)}
                   className={`w-full flex items-center gap-3 px-4 py-2.5 transition-colors text-left group ${
                     session.id === currentSessionId
                       ? "bg-stone-100 dark:bg-stone-800/60"
@@ -278,32 +311,27 @@ export function RecentChatsDialog({
                       {formatDateTime(session.updated_at)}
                     </div>
                   </div>
-                  {isGenerating && (
-                    <span
-                      title={t(
-                        taskStatus === "pending"
-                          ? "sidebar.pendingStatus"
-                          : "sidebar.runningStatus",
-                        taskStatus === "pending" ? "等待中" : "运行中",
-                      )}
-                      aria-label={t(
-                        taskStatus === "pending"
-                          ? "sidebar.pendingStatus"
-                          : "sidebar.runningStatus",
-                        taskStatus === "pending" ? "等待中" : "运行中",
-                      )}
-                      className="shrink-0 inline-flex items-center justify-center w-4 h-4 rounded-full border-2 border-amber-500/25 border-t-amber-500 dark:border-t-amber-400 animate-spin"
-                    />
+                  {isGenerating && runningLabel && (
+                    <Tooltip content={runningLabel} open={statusTooltipOpen}>
+                      <span
+                        aria-label={runningLabel}
+                        className="shrink-0 inline-flex items-center justify-center w-4 h-4 rounded-full border-2 border-amber-500/25 border-t-amber-500 dark:border-t-amber-400 animate-spin"
+                      />
+                    </Tooltip>
                   )}
                   {isWaitingForHuman && (
-                    <span
-                      data-session-status="ask-human"
-                      title="Ask human · 等待你的回复"
-                      aria-label="Ask human · 等待你的回复"
-                      className="shrink-0 inline-flex items-center justify-center w-4 h-4 text-amber-500 dark:text-amber-400"
+                    <Tooltip
+                      content={t("sidebar.waitingHuman", "等待回复")}
+                      open={statusTooltipOpen}
                     >
-                      <AlertCircle size={16} strokeWidth={2.3} />
-                    </span>
+                      <span
+                        data-session-status="ask-human"
+                        aria-label="Ask human · 等待你的回复"
+                        className="shrink-0 inline-flex items-center justify-center w-4 h-4 text-amber-500 dark:text-amber-400"
+                      >
+                        <AlertCircle size={16} strokeWidth={2.3} />
+                      </span>
+                    </Tooltip>
                   )}
                   {session.unread_count != null && session.unread_count > 0 && (
                     <span className="shrink-0 inline-flex h-4 min-w-[16px] items-center justify-center rounded-full bg-red-500 px-1 text-10 font-medium leading-none text-white">

--- a/frontend/src/components/sidebar/ScheduledTaskSidebarItem.tsx
+++ b/frontend/src/components/sidebar/ScheduledTaskSidebarItem.tsx
@@ -298,7 +298,7 @@ export const ScheduledTaskSidebarItem = forwardRef<
             badgeId={`task-${task.id}`}
             markingReadId={markingReadId ?? null}
             onMarkAllRead={() => onMarkAllRead?.({ scheduledTaskId: task.id })}
-            title={t("sidebar.markAllRead")}
+            tooltip={t("sidebar.markAllRead")}
           />
         )}
       </div>

--- a/frontend/src/components/sidebar/SessionItem.tsx
+++ b/frontend/src/components/sidebar/SessionItem.tsx
@@ -10,6 +10,7 @@ import type { BackendSession } from "../../services/api/session";
 import type { Project } from "../../types";
 import { sessionApi } from "../../services/api";
 import { SessionMenu } from "./SessionMenu";
+import { Tooltip } from "../common/Tooltip";
 import { shouldBlockSessionSelection } from "../../utils/sessionSelectionGuard";
 
 interface SessionItemProps {
@@ -353,31 +354,30 @@ function SessionItemComponent({
         </div>
 
         {/* Task running indicator - same position/size as unread badge */}
-        {isGenerating && (
-          <span
-            title={taskStatusLabel ?? undefined}
-            aria-label={taskStatusLabel ?? undefined}
-            className="shrink-0 inline-flex items-center justify-center gap-1 text-xs text-amber-500 dark:text-amber-400"
-          >
-            <span className="inline-flex items-center justify-center w-4 h-4 rounded-full border-2 border-amber-500/25 border-t-amber-500 dark:border-t-amber-400 animate-spin" />
-            {isTouched && <span>{taskStatusLabel}</span>}
-          </span>
+        {isGenerating && taskStatusLabel && (
+          <Tooltip content={taskStatusLabel} open={isTouched}>
+            <span
+              aria-label={taskStatusLabel}
+              className="shrink-0 inline-flex items-center justify-center"
+            >
+              <span className="inline-flex items-center justify-center w-4 h-4 rounded-full border-2 border-amber-500/25 border-t-amber-500 dark:border-t-amber-400 animate-spin" />
+            </span>
+          </Tooltip>
         )}
 
         {isWaitingForHuman && (
-          <span
-            data-session-status="ask-human"
-            title="Ask human · 等待你的回复"
-            aria-label="Ask human · 等待你的回复"
-            className="shrink-0 inline-flex items-center justify-center w-4 h-4 text-amber-500 dark:text-amber-400"
+          <Tooltip
+            content={t("sidebar.waitingHuman", "等待回复")}
+            open={isTouched}
           >
-            <AlertCircle size={16} strokeWidth={2.3} />
-            {isTouched && (
-              <span className="ml-1 text-xs">
-                {t("sidebar.waitingHuman", "等待回复")}
-              </span>
-            )}
-          </span>
+            <span
+              data-session-status="ask-human"
+              aria-label="Ask human · 等待你的回复"
+              className="shrink-0 inline-flex items-center justify-center w-4 h-4 text-amber-500 dark:text-amber-400"
+            >
+              <AlertCircle size={16} strokeWidth={2.3} />
+            </span>
+          </Tooltip>
         )}
 
         {/* Unread dot - hidden when session is active (user is viewing it) */}
@@ -396,18 +396,23 @@ function SessionItemComponent({
             </span>
           )}
         {!selectionMode && !isEditing && (
-          <button
-            ref={menuButtonRef}
-            onClick={handleMenuClick}
-            className="flex-shrink-0 rounded p-1 hover:bg-stone-200/60 dark:hover:bg-stone-700/60 transition-all opacity-0 group-hover:opacity-100"
-            style={isTouched ? { opacity: 1 } : undefined}
-            title={t("sidebar.moreOptions")}
+          <Tooltip
+            content={t("sidebar.moreOptions")}
+            open={isTouched && !isMenuOpen}
           >
-            <MoreHorizontal
-              size={14}
-              className="text-stone-400 hover:text-stone-600 dark:text-stone-500 dark:hover:text-stone-300"
-            />
-          </button>
+            <button
+              ref={menuButtonRef}
+              onClick={handleMenuClick}
+              aria-label={t("sidebar.moreOptions")}
+              className="flex-shrink-0 rounded p-1 hover:bg-stone-200/60 dark:hover:bg-stone-700/60 transition-all opacity-0 group-hover:opacity-100"
+              style={isTouched ? { opacity: 1 } : undefined}
+            >
+              <MoreHorizontal
+                size={14}
+                className="text-stone-400 hover:text-stone-600 dark:text-stone-500 dark:hover:text-stone-300"
+              />
+            </button>
+          </Tooltip>
         )}
       </div>
       {/* Context Menu */}

--- a/frontend/src/components/sidebar/__tests__/SessionItemIndicator.test.tsx
+++ b/frontend/src/components/sidebar/__tests__/SessionItemIndicator.test.tsx
@@ -1,8 +1,20 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from "vitest";
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, within } from "@testing-library/react";
 import { SessionItem } from "../SessionItem";
 import type { BackendSession } from "../../../services/api/session";
+
+// Keep label assertions locale-independent: return the in-code fallback text
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>();
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, defaultValue?: string) => defaultValue ?? key,
+      i18n: { language: "zh" },
+    }),
+  };
+});
 
 const baseSession = {
   id: "sess_1",
@@ -13,55 +25,58 @@ const baseSession = {
   metadata: {},
 } satisfies BackendSession;
 
+function renderSessionItem(metadata: Record<string, unknown>) {
+  const view = render(
+    <SessionItem
+      session={{ ...baseSession, metadata }}
+      isActive={false}
+      projects={[]}
+      onSelect={vi.fn()}
+      onDelete={vi.fn()}
+      onMoveToProject={vi.fn()}
+      onSessionUpdate={vi.fn()}
+    />,
+  );
+  return { ...view, row: view.container.firstElementChild as HTMLElement };
+}
+
+const touchRow = (row: HTMLElement) =>
+  fireEvent.touchStart(row, { touches: [{ clientX: 10, clientY: 10 }] });
+
 describe("SessionItem task running indicator", () => {
-  it("shows spinner when task_status is running", () => {
-    const view = render(
-      <SessionItem
-        session={{ ...baseSession, metadata: { task_status: "running" } }}
-        isActive={false}
-        projects={[]}
-        onSelect={vi.fn()}
-        onDelete={vi.fn()}
-        onMoveToProject={vi.fn()}
-        onSessionUpdate={vi.fn()}
-      />,
-    );
+  it("labels the running spinner via aria-label without a native title", () => {
+    renderSessionItem({ task_status: "running" });
     const indicator = document.querySelector(".animate-spin")?.parentElement;
-    expect(indicator).toHaveAttribute("title", "运行中");
     expect(indicator).toHaveAttribute("aria-label", "运行中");
-    fireEvent.touchStart(view.container.firstElementChild!, {
-      touches: [{ clientX: 10, clientY: 10 }],
-    });
-    expect(view.getByText("运行中")).toBeInTheDocument();
+    expect(indicator).not.toHaveAttribute("title");
   });
-  it("shows spinner when task_status is pending", () => {
-    render(
-      <SessionItem
-        session={{ ...baseSession, metadata: { task_status: "pending" } }}
-        isActive={false}
-        projects={[]}
-        onSelect={vi.fn()}
-        onDelete={vi.fn()}
-        onMoveToProject={vi.fn()}
-        onSessionUpdate={vi.fn()}
-      />,
-    );
+  it("labels the pending spinner via aria-label", () => {
+    renderSessionItem({ task_status: "pending" });
     const indicator = document.querySelector(".animate-spin")?.parentElement;
-    expect(indicator).toHaveAttribute("title", "等待中");
     expect(indicator).toHaveAttribute("aria-label", "等待中");
   });
+  it("shows the running label as a tooltip bubble, not inline text, on touch", () => {
+    const { row } = renderSessionItem({ task_status: "running" });
+    expect(within(row).queryByText("运行中")).not.toBeInTheDocument();
+    touchRow(row);
+    const bubble = within(document.body).getByText("运行中");
+    expect(bubble).toHaveClass("fixed", "pointer-events-none");
+    expect(
+      document.querySelector(".animate-spin")?.parentElement?.textContent,
+    ).toBe("");
+  });
+  it("shows the waiting-for-reply label as a tooltip bubble, not inline text, on touch", () => {
+    const { row } = renderSessionItem({ task_status: "waiting_human" });
+    expect(within(row).queryByText("等待回复")).not.toBeInTheDocument();
+    touchRow(row);
+    const bubble = within(document.body).getByText("等待回复");
+    expect(bubble).toHaveClass("fixed", "pointer-events-none");
+    expect(
+      document.querySelector("[data-session-status=ask-human]")?.textContent,
+    ).toBe("");
+  });
   it("shows only a running-indicator-sized icon while waiting for a reply", () => {
-    render(
-      <SessionItem
-        session={{ ...baseSession, metadata: { task_status: "waiting_human" } }}
-        isActive={false}
-        projects={[]}
-        onSelect={vi.fn()}
-        onDelete={vi.fn()}
-        onMoveToProject={vi.fn()}
-        onSessionUpdate={vi.fn()}
-      />,
-    );
+    renderSessionItem({ task_status: "waiting_human" });
     const indicator = document.querySelector("[data-session-status=ask-human]");
     expect(indicator).toBeInTheDocument();
     expect(indicator).toHaveClass("w-4", "h-4");
@@ -71,31 +86,27 @@ describe("SessionItem task running indicator", () => {
     expect(indicator?.querySelector("svg")).toHaveAttribute("height", "16");
   });
   it("hides spinner when task_status is completed", () => {
-    render(
-      <SessionItem
-        session={{ ...baseSession, metadata: { task_status: "completed" } }}
-        isActive={false}
-        projects={[]}
-        onSelect={vi.fn()}
-        onDelete={vi.fn()}
-        onMoveToProject={vi.fn()}
-        onSessionUpdate={vi.fn()}
-      />,
-    );
+    renderSessionItem({ task_status: "completed" });
     expect(document.querySelector(".animate-spin")).not.toBeInTheDocument();
   });
   it("hides spinner when task_status is absent", () => {
-    render(
-      <SessionItem
-        session={baseSession}
-        isActive={false}
-        projects={[]}
-        onSelect={vi.fn()}
-        onDelete={vi.fn()}
-        onMoveToProject={vi.fn()}
-        onSessionUpdate={vi.fn()}
-      />,
-    );
+    renderSessionItem({});
     expect(document.querySelector(".animate-spin")).not.toBeInTheDocument();
+  });
+});
+
+describe("SessionItem more-options button tooltip", () => {
+  it("reveals the more-options label as a tooltip bubble on touch", () => {
+    // The i18n mock returns the key itself when no in-code fallback exists
+    const { row } = renderSessionItem({});
+    const moreButton = row.querySelector("button");
+    expect(moreButton).not.toHaveAttribute("title");
+    expect(moreButton).toHaveAttribute("aria-label", "sidebar.moreOptions");
+    touchRow(row);
+    const bubble = within(document.body).getByText("sidebar.moreOptions");
+    expect(bubble).toHaveClass("fixed", "pointer-events-none");
+    expect(
+      within(row).queryByText("sidebar.moreOptions"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/sidebar/__tests__/markAllReadBadgeTooltip.test.tsx
+++ b/frontend/src/components/sidebar/__tests__/markAllReadBadgeTooltip.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { act, fireEvent, render, within } from "@testing-library/react";
+import { MarkAllReadBadge } from "../MarkAllReadBadge";
+
+const renderBadge = () =>
+  render(
+    <MarkAllReadBadge
+      count={3}
+      badgeId="badge"
+      markingReadId={null}
+      onMarkAllRead={() => {}}
+      tooltip="全部已读"
+    />,
+  );
+
+const getBadge = () => document.querySelector("[role=button]") as HTMLElement;
+
+describe("MarkAllReadBadge tooltip", () => {
+  it("shows a tooltip bubble on hover instead of a native title", () => {
+    renderBadge();
+    const badge = getBadge();
+    expect(badge).not.toHaveAttribute("title");
+    expect(badge).toHaveAttribute("aria-label", "全部已读");
+    fireEvent.mouseEnter(badge);
+    expect(within(document.body).getByText("全部已读")).toHaveClass(
+      "fixed",
+      "pointer-events-none",
+    );
+  });
+
+  it("shows the tooltip bubble after a long press on touch", () => {
+    vi.useFakeTimers();
+    try {
+      renderBadge();
+      const badge = getBadge();
+      fireEvent.touchStart(badge);
+      expect(
+        within(document.body).queryByText("全部已读"),
+      ).not.toBeInTheDocument();
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+      expect(within(document.body).getByText("全部已读")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/frontend/src/components/sidebar/__tests__/recentChatsStatus.test.ts
+++ b/frontend/src/components/sidebar/__tests__/recentChatsStatus.test.ts
@@ -15,8 +15,14 @@ test("recent chats renders the same task status indicators as the sidebar", () =
   );
   expect(source).toMatch(/taskStatus === "waiting_human"/);
   expect(source).toMatch(/data-session-status="ask-human"/);
-  expect(source).toMatch(/title=\{t\(/);
-  expect(source).toMatch(/aria-label=\{t\(/);
-  expect(source).toMatch(/title="Ask human · 等待你的回复"/);
+  expect(source).toMatch(/aria-label=\{runningLabel\}/);
   expect(source).toMatch(/animate-spin/);
+});
+
+test("recent chats surfaces status labels as touch tooltips, not inline text", () => {
+  expect(source).toMatch(/<Tooltip/);
+  expect(source).toMatch(/open=\{statusTooltipOpen\}/);
+  expect(source).toMatch(/handleRowTouchStart/);
+  expect(source).toMatch(/touchedSessionId/);
+  expect(source).toMatch(/sidebar\.waitingHuman/);
 });

--- a/frontend/src/components/sidebar/__tests__/sidebarTouchTooltipsSource.test.ts
+++ b/frontend/src/components/sidebar/__tests__/sidebarTouchTooltipsSource.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(__dirname, rel), "utf8");
+
+// Touch devices never show native title attributes; every icon-only affordance
+// in the sidebar must surface its label through the shared Tooltip instead.
+describe("sidebar touch tooltips", () => {
+  it("rail buttons use Tooltip instead of native titles", () => {
+    const source = read("../../panels/SidebarParts/SidebarRail.tsx");
+    expect(source).toMatch(/from "\.\.\/\.\.\/common\/Tooltip"/);
+    expect(source).toMatch(/<Tooltip content=\{t\(/);
+    expect(source).not.toMatch(/title=\{t\(/);
+  });
+  it("session list header and toolbar buttons use Tooltip instead of native titles", () => {
+    const source = read("../../panels/SidebarParts/SessionListContent.tsx");
+    expect(source).toMatch(/from "\.\.\/\.\.\/common\/Tooltip"/);
+    expect(source).toMatch(/<Tooltip content=\{t\(/);
+    expect(source).not.toMatch(/title=\{t\(/);
+  });
+  it("project item icon affordances use Tooltip instead of native titles", () => {
+    const source = read("../ProjectItem.tsx");
+    expect(source).toMatch(/from "\.\.\/common\/Tooltip"/);
+    expect(source).toMatch(/open=\{isTouched && !isMenuOpen\}/);
+    expect(source).not.toMatch(/title=\{t\(/);
+  });
+  it("session item more button uses Tooltip instead of a native title", () => {
+    const source = read("../SessionItem.tsx");
+    expect(source).toMatch(/open=\{isTouched && !isMenuOpen\}/);
+    expect(source).not.toMatch(/title=\{t\(/);
+  });
+  it("mark-all-read badge renders a Tooltip instead of a native title", () => {
+    const source = read("../MarkAllReadBadge.tsx");
+    expect(source).toMatch(/from "\.\.\/common\/Tooltip"/);
+    expect(source).toMatch(/<Tooltip content=\{tooltip\}/);
+    expect(source).not.toMatch(/title=\{tooltip\}/);
+  });
+});

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -267,7 +267,6 @@
     "continue": "Continue",
     "enterResponse": "Enter your response...",
     "ignore": "Ignore",
-    "mainGoal": "Main goal",
     "multiSelectHint": "Multiple selections allowed · Click an option to select or clear",
     "needsConfirmation": "Needs Confirmation",
     "next": "Next item",
@@ -289,7 +288,7 @@
     },
     "selectOption": "Select an option",
     "send": "Send",
-    "shortcutHint": "↑↓ navigate · Enter confirm · 1-9 select",
+    "shortcutHint": "Enter to submit",
     "submit": "Submit"
   },
   "auth": {
@@ -2881,6 +2880,7 @@
     "noSessions": "No chat sessions yet",
     "older": "Older",
     "open": "open",
+    "pendingStatus": "Pending",
     "pinToTop": "Pin to top",
     "pinToggleFailed": "Failed to update pin status",
     "pinned": "Pinned",
@@ -2901,6 +2901,7 @@
     "renameFailed": "Failed to rename session",
     "renamed": "Session renamed",
     "retry": "Retry",
+    "runningStatus": "Running",
     "scrollToTop": "Scroll to top",
     "searchResultCount": "{{count}} results",
     "searchSessions": "Search sessions",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -267,7 +267,6 @@
     "continue": "続ける",
     "enterResponse": "返信を入力...",
     "ignore": "無視",
-    "mainGoal": "主な目標",
     "multiSelectHint": "複数選択できます · クリックで選択/解除",
     "needsConfirmation": "確認が必要です",
     "next": "次の項目",
@@ -289,7 +288,7 @@
     },
     "selectOption": "オプションを選択",
     "send": "送信",
-    "shortcutHint": "↑↓ 移動 · Enter 決定 · 1-9 選択",
+    "shortcutHint": "Enter で送信",
     "submit": "確定"
   },
   "auth": {
@@ -2881,6 +2880,7 @@
     "noSessions": "まだチャットセッションがありません",
     "older": "それ以前",
     "open": "開く",
+    "pendingStatus": "待機中",
     "pinToTop": "ピン留め",
     "pinToggleFailed": "ピン留め状態の更新に失敗しました",
     "pinned": "ピン留めしました",
@@ -2901,6 +2901,7 @@
     "renameFailed": "セッション名の変更に失敗しました",
     "renamed": "セッション名が変更されました",
     "retry": "再試行",
+    "runningStatus": "実行中",
     "scrollToTop": "トップへ戻る",
     "searchResultCount": "{{count}} 件",
     "searchSessions": "セッションを検索",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -267,7 +267,6 @@
     "continue": "계속",
     "enterResponse": "응답 입력...",
     "ignore": "무시",
-    "mainGoal": "주요 목표",
     "multiSelectHint": "여러 항목을 선택할 수 있습니다 · 클릭하여 선택/해제",
     "needsConfirmation": "확인 필요",
     "next": "다음 항목",
@@ -289,7 +288,7 @@
     },
     "selectOption": "옵션을 선택하세요",
     "send": "전송",
-    "shortcutHint": "↑↓ 이동 · Enter 확인 · 1-9 선택",
+    "shortcutHint": "Enter 제출",
     "submit": "확인"
   },
   "auth": {
@@ -2881,6 +2880,7 @@
     "noSessions": "아직 채팅 세션이 없습니다",
     "older": "이전",
     "open": "열기",
+    "pendingStatus": "대기 중",
     "pinToTop": "고정",
     "pinToggleFailed": "고정 상태 업데이트 실패",
     "pinned": "고정됨",
@@ -2901,6 +2901,7 @@
     "renameFailed": "세션 이름 변경에 실패했습니다",
     "renamed": "세션 이름이 변경되었습니다",
     "retry": "재시도",
+    "runningStatus": "실행 중",
     "scrollToTop": "맨 위로",
     "searchResultCount": "{{count}}개 결과",
     "searchSessions": "세션 검색",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -267,7 +267,6 @@
     "continue": "Продолжить",
     "enterResponse": "Введите ваш ответ...",
     "ignore": "Игнорировать",
-    "mainGoal": "Основная цель",
     "multiSelectHint": "Можно выбрать несколько · Нажмите, чтобы выбрать или снять выбор",
     "needsConfirmation": "Требуется подтверждение",
     "next": "Следующий пункт",
@@ -289,7 +288,7 @@
     },
     "selectOption": "Выберите параметр",
     "send": "Отправить",
-    "shortcutHint": "↑↓ выбор · Enter подтвердить · 1-9 выбор",
+    "shortcutHint": "Enter — отправить",
     "submit": "Отправить"
   },
   "auth": {
@@ -2881,6 +2880,7 @@
     "noSessions": "Чат-сессий пока нет",
     "older": "Старее",
     "open": "открыть",
+    "pendingStatus": "Ожидание",
     "pinToTop": "Закрепить",
     "pinToggleFailed": "Не удалось обновить статус закрепления",
     "pinned": "Закреплено",
@@ -2901,6 +2901,7 @@
     "renameFailed": "Не удалось переименовать сессию",
     "renamed": "Сессия переименована",
     "retry": "Повторить",
+    "runningStatus": "Выполняется",
     "scrollToTop": "В начало",
     "searchResultCount": "{{count}} результатов",
     "searchSessions": "Поиск сессий",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -267,7 +267,6 @@
     "continue": "继续",
     "enterResponse": "请输入回复...",
     "ignore": "忽略",
-    "mainGoal": "主要目标",
     "multiSelectHint": "可多选 · 点击选项进行选择或取消",
     "needsConfirmation": "需要确认",
     "next": "下一项",
@@ -289,7 +288,7 @@
     },
     "selectOption": "选择一个选项",
     "send": "发送",
-    "shortcutHint": "↑↓ 切换 · Enter 确认 · 数字键选择",
+    "shortcutHint": "Enter 提交",
     "submit": "提交"
   },
   "auth": {
@@ -2881,6 +2880,7 @@
     "noSessions": "暂无对话记录",
     "older": "更早",
     "open": "打开",
+    "pendingStatus": "等待中",
     "pinToTop": "置顶",
     "pinToggleFailed": "置顶状态更新失败",
     "pinned": "已置顶",
@@ -2901,6 +2901,7 @@
     "renameFailed": "重命名会话失败",
     "renamed": "会话已重命名",
     "retry": "重试",
+    "runningStatus": "运行中",
     "scrollToTop": "回到顶部",
     "searchResultCount": "{{count}} 个结果",
     "searchSessions": "搜索会话",

--- a/frontend/src/styles/approval.css
+++ b/frontend/src/styles/approval.css
@@ -117,25 +117,11 @@
   white-space: normal;
 }
 
-.approval-ask-human-badge {
-  flex-shrink: 0;
-  border: 1px solid
-    color-mix(in srgb, var(--approval-text-dim) 45%, var(--approval-border));
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--approval-bg) 80%, white 4%);
-  padding: 0.22rem 0.62rem;
-  color: var(--approval-text);
-  font-size: 0.75rem;
-  font-weight: 400;
-  letter-spacing: 0.01em;
-  white-space: nowrap;
-}
-
 .approval-ask-human-question {
   min-width: 0;
   overflow-wrap: anywhere;
   color: var(--approval-text);
-  font-size: 1rem;
+  font-size: 0.875rem;
   font-weight: 400;
   letter-spacing: 0;
   line-height: 1.5;
@@ -199,7 +185,7 @@
   align-items: center;
   gap: 0.45rem;
   color: var(--approval-text-dim);
-  font-size: 0.8125rem;
+  font-size: 0.6875rem;
   line-height: 1.4;
   opacity: 0.82;
 }
@@ -217,15 +203,15 @@
 .approval-ask-human-option {
   display: grid;
   grid-template-columns: 1.65rem minmax(0, 1fr);
-  min-height: 2.75rem;
+  min-height: 2.5rem;
   align-items: center;
   column-gap: 0.8rem;
   border: 1px solid color-mix(in srgb, var(--approval-border) 42%, transparent);
   border-radius: 0.75rem;
   background: color-mix(in srgb, var(--approval-bg) 88%, transparent);
-  padding: 0.45rem 0.75rem;
+  padding: 0.4rem 0.7rem;
   color: var(--approval-text);
-  font-size: 1rem;
+  font-size: 0.8125rem;
   font-weight: 400;
   line-height: 1.5;
   text-align: left;
@@ -249,7 +235,7 @@
     color-mix(in srgb, var(--approval-border) 75%, var(--approval-text-dim));
   border-radius: 999px;
   color: var(--approval-text-dim);
-  font-size: 0.78rem;
+  font-size: 0.6875rem;
   font-variant-numeric: tabular-nums;
   font-weight: 600;
   line-height: 1;
@@ -263,56 +249,46 @@
 .approval-ask-human-option:hover:not(.approval-ask-human-option--selected) {
   border-color: color-mix(
     in srgb,
-    var(--approval-accent) 42%,
+    var(--approval-accent) 32%,
     var(--approval-border)
   );
   background: color-mix(
     in srgb,
-    var(--approval-accent-light) 12%,
+    var(--approval-accent-light) 8%,
     var(--approval-bg)
   );
   color: var(--approval-text);
 }
 
-.approval-ask-human-option--focused:not(.approval-ask-human-option--selected) {
+.approval-ask-human-option:hover:not(.approval-ask-human-option--selected)
+  .approval-ask-human-option-indicator {
   border-color: color-mix(
     in srgb,
-    var(--approval-accent) 58%,
+    var(--approval-accent) 45%,
     var(--approval-border)
   );
-  box-shadow: 0 0 0 2px
-    color-mix(in srgb, var(--approval-accent) 16%, transparent);
-}
-
-.approval-ask-human-option:hover:not(.approval-ask-human-option--selected)
-  .approval-ask-human-option-indicator,
-.approval-ask-human-option--focused:not(.approval-ask-human-option--selected)
-  .approval-ask-human-option-indicator {
-  border-color: var(--approval-accent);
-  background: color-mix(in srgb, var(--approval-accent-light) 28%, transparent);
-  color: var(--approval-accent);
+  color: var(--approval-text);
 }
 
 .approval-ask-human-option--selected {
   border-color: color-mix(
     in srgb,
-    var(--approval-accent) 66%,
+    var(--approval-accent) 55%,
     var(--approval-border)
   );
   background: color-mix(
     in srgb,
-    var(--approval-accent-light) 18%,
+    var(--approval-accent-light) 14%,
     var(--approval-bg)
   );
   color: var(--approval-text);
   font-weight: 500;
-  box-shadow: 0 3px 12px -9px color-mix(in srgb, var(--approval-accent) 70%, transparent);
 }
 
 .approval-ask-human-option--selected:hover {
   background: color-mix(
     in srgb,
-    var(--approval-accent-light) 32%,
+    var(--approval-accent-light) 20%,
     var(--approval-bg)
   );
 }
@@ -336,7 +312,7 @@
   align-items: center;
   gap: 0.25rem;
   padding: 0 1.1rem 0.4rem;
-  font-size: 0.875rem;
+  font-size: 0.8125rem;
   line-height: 1.5;
   letter-spacing: 0.01em;
   color: var(--approval-text-dim, var(--theme-text-secondary));
@@ -347,7 +323,7 @@
   display: block;
   margin-bottom: 0.5rem;
   color: var(--approval-text-dim);
-  font-size: 0.85rem;
+  font-size: 0.8125rem;
 }
 
 .approval-ask-human-footer {
@@ -455,9 +431,12 @@
 }
 
 @media (min-width: 641px) {
-  .approval-ask-human-question,
+  .approval-ask-human-question {
+    font-size: 0.875rem;
+  }
+
   .approval-ask-human-option {
-    font-size: 1rem;
+    font-size: 0.8125rem;
   }
 }
 
@@ -672,7 +651,7 @@
 .approval-form--ask-human {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 1rem;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
 }
@@ -680,7 +659,7 @@
 .approval-form--ask-human > div {
   display: flex;
   flex-direction: column;
-  gap: 0.45rem;
+  gap: 0.6rem;
   padding: 0;
 }
 
@@ -695,12 +674,13 @@
 
 .approval-form--ask-human > div > label {
   margin-bottom: 0;
-  font-size: 1rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
   line-height: 1.5;
 }
 
 .approval-form--ask-human .approval-input {
-  font-size: 1rem;
+  font-size: 0.8125rem;
   line-height: 1.5;
 }
 

--- a/src/api/routes/chat.py
+++ b/src/api/routes/chat.py
@@ -826,6 +826,15 @@ async def cancel_session(
     task_manager = get_task_manager()
     result = await task_manager.cancel(session_id, user_id=user.sub)
 
+    # 取消 × ask_human 挂起竞态调和：挂起 run 的协程已返回，cancel 只覆写
+    # task_status、不关挂起审批也不写终态事件——审批会因会话已离开
+    # WAITING_HUMAN 永远无法恢复，前端审批卡 + 隐藏输入框死锁会话。
+    from src.api.routes.hitl_interrupt_cleanup import reconcile_cancelled_hitl_approvals
+
+    await reconcile_cancelled_hitl_approvals(
+        session_id, user_id=user.sub, task_manager=task_manager
+    )
+
     # 如果本地没有取消到，尝试从排队队列中移除
     if not result.get("cancelled_locally"):
         try:

--- a/src/api/routes/chat_steer.py
+++ b/src/api/routes/chat_steer.py
@@ -7,6 +7,10 @@ ask_human interrupt 模式下图挂在 interrupt 上，插话永远等不到下�
 """
 
 from src.api.deps import TokenPayload
+from src.api.routes.hitl_interrupt_cleanup import (
+    pending_interrupt_approvals,
+    seal_suspended_run,
+)
 from src.infra.logging import get_logger
 from src.infra.task.status import TaskStatus
 from src.kernel.errors import AppError, ErrorCode
@@ -29,28 +33,13 @@ async def steer_interrupt_waiting_human(
     + done 事件（前端据此把状态行「工作中」切为「已停止」），并关闭挂起
     审批避免卡片残留。
     """
-    from src.infra.session.dual_writer import get_dual_writer
-    from src.infra.storage.mongodb import get_approval_storage
-    from src.infra.task.hitl import (
-        _acquire_resume_lock,
-        _release_resume_lock,
-        is_interrupt_approval,
-    )
-    from src.infra.task.steer import purge_stale_steers
-    from src.infra.utils.datetime import utc_now_iso
-
-    metadata = getattr(session, "metadata", None) or {}
-    run_id = str(metadata.get("current_run_id") or "")
-    trace_id = str(metadata.get("trace_id") or "") or None
-
     # 挂起审批先抢恢复锁：与「回答审批」的恢复提交互斥。抢锁失败说明
     # 恢复正在别的请求里启动，插话按会话不可插话冲突返回；抢到锁后
     # 对方的 submit_hitl_resume_run 会因会话已离开 WAITING_HUMAN 跳过。
-    approvals = [
-        approval
-        for approval in await get_approval_storage().list_pending(session_id=session_id, limit=20)
-        if is_interrupt_approval(approval)
-    ]
+    from src.infra.task.hitl import _acquire_resume_lock, _release_resume_lock
+    from src.infra.task.steer import purge_stale_steers
+
+    approvals = await pending_interrupt_approvals(session_id)
     held_locks: list[tuple[str, str]] = []
     try:
         for approval in approvals:
@@ -63,65 +52,16 @@ async def steer_interrupt_waiting_human(
             held_locks.append((approval.id, token))
 
         await task_manager.cancel(session_id, user_id=user.sub)
-        # cancel_run 不改 task_status（挂起 run 无执行器协程写终态），
-        # 显式落 CANCELLED：恢复方、后续 steer 与普通发送都以状态机为准。
-        if task_manager._executor is None:
-            from src.infra.task.executor import TaskExecutor
 
-            task_manager._executor = TaskExecutor(
-                task_manager.storage, task_manager._run_info, task_manager._heartbeat
-            )
-        await task_manager._executor._update_session_status(
-            session_id, TaskStatus.CANCELLED, "Interrupted by steer", run_id=run_id or None
+        await seal_suspended_run(
+            session=session,
+            task_manager=task_manager,
+            user_id=user.sub,
+            approvals=approvals,
+            cancel_reason="steer",
+            resolved_message="已被新插话打断",
+            status_error="Interrupted by steer",
         )
-
-        dual_writer = get_dual_writer()
-        for approval in approvals:
-            # cancelled 而非 approved/rejected：不携带恢复值，纯关卡片
-            await get_approval_storage().update_status(approval.id, "cancelled")
-            await dual_writer.write_event(
-                session_id=session_id,
-                event_type="approval_resolved",
-                data={
-                    "id": approval.id,
-                    "tool_call_id": (getattr(approval, "metadata", None) or {}).get("tool_call_id"),
-                    "interrupt_id": (getattr(approval, "metadata", None) or {}).get("interrupt_id"),
-                    "status": "cancelled",
-                    "success": False,
-                    "result": {"status": "cancelled", "message": "已被新插话打断"},
-                    "timestamp": utc_now_iso(),
-                },
-                run_id=run_id or None,
-                trace_id=trace_id,
-            )
-
-        # 封存旧消息：user:cancel 带 reason=steer（前端不追加已取消胶囊，
-        # 只切状态行文字），done 关闭流让前端把插话补发为普通消息
-        await dual_writer.write_event(
-            session_id=session_id,
-            event_type="user:cancel",
-            data={
-                "user_id": user.sub,
-                "run_id": run_id,
-                "timestamp": utc_now_iso(),
-                "reason": "steer",
-            },
-            run_id=run_id or None,
-            trace_id=trace_id,
-        )
-        await dual_writer.write_event(
-            session_id=session_id,
-            event_type="done",
-            data={
-                "status": "cancelled",
-                "run_id": run_id,
-                "timestamp": utc_now_iso(),
-            },
-            run_id=run_id or None,
-            trace_id=trace_id,
-        )
-        if run_id:
-            await task_manager._executor._expire_terminal_stream(session_id, run_id, dual_writer)
 
         # 挂起前残留在插话队列的条目一并清空：新 run 不应把它们当插话注入
         try:

--- a/src/api/routes/hitl_interrupt_cleanup.py
+++ b/src/api/routes/hitl_interrupt_cleanup.py
@@ -1,0 +1,175 @@
+"""ask_human 挂起 run 的统一封存（steer 打断与普通取消共用）。
+
+挂起 run 的执行器协程已返回（图停在 interrupt 上），普通取消路径不会替它
+写终态——run 被取消后会话离开 WAITING_HUMAN，挂起审批既无法恢复（
+submit_hitl_resume_run 校验状态直接跳过）也没人关闭，前端审批卡永远
+pending、输入框被隐藏，会话彻底卡死（2026-09-05 生产事故）。
+
+封存动作：落 CANCELLED 状态、关闭挂起审批（cancelled 而非
+approved/rejected——不携带恢复值）、补 approval_resolved + user:cancel +
+done 终态事件、过期实时流。与「回答审批」的恢复提交靠恢复锁互斥。
+"""
+
+from src.infra.logging import get_logger
+from src.infra.task.status import TaskStatus
+
+logger = get_logger(__name__)
+
+
+async def pending_interrupt_approvals(session_id: str) -> list:
+    """列出会话所有挂起中的 interrupt 审批。"""
+    from src.infra.storage.mongodb import get_approval_storage
+    from src.infra.task.hitl import is_interrupt_approval
+
+    approvals = await get_approval_storage().list_pending(session_id=session_id, limit=20)
+    return [approval for approval in approvals if is_interrupt_approval(approval)]
+
+
+def approvals_bound_to_run(approvals: list, run_id: str) -> list:
+    """过滤出绑定当前 run 的审批；未绑定 run 的残留审批一并纳入。"""
+    bound = []
+    for approval in approvals:
+        approval_run = str((getattr(approval, "metadata", None) or {}).get("run_id") or "")
+        if not approval_run or not run_id or approval_run == run_id:
+            bound.append(approval)
+    return bound
+
+
+async def seal_suspended_run(
+    *,
+    session,
+    task_manager,
+    user_id: str,
+    approvals: list,
+    cancel_reason: str | None,
+    resolved_message: str,
+    status_error: str,
+) -> None:
+    """封存挂起 run（调用方需已持有各审批的恢复锁）。
+
+    落 CANCELLED、关闭审批卡片、写 user:cancel + done 终态事件、过期流。
+    approvals 为空时仍封存 run 本身（WAITING_HUMAN 残留态自愈）。
+    """
+    from src.infra.session.dual_writer import get_dual_writer
+    from src.infra.storage.mongodb import get_approval_storage
+    from src.infra.utils.datetime import utc_now_iso
+
+    session_id = getattr(session, "session_id", None) or (
+        getattr(approvals[0], "session_id", None) if approvals else None
+    )
+    if not session_id:
+        return
+    metadata = getattr(session, "metadata", None) or {}
+    run_id = str(metadata.get("current_run_id") or "")
+    trace_id = str(metadata.get("trace_id") or "") or None
+
+    # cancel_run 不改 task_status（挂起 run 无执行器协程写终态），
+    # 显式落 CANCELLED：恢复方、后续 steer 与普通发送都以状态机为准。
+    if task_manager._executor is None:
+        from src.infra.task.executor import TaskExecutor
+
+        task_manager._executor = TaskExecutor(
+            task_manager.storage, task_manager._run_info, task_manager._heartbeat
+        )
+    await task_manager._executor._update_session_status(
+        session_id, TaskStatus.CANCELLED, status_error, run_id=run_id or None
+    )
+
+    dual_writer = get_dual_writer()
+    for approval in approvals:
+        # cancelled 而非 approved/rejected：不携带恢复值，纯关卡片
+        await get_approval_storage().update_status(approval.id, "cancelled")
+        await dual_writer.write_event(
+            session_id=session_id,
+            event_type="approval_resolved",
+            data={
+                "id": approval.id,
+                "tool_call_id": (getattr(approval, "metadata", None) or {}).get("tool_call_id"),
+                "interrupt_id": (getattr(approval, "metadata", None) or {}).get("interrupt_id"),
+                "status": "cancelled",
+                "success": False,
+                "result": {"status": "cancelled", "message": resolved_message},
+                "timestamp": utc_now_iso(),
+            },
+            run_id=run_id or None,
+            trace_id=trace_id,
+        )
+
+    # 封存旧消息：普通取消不带 reason（前端追加「已取消」胶囊）；
+    # steer 带 reason=steer（前端只切状态行文字，不追加胶囊）。
+    cancel_data = {"user_id": user_id, "run_id": run_id, "timestamp": utc_now_iso()}
+    if cancel_reason:
+        cancel_data["reason"] = cancel_reason
+    await dual_writer.write_event(
+        session_id=session_id,
+        event_type="user:cancel",
+        data=cancel_data,
+        run_id=run_id or None,
+        trace_id=trace_id,
+    )
+    await dual_writer.write_event(
+        session_id=session_id,
+        event_type="done",
+        data={"status": "cancelled", "run_id": run_id, "timestamp": utc_now_iso()},
+        run_id=run_id or None,
+        trace_id=trace_id,
+    )
+    if run_id:
+        await task_manager._executor._expire_terminal_stream(session_id, run_id, dual_writer)
+
+
+async def reconcile_cancelled_hitl_approvals(
+    session_id: str,
+    *,
+    user_id: str,
+    task_manager,
+) -> bool:
+    """普通取消后的调和：关闭竞态残留的挂起 interrupt 审批并封存 run。
+
+    覆盖两种竞态形态（都会让审批永 pending 而无法恢复）：
+    ① 取消到达时 run 已挂起：cancel 把 WAITING_HUMAN 覆写成 CANCELLED；
+    ② 取消与挂起同时发生：run 在取消宽限窗口内挂起，状态同样被覆写。
+    只处理绑定当前 run 的审批；恢复锁被「回答审批」请求持有时整单跳过
+    （恢复后的 run 由取消中断信号走正常终止路径写终态事件）。
+    """
+    from src.infra.session.storage import SessionStorage
+    from src.infra.task.hitl import _acquire_resume_lock, _release_resume_lock
+
+    approvals = await pending_interrupt_approvals(session_id)
+    if not approvals:
+        return False
+
+    session = await SessionStorage().get_by_session_id(session_id)
+    if session is None:
+        return False
+    run_id = str((getattr(session, "metadata", None) or {}).get("current_run_id") or "")
+    approvals = approvals_bound_to_run(approvals, run_id)
+    if not approvals:
+        return False
+
+    held_locks: list[tuple[str, str]] = []
+    try:
+        for approval in approvals:
+            token = await _acquire_resume_lock(approval.id)
+            if token is None:
+                # 恢复提交正在进行：不动状态、不关审批、不写事件，
+                # 由恢复后的 run 走正常取消路径。
+                return False
+            held_locks.append((approval.id, token))
+
+        await seal_suspended_run(
+            session=session,
+            task_manager=task_manager,
+            user_id=user_id,
+            approvals=approvals,
+            cancel_reason=None,
+            resolved_message="运行已取消",
+            status_error="Task cancelled",
+        )
+        return True
+    except Exception as e:
+        logger.warning(f"Failed to reconcile cancelled HITL approvals: {e}")
+        return False
+    finally:
+        for approval_id, token in held_locks:
+            await _release_resume_lock(approval_id, token)

--- a/tests/api/routes/test_chat_cancel_waiting_human.py
+++ b/tests/api/routes/test_chat_cancel_waiting_human.py
@@ -1,0 +1,226 @@
+"""POST /chat/sessions/{id}/cancel × ask_human 挂起（WAITING_HUMAN）。
+
+生产事故（2026-09-05）：用户点「停止」的瞬间 run 恰好挂在 ask_human interrupt 上。
+挂起 run 的执行器协程已返回，取消路径只把 task_status 覆写成 CANCELLED、trace 打成
+error，却不关闭挂起审批、不补 user:cancel/done 终态事件——前端审批卡永远 pending、
+输入框被隐藏、审批又因会话已离开 WAITING_HUMAN 被拒绝恢复，会话彻底卡死。
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from src.api.routes.chat import cancel_session
+from src.infra.task.status import TaskStatus
+
+
+def _user(sub="user-1"):
+    return SimpleNamespace(sub=sub)
+
+
+class _CancelHarness:
+    def __init__(self, *, status_after_cancel: str = "cancelled") -> None:
+        self.cancel_calls: list[tuple[str, str | None]] = []
+        self.status_calls: list[tuple[str, TaskStatus]] = []
+        self.expired_streams: list[str] = []
+        self.written_events: list[tuple[str, dict]] = []
+        self.approval_updates: list[tuple[str, str]] = []
+        self.lock_fail_ids: set[str] = set()
+        self.held_locks: list[str] = []
+        self.session_status = "waiting_human"
+        self._status_after_cancel = status_after_cancel
+
+    def session(self):
+        harness = self
+        return SimpleNamespace(
+            user_id="user-1",
+            session_id="session-1",
+            metadata={
+                "current_run_id": "run-9",
+                "trace_id": "trace-9",
+                "agent_id": "fast",
+                "task_status": harness.session_status,
+            },
+        )
+
+    def task_manager(self) -> SimpleNamespace:
+        harness = self
+
+        class _Executor:
+            async def _update_session_status(
+                self, session_id, task_status, error=None, run_id=None
+            ):
+                harness.status_calls.append((session_id, task_status))
+                harness.session_status = task_status.value
+
+            async def _expire_terminal_stream(self, session_id, run_id, dual_writer):
+                harness.expired_streams.append(run_id)
+
+        class _Manager:
+            _executor = _Executor()
+
+            async def cancel(self, session_id, user_id=None):
+                harness.cancel_calls.append((session_id, user_id))
+                # 真实 manager.cancel_run 在中断信号设置成功后无条件覆写 CANCELLED
+                harness.session_status = harness._status_after_cancel
+                return {
+                    "success": True,
+                    "cancelled_locally": False,
+                    "run_id": "run-9",
+                    "message": "取消信号已发送",
+                }
+
+        return _Manager()
+
+    def approval_storage(self, approvals: list) -> SimpleNamespace:
+        harness = self
+
+        async def _list_pending(session_id=None, user_id=None, limit=100):
+            return approvals
+
+        async def _update_status(approval_id, status, response=None):
+            harness.approval_updates.append((approval_id, status))
+            return True
+
+        return SimpleNamespace(list_pending=_list_pending, update_status=_update_status)
+
+    def dual_writer(self) -> SimpleNamespace:
+        harness = self
+
+        async def _write_event(session_id, event_type, data, run_id=None, trace_id=None):
+            harness.written_events.append((event_type, data))
+
+        return SimpleNamespace(write_event=_write_event)
+
+    def wire(self, monkeypatch, approvals: list) -> None:
+        import src.infra.task.hitl as hitl
+
+        harness = self
+
+        class _SessionManager:
+            async def get_session(self, session_id):
+                return harness.session()
+
+        monkeypatch.setattr("src.api.routes.chat.SessionManager", _SessionManager)
+        monkeypatch.setattr("src.api.routes.chat.get_task_manager", lambda: harness.task_manager())
+        monkeypatch.setattr(
+            "src.infra.storage.mongodb.get_approval_storage",
+            lambda: harness.approval_storage(approvals),
+        )
+        monkeypatch.setattr(
+            "src.infra.session.storage.SessionStorage",
+            lambda: SimpleNamespace(
+                get_by_session_id=AsyncMock(side_effect=lambda _: harness.session())
+            ),
+        )
+        monkeypatch.setattr(
+            "src.infra.session.dual_writer.get_dual_writer",
+            lambda: harness.dual_writer(),
+        )
+
+        async def _acquire(approval_id: str):
+            if approval_id in harness.lock_fail_ids:
+                return None
+            harness.held_locks.append(approval_id)
+            return f"token-{approval_id}"
+
+        async def _release(approval_id: str, token: str) -> None:
+            if approval_id in harness.held_locks:
+                harness.held_locks.remove(approval_id)
+
+        monkeypatch.setattr(hitl, "_acquire_resume_lock", _acquire)
+        monkeypatch.setattr(hitl, "_release_resume_lock", _release)
+        # 队列移除兜底：本地未取消到时会调用，测试中不关心
+        monkeypatch.setattr(
+            "src.infra.task.concurrency.get_concurrency_limiter",
+            lambda: SimpleNamespace(remove_from_queue=AsyncMock(return_value=0)),
+        )
+
+
+def _interrupt_approval(approval_id="appr-1", run_id="run-9"):
+    return SimpleNamespace(
+        id=approval_id,
+        session_id="session-1",
+        user_id="user-1",
+        status="pending",
+        message="要继续吗？",
+        metadata={"mode": "interrupt", "run_id": run_id, "trace_id": "trace-9"},
+    )
+
+
+async def test_cancel_waiting_human_closes_approval_and_writes_terminal_events(
+    monkeypatch,
+) -> None:
+    """挂起中取消：关闭挂起审批、补 approval_resolved + user:cancel + done、过期流。"""
+    harness = _CancelHarness()
+    harness.wire(monkeypatch, [_interrupt_approval()])
+
+    result = await cancel_session("session-1", user=_user())
+
+    assert result["success"] is True
+    assert harness.cancel_calls == [("session-1", "user-1")]
+    assert harness.approval_updates == [("appr-1", "cancelled")]
+    assert harness.held_locks == []
+    event_types = [event_type for event_type, _ in harness.written_events]
+    assert "approval_resolved" in event_types
+    assert event_types[-2] == "user:cancel"
+    assert event_types[-1] == "done"
+    cancel_data = harness.written_events[-2][1]
+    assert cancel_data["run_id"] == "run-9"
+    assert cancel_data["user_id"] == "user-1"
+    # 普通取消：不带 steer reason，前端追加「已取消」胶囊
+    assert cancel_data.get("reason") != "steer"
+    assert harness.written_events[-1][1]["status"] == "cancelled"
+    assert harness.expired_streams == ["run-9"]
+    assert harness.session_status == "cancelled"
+
+
+async def test_cancel_race_after_status_clobbered_still_reconciles(monkeypatch) -> None:
+    """竞态形态：cancel 已把 task_status 盖成 cancelled、审批仍 pending → 同样调和。"""
+    harness = _CancelHarness()
+    harness.session_status = "cancelled"  # 取消请求到达前状态已被覆写
+    harness.wire(monkeypatch, [_interrupt_approval()])
+
+    await cancel_session("session-1", user=_user())
+
+    assert harness.approval_updates == [("appr-1", "cancelled")]
+    event_types = [event_type for event_type, _ in harness.written_events]
+    assert event_types[-2:] == ["user:cancel", "done"]
+
+
+async def test_cancel_skips_approval_locked_by_inflight_resume(monkeypatch) -> None:
+    """取消与「回答审批」同时到达：恢复锁被占的审批不动，由恢复后的 run 走正常取消。"""
+    harness = _CancelHarness()
+    harness.lock_fail_ids = {"appr-1"}
+    harness.wire(monkeypatch, [_interrupt_approval()])
+
+    result = await cancel_session("session-1", user=_user())
+
+    assert result["success"] is True
+    assert harness.approval_updates == []
+    assert harness.written_events == []
+    assert harness.expired_streams == []
+
+
+async def test_cancel_ignores_approvals_of_other_runs(monkeypatch) -> None:
+    """只关闭属于当前 run 的挂起审批，历史 run 的残留不动。"""
+    harness = _CancelHarness()
+    harness.wire(monkeypatch, [_interrupt_approval(run_id="run-old")])
+
+    await cancel_session("session-1", user=_user())
+
+    assert harness.approval_updates == []
+    assert harness.written_events == []
+
+
+async def test_cancel_running_session_without_approvals_unchanged(monkeypatch) -> None:
+    """普通运行中取消（无挂起审批）：不写任何补偿事件，行为与之前一致。"""
+    harness = _CancelHarness()
+    harness.session_status = "running"
+    harness.wire(monkeypatch, [])
+
+    result = await cancel_session("session-1", user=_user())
+
+    assert result["success"] is True
+    assert harness.approval_updates == []
+    assert harness.written_events == []
+    assert harness.expired_streams == []


### PR DESCRIPTION
## Summary

- 修复取消挂起在 ask_human 上的会话后，审批卡永远 pending、输入框被隐藏导致的会话死锁（2026-09-05 生产事故）
- 简化 ask_human 审批表单交互，并为侧边栏补充触控友好的 Tooltip

## Changes

### 后端

- 新增 `src/api/routes/hitl_interrupt_cleanup.py`：挂起 run 的统一封存（落 CANCELLED 状态、关闭挂起审批、补 `approval_resolved` / `user:cancel` / `done` 终态事件、过期实时流）
- `POST /chat/{id}/cancel`：取消后调和残留的挂起 interrupt 审批（`reconcile_cancelled_hitl_approvals`），避免会话离开 WAITING_HUMAN 后审批无法恢复
- `chat_steer.py` 插话打断路径重构为复用同一封存流程，与「回答审批」的恢复提交靠恢复锁互斥

### 前端

- ask_human 单选点已选项可取消选择（`toggleSingleSelectValue`），移除方向键/数字键导航，提示收敛为「Enter 提交」
- `Tooltip` 新增受控 `open` 属性；会话项、未读徽标等侧边栏元素在触屏上长按显示气泡
- 会话列表与最近对话为等待人工状态显示「等待中」
- 工具详情面板滚动布局修正（flex + min-h-0，代码块不限高）
- i18n 同步 zh / en / ja / ko / ru 五语

## Testing

- [x] `uv run pytest tests/api/routes/` — 323 passed（含新增 `test_chat_cancel_waiting_human.py` 5 例）
- [x] `cd frontend && pnpm test` — 2165 passed
- [x] `make lint` / `make typecheck` — 通过
- [x] `cd frontend && pnpm run lint`（0 errors）/ `pnpm run build` — 通过
