### PR TITLE
fix(client): Windows cp1252 控制台中文输出崩溃修复（PR #410 漏合并的后续提交）

### DIFF
--- a/client/lambchat_sandbox/__main__.py
+++ b/client/lambchat_sandbox/__main__.py
@@ -54,7 +54,23 @@ def _watch_parent_windows() -> None:
     watch_parent(_thread.interrupt_main)
 
 
+def _force_utf8_stdio() -> None:
+    """std 统一 UTF-8：Windows 控制台/管道默认 cp1252，中文输出（cli.py 的
+    login/status 提示等）直接 UnicodeEncodeError；errors=replace 保证写失败
+    也不致命（打印诊断信息绝不该带崩主流程）。
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="replace")
+        except Exception:  # noqa: BLE001 - 降级即可，不阻塞启动
+            pass
+
+
 if __name__ == "__main__":
+    _force_utf8_stdio()
     _enable_parent_death_signal()
     _watch_parent_windows()
     from lambchat_sandbox.cli import main

--- a/client/scripts/fetch-pbs.py
+++ b/client/scripts/fetch-pbs.py
@@ -127,7 +127,22 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _force_utf8_stdio() -> None:
+    """std 统一 UTF-8：Windows runner 控制台默认 cp1252，中文进度输出
+    （"==> 下载 …"）直接 UnicodeEncodeError 使 CI 挂掉（Linux/macOS 不触发）。
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="replace")
+        except Exception:  # noqa: BLE001 - 降级即可，不阻塞下载
+            pass
+
+
 def main(argv: list[str] | None = None) -> int:
+    _force_utf8_stdio()
     args = build_parser().parse_args(argv)
     if args.platform == "all":
         targets = sorted(PLATFORM_TRIPLES)


### PR DESCRIPTION
PR #410 合并时只带上了 aa765587，本分支尚有 1 个未合并提交 a4b28bff（App Release Windows 任务 Fetch PBS 步骤的 UnicodeEncodeError 修复 + daemon 入口 UTF-8 stdio 收口）。CI 已在 App Release run 33985657670 验证通过。