### PR TITLE
fix(sandbox): 本地沙箱 Windows/macOS 可用性——非零退出码透传 + shell 方言提示

### DIFF
--- a/src/agents/core/prompt_policy.py
+++ b/src/agents/core/prompt_policy.py
@@ -30,7 +30,40 @@ Use this alias only with file tools and uploads. For shell commands, use relativ
 - `upload_url_to_sandbox` downloads inside the sandbox; pass `{work_dir}/<name>` as the target so the file lands in `$LAMBCHAT_WORKSPACE` for later shell commands."""
 
 WORKSPACE_POLICY = """### Workspace Boundaries
-Check whether a target exists before creating it. Modify an existing project only when requested or relevant; otherwise use a named directory in the current session workspace."""
+Check whether a target exists before creating it. Modify an existing project only when requested or clearly relevant; otherwise use a named directory in the current session workspace."""
+
+#: win32 本地 daemon 的 shell 方言提示（cmd.exe）。daemon 上报平台经注册表第三段
+#: 查得（win32/linux/darwin），linux 与未上报不加段——云端沙箱与 Linux 本地
+#: 的 prompt 逐字节保持现状，provider 前缀缓存零失效。
+_SANDBOX_SHELL_WIN32 = """### Local Machine Shell: Windows (cmd.exe)
+
+The local sandbox is the user's Windows machine; `execute` runs commands through cmd.exe, NOT bash.
+- Use Windows syntax: `%ERRORLEVEL%` (not POSIX exit-variable), `%VAR%` (not POSIX variable expansion), `set X=Y` (not `export`), `^` as escape (not `\\`), `REM` for comments (not `#`), `dir` / `type` / `findstr` instead of `ls` / `cat` / `grep`.
+- The session workspace env var is `%LAMBCHAT_WORKSPACE%` in cmd.exe. There is no `/proc`, no `uname`, no POSIX pipes-with-stderr like `2>/dev/null`.
+- Prefer `python3 -c "..."` (embedded interpreter, on PATH) for anything nontrivial — quoting, JSON, math, file inspection — instead of shell gymnastics.
+- A command may legitimately fail (non-zero exit); its stdout/stderr come back to you — read the error text and adapt (e.g. fall back to `python3`) instead of assuming the sandbox is blocked."""
+
+#: darwin 本地 daemon：POSIX shell 可用，但 BSD userland 与 Linux 有差集。
+_SANDBOX_SHELL_DARWIN = """### Local Machine Shell: macOS (POSIX/BSD)
+
+The local sandbox is the user's Mac; `execute` runs commands via /bin/sh (POSIX). Shell syntax works as usual, but the userland is BSD: there is no `/proc`, no `free`, and some GNU flags differ (`sed -i ''`, `tar` quirks).
+- `$LAMBCHAT_WORKSPACE` is the session workspace directory.
+- Prefer `python3 -c "..."` (embedded interpreter, on PATH) for system introspection and portable work (e.g. memory/CPU info via `os.sysconf`, `platform`, `subprocess`), since Linux-style `/proc` reads do not exist.
+- A command may legitimately fail (non-zero exit); its stdout/stderr come back to you — read the error text and adapt."""
+
+
+def sandbox_shell_platform_section(daemon_platform: str) -> str:
+    """daemon 上报平台 → 沙箱运行时提示追加段；空串 = 不追加（保持现状）。
+
+    平台串是注册表第三段的归一值（win32/linux/darwin）；空串涵盖云端沙箱、
+    daemon 离线与旧版未上报——一律不加段，绝不错入 Windows 分支。
+    """
+    if daemon_platform == "win32":
+        return _SANDBOX_SHELL_WIN32
+    if daemon_platform == "darwin":
+        return _SANDBOX_SHELL_DARWIN
+    return ""
+
 
 ARTIFACT_POLICY = """### Artifact Delivery
 `write_file`/`edit_file` outputs are auto-staged; workspace shell outputs are detected by snapshots. Use `reveal_file` for an external HTTP(S) URL or one file and use its returned URL in user-facing documents. Use `reveal_project` for a multi-file project or folder.

--- a/src/agents/search_agent/nodes.py
+++ b/src/agents/search_agent/nodes.py
@@ -26,6 +26,7 @@ from src.agents.core.node_utils import (
     resolve_model_supports_vision,
 )
 from src.agents.core.persona import build_persona_prompt_sections
+from src.agents.core.prompt_policy import sandbox_shell_platform_section
 from src.agents.core.startup_preparation import prepare_agent_inputs
 from src.agents.core.subagent_prompts import (
     CODEBASE_INVESTIGATOR_PROMPT,
@@ -85,6 +86,28 @@ logger = get_logger(__name__)
 # ============================================================================
 # 节点函数
 # ============================================================================
+
+
+async def _build_sandbox_runtime_policy(
+    sandbox_backend: Any, sandbox_work_dir: str | None, *, user_id: str
+) -> str:
+    """沙箱运行时提示段：workspace 策略 + （仅本地 daemon）shell 方言段。
+
+    本地 daemon 在 win32/darwin 上时追加平台段（prompt_policy.sandbox_shell_platform_section），
+    让模型生成 cmd.exe / macOS 兼容命令——否则模型默认 POSIX 语法在 Windows
+    cmd.exe 全军覆没（实测根因之二）。云端沙箱与 Linux/未上报一律不加段，
+    prompt 逐字节保持现状；段文本随会话内 daemon 平台稳定，provider 前缀
+    缓存不受逐 turn 影响。
+    """
+    if not sandbox_backend or not sandbox_work_dir:
+        return ""
+    from src.infra.backend.local import WorkspaceAliasBackend, _lookup_daemon_platform
+
+    shell_section = ""
+    if isinstance(sandbox_backend, WorkspaceAliasBackend):
+        shell_section = sandbox_shell_platform_section(await _lookup_daemon_platform(user_id))
+    base = SANDBOX_RUNTIME_SECTION.format(work_dir=sandbox_work_dir)
+    return "\n\n".join(part for part in (base, shell_section) if part)
 
 
 async def agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict[str, Any]:
@@ -198,10 +221,8 @@ async def agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict[str,
     # 自定义子代理配置 - 强制将所有中间信息保存到文件
     search_base_url = configurable.get("base_url", "")
     subagent_prompt_sections = [s for s in (*persona_sections, memory_guide) if s]
-    sandbox_runtime_policy = (
-        SANDBOX_RUNTIME_SECTION.format(work_dir=sandbox_work_dir)
-        if sandbox_backend and sandbox_work_dir
-        else ""
+    sandbox_runtime_policy = await _build_sandbox_runtime_policy(
+        sandbox_backend, sandbox_work_dir, user_id=context.user_id or "default"
     )
 
     def _build_subagent_middleware(subagent_type: str) -> list:
@@ -322,14 +343,10 @@ async def agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict[str,
                 ),
             )
         )
-        if sandbox_work_dir:
+        if sandbox_runtime_policy:
             from src.infra.agent.middleware import SandboxWorkspaceMiddleware
 
-            user_middleware.append(
-                SandboxWorkspaceMiddleware(
-                    policy_text=SANDBOX_RUNTIME_SECTION.format(work_dir=sandbox_work_dir)
-                )
-            )
+            user_middleware.append(SandboxWorkspaceMiddleware(policy_text=sandbox_runtime_policy))
     # Tool search: per-turn dynamic content
     if context.deferred_manager is not None:
         from src.infra.agent.middleware import ToolSearchMiddleware

--- a/src/infra/agent/events/tool_events.py
+++ b/src/infra/agent/events/tool_events.py
@@ -93,7 +93,14 @@ class ToolEventMixin:
 
         if isinstance(error, BaseException):
             error_type = type(error).__name__
-            error_message = str(error) if str(error) else repr(error)
+            # AppError 的 str() 是未插值的默认模板（生产实测裸奔 "{{detail}}"）；
+            # 面向模型/前端的单条文本必须走 display_message 的插值版。
+            from src.kernel.errors import AppError
+
+            if isinstance(error, AppError):
+                error_message = error.display_message or repr(error)
+            else:
+                error_message = str(error) if str(error) else repr(error)
             return f"[MCP Tool Error] {tool_name} failed: [{error_type}] {error_message}"
 
         if isinstance(error, dict):

--- a/src/infra/backend/local.py
+++ b/src/infra/backend/local.py
@@ -176,8 +176,11 @@ class LocalSandboxBackend(BaseSandbox):
         )
         stdout = result.get("stdout") or ""
         stderr = result.get("stderr") or ""
+        # executor 错误标记（timeout/expired）：并入 output 让模型能区分
+        # 「命令超时/迟到」与「命令以非零码退出」（后者的 error 为 None）。
+        error = str(result.get("error") or "")
         # ExecuteResponse 只有合并 output 字段（protocol.py），照 E2BBackend 的拼接方式
-        output = f"{stdout}\n{stderr}" if stdout and stderr else (stdout or stderr)
+        output = "\n".join(part for part in (stdout, stderr, error) if part)
         exit_code = result.get("exit_code")
         # 缺失 exit_code 透传 None（协议：未确定），不伪装成 0 成功
         return ExecuteResponse(

--- a/src/infra/sandbox/relay/dispatch.py
+++ b/src/infra/sandbox/relay/dispatch.py
@@ -58,9 +58,19 @@ async def dispatch_local_call(
             if resp is not None and resp.get("stage") == "done":
                 await redis.delete(resp_key)
                 if resp.get("status") != "ok":
+                    # exec 的非零退出码/命令超时是**命令结局**而非中继故障（daemon
+                    # executor 的 status 镜像 exit_code）：带 executor 结果字段的
+                    # done 载荷原样回传，由 LocalSandboxBackend.aexecute 构造
+                    # ExecuteResponse——模型看得到 stdout/stderr/exit_code 才能自行
+                    # 纠错（Windows cmd.exe 上命令失败是常态；劫持成 AppError 会让
+                    # 模型只见 "execution failed" 而无从换命令）。其余 op（fs_* 的
+                    # 内部异常）与 exec 的 daemon 级错误（expired/unsupported，无
+                    # 结果字段）仍按中继失败上抛。
+                    if op == "exec" and ("exit_code" in resp or "stdout" in resp):
+                        return resp
                     raise AppError(
                         ErrorCode.SANDBOX_EXEC_FAILED,
-                        args={"detail": str(resp.get("error", "local execution failed"))},
+                        args={"detail": str(resp.get("error") or "local execution failed")},
                     )
                 return resp
             if not acked and time.monotonic() > ack_deadline:

--- a/tests/agents/core/test_prompt_policy.py
+++ b/tests/agents/core/test_prompt_policy.py
@@ -1,6 +1,10 @@
 """Prompt policy 契约：归属纪律条目必须存在于所有主 agent 的共享 prompt。"""
 
-from src.agents.core.prompt_policy import SAFETY_POLICY, WORKFLOW_POLICY
+from src.agents.core.prompt_policy import (
+    SAFETY_POLICY,
+    WORKFLOW_POLICY,
+    sandbox_shell_platform_section,
+)
 from src.agents.core.subagent_prompts import MAIN_AGENT_PROMPT_SECTIONS
 
 
@@ -18,3 +22,30 @@ def test_attribution_discipline_reaches_all_main_agents():
     for phrase in ("explicitly", "unconfirmed", "possibly stale", "confirmed-current"):
         assert phrase in WORKFLOW_POLICY
         assert any(phrase in section for section in MAIN_AGENT_PROMPT_SECTIONS)
+
+
+def test_shell_platform_section_empty_for_posix_and_unknown():
+    """linux/空串（云端沙箱、未上报、查询失败）不加平台段：prompt 逐字节保持
+    现状，provider 前缀缓存零失效。"""
+    assert sandbox_shell_platform_section("") == ""
+    assert sandbox_shell_platform_section("linux") == ""
+    assert sandbox_shell_platform_section("winxp") == ""
+
+
+def test_shell_platform_section_win32_guides_cmdexe_syntax():
+    """win32 daemon：提示 cmd.exe 语法要点（%ERRORLEVEL%、%VAR%、无 POSIX 语法），
+    否则模型默认生成 POSIX 命令在 cmd.exe 全军覆没（生产实测根因之一）。"""
+    section = sandbox_shell_platform_section("win32")
+    assert "cmd.exe" in section
+    assert "%ERRORLEVEL%" in section
+    assert "%LAMBCHAT_WORKSPACE%" in section
+    # 反面约束：别把 POSIX 习惯带进 cmd.exe
+    assert "$?" not in section.replace("$LAMBCHAT", "")
+
+
+def test_shell_platform_section_darwin_guides_bsd_userland():
+    """darwin daemon：macOS 是 POSIX shell 但 BSD userland（无 /proc、无 free），
+    提示用 python3 做跨平台活。"""
+    section = sandbox_shell_platform_section("darwin")
+    assert "macOS" in section
+    assert "python3" in section

--- a/tests/infra/agent/test_tool_events_error_format.py
+++ b/tests/infra/agent/test_tool_events_error_format.py
@@ -1,0 +1,34 @@
+"""工具错误事件格式化：AppError 必须走 display_message 插值。
+
+生产实测：本地沙箱命令失败上抛 AppError 后，模型与前端看到的都是
+``Local sandbox execution failed: {{detail}}`` 原文——``str(AppError)`` 返回
+未插值的默认模板，插值版在 ``AppError.display_message``。
+"""
+
+from src.infra.agent.events.tool_events import ToolEventMixin
+from src.kernel.errors import AppError, ErrorCode
+
+
+def _format(error) -> str:
+    return ToolEventMixin()._format_tool_error("execute", error)
+
+
+def test_app_error_interpolates_display_message():
+    err = AppError(ErrorCode.SANDBOX_EXEC_FAILED, args={"detail": "illegal cwd"})
+    text = _format(err)
+    assert "{{detail}}" not in text
+    assert "illegal cwd" in text
+
+
+def test_app_error_falls_back_to_error_name_when_args_missing():
+    """args 未提供占位值时保留 ``{{param}}`` 原文（display_message 语义），
+    但仍不应把异常类名拼错——格式保持 [AppError] 前缀链路可解析。"""
+    err = AppError(ErrorCode.SANDBOX_EXEC_FAILED)
+    text = _format(err)
+    assert "[AppError]" in text
+    assert "Local sandbox execution failed" in text
+
+
+def test_plain_exception_format_unchanged():
+    text = _format(RuntimeError("boom"))
+    assert text == "[MCP Tool Error] execute failed: [RuntimeError] boom"

--- a/tests/infra/backend/test_local_backend.py
+++ b/tests/infra/backend/test_local_backend.py
@@ -214,6 +214,48 @@ def test_classify_file_error_real_daemon_strings():
     assert classify("mkdir: cannot create directory '/x': Permission denied") == "permission_denied"
 
 
+async def test_aexecute_returns_failed_command_output(monkeypatch):
+    """非零退出码的命令结果必须回到模型（output 含 stderr、exit_code 透传）——
+    不能在中继层被劫持成 AppError（Windows 实测：模型看不到 'free' is not
+    recognized，无从换成正确命令）。"""
+
+    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+        return {
+            "status": "error",
+            "stdout": "",
+            "stderr": "'free' is not recognized as an internal or external command",
+            "exit_code": 1,
+            "error": None,
+        }
+
+    monkeypatch.setattr(local_module, "dispatch_local_call", fake_dispatch)
+    backend = LocalSandboxBackend(user_id="u1", session_id="s1")
+    resp = await backend.aexecute("free -h")
+    assert resp.exit_code == 1
+    assert "not recognized" in resp.output
+
+
+async def test_aexecute_appends_executor_error_marker(monkeypatch):
+    """executor 超时结果（error="timeout"，exit_code=None）：error 字段并入
+    output 作显式标记，模型能区分「命令超时」与「命令失败」。"""
+
+    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+        return {
+            "status": "error",
+            "stdout": "partial",
+            "stderr": "",
+            "exit_code": None,
+            "error": "timeout",
+        }
+
+    monkeypatch.setattr(local_module, "dispatch_local_call", fake_dispatch)
+    backend = LocalSandboxBackend(user_id="u1", session_id="s1")
+    resp = await backend.aexecute("sleep 999")
+    assert resp.exit_code is None
+    assert "partial" in resp.output
+    assert "timeout" in resp.output
+
+
 async def test_aexecute_missing_exit_code_is_undetermined(monkeypatch):
     async def fake_dispatch(user_id, op, payload, *, timeout=None):
         return {"status": "ok", "stdout": "partial"}

--- a/tests/infra/sandbox/relay/test_dispatch.py
+++ b/tests/infra/sandbox/relay/test_dispatch.py
@@ -84,6 +84,75 @@ async def test_offline_fails_fast(fake, monkeypatch):
     assert not fake.lists  # rpush 之前快速失败，不产生孤儿请求
 
 
+async def test_exec_done_error_status_returns_command_outcome(fake, monkeypatch):
+    """exec 的非零退出码是命令结局而非中继故障：done 载荷带 executor 结果字段
+    （stdout/stderr/exit_code）时原样回传，由 aexecute 构造 ExecuteResponse 让
+    模型看到真实输出（Windows cmd.exe 上命令失败是常态，不能全部变成不透明
+    AppError——生产实测模型连续 6 条命令只见 "execution failed"，无从纠错）。"""
+    monkeypatch.setattr(dispatch_module, "_POLL_INTERVAL", 0.01)
+    monkeypatch.setattr(dispatch_module.settings, "SANDBOX_LOCAL_ACK_TIMEOUT", 2)
+    monkeypatch.setattr(dispatch_module.settings, "SANDBOX_LOCAL_EXEC_TIMEOUT", 5)
+
+    async def daemon():
+        await asyncio.sleep(0.02)
+        req = json.loads(await fake.lpop("sandbox:req:u1"))
+        await fake.set(
+            f"sandbox:resp:{req['call_id']}",
+            json.dumps(
+                {
+                    "user_id": "u1",
+                    "stage": "ack",
+                }
+            ),
+        )
+        await asyncio.sleep(0.02)
+        await fake.set(
+            f"sandbox:resp:{req['call_id']}",
+            json.dumps(
+                {
+                    "user_id": "u1",
+                    "stage": "done",
+                    "status": "error",
+                    "stdout": "",
+                    "stderr": "'free' is not recognized as an internal or external command",
+                    "exit_code": 1,
+                    "error": None,
+                }
+            ),
+        )
+
+    task = asyncio.create_task(daemon())
+    result = await dispatch_local_call("u1", "exec", {"command": "free -h"})
+    await task
+    assert result["exit_code"] == 1
+    assert "not recognized" in result["stderr"]
+
+
+async def test_fs_op_done_error_status_still_raises(fake, monkeypatch):
+    """fs_* op 的 status=error 是 daemon 内部异常（ExecutorError 等）：仍按
+    SANDBOX_EXEC_FAILED 上抛；detail 取 error 字段（None 不落成字面 "None"）。"""
+    monkeypatch.setattr(dispatch_module, "_POLL_INTERVAL", 0.01)
+    monkeypatch.setattr(dispatch_module.settings, "SANDBOX_LOCAL_ACK_TIMEOUT", 2)
+    monkeypatch.setattr(dispatch_module.settings, "SANDBOX_LOCAL_EXEC_TIMEOUT", 5)
+
+    async def daemon():
+        await asyncio.sleep(0.02)
+        req = json.loads(await fake.lpop("sandbox:req:u1"))
+        await fake.set(
+            f"sandbox:resp:{req['call_id']}",
+            json.dumps(
+                {"user_id": "u1", "stage": "done", "status": "error", "error": "illegal cwd"}
+            ),
+        )
+
+    task = asyncio.create_task(daemon())
+    with pytest.raises(AppError) as exc:
+        await dispatch_local_call("u1", "fs_read", {"path": "a.txt"})
+    await task
+    assert exc.value.error_code == ErrorCode.SANDBOX_EXEC_FAILED
+    assert exc.value.args_data == {"detail": "illegal cwd"}
+
+
 async def test_ack_timeout_raises(fake, monkeypatch):
     monkeypatch.setattr(dispatch_module, "_POLL_INTERVAL", 0.01)
     monkeypatch.setattr(dispatch_module.settings, "SANDBOX_LOCAL_ACK_TIMEOUT", 0.05)


### PR DESCRIPTION
## 问题

https://lambchat.com/chat/787138e7-fac5-42bb-80be-9fbaad18f728（Windows 桌面端，本地沙箱）：`echo ok` 能跑，其余命令全部变成 `[AppError] Local sandbox execution failed: {{detail}}`，模型看不到任何输出，连试 8 次后误判"沙箱被锁死"。macOS 同链路受同样影响。

## 根因（生产 trace + pod 日志实锤）

1. **中继层把命令失败当沙箱故障**：daemon executor 的 `status` 镜像退出码（非 0 → `error`），而 `dispatch_local_call` 对 `status != ok` 一律抛 `SANDBOX_EXEC_FAILED`——非零退出命令的 stdout/stderr/exit_code 全被吞掉，模型无从纠错（Windows cmd.exe 上非零退出是常态）。
2. **系统提示无平台分支**：daemon 已上报平台（注册表第三段），prompt 从不告知，模型默认生成 POSIX 命令。
3. **`{{detail}}` 裸模板**：`_format_tool_error` 用 `str(AppError)` 而非 `display_message`。

## 修复（全部服务端，无需重发桌面端）

- `dispatch.py`：exec 的 done 载荷带命令结果字段时原样回传；fs_* 内部异常与 expired/unsupported 仍上抛；`detail=None` 不再落成字面 `"None"`
- `local.py`：`aexecute` 把 executor `error`（timeout/expired）并入 output
- `prompt_policy.py` + `search_agent/nodes.py`：win32 → cmd.exe 方言提示（`%ERRORLEVEL%`、`%LAMBCHAT_WORKSPACE%`、优先 `python3`）；darwin → BSD userland 提示；仅本地 `WorkspaceAliasBackend` 追加，linux/云端/未上报不加段（现有 prompt 逐字节不变，前缀缓存零失效）
- `tool_events.py`：AppError 走 `display_message` 插值

## 验证

- TDD：3 个 RED 测试先行，全量后端 3803 passed、client 302 passed、ruff/mypy 通过
- E2E 模拟（真实 dispatch + backend + 模拟 Windows daemon）：`free -h` → `exit_code=9009` + `'free' is not recognized...` 回到模型 → 改用 `python3` 成功