### PR TITLE
test: 修复 develop CI 两个时序 flake（procfs ESRCH / 线程池幽灵引用）

### DIFF
--- a/tests/api/test_github_routes.py
+++ b/tests/api/test_github_routes.py
@@ -192,6 +192,14 @@ async def test_fetch_github_file_releases_download_chunks_between_reads(
 
     monkeypatch.setattr(github.httpx, "AsyncClient", lambda: _FakeClient())
 
+    async def _inline_blocking_io(fn, *args):
+        # 线程池实现里 future 解析后、工作线程退栈前，线程栈帧仍持有 chunk
+        # 参数引用——慢机上这个"幽灵引用"使释放断言假阴性（gc 收不回活引用）。
+        # 内联执行去掉测量噪声，只验证消费侧 del chunk 的释放纪律。
+        return fn(*args)
+
+    monkeypatch.setattr(github, "run_blocking_io", _inline_blocking_io)
+
     content = await github.fetch_github_file("owner", "repo", "main", "skill/SKILL.md")
 
     assert content == "hello world"

--- a/tests/client/test_executor.py
+++ b/tests/client/test_executor.py
@@ -147,8 +147,10 @@ def _wait_until_dead(pid: int, deadline_s: float = 3.0) -> bool:
     while time.monotonic() < end:
         try:
             stat = Path(f"/proc/{pid}/stat").read_text()
-        except FileNotFoundError:
-            return True  # 已被 init 回收
+        except (FileNotFoundError, ProcessLookupError):
+            # procfs 回收竞态下"进程已没了"有两种表现：ENOENT（目录已摘除）
+            # 与 ESRCH（task 正被收尸），都按已死处理，绝不能当异常炸掉
+            return True
         state = stat.rsplit(")", 1)[1].split()[0]
         if state in {"Z", "X"}:
             return True  # 僵尸/死亡：已被 SIGKILL


### PR DESCRIPTION
## 问题

develop 连续两次 Backend Tests 失败（run 33987404793、33987841162），均为时序 flake，阻塞晋升链路：

1. `tests/client/test_executor.py` 杀组断言：`_wait_until_dead` 读 `/proc/<pid>/stat` 在回收竞态下抛 `ProcessLookupError`（ESRCH），原助手只捕 `FileNotFoundError`——ESRCH 同样表示进程已死，应判活失败为否
2. `tests/api/test_github_routes.py` chunk 释放断言假阴性：`run_blocking_io` 线程池在 future 解析后、工作线程退栈前仍持有 chunk 参数引用（活引用，gc 收不回），慢机上 `first_chunk_released_before_second` 偶发 False

## 修复（均为测试侧，不动生产代码）

- ESRCH 与 ENOENT 同判"已死"
- 该测试内联执行 `run_blocking_io`，剥离线程池测量噪声，只验证消费侧 `del chunk` 释放纪律

## 验证

两个文件全量 5 连跑 + 目标用例 20 连跑全绿。