### PR TITLE
fix(api): CORS 白名单补 https://localhost——修复 Android 端登录 Failed to fetch

### DIFF
--- a/src/kernel/config/base.py
+++ b/src/kernel/config/base.py
@@ -341,6 +341,9 @@ class Settings(BaseSettings):
             "http://tauri.localhost",
             "capacitor://localhost",
             "http://localhost",
+            # Capacitor 5+ Android 默认 androidScheme=https，WebView origin 为
+            # https://localhost；缺失时移动端请求全被 CORS 拦（Failed to fetch）
+            "https://localhost",
         ]
     )
     DEFAULT_AGENT: str = "fast"

--- a/tests/kernel/config/test_allowed_origins.py
+++ b/tests/kernel/config/test_allowed_origins.py
@@ -1,0 +1,22 @@
+"""原生壳 WebView origin 与 CORS 白名单对齐（Capacitor/Tauri 各版本默认 scheme）。
+
+背景（2026-09 Android 登录 Failed to fetch 排查）：Capacitor 5+ 的 Android
+默认 ``androidScheme: "https"``，WebView origin 是 ``https://localhost``；
+白名单里只有 ``http://localhost`` / ``capacitor://localhost``，导致预检 400、
+无 allow-origin 头，移动端所有 API 请求被浏览器 CORS 拦截。iOS 默认
+``capacitor://`` 不受影响。
+"""
+
+from src.kernel.config.base import Settings
+
+
+def test_allowed_origins_defaults_cover_native_webview_origins() -> None:
+    origins = Settings.model_fields["ALLOWED_ORIGINS"].default_factory()  # type: ignore[no-any-return]
+    # Capacitor 6 Android（https scheme）
+    assert "https://localhost" in origins
+    # Capacitor 3-4 / iOS（capacitor scheme）与旧 Android（http scheme）
+    assert "capacitor://localhost" in origins
+    assert "http://localhost" in origins
+    # Tauri 桌面壳
+    assert "tauri://localhost" in origins
+    assert "https://tauri.localhost" in origins


### PR DESCRIPTION
## 问题

Android App（v0.2.0-rc1 及所有 Capacitor 5+ 构建的包）登录报 `Failed to fetch`，实测：

- `OPTIONS /api/auth/login` + `Origin: capacitor://localhost` → 200 ✅
- 同请求 + `Origin: https://localhost` → **400，无 access-control-allow-origin** ❌

## 根因

Capacitor 5+ 的 Android 默认 `androidScheme: "https"`，WebView origin 是 `https://localhost`；而默认 `ALLOWED_ORIGINS`（Capacitor 4 时代写就）只有 `http://localhost` 和 `capacitor://localhost`。移动端所有请求被浏览器 CORS 拦截。iOS 默认 `capacitor://` 不受影响。

## 修复

默认白名单补 `https://localhost`（TDD：先红后绿，见新增测试）。

## 部署提醒

- 生产生效需按常规流程晋升 develop → main 并 `update.sh`；生效前 Android 端仍无法登录
- 若生产通过 `ALLOWED_ORIGINS` 环境变量覆盖了默认值，需同步把 `https://localhost` 加进环境变量