### PR TITLE
chore(release): 晋升 develop → main——本地沙箱多机支持

### DIFF
--- a/client/lambchat_sandbox/__init__.py
+++ b/client/lambchat_sandbox/__init__.py
@@ -7,4 +7,4 @@ value（``node_id|version``），经 ``GET /api/sandbox/status`` 的
 self-update 与服务端最低版本拒连打底。发版时同步递增本值。
 """
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/client/lambchat_sandbox/config.py
+++ b/client/lambchat_sandbox/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -24,6 +25,16 @@ class SandboxConfig:
     # 壳侧配对回执（Rust save_pairing 落盘）：daemon 目前只回读不使用，
     # 网页端 PAT 管理页可据此对上"哪一条是本机桌面壳"。
     pat_id: str | None = None
+    # 机器身份（多机 daemon）：machine_id 首启生成并立即持久化（不落盘则
+    # 每次进程重启换新身份，服务端注册表堆积幽灵机器）；machine_name 为空
+    # 时连接上报退回 hostname。
+    machine_id: str = ""
+    machine_name: str = ""
+
+
+def new_machine_id() -> str:
+    """生成机器身份标识（与服务端 client_id 同规格的 12 位 hex）。"""
+    return uuid.uuid4().hex[:12]
 
 
 def config_path() -> Path:
@@ -35,7 +46,13 @@ def load_config(path: Path | None = None) -> SandboxConfig:
     """加载配置；文件不存在时返回默认值，不写盘。"""
     p = path if path is not None else config_path()
     if not p.exists():
-        return SandboxConfig()
+        cfg = SandboxConfig()
+        cfg.machine_id = new_machine_id()  # 首启：身份生成并立即持久化（见 SandboxConfig 注释）
+        try:
+            save_config(cfg, p)
+        except OSError:  # 只读家目录等：退化为进程内身份，不阻塞启动
+            pass
+        return cfg
     try:
         raw = json.loads(p.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
@@ -51,14 +68,30 @@ def load_config(path: Path | None = None) -> SandboxConfig:
     if raw_pat_id is not None and not isinstance(raw_pat_id, str):  # 壳侧写入；缺键走 None
         raise ConfigError(f"pat_id must be a string or null, got {raw_pat_id!r} ({p})")
 
+    raw_machine_id = raw.get("machine_id", "")
+    if not isinstance(raw_machine_id, str):  # 旧配置缺字段走默认；非字符串拒绝
+        raise ConfigError(f"machine_id must be a string, got {raw_machine_id!r} ({p})")
+
+    raw_machine_name = raw.get("machine_name", "")
+    if not isinstance(raw_machine_name, str):  # 旧配置缺字段走默认；非字符串拒绝
+        raise ConfigError(f"machine_name must be a string, got {raw_machine_name!r} ({p})")
+
     cfg = SandboxConfig(
         server_url=str(raw.get("server_url", SandboxConfig.server_url)),
         data_root=Path(str(raw.get("data_root", SandboxConfig.data_root))),
         confirm_policy=str(raw.get("confirm_policy", SandboxConfig.confirm_policy)),
         embedded_python=raw_embedded,
         pat_id=raw_pat_id,
+        machine_id=raw_machine_id,
+        machine_name=raw_machine_name,
     )
     _validate(cfg, p)
+    if not cfg.machine_id:  # 首启/旧配置补身份：生成并立即持久化（见 SandboxConfig 注释）
+        cfg.machine_id = new_machine_id()
+        try:
+            save_config(cfg, p)
+        except OSError:  # 只读目录等：身份退化为进程内随机（注册表会每次换机，但不阻塞启动）
+            pass
     return cfg
 
 
@@ -76,7 +109,10 @@ def save_config(cfg: SandboxConfig, path: Path | None = None) -> None:
         "data_root": str(cfg.data_root),
         "confirm_policy": cfg.confirm_policy,
         "embedded_python": cfg.embedded_python,
+        "machine_id": cfg.machine_id,
     }
+    if cfg.machine_name:
+        payload["machine_name"] = cfg.machine_name
     if cfg.pat_id is not None:  # 未设置不落键，保持旧配置文件形态
         payload["pat_id"] = cfg.pat_id
     body = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"

--- a/client/lambchat_sandbox/daemon.py
+++ b/client/lambchat_sandbox/daemon.py
@@ -55,6 +55,14 @@ DEFAULT_AUDIT_ROOT = Path.home() / ".lambchat" / "audit"
 DEFAULT_EXEC_TIMEOUT_S = 60.0  # 帧缺失/非正 timeout 的兜底，避免 communicate(timeout=0) 立即超时
 DAEMON_AUDIT_SESSION = "daemon"  # shutdown 等进程级事件的审计会话（过 Auditor 白名单）
 
+
+def _default_machine_name() -> str:
+    """machine_name 未配置时的展示名退回 hostname（截断防超长 URL）。"""
+    import socket
+
+    return socket.gethostname()[:64]
+
+
 _DONE_KEYS = ("status", "stdout", "stderr", "exit_code", "error")
 
 
@@ -73,7 +81,13 @@ async def run_daemon(
     factory = (
         client_factory
         if client_factory is not None
-        else lambda: ChannelClient(cfg.server_url, pat, confirm_policy=cfg.confirm_policy)
+        else lambda: ChannelClient(
+            cfg.server_url,
+            pat,
+            confirm_policy=cfg.confirm_policy,
+            machine_id=cfg.machine_id,
+            machine_name=cfg.machine_name or _default_machine_name(),
+        )
     )
     # 启动即装配内嵌 Python 运行时（embedded_python=true 且归档在位时）：
     # shim bin 目录前置进 executor 子进程 PATH，python3 命中内嵌解释器。

--- a/client/lambchat_sandbox/transport.py
+++ b/client/lambchat_sandbox/transport.py
@@ -132,11 +132,15 @@ class ChannelClient:
         pat: str,
         *,
         confirm_policy: str = "",
+        machine_id: str = "",
+        machine_name: str = "",
         client: httpx.AsyncClient | None = None,
     ) -> None:
         self._base = server_url.rstrip("/")
         self._pat = pat
         self._confirm_policy = confirm_policy
+        self._machine_id = machine_id
+        self._machine_name = machine_name
         self._client = (
             client
             if client is not None
@@ -157,15 +161,23 @@ class ChannelClient:
         平台随每次建连上报（服务端访问日志与注册表均可见）——平台是服务端
         文件命令生成分支（M4 T3）的依据，与版本同链路扩展；``confirm_policy``
         （all/commands/none）是服务端统一确认门的策略来源，随连接上报进
-        注册表第四段（空值省略参数，服务端按未上报归 all 保守确认）。
+        注册表第四段（空值省略参数，服务端按未上报归 all 保守确认）；
+        ``machine_id``/``machine_name``（多机 daemon）是注册表按机器分槽的
+        主键与展示名，空值省略参数——服务端按 legacy 单机路径兼容。
         """
         policy_param = (
             f"&confirm_policy={quote(self._confirm_policy)}" if self._confirm_policy else ""
         )
+        machine_params = (
+            f"&machine_id={quote(self._machine_id)}&machine_name={quote(self._machine_name)}"
+            if self._machine_id
+            else ""
+        )
         cm = self._client.stream(
             "GET",
             f"{self._base}/api/sandbox/channel"
-            f"?version={quote(__version__)}&platform={quote(daemon_platform())}{policy_param}",
+            f"?version={quote(__version__)}&platform={quote(daemon_platform())}"
+            f"{policy_param}{machine_params}",
             headers={"Authorization": f"Bearer {self._pat}", "Accept": "text/event-stream"},
         )
         response = await cm.__aenter__()

--- a/frontend/src/components/chat/ChatInputSelectors.tsx
+++ b/frontend/src/components/chat/ChatInputSelectors.tsx
@@ -145,8 +145,8 @@ export function ChatInputSelectors({
     ? buildSandboxMachineOption(machines, defaultMachineId, t)
     : null;
   const enrichedAgentOptions = machineOption
-    ? { ...agentOptions, [SANDBOX_MACHINE_AGENT_OPTION_KEY]: machineOption }
-    : agentOptions;
+    ? { ...(agentOptions ?? {}), [SANDBOX_MACHINE_AGENT_OPTION_KEY]: machineOption }
+    : (agentOptions ?? {});
 
   return (
     <>

--- a/frontend/src/components/chat/ChatInputSelectors.tsx
+++ b/frontend/src/components/chat/ChatInputSelectors.tsx
@@ -12,7 +12,10 @@ import { isShellAvailable } from "../../services/tauri/sandboxShell";
 import {
   SANDBOX_AGENT_OPTION_KEY,
   SANDBOX_LOCAL_VALUE,
+  SANDBOX_MACHINE_AGENT_OPTION_KEY,
   adaptSandboxAgentOption,
+  buildSandboxMachineOption,
+  shouldShowSandboxMachineOption,
 } from "./sandboxOption";
 import type { FeaturePanel } from "../selectors/FeatureMenu";
 import type {
@@ -134,8 +137,16 @@ export function ChatInputSelectors({
   const navigate = useNavigate();
   const { t } = useTranslation();
   // 沙箱选择器动态适配：壳检测 + daemon 在线状态双条件
-  const { online: sandboxOnline } = useSandboxStatus();
+  const { online: sandboxOnline, machines, defaultMachineId } = useSandboxStatus();
   const sandboxShell = isShellAvailable();
+  // 多机 daemon：本地档时动态注入机器选择器（sandbox_machine_id 会话级选机）
+  const sandboxValue = agentOptionValues[SANDBOX_AGENT_OPTION_KEY] ?? "cloud";
+  const machineOption = shouldShowSandboxMachineOption(sandboxValue, machines)
+    ? buildSandboxMachineOption(machines, defaultMachineId, t)
+    : null;
+  const enrichedAgentOptions = machineOption
+    ? { ...agentOptions, [SANDBOX_MACHINE_AGENT_OPTION_KEY]: machineOption }
+    : agentOptions;
 
   return (
     <>
@@ -221,7 +232,7 @@ export function ChatInputSelectors({
       {agentOptions &&
         onToggleAgentOption &&
         Object.keys(agentOptions).length > 0 &&
-        Object.entries(agentOptions)
+        Object.entries(enrichedAgentOptions)
           .filter(
             ([key, opt]) =>
               opt.options &&

--- a/frontend/src/components/chat/__tests__/sandboxMachineOption.test.ts
+++ b/frontend/src/components/chat/__tests__/sandboxMachineOption.test.ts
@@ -1,0 +1,42 @@
+/** 会话级机器选择器选项构建（纯函数）：档位联动、默认值与展示名 */
+import { describe, expect, it } from "vitest";
+import type { SandboxMachine } from "../../../services/api/sandbox";
+import {
+  SANDBOX_MACHINE_AGENT_OPTION_KEY,
+  buildSandboxMachineOption,
+  shouldShowSandboxMachineOption,
+} from "../sandboxOption";
+
+const machines: SandboxMachine[] = [
+  { machine_id: "mac1", name: "MacBook", platform: "darwin", version: "0.3.0",
+    confirm_policy: "all", online: true },
+  { machine_id: "srv1", name: "Server", platform: "linux", version: "0.3.0",
+    confirm_policy: "none", online: true },
+];
+const t = (k: string) => k;
+
+describe("shouldShowSandboxMachineOption", () => {
+  it("仅本地档且存在机器时显示", () => {
+    expect(shouldShowSandboxMachineOption("local", machines)).toBe(true);
+    expect(shouldShowSandboxMachineOption("cloud", machines)).toBe(false);
+    expect(shouldShowSandboxMachineOption("local", [])).toBe(false);
+  });
+});
+
+describe("buildSandboxMachineOption", () => {
+  it("首档为「自动（默认机）」，随后按机器生成档位", () => {
+    const option = buildSandboxMachineOption(machines, "MacBook", t)!;
+    expect(option).not.toBeNull();
+    expect(option.options?.[0]).toMatchObject({ value: "", label_key: "agentOptions.sandboxMachine.auto" });
+    expect(option.options?.map((o) => o.value)).toEqual(["", "mac1", "srv1"]);
+    expect(option.default).toBe("mac1"); // 默认机优先，无默认取首台
+  });
+
+  it("无机器返回 null（选择器整体隐藏）", () => {
+    expect(buildSandboxMachineOption([], null, t)).toBeNull();
+  });
+
+  it("选项键固定为 sandbox_machine_id（与后端 agent_options 契约一致）", () => {
+    expect(SANDBOX_MACHINE_AGENT_OPTION_KEY).toBe("sandbox_machine_id");
+  });
+});

--- a/frontend/src/components/chat/chatInputConstants.ts
+++ b/frontend/src/components/chat/chatInputConstants.ts
@@ -1,4 +1,4 @@
-import { Brain, Zap, Settings, Monitor, type LucideIcon } from "lucide-react";
+import { Brain, Zap, Settings, Monitor, Laptop, type LucideIcon } from "lucide-react";
 import { Permission, type FileCategory } from "../../types";
 
 export const FILE_CATEGORY_PERMISSIONS: Record<FileCategory, Permission> = {
@@ -13,6 +13,7 @@ export const ICON_MAP: Record<string, LucideIcon> = {
   Zap,
   Settings,
   Monitor,
+  Laptop,
 };
 
 /** When pasted text exceeds this length, auto-convert to a .txt file upload. */

--- a/frontend/src/components/chat/sandboxOption.ts
+++ b/frontend/src/components/chat/sandboxOption.ts
@@ -78,3 +78,52 @@ export function resolveSandboxPresentation(
       : selected?.label || String(value),
   };
 }
+
+// ---------------------------------------------------------------------------
+// 会话级机器选择（多机 daemon）：动态注入 sandbox_machine_id 选项
+// ---------------------------------------------------------------------------
+
+import type { SandboxMachine } from "../../services/api/sandbox";
+
+/** 会话选机键：与后端 agent_options.sandbox_machine_id 契约一致。 */
+export const SANDBOX_MACHINE_AGENT_OPTION_KEY = "sandbox_machine_id";
+
+/** 机器选择器只在「本地档 + 至少一台在线机」时有意义。 */
+export function shouldShowSandboxMachineOption(
+  sandboxValue: boolean | string | number,
+  machines: SandboxMachine[],
+): boolean {
+  return sandboxValue === SANDBOX_LOCAL_VALUE && machines.length > 0;
+}
+
+/**
+ * 由在线机器动态构建选择器选项：首档「自动」（后端默认解析：默认机→
+ * 唯一在线→legacy），其余按机器列出。default 取用户默认机（无则首台），
+ * 已存会话值不受影响（与 sandbox 档位同规则：只裁剪显示，不篡改存储）。
+ */
+export function buildSandboxMachineOption(
+  machines: SandboxMachine[],
+  defaultMachineId: string | null,
+  t: (key: string) => string,
+): AgentOption | null {
+  if (machines.length === 0) return null;
+  const options = [
+    { value: "", label_key: "agentOptions.sandboxMachine.auto" },
+    ...machines.map((m) => ({
+      value: m.machine_id,
+      label: m.name || m.machine_id,
+    })),
+  ];
+  return {
+    type: "string",
+    default: defaultMachineId && machines.some((m) => m.machine_id === defaultMachineId)
+      ? defaultMachineId
+      : machines[0].machine_id,
+    label: t("agentOptions.sandboxMachine.label"),
+    label_key: "agentOptions.sandboxMachine.label",
+    description: t("agentOptions.sandboxMachine.description"),
+    description_key: "agentOptions.sandboxMachine.description",
+    icon: "Laptop",
+    options,
+  };
+}

--- a/frontend/src/components/profile/LocalSandboxSection.tsx
+++ b/frontend/src/components/profile/LocalSandboxSection.tsx
@@ -22,6 +22,7 @@ import {
 } from "../../services/tauri/sandboxShell";
 import { SkeletonLine } from "../skeletons";
 import { SelectRow } from "./SelectRow";
+import { SandboxMachinesCard } from "./SandboxMachinesCard";
 
 const PROCESS_POLL_INTERVAL_MS = 10 * 1000;
 
@@ -415,6 +416,9 @@ export function LocalSandboxSection({ embedded = false }: { embedded?: boolean }
                   : t("profile.localSandbox.unpair")}
               </button>
             </div>
+
+            {/* 多机管理：在线机器列表 + 默认机/重命名 + 当前服务器地址 */}
+            <SandboxMachinesCard />
           </>
         )}
       </div>

--- a/frontend/src/components/profile/SandboxMachinesCard.tsx
+++ b/frontend/src/components/profile/SandboxMachinesCard.tsx
@@ -1,0 +1,175 @@
+/**
+ * 本地沙箱机器管理卡（多机 daemon）：在线机器列表 + 默认机/重命名管理 +
+ * 当前连接的服务器地址展示。
+ *
+ * 机器列表只含在线机（注册表 TTL 判活，离线机自然消失；rename 覆盖层在
+ * 机器重连时自动恢复展示）。默认机是无会话级选择时的执行目标（服务端
+ * resolve：默认机 → 唯一在线 → legacy）。
+ */
+
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "react-hot-toast";
+import { Check, Laptop, Link2, Pencil, Star, X } from "lucide-react";
+import { useSandboxStatus, notifySandboxStatusRefresh } from "../../hooks/useSandboxStatus";
+import {
+  machinePlatformLabel,
+  sandboxApiMachines,
+  type SandboxMachine,
+} from "../../services/api/sandbox";
+import { effectiveApiBase } from "../../services/api/serverConfig";
+
+export function SandboxMachinesCard() {
+  const { t } = useTranslation();
+  const { machines, defaultMachineId, online } = useSandboxStatus();
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const serverUrl = effectiveApiBase() || window.location.origin;
+
+  const handleSetDefault = async (machineId: string) => {
+    if (busy || machineId === defaultMachineId) return;
+    setBusy(true);
+    try {
+      await sandboxApiMachines.setDefaultMachine(machineId);
+      notifySandboxStatusRefresh();
+    } catch (err) {
+      toast.error((err as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const startRename = (machine: SandboxMachine) => {
+    setRenamingId(machine.machine_id);
+    setRenameValue(machine.name);
+  };
+
+  const submitRename = async () => {
+    if (!renamingId || busy) return;
+    const name = renameValue.trim();
+    if (!name) return;
+    setBusy(true);
+    try {
+      await sandboxApiMachines.renameMachine(renamingId, name);
+      setRenamingId(null);
+      notifySandboxStatusRefresh();
+    } catch (err) {
+      toast.error((err as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="mt-3 border-t border-stone-200/70 dark:border-stone-600/50 pt-3">
+      <div className="flex items-center gap-1.5">
+        <Laptop size={13} className="text-stone-400 dark:text-stone-500 shrink-0" />
+        <span className="font-medium font-serif text-sm text-stone-900 dark:text-stone-100">
+          {t("profile.localSandbox.machines")}
+        </span>
+      </div>
+      <p className="text-xs text-stone-500 dark:text-stone-400 mt-1 leading-relaxed">
+        {t("profile.localSandbox.machinesDesc")}
+      </p>
+
+      {/* 当前服务器：配对/登录目标一目了然（运行时配置优先，构建期烘焙兜底） */}
+      <div className="mt-2 flex items-center gap-1.5 text-xs text-stone-500 dark:text-stone-400">
+        <Link2 size={12} className="opacity-50 shrink-0" />
+        <span>{t("profile.localSandbox.currentServer")}</span>
+        <span className="font-mono truncate" data-sandbox-server-url>
+          {serverUrl}
+        </span>
+      </div>
+
+      <div className="mt-1.5 space-y-0.5" data-sandbox-machines-count={machines.length}>
+        {online && machines.length === 0 && (
+          <p className="text-xs text-stone-400 dark:text-stone-500 py-1.5">
+            {t("profile.localSandbox.machinesEmpty")}
+          </p>
+        )}
+        {machines.map((machine) => {
+          const isDefault = machine.machine_id === defaultMachineId;
+          const renaming = renamingId === machine.machine_id;
+          return (
+            <div
+              key={machine.machine_id}
+              className="flex items-center gap-2 rounded-lg px-1.5 py-1.5 transition-colors hover:bg-stone-100/70 dark:hover:bg-stone-700/40"
+              data-sandbox-machine={machine.machine_id}
+            >
+              <span className="h-2 w-2 rounded-full bg-green-500 shrink-0" />
+              {renaming ? (
+                <span className="flex min-w-0 flex-1 items-center gap-1.5">
+                  <input
+                    autoFocus
+                    value={renameValue}
+                    onChange={(e) => setRenameValue(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") void submitRename();
+                      if (e.key === "Escape") setRenamingId(null);
+                    }}
+                    className="min-w-0 flex-1 rounded-md border border-amber-300 dark:border-amber-500/60 bg-theme-bg-card dark:bg-stone-800 px-2 py-1 text-sm text-stone-800 dark:text-stone-100 focus:outline-none focus:ring-1 focus:ring-amber-400"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => void submitRename()}
+                    disabled={busy || !renameValue.trim()}
+                    className="rounded-md p-1 text-stone-500 hover:text-amber-500 disabled:opacity-40"
+                    title={t("profile.localSandbox.renameSave")}
+                  >
+                    <Check size={13} />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setRenamingId(null)}
+                    className="rounded-md p-1 text-stone-500 hover:text-stone-700 dark:hover:text-stone-300"
+                    title={t("profile.localSandbox.renameCancel")}
+                  >
+                    <X size={13} />
+                  </button>
+                </span>
+              ) : (
+                <>
+                  <span className="min-w-0 flex-1 truncate text-sm text-stone-800 dark:text-stone-100">
+                    {machine.name}
+                    {isDefault && (
+                      <span className="ml-1.5 rounded-full bg-amber-100 dark:bg-amber-500/15 px-1.5 py-0.5 text-10 font-medium text-amber-700 dark:text-amber-400">
+                        {t("profile.localSandbox.defaultBadge")}
+                      </span>
+                    )}
+                    <span className="ml-1.5 text-xs text-stone-500 dark:text-stone-400">
+                      {machinePlatformLabel(machine.platform, t)}
+                      {machine.version ? ` · v${machine.version}` : ""}
+                    </span>
+                  </span>
+                  {!isDefault && (
+                    <button
+                      type="button"
+                      onClick={() => void handleSetDefault(machine.machine_id)}
+                      disabled={busy}
+                      className="flex items-center gap-1 rounded-md px-1.5 py-1 text-xs text-stone-500 dark:text-stone-400 transition-colors hover:text-amber-600 dark:hover:text-amber-400 disabled:opacity-50"
+                      title={t("profile.localSandbox.setDefault")}
+                    >
+                      <Star size={12} className="opacity-70" />
+                      {t("profile.localSandbox.setDefault")}
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => startRename(machine)}
+                    disabled={busy}
+                    className="rounded-md p-1 text-stone-500 dark:text-stone-400 transition-colors hover:text-stone-700 dark:hover:text-stone-300 disabled:opacity-50"
+                    title={t("profile.localSandbox.rename")}
+                  >
+                    <Pencil size={12} className="opacity-70" />
+                  </button>
+                </>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useSandboxStatus.ts
+++ b/frontend/src/hooks/useSandboxStatus.ts
@@ -3,7 +3,12 @@
 // 配对/重启完成后由 LocalSandboxSection 派发 sandbox-status-refresh 立即重拉；
 // 聊天输入区的沙箱选择器也消费该状态做动态适配（纯 web 仅在线时渲染本地档）。
 import { useCallback, useEffect, useRef, useState } from "react";
-import { sandboxApi, type SandboxStatus } from "../services/api/sandbox";
+import {
+  sandboxApi,
+  sandboxApiMachines,
+  type SandboxMachine,
+  type SandboxStatus,
+} from "../services/api/sandbox";
 
 const REFRESH_INTERVAL_MS = 10 * 1000;
 export const SANDBOX_STATUS_REFRESH_EVENT = "sandbox-status-refresh";
@@ -34,11 +39,15 @@ export function useSandboxStatus(
   status: SandboxStatus | null;
   statusError: SandboxStatusError;
   online: boolean;
+  machines: SandboxMachine[];
+  defaultMachineId: string | null;
   refresh: () => void;
 } {
   const enabled = options?.enabled ?? true;
   const [status, setStatus] = useState<SandboxStatus | null>(null);
   const [statusError, setStatusError] = useState<SandboxStatusError>(null);
+  const [machines, setMachines] = useState<SandboxMachine[]>([]);
+  const [defaultMachineId, setDefaultMachineId] = useState<string | null>(null);
   const inFlight = useRef(false);
   const pending = useRef(false);
 
@@ -65,22 +74,43 @@ export function useSandboxStatus(
     }
   }, []);
 
+  // 机器列表与状态同一节拍拉取（多机 daemon）；失败静默——单机/旧后端用户
+  // 的机器选择器自然隐藏，不影响既有 status 消费方。
+  const fetchMachines = useCallback(async () => {
+    try {
+      const data = await sandboxApiMachines.listMachines();
+      setMachines(data.machines);
+      setDefaultMachineId(data.default_machine_id);
+    } catch {
+      // 静默：machines 是附加能力，不污染 status 错误通道
+    }
+  }, []);
+
   useEffect(() => {
     if (!enabled) return;
     fetchStatus();
-    const timer = setInterval(fetchStatus, REFRESH_INTERVAL_MS);
-    const onRefresh = () => fetchStatus();
+    fetchMachines();
+    const timer = setInterval(() => {
+      fetchStatus();
+      fetchMachines();
+    }, REFRESH_INTERVAL_MS);
+    const onRefresh = () => {
+      fetchStatus();
+      fetchMachines();
+    };
     window.addEventListener(SANDBOX_STATUS_REFRESH_EVENT, onRefresh);
     return () => {
       clearInterval(timer);
       window.removeEventListener(SANDBOX_STATUS_REFRESH_EVENT, onRefresh);
     };
-  }, [fetchStatus, enabled]);
+  }, [fetchStatus, fetchMachines, enabled]);
 
   return {
     status,
     statusError,
     online: !!status?.online,
+    machines,
+    defaultMachineId,
     refresh: fetchStatus,
   };
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -254,6 +254,11 @@
       },
       "offlineHint": "Local sandbox is offline. Pair it in Settings first.",
       "restoredOffline": "The saved local sandbox tier is currently offline."
+    },
+    "sandboxMachine": {
+      "label": "Machine",
+      "description": "Choose which machine runs local sandbox commands",
+      "auto": "Auto (default)"
     }
   },
   "agents": {
@@ -646,7 +651,9 @@
     "sandboxTimeout": "Local sandbox call timed out after {{seconds}}s",
     "sandboxPayloadTooLarge": "Local sandbox payload exceeds limit",
     "sandboxExecFailed": "Local sandbox execution failed: {{detail}}",
-    "daemonVersionUnsupported": "Daemon version {{version}} is below minimum {{min}}; please update"
+    "daemonVersionUnsupported": "Daemon version {{version}} is below minimum {{min}}; please update",
+    "sandboxMachineOffline": "Selected sandbox machine '{{machine}}' is offline",
+    "sandboxMachineNotFound": "Sandbox machine '{{machine}}' not found or removed"
   },
   "categories": {
     "agent": "Agent",
@@ -2158,7 +2165,22 @@
       "needDesktop": "The local sandbox requires the LambChat desktop app. Only the cloud sandbox is available on the web.",
       "pairFailed": "Pairing failed. Check your credentials and try again.",
       "unpair": "Unpair",
-      "unpaired": "Pairing removed"
+      "unpaired": "Pairing removed",
+      "machines": "My Machines",
+      "machinesDesc": "Connected local sandbox machines; pick the target per session, the default is used when unset.",
+      "machinesEmpty": "No machines online",
+      "currentServer": "Server: ",
+      "setDefault": "Set default",
+      "defaultBadge": "Default",
+      "rename": "Rename",
+      "renameSave": "Save",
+      "renameCancel": "Cancel",
+      "platform": {
+        "windows": "Windows",
+        "macos": "macOS",
+        "linux": "Linux",
+        "unknown": "Unknown"
+      }
     },
     "maxPinnedModels": "Pin up to {{max}} models",
     "memoryToggle": "Cross-session memory",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -254,6 +254,11 @@
       },
       "offlineHint": "ローカルサンドボックスはオフラインです。先に設定でペアリングしてください。",
       "restoredOffline": "保存されたローカルサンドボックス設定は現在オフラインです。"
+    },
+    "sandboxMachine": {
+      "label": "マシン",
+      "description": "ローカルサンドボックスコマンドの実行マシンを選択",
+      "auto": "自動（デフォルト）"
     }
   },
   "agents": {
@@ -646,7 +651,9 @@
     "sandboxTimeout": "ローカルサンドボックス呼び出しがタイムアウトしました（{{seconds}}秒）",
     "sandboxPayloadTooLarge": "ローカルサンドボックスのペイロードが大きすぎます",
     "sandboxExecFailed": "ローカルサンドボックスの実行に失敗しました：{{detail}}",
-    "daemonVersionUnsupported": "ローカルサンドボックスデーモンのバージョン {{version}} は最低要件 {{min}} 未満です。アップデートしてください"
+    "daemonVersionUnsupported": "ローカルサンドボックスデーモンのバージョン {{version}} は最低要件 {{min}} 未満です。アップデートしてください",
+    "sandboxMachineOffline": "選択したサンドボックスマシン「{{machine}}」は現在オフラインです",
+    "sandboxMachineNotFound": "サンドボックスマシン「{{machine}}」が見つからないか、削除されました"
   },
   "categories": {
     "agent": "エージェント",
@@ -2158,7 +2165,22 @@
       "needDesktop": "ローカルサンドボックスには LambChat デスクトップアプリが必要です。ウェブではクラウドサンドボックスのみ利用できます。",
       "pairFailed": "ペアリングに失敗しました。認証情報を確認して再試行してください。",
       "unpair": "ペアリング解除",
-      "unpaired": "ペアリングを解除しました"
+      "unpaired": "ペアリングを解除しました",
+      "machines": "マイマシン",
+      "machinesDesc": "接続中のローカルサンドボックスマシン。セッションごとに実行先を選択でき、未選択時はデフォルト機を使用します。",
+      "machinesEmpty": "オンラインのマシンはありません",
+      "currentServer": "サーバー：",
+      "setDefault": "デフォルトに設定",
+      "defaultBadge": "デフォルト",
+      "rename": "名前を変更",
+      "renameSave": "保存",
+      "renameCancel": "キャンセル",
+      "platform": {
+        "windows": "Windows",
+        "macos": "macOS",
+        "linux": "Linux",
+        "unknown": "不明"
+      }
     },
     "maxPinnedModels": "最大{{max}}個のモデルをピン留めできます",
     "memoryToggle": "セッション横断メモリ",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -254,6 +254,11 @@
       },
       "offlineHint": "로컬 샌드박스가 오프라인입니다. 먼저 설정에서 페어링하세요.",
       "restoredOffline": "저장된 로컬 샌드박스 설정이 현재 오프라인입니다."
+    },
+    "sandboxMachine": {
+      "label": "머신",
+      "description": "로컬 샌드박스 명령을 실행할 머신 선택",
+      "auto": "자동 (기본)"
     }
   },
   "agents": {
@@ -646,7 +651,9 @@
     "sandboxTimeout": "로컬 샌드박스 호출 시간 초과({{seconds}}초)",
     "sandboxPayloadTooLarge": "로컬 샌드박스 페이로드가 너무 큽니다",
     "sandboxExecFailed": "로컬 샌드박스 실행 실패: {{detail}}",
-    "daemonVersionUnsupported": "로컬 샌드박스 데몬 버전 {{version}}이(가) 최소 요구 사항 {{min}} 미만입니다. 업데이트해 주세요"
+    "daemonVersionUnsupported": "로컬 샌드박스 데몬 버전 {{version}}이(가) 최소 요구 사항 {{min}} 미만입니다. 업데이트해 주세요",
+    "sandboxMachineOffline": "선택한 샌드박스 머신 '{{machine}}'이(가) 오프라인 상태입니다",
+    "sandboxMachineNotFound": "샌드박스 머신 '{{machine}}'을(를) 찾을 수 없거나 제거되었습니다"
   },
   "categories": {
     "agent": "에이전트",
@@ -2158,7 +2165,22 @@
       "needDesktop": "로컬 샌드박스에는 LambChat 데스크톱 앱이 필요합니다. 웹에서는 클라우드 샌드박스만 사용할 수 있습니다.",
       "pairFailed": "페어링에 실패했습니다. 계정 정보를 확인하고 다시 시도하세요.",
       "unpair": "페어링 해제",
-      "unpaired": "페어링이 해제되었습니다"
+      "unpaired": "페어링이 해제되었습니다",
+      "machines": "내 머신",
+      "machinesDesc": "연결된 로컬 샌드박스 머신입니다. 세션마다 실행 대상을 선택할 수 있으며 미선택 시 기본 머신을 사용합니다.",
+      "machinesEmpty": "온라인 머신 없음",
+      "currentServer": "서버: ",
+      "setDefault": "기본으로 설정",
+      "defaultBadge": "기본",
+      "rename": "이름 변경",
+      "renameSave": "저장",
+      "renameCancel": "취소",
+      "platform": {
+        "windows": "Windows",
+        "macos": "macOS",
+        "linux": "Linux",
+        "unknown": "알 수 없음"
+      }
     },
     "maxPinnedModels": "최대 {{max}}개 모델을 고정할 수 있습니다",
     "memoryToggle": "세션 간 메모리",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -254,6 +254,11 @@
       },
       "offlineHint": "Локальная песочница офлайн. Сначала выполните сопряжение в настройках.",
       "restoredOffline": "Сохранённый локальный режим песочницы сейчас офлайн."
+    },
+    "sandboxMachine": {
+      "label": "Машина",
+      "description": "Выберите машину для локальных команд песочницы",
+      "auto": "Авто (по умолчанию)"
     }
   },
   "agents": {
@@ -646,7 +651,9 @@
     "sandboxTimeout": "Превышено время ожидания локального sandbox ({{seconds}} с)",
     "sandboxPayloadTooLarge": "Полезная нагрузка локального sandbox слишком велика",
     "sandboxExecFailed": "Ошибка выполнения локального sandbox: {{detail}}",
-    "daemonVersionUnsupported": "Версия локального sandbox-демона {{version}} ниже минимальной {{min}}, обновите его"
+    "daemonVersionUnsupported": "Версия локального sandbox-демона {{version}} ниже минимальной {{min}}, обновите его",
+    "sandboxMachineOffline": "Выбранная машина песочницы «{{machine}}» сейчас не в сети",
+    "sandboxMachineNotFound": "Машина песочницы «{{machine}}» не найдена или удалена"
   },
   "categories": {
     "agent": "Агент",
@@ -2158,7 +2165,22 @@
       "needDesktop": "Локальная песочница требует настольное приложение LambChat. В веб-доступна только облачная песочница.",
       "pairFailed": "Не удалось выполнить сопряжение. Проверьте учётные данные и повторите попытку.",
       "unpair": "Отменить сопряжение",
-      "unpaired": "Сопряжение отменено"
+      "unpaired": "Сопряжение отменено",
+      "machines": "Мои машины",
+      "machinesDesc": "Подключённые машины локальной песочницы; цель выбирается на уровне сессии, по умолчанию — машина по умолчанию.",
+      "machinesEmpty": "Нет машин в сети",
+      "currentServer": "Сервер: ",
+      "setDefault": "Сделать основной",
+      "defaultBadge": "Основная",
+      "rename": "Переименовать",
+      "renameSave": "Сохранить",
+      "renameCancel": "Отмена",
+      "platform": {
+        "windows": "Windows",
+        "macos": "macOS",
+        "linux": "Linux",
+        "unknown": "Неизвестно"
+      }
     },
     "maxPinnedModels": "Можно закрепить до {{max}} моделей",
     "memoryToggle": "Межсессионная память",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -254,6 +254,11 @@
       },
       "offlineHint": "本地沙箱离线，请先在设置中配对",
       "restoredOffline": "已保存的本地沙箱档当前离线"
+    },
+    "sandboxMachine": {
+      "label": "机器",
+      "description": "选择本地沙箱命令的执行机器",
+      "auto": "自动（默认机）"
     }
   },
   "agents": {
@@ -646,7 +651,9 @@
     "sandboxTimeout": "本地沙箱调用超时（{{seconds}} 秒）",
     "sandboxPayloadTooLarge": "本地沙箱载荷超限",
     "sandboxExecFailed": "本地沙箱执行失败：{{detail}}",
-    "daemonVersionUnsupported": "本地沙箱守护进程版本 {{version}} 低于最低要求 {{min}}，请升级"
+    "daemonVersionUnsupported": "本地沙箱守护进程版本 {{version}} 低于最低要求 {{min}}，请升级",
+    "sandboxMachineOffline": "所选沙箱机器「{{machine}}」当前离线",
+    "sandboxMachineNotFound": "沙箱机器「{{machine}}」不存在或已移除"
   },
   "categories": {
     "agent": "代理",
@@ -2158,7 +2165,22 @@
       "needDesktop": "本地沙箱需要 LambChat 桌面端，网页端仅支持云端沙箱。",
       "pairFailed": "配对失败，请检查账号密码后重试",
       "unpair": "取消配对",
-      "unpaired": "已取消配对"
+      "unpaired": "已取消配对",
+      "machines": "我的机器",
+      "machinesDesc": "已连接的本地沙箱机器；会话中可选择执行目标，默认机用于未选择时。",
+      "machinesEmpty": "暂无在线机器",
+      "currentServer": "当前服务器：",
+      "setDefault": "设为默认",
+      "defaultBadge": "默认",
+      "rename": "重命名",
+      "renameSave": "保存",
+      "renameCancel": "取消",
+      "platform": {
+        "windows": "Windows",
+        "macos": "macOS",
+        "linux": "Linux",
+        "unknown": "未知平台"
+      }
     },
     "maxPinnedModels": "最多置顶 {{max}} 个模型",
     "memoryToggle": "跨会话记忆",

--- a/frontend/src/services/api/__tests__/sandboxMachines.test.ts
+++ b/frontend/src/services/api/__tests__/sandboxMachines.test.ts
@@ -1,0 +1,20 @@
+/** sandbox 多机服务：machines 接口与展示纯函数 */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("../sandbox.ts", import.meta.url), "utf-8");
+
+describe("sandboxApi machines 接口", () => {
+  it("定义 SandboxMachine 接口与四个 machines 方法", () => {
+    expect(source).toContain("interface SandboxMachine");
+    expect(source).toContain("listMachines");
+    expect(source).toContain("setDefaultMachine");
+    expect(source).toContain("renameMachine");
+    expect(source).toContain("forgetMachine");
+  });
+
+  it("machines 端点路径与后端路由一致", () => {
+    expect(source).toContain("/api/sandbox/machines");
+    expect(source).toContain("/default");
+  });
+});

--- a/frontend/src/services/api/sandbox.ts
+++ b/frontend/src/services/api/sandbox.ts
@@ -130,3 +130,66 @@ export const sandboxApi = {
     }
   },
 };
+
+// ---------------------------------------------------------------------------
+// 多机 daemon：机器列表与管理
+// ---------------------------------------------------------------------------
+
+/** 在线机器条目（GET /api/sandbox/machines）。 */
+export interface SandboxMachine {
+  machine_id: string;
+  name: string;
+  platform: string;
+  version: string;
+  confirm_policy: string;
+  online: boolean;
+}
+
+export interface SandboxMachinesResponse {
+  machines: SandboxMachine[];
+  default_machine_id: string | null;
+}
+
+export const sandboxApiMachines = {
+  /** 在线机器列表 + 当前默认机（PAT/JWT 双通道） */
+  async listMachines(): Promise<SandboxMachinesResponse> {
+    return authFetch<SandboxMachinesResponse>(`${API_BASE}/api/sandbox/machines`);
+  },
+
+  /** 设默认机：无会话级选择时的执行目标 */
+  async setDefaultMachine(machineId: string): Promise<void> {
+    await authFetch(`${API_BASE}/api/sandbox/machines/${encodeURIComponent(machineId)}/default`, {
+      method: "PUT",
+    });
+  },
+
+  /** 重命名机器（rename 覆盖层，daemon 重连不冲掉自定义名） */
+  async renameMachine(machineId: string, name: string): Promise<void> {
+    await authFetch(`${API_BASE}/api/sandbox/machines/${encodeURIComponent(machineId)}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name }),
+    });
+  },
+
+  /** 移除离线机器（清集合、rename 与默认机指向） */
+  async forgetMachine(machineId: string): Promise<void> {
+    await authFetch(`${API_BASE}/api/sandbox/machines/${encodeURIComponent(machineId)}`, {
+      method: "DELETE",
+    });
+  },
+};
+
+/** 机器展示纯函数：平台 → 图标语义标签（选择器/设置卡共用）。 */
+export function machinePlatformLabel(platform: string, t: (k: string) => string): string {
+  switch (platform) {
+    case "win32":
+      return t("profile.localSandbox.platform.windows");
+    case "darwin":
+      return t("profile.localSandbox.platform.macos");
+    case "linux":
+      return t("profile.localSandbox.platform.linux");
+    default:
+      return platform || t("profile.localSandbox.platform.unknown");
+  }
+}

--- a/src/agents/core/prompt_policy.py
+++ b/src/agents/core/prompt_policy.py
@@ -30,7 +30,40 @@ Use this alias only with file tools and uploads. For shell commands, use relativ
 - `upload_url_to_sandbox` downloads inside the sandbox; pass `{work_dir}/<name>` as the target so the file lands in `$LAMBCHAT_WORKSPACE` for later shell commands."""
 
 WORKSPACE_POLICY = """### Workspace Boundaries
-Check whether a target exists before creating it. Modify an existing project only when requested or relevant; otherwise use a named directory in the current session workspace."""
+Check whether a target exists before creating it. Modify an existing project only when requested or clearly relevant; otherwise use a named directory in the current session workspace."""
+
+#: win32 本地 daemon 的 shell 方言提示（cmd.exe）。daemon 上报平台经注册表第三段
+#: 查得（win32/linux/darwin），linux 与未上报不加段——云端沙箱与 Linux 本地
+#: 的 prompt 逐字节保持现状，provider 前缀缓存零失效。
+_SANDBOX_SHELL_WIN32 = """### Local Machine Shell: Windows (cmd.exe)
+
+The local sandbox is the user's Windows machine; `execute` runs commands through cmd.exe, NOT bash.
+- Use Windows syntax: `%ERRORLEVEL%` (not POSIX exit-variable), `%VAR%` (not POSIX variable expansion), `set X=Y` (not `export`), `^` as escape (not `\\`), `REM` for comments (not `#`), `dir` / `type` / `findstr` instead of `ls` / `cat` / `grep`.
+- The session workspace env var is `%LAMBCHAT_WORKSPACE%` in cmd.exe. There is no `/proc`, no `uname`, no POSIX pipes-with-stderr like `2>/dev/null`.
+- Prefer `python3 -c "..."` (embedded interpreter, on PATH) for anything nontrivial — quoting, JSON, math, file inspection — instead of shell gymnastics.
+- A command may legitimately fail (non-zero exit); its stdout/stderr come back to you — read the error text and adapt (e.g. fall back to `python3`) instead of assuming the sandbox is blocked."""
+
+#: darwin 本地 daemon：POSIX shell 可用，但 BSD userland 与 Linux 有差集。
+_SANDBOX_SHELL_DARWIN = """### Local Machine Shell: macOS (POSIX/BSD)
+
+The local sandbox is the user's Mac; `execute` runs commands via /bin/sh (POSIX). Shell syntax works as usual, but the userland is BSD: there is no `/proc`, no `free`, and some GNU flags differ (`sed -i ''`, `tar` quirks).
+- `$LAMBCHAT_WORKSPACE` is the session workspace directory.
+- Prefer `python3 -c "..."` (embedded interpreter, on PATH) for system introspection and portable work (e.g. memory/CPU info via `os.sysconf`, `platform`, `subprocess`), since Linux-style `/proc` reads do not exist.
+- A command may legitimately fail (non-zero exit); its stdout/stderr come back to you — read the error text and adapt."""
+
+
+def sandbox_shell_platform_section(daemon_platform: str) -> str:
+    """daemon 上报平台 → 沙箱运行时提示追加段；空串 = 不追加（保持现状）。
+
+    平台串是注册表第三段的归一值（win32/linux/darwin）；空串涵盖云端沙箱、
+    daemon 离线与旧版未上报——一律不加段，绝不错入 Windows 分支。
+    """
+    if daemon_platform == "win32":
+        return _SANDBOX_SHELL_WIN32
+    if daemon_platform == "darwin":
+        return _SANDBOX_SHELL_DARWIN
+    return ""
+
 
 ARTIFACT_POLICY = """### Artifact Delivery
 `write_file`/`edit_file` outputs are auto-staged; workspace shell outputs are detected by snapshots. Use `reveal_file` for an external HTTP(S) URL or one file and use its returned URL in user-facing documents. Use `reveal_project` for a multi-file project or folder.

--- a/src/agents/search_agent/nodes.py
+++ b/src/agents/search_agent/nodes.py
@@ -609,7 +609,7 @@ async def _create_backend_and_prompt(
         local_backend = WorkspaceAliasBackend(
             user_id=user_id,
             session_id=session_id,
-            machine_id=agent_options.get("sandbox_machine_id") or None,
+            machine_id=(agent_options or {}).get("sandbox_machine_id") or None,
         )
         # 用户 env 变量注入（对齐云端：backend.env_vars → 执行时下发）；
         # env_var 工具运行中改动经 sync_envvar_change 实时刷新同一属性

--- a/src/agents/search_agent/nodes.py
+++ b/src/agents/search_agent/nodes.py
@@ -320,6 +320,12 @@ async def agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict[str,
                     if isinstance(sandbox_backend, WorkspaceAliasBackend)
                     else _CloudPolicyResolver(context.user_id or "default")
                 ),
+                # 确认策略与执行同机（本地多机）：会话选机透传，与 dispatch 同源
+                machine_id=(
+                    (agent_options or {}).get("sandbox_machine_id") or None
+                    if isinstance(sandbox_backend, WorkspaceAliasBackend)
+                    else None
+                ),
             )
         )
         if sandbox_work_dir:
@@ -598,7 +604,13 @@ async def _create_backend_and_prompt(
 
         # WorkspaceAliasBackend：prompt_policy 让模型用 /workspace/{sid}/x 别名
         # 路径调文件工具，别名剥离层把路径翻译回相对路径再构造命令（F1）。
-        local_backend = WorkspaceAliasBackend(user_id=user_id, session_id=session_id)
+        # 会话级选机（多机 daemon）：agent_options.sandbox_machine_id 缺省走
+        # 注册表默认解析（默认机→唯一在线→legacy）
+        local_backend = WorkspaceAliasBackend(
+            user_id=user_id,
+            session_id=session_id,
+            machine_id=agent_options.get("sandbox_machine_id") or None,
+        )
         # 用户 env 变量注入（对齐云端：backend.env_vars → 执行时下发）；
         # env_var 工具运行中改动经 sync_envvar_change 实时刷新同一属性
         await sync_sandbox_env_vars(local_backend, user_id)

--- a/src/agents/search_agent/nodes.py
+++ b/src/agents/search_agent/nodes.py
@@ -26,6 +26,7 @@ from src.agents.core.node_utils import (
     resolve_model_supports_vision,
 )
 from src.agents.core.persona import build_persona_prompt_sections
+from src.agents.core.prompt_policy import sandbox_shell_platform_section
 from src.agents.core.startup_preparation import prepare_agent_inputs
 from src.agents.core.subagent_prompts import (
     CODEBASE_INVESTIGATOR_PROMPT,
@@ -85,6 +86,28 @@ logger = get_logger(__name__)
 # ============================================================================
 # 节点函数
 # ============================================================================
+
+
+async def _build_sandbox_runtime_policy(
+    sandbox_backend: Any, sandbox_work_dir: str | None, *, user_id: str
+) -> str:
+    """沙箱运行时提示段：workspace 策略 + （仅本地 daemon）shell 方言段。
+
+    本地 daemon 在 win32/darwin 上时追加平台段（prompt_policy.sandbox_shell_platform_section），
+    让模型生成 cmd.exe / macOS 兼容命令——否则模型默认 POSIX 语法在 Windows
+    cmd.exe 全军覆没（实测根因之二）。云端沙箱与 Linux/未上报一律不加段，
+    prompt 逐字节保持现状；段文本随会话内 daemon 平台稳定，provider 前缀
+    缓存不受逐 turn 影响。
+    """
+    if not sandbox_backend or not sandbox_work_dir:
+        return ""
+    from src.infra.backend.local import WorkspaceAliasBackend, _lookup_daemon_platform
+
+    shell_section = ""
+    if isinstance(sandbox_backend, WorkspaceAliasBackend):
+        shell_section = sandbox_shell_platform_section(await _lookup_daemon_platform(user_id))
+    base = SANDBOX_RUNTIME_SECTION.format(work_dir=sandbox_work_dir)
+    return "\n\n".join(part for part in (base, shell_section) if part)
 
 
 async def agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict[str, Any]:
@@ -198,10 +221,8 @@ async def agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict[str,
     # 自定义子代理配置 - 强制将所有中间信息保存到文件
     search_base_url = configurable.get("base_url", "")
     subagent_prompt_sections = [s for s in (*persona_sections, memory_guide) if s]
-    sandbox_runtime_policy = (
-        SANDBOX_RUNTIME_SECTION.format(work_dir=sandbox_work_dir)
-        if sandbox_backend and sandbox_work_dir
-        else ""
+    sandbox_runtime_policy = await _build_sandbox_runtime_policy(
+        sandbox_backend, sandbox_work_dir, user_id=context.user_id or "default"
     )
 
     def _build_subagent_middleware(subagent_type: str) -> list:
@@ -322,14 +343,10 @@ async def agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict[str,
                 ),
             )
         )
-        if sandbox_work_dir:
+        if sandbox_runtime_policy:
             from src.infra.agent.middleware import SandboxWorkspaceMiddleware
 
-            user_middleware.append(
-                SandboxWorkspaceMiddleware(
-                    policy_text=SANDBOX_RUNTIME_SECTION.format(work_dir=sandbox_work_dir)
-                )
-            )
+            user_middleware.append(SandboxWorkspaceMiddleware(policy_text=sandbox_runtime_policy))
     # Tool search: per-turn dynamic content
     if context.deferred_manager is not None:
         from src.infra.agent.middleware import ToolSearchMiddleware

--- a/src/api/routes/sandbox.py
+++ b/src/api/routes/sandbox.py
@@ -9,7 +9,7 @@ from typing import AsyncIterator, Optional
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 from src.api.deps import get_current_user_pat_or_jwt, require_pat_only
 from src.infra.logging import get_logger
@@ -31,6 +31,14 @@ router = APIRouter()
 _POLL_INTERVAL = 0.05
 _HEARTBEAT_SECONDS = 15
 _NODE_ID = f"{socket.gethostname()}:{uuid.uuid4().hex[:8]}"
+
+#: 多机 channel 的属主键前缀：同机重连换属主，旧流心跳时据此退场（对应
+#: legacy 路径 register 清 hash 的「后连踢前连」语义）。
+_OWNER_PREFIX = "sandbox:machineowner"
+
+
+def _owner_key(user_id: str, machine_id: str) -> str:
+    return f"{_OWNER_PREFIX}:{user_id}:{machine_id}"
 
 
 def _redis():
@@ -62,6 +70,8 @@ async def channel_frames(
     version: str = "",
     platform: str = "",
     confirm_policy: str = "",
+    machine_id: str = "",
+    machine_name: str = "",
 ) -> AsyncIterator[str]:
     """SSE 帧生成器：hello -> (tool_call | 心跳) 循环；连接期心跳注册表。
 
@@ -71,19 +81,32 @@ async def channel_frames(
     /``confirm_policy`` 重写——不带会把注册值降级回纯 node_id，daemon
     版本/平台/策略 15s 后丢失。
 
+    多机（``machine_id`` 非空）：属主校验按机器属主键（同机重连换属主踢旧流），
+    下发队列按 ``registry.queue_key`` 分机器；legacy 路径语义零变化。
+
     陈旧请求丢弃：daemon 重连后 list 里残留的断连前积压请求，按 dispatch 写入
     的 ts 判龄，超过 ACK 超时的直接丢弃——执行窗口早已超时，下发只会白白
     消耗 daemon 并让调用方等到 exec 超时。
     """
-    yield f"event: hello\ndata: {json.dumps({'client_id': client_id})}\n\n"
+    hello = {"client_id": client_id}
+    if machine_id:
+        hello["machine_id"] = machine_id
+    yield f"event: hello\ndata: {json.dumps(hello)}\n\n"
     loop = asyncio.get_event_loop()
     last_beat = loop.time()  # 首个心跳在间隔之后到点，保证 hello 后紧跟的是 tool_call
+    req_key = registry.queue_key(user_id, machine_id) if machine_id else f"sandbox:req:{user_id}"
     while not stop.is_set():
         now = loop.time()
         if now - last_beat >= _HEARTBEAT_SECONDS:
-            active = await registry.get_active(user_id)
-            if active is None or active[0] != client_id:
-                return  # 已被新连接取代（或注册表失效），旧流退场
+            if machine_id:
+                # 多机属主校验：同机新连接已改写属主键时，旧流退场
+                owner = await redis.get(_owner_key(user_id, machine_id))
+                if owner != client_id:
+                    return
+            else:
+                active = await registry.get_active(user_id)
+                if active is None or active[0] != client_id:
+                    return  # 已被新连接取代（或注册表失效），旧流退场
             await registry.heartbeat(
                 user_id,
                 client_id,
@@ -91,10 +114,14 @@ async def channel_frames(
                 version=version,
                 platform=platform,
                 confirm_policy=confirm_policy,
+                machine_id=machine_id,
+                machine_name=machine_name,
             )
+            if machine_id:
+                await redis.set(_owner_key(user_id, machine_id), client_id, ex=35)
             last_beat = now
             yield ": heartbeat\n\n"
-        raw = await redis.lpop(f"sandbox:req:{user_id}")
+        raw = await redis.lpop(req_key)
         if raw is not None:
             age = _request_age_seconds(raw)
             if age > settings.SANDBOX_LOCAL_ACK_TIMEOUT:
@@ -133,6 +160,8 @@ async def sandbox_channel(
     version: str = "",
     platform: str = "",
     confirm_policy: str = "",
+    machine_id: str = "",
+    machine_name: str = "",
     user: TokenPayload = Depends(require_pat_only("sandbox:execute")),
 ):
     """daemon SSE 通道。``?version=``/``?platform=``/``?confirm_policy=`` 是
@@ -140,7 +169,9 @@ async def sandbox_channel(
     可见），随 register/heartbeat 存入注册表 hash value，status 端点解析成
     daemon_version/daemon_platform/daemon_confirm_policy 暴露；platform 供
     文件命令生成的平台分支（M4 T3）、confirm_policy 供服务端统一确认门
-    实时查询（非法值在入口归一空串，门侧按未上报归 all 保守确认）。
+    实时查询（非法值在入口归一空串，门侧按未上报归 all 保守确认）；
+    ``machine_id``/``machine_name``（多机 daemon）是注册表机器分槽主键与
+    展示名，空值走 legacy 单机路径（0.2.0 兼容）。
 
     版本门（M4 T5）：version 低于 ``SANDBOX_MIN_DAEMON_VERSION``（缺失按最低）
     直接 426 拒连——错误在 StreamingResponse 建立前 raise，走全局 AppError
@@ -171,7 +202,11 @@ async def sandbox_channel(
         version=version,
         platform=platform,
         confirm_policy=confirm_policy,
+        machine_id=machine_id,
+        machine_name=machine_name,
     )
+    if machine_id:  # 多机属主：同机重连改写属主键，旧流心跳时据此退场
+        await _redis().set(_owner_key(user.sub, machine_id), client_id, ex=35)
     stop = asyncio.Event()
 
     async def generator():
@@ -185,10 +220,12 @@ async def sandbox_channel(
                 version=version,
                 platform=platform,
                 confirm_policy=confirm_policy,
+                machine_id=machine_id,
+                machine_name=machine_name,
             ):
                 yield frame
         finally:
-            await registry.unregister(user.sub, client_id)
+            await registry.unregister(user.sub, client_id, machine_id=machine_id)
 
     return StreamingResponse(
         generator(),
@@ -225,6 +262,66 @@ async def sandbox_result(
     return {"status": "ok"}
 
 
+@router.get("/machines")
+async def sandbox_machines(user: TokenPayload = Depends(get_current_user_pat_or_jwt)):
+    """在线机器列表（多机 daemon）：machine_id/name/platform/version/policy。"""
+    machines = await _registry().list_machines(user.sub)
+    default = await _registry().get_default_machine(user.sub)
+    return {"machines": machines, "default_machine_id": default}
+
+
+class MachineRenameRequest(BaseModel):
+    name: str
+
+    @field_validator("name")
+    @classmethod
+    def _name_not_blank(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("name must not be blank")
+        return value
+
+
+@router.patch("/machines/{machine_id}")
+async def sandbox_machine_rename(
+    machine_id: str,
+    body: MachineRenameRequest,
+    user: TokenPayload = Depends(get_current_user_pat_or_jwt),
+):
+    """重命名机器：写 rename 覆盖层，daemon 重连上报的 hostname 不冲掉自定义名。"""
+    name = body.name.strip()
+    if not name:
+        raise AppError(ErrorCode.SANDBOX_MACHINE_NOT_FOUND, args={"machine": machine_id})
+    if len(name) > 64:
+        name = name[:64]
+    await _registry().rename_machine(user.sub, machine_id, name)
+    return {"status": "ok", "machine_id": machine_id, "name": name}
+
+
+@router.put("/machines/{machine_id}/default")
+async def sandbox_machine_set_default(
+    machine_id: str,
+    user: TokenPayload = Depends(get_current_user_pat_or_jwt),
+):
+    """设默认机：无会话级选择时的执行目标。"""
+    await _registry().set_default_machine(user.sub, machine_id)
+    return {"status": "ok", "default_machine_id": machine_id}
+
+
+@router.delete("/machines/{machine_id}")
+async def sandbox_machine_forget(
+    machine_id: str,
+    user: TokenPayload = Depends(get_current_user_pat_or_jwt),
+):
+    """移除离线机器（清集合成员、rename 覆盖层与默认机指向）。"""
+    removed = await _registry().forget_machine(user.sub, machine_id)
+    if not removed:
+        raise AppError(
+            ErrorCode.SANDBOX_MACHINE_NOT_FOUND,
+            args={"machine": machine_id},
+        )
+    return {"status": "ok"}
+
+
 @router.get("/status")
 async def sandbox_status(user: TokenPayload = Depends(get_current_user_pat_or_jwt)):
     active = await _registry().get_active(user.sub)
@@ -243,13 +340,21 @@ async def sandbox_status(user: TokenPayload = Depends(get_current_user_pat_or_jw
 
 
 @router.post("/offline")
-async def sandbox_offline(user: TokenPayload = Depends(require_pat_only("sandbox:execute"))):
-    """daemon 优雅退出通知：主动注销当前活跃连接。
+async def sandbox_offline(
+    machine_id: str = "",
+    user: TokenPayload = Depends(require_pat_only("sandbox:execute")),
+):
+    """daemon 优雅退出通知：主动注销当前活跃连接（``machine_id`` 定向注销多机
+    中的本机；缺省走 legacy 活跃连接）。
 
     不打此端点时，断连要等注册表 TTL（35s）或心跳属主校验（15s 周期）才暴露——
     M1 冒烟实证的窗口是 15-35s；daemon 退出前调一次 offline 把窗口收敛到一次 RTT。
     """
     registry = _registry()
+    if machine_id:
+        await registry.unregister(user.sub, "", machine_id)
+        await _redis().delete(_owner_key(user.sub, machine_id))
+        return {"status": "offline", "machine_id": machine_id}
     active = await registry.get_active(user.sub)
     if active is not None:
         await registry.unregister(user.sub, active[0])

--- a/src/infra/agent/events/tool_events.py
+++ b/src/infra/agent/events/tool_events.py
@@ -93,7 +93,14 @@ class ToolEventMixin:
 
         if isinstance(error, BaseException):
             error_type = type(error).__name__
-            error_message = str(error) if str(error) else repr(error)
+            # AppError 的 str() 是未插值的默认模板（生产实测裸奔 "{{detail}}"）；
+            # 面向模型/前端的单条文本必须走 display_message 的插值版。
+            from src.kernel.errors import AppError
+
+            if isinstance(error, AppError):
+                error_message = error.display_message or repr(error)
+            else:
+                error_message = str(error) if str(error) else repr(error)
             return f"[MCP Tool Error] {tool_name} failed: [{error_type}] {error_message}"
 
         if isinstance(error, dict):

--- a/src/infra/agent/middleware/sandbox_confirm.py
+++ b/src/infra/agent/middleware/sandbox_confirm.py
@@ -73,10 +73,14 @@ def _op_description(tool_name: str, args: dict[str, Any]) -> tuple[str, str]:
     return f"{label}：{path}", f"rm {tool_name} {path}"
 
 
-async def _lookup_confirm_policy(user_id: str) -> str:
-    """本地沙箱策略源：当前活跃 daemon 上报（缺失/故障归 all 保守确认）。"""
+async def _lookup_confirm_policy(user_id: str, machine_id: str | None = None) -> str:
+    """本地沙箱策略源：目标机 daemon 上报（缺失/故障归 all 保守确认）。
+
+    ``machine_id`` 与 dispatch 同源（会话级选机）——确认策略与实际执行必须
+    同机，否则「A 机报 none 放行、命令却落到策略 all 的 B 机」会绕过确认。
+    """
     try:
-        policy = await SandboxClientRegistry().get_confirm_policy(user_id)
+        policy = await SandboxClientRegistry().get_confirm_policy(user_id, machine_id)
         return policy if policy in ("all", "commands", "none") else "all"
     except Exception:  # noqa: BLE001 - 查询尽力而为，失败保守归 all
         logger.warning("confirm policy lookup failed for user %s; defaulting to all", user_id)
@@ -107,13 +111,14 @@ async def _lookup_cloud_confirm_policy(user_id: str) -> str:
 
 
 class _RegistryPolicyResolver:
-    """本地策略源闭包（daemon 注册表上报，缺失/故障归 all）。"""
+    """本地策略源闭包（目标机 daemon 注册表上报，缺失/故障归 all）。"""
 
-    def __init__(self, user_id: str) -> None:
+    def __init__(self, user_id: str, machine_id: str | None = None) -> None:
         self._user_id = user_id
+        self._machine_id = machine_id
 
     async def __call__(self) -> str:
-        return await _lookup_confirm_policy(self._user_id)
+        return await _lookup_confirm_policy(self._user_id, self._machine_id)
 
 
 class _CloudPolicyResolver:
@@ -175,10 +180,11 @@ class SandboxConfirmMiddleware(AgentMiddleware):
         *,
         user_id: str,
         policy_resolver: Callable[[], Awaitable[str]] | None = None,
+        machine_id: str | None = None,
     ) -> None:
         super().__init__()
         self._user_id = user_id
-        self._policy_resolver = policy_resolver or _RegistryPolicyResolver(user_id)
+        self._policy_resolver = policy_resolver or _RegistryPolicyResolver(user_id, machine_id)
 
     async def awrap_tool_call(
         self,

--- a/src/infra/backend/local.py
+++ b/src/infra/backend/local.py
@@ -74,15 +74,15 @@ logger = get_logger(__name__)
 T = TypeVar("T")
 
 
-async def _lookup_daemon_platform(user_id: str) -> str:
-    """经注册表查当前活跃 daemon 的上报平台（win32/linux/darwin）。
+async def _lookup_daemon_platform(user_id: str, machine_id: str | None = None) -> str:
+    """经注册表查目标机 daemon 的上报平台（win32/linux/darwin）。
 
     一次 redis 读（注册表 value 第三段，M4 T3）；离线/旧格式/未上报返回
     空串，任何故障（redis 不可达等）也回落空串——空串在 :func:`_platform_ctx`
     归一为 posix，文件操作不因平台查询失败而中断。
     """
     try:
-        return await SandboxClientRegistry().get_platform(user_id)
+        return await SandboxClientRegistry().get_platform(user_id, machine_id)
     except Exception:  # noqa: BLE001 - 平台查询尽力而为，失败回落 posix
         logger.warning("daemon platform lookup failed for user %s; falling back to posix", user_id)
         return ""
@@ -119,9 +119,12 @@ class LocalSandboxBackend(BaseSandbox):
         exec_timeout: int | None = None,
         platform_hint: str | None = None,
         env_vars: dict[str, str] | None = None,
+        machine_id: str | None = None,
     ):
         self._user_id = user_id
         self._session_id = session_id
+        # 会话级选机（多机 daemon）：None = 注册表默认解析（默认机→唯一在线→legacy）
+        self._machine_id = machine_id
         self._exec_timeout = exec_timeout or settings.SANDBOX_LOCAL_EXEC_TIMEOUT
         # 显式平台提示（构造期已知 daemon 平台的 wiring/测试用）；None = 每次
         # 文件操作前经注册表查当前活跃 daemon 的平台（一次 redis 读）。
@@ -135,7 +138,7 @@ class LocalSandboxBackend(BaseSandbox):
         """本次命令生成所用平台：显式 hint 优先，否则查注册表（容错 posix）。"""
         if self._platform_hint is not None:
             return self._platform_hint
-        return await _lookup_daemon_platform(self._user_id)
+        return await _lookup_daemon_platform(self._user_id, self._machine_id)
 
     @property
     def id(self) -> str:
@@ -173,6 +176,7 @@ class LocalSandboxBackend(BaseSandbox):
             "exec",
             payload,
             timeout=float(timeout or self._exec_timeout),
+            machine_id=self._machine_id,
         )
         stdout = result.get("stdout") or ""
         stderr = result.get("stderr") or ""
@@ -345,6 +349,7 @@ class LocalSandboxBackend(BaseSandbox):
             "exec",
             {"command": self._download_command(path, platform=platform), "cwd": self.work_dir},
             timeout=float(self._exec_timeout),
+            machine_id=self._machine_id,
         )
         return self._download_response(path, result)
 
@@ -456,6 +461,7 @@ class WorkspaceAliasBackend(LocalSandboxBackend):
             op,
             {**payload, "cwd": self.work_dir},
             timeout=float(self._exec_timeout),
+            machine_id=self._machine_id,
         )
         result = resp.get("result")
         return result if isinstance(result, dict) else {}

--- a/src/infra/backend/local.py
+++ b/src/infra/backend/local.py
@@ -176,8 +176,11 @@ class LocalSandboxBackend(BaseSandbox):
         )
         stdout = result.get("stdout") or ""
         stderr = result.get("stderr") or ""
+        # executor 错误标记（timeout/expired）：并入 output 让模型能区分
+        # 「命令超时/迟到」与「命令以非零码退出」（后者的 error 为 None）。
+        error = str(result.get("error") or "")
         # ExecuteResponse 只有合并 output 字段（protocol.py），照 E2BBackend 的拼接方式
-        output = f"{stdout}\n{stderr}" if stdout and stderr else (stdout or stderr)
+        output = "\n".join(part for part in (stdout, stderr, error) if part)
         exit_code = result.get("exit_code")
         # 缺失 exit_code 透传 None（协议：未确定），不伪装成 0 成功
         return ExecuteResponse(

--- a/src/infra/sandbox/relay/dispatch.py
+++ b/src/infra/sandbox/relay/dispatch.py
@@ -22,10 +22,28 @@ def _registry() -> SandboxClientRegistry:
 
 
 async def dispatch_local_call(
-    user_id: str, op: str, payload: dict, *, timeout: float | None = None
+    user_id: str,
+    op: str,
+    payload: dict,
+    *,
+    timeout: float | None = None,
+    machine_id: str | None = None,
 ) -> dict:
-    if not await _registry().is_online(user_id):
-        raise AppError(ErrorCode.DAEMON_OFFLINE)
+    """下发工具调用到目标机。
+
+    ``machine_id``：会话级选机（None = 注册表默认解析：默认机 → 唯一在线机
+    → legacy）。显式指定且该机离线时报 SANDBOX_MACHINE_OFFLINE（区别于无任何
+    机器在线的 DAEMON_OFFLINE，前端据此提示换机）。
+    """
+    registry = _registry()
+    if machine_id:
+        target = await registry.resolve_target(user_id, machine_id)
+        if target is None:
+            raise AppError(ErrorCode.SANDBOX_MACHINE_OFFLINE, args={"machine": machine_id})
+    else:
+        target = await registry.resolve_target(user_id)
+        if target is None:
+            raise AppError(ErrorCode.DAEMON_OFFLINE)
     exec_timeout = timeout if timeout is not None else float(settings.SANDBOX_LOCAL_EXEC_TIMEOUT)
     call_id = uuid.uuid4().hex
     req = {
@@ -38,7 +56,7 @@ async def dispatch_local_call(
     }
     redis = _redis()
     resp_key = f"sandbox:resp:{call_id}"
-    await redis.rpush(f"sandbox:req:{user_id}", json.dumps(req))
+    await redis.rpush(registry.queue_key(user_id, target), json.dumps(req))
 
     start = time.monotonic()
     acked = False

--- a/src/infra/sandbox/relay/dispatch.py
+++ b/src/infra/sandbox/relay/dispatch.py
@@ -58,9 +58,19 @@ async def dispatch_local_call(
             if resp is not None and resp.get("stage") == "done":
                 await redis.delete(resp_key)
                 if resp.get("status") != "ok":
+                    # exec 的非零退出码/命令超时是**命令结局**而非中继故障（daemon
+                    # executor 的 status 镜像 exit_code）：带 executor 结果字段的
+                    # done 载荷原样回传，由 LocalSandboxBackend.aexecute 构造
+                    # ExecuteResponse——模型看得到 stdout/stderr/exit_code 才能自行
+                    # 纠错（Windows cmd.exe 上命令失败是常态；劫持成 AppError 会让
+                    # 模型只见 "execution failed" 而无从换命令）。其余 op（fs_* 的
+                    # 内部异常）与 exec 的 daemon 级错误（expired/unsupported，无
+                    # 结果字段）仍按中继失败上抛。
+                    if op == "exec" and ("exit_code" in resp or "stdout" in resp):
+                        return resp
                     raise AppError(
                         ErrorCode.SANDBOX_EXEC_FAILED,
-                        args={"detail": str(resp.get("error", "local execution failed"))},
+                        args={"detail": str(resp.get("error") or "local execution failed")},
                     )
                 return resp
             if not acked and time.monotonic() > ack_deadline:

--- a/src/infra/sandbox/relay/registry.py
+++ b/src/infra/sandbox/relay/registry.py
@@ -1,43 +1,73 @@
-"""daemon 连接注册表：Redis hash + TTL 心跳判活（spec §3.2）。同用户仅一个活跃连接。
+"""daemon 连接注册表：Redis + TTL 心跳判活（spec §3.2）。
 
-版本/平台/确认策略地基（M2 终审 + M4 T3 + 服务端确认门）：hash value 存下列形态之一——
+多机形态（每用户多台机器共存）：
+
+- ``sandbox:machine:{uid}:{mid}``  string  TTL 35s 判活，value 第五段 machine_name；
+- ``sandbox:machset:{uid}``        set     在册 machine_id（懒清理失效成员）；
+- ``sandbox:machname:{uid}``       hash    mid → 自定义展示名（rename 覆盖层，
+  daemon 重连上报的 hostname 不会冲掉用户起的名字）；
+- ``sandbox:machdefault:{uid}``    string  用户默认机。
+
+legacy（未上报 machine_id 的 0.2.0 daemon）沿用旧 ``sandbox:clients:{uid}``
+hash + 后连踢前连语义 + ``sandbox:req:{uid}`` 队列，在机器列表中以
+:data:`LEGACY_MACHINE_ID` 伪机器出现——选择它时 :meth:`queue_key` 路由回
+旧队列，老客户端零变化。
+
+单机 value 形态（legacy hash 与多机 string 同构，按已知段数追加）：
 
 - ``node_id``（M1 旧格式：未上报版本）；
-- ``node_id|version``（M2：daemon connect URL 带 ``?version=``，channel 注册
-  与心跳时写入，与仅版本的旧调用方字节形态保持一致）；
-- ``node_id|version|platform``（M4 T3：URL 再带 ``?platform=``，第三段是
-  ``sys.platform`` 归一值 linux/darwin/win32，服务端文件命令生成分支依据）；
-- ``node_id|version|platform|confirm_policy``（服务端确认门：URL 再带
-  ``?confirm_policy=``，第四段是 all/commands/none——服务端门侧实时读取，
-  未上报归一 all 保守确认）。
-
-``/api/sandbox/status`` 用 :func:`parse_daemon_version` /
-:func:`parse_daemon_platform` / :func:`parse_confirm_policy` 反解暴露；
-:func:`get_platform` / :func:`get_confirm_policy` 供命令生成与确认门侧
-直接查询。段数不足的旧 value 解析出空——调用方按空归一（平台 posix /
-策略 all），即「无信息 → 最保守现状」。
+- ``node_id|version``（M2）；
+- ``node_id|version|platform``（M4 T3）；
+- ``node_id|version|platform|confirm_policy``（服务端确认门）；
+- ``node_id|version|platform|confirm_policy|machine_name``（多机）。
 """
 
 from src.infra.storage.redis import get_redis_client
 
 _TTL_SECONDS = 35
 
+#: 旧 daemon（无 machine_id）的伪机器标识：机器列表占位 + 旧队列路由。
+LEGACY_MACHINE_ID = "legacy"
+
 
 def _key(user_id: str) -> str:
     return f"sandbox:clients:{user_id}"
 
 
+def _machine_key(user_id: str, machine_id: str) -> str:
+    return f"sandbox:machine:{user_id}:{machine_id}"
+
+
+def _machset_key(user_id: str) -> str:
+    return f"sandbox:machset:{user_id}"
+
+
+def _machname_key(user_id: str) -> str:
+    return f"sandbox:machname:{user_id}"
+
+
+def _machdefault_key(user_id: str) -> str:
+    return f"sandbox:machdefault:{user_id}"
+
+
 def encode_node_value(
-    node_id: str, version: str = "", platform: str = "", confirm_policy: str = ""
+    node_id: str,
+    version: str = "",
+    platform: str = "",
+    confirm_policy: str = "",
+    machine_name: str = "",
 ) -> str:
     """hash value 编码：按已知段数追加，旧调用方保持旧形态。
 
+    - 版本+平台+策略+机器名：``node_id|version|platform|confirm_policy|machine_name``；
     - 版本+平台+策略：``node_id|version|platform|confirm_policy``；
     - 版本+平台：``node_id|version|platform``；
     - 仅版本：``node_id|version``（M2 字节形态不变）；
     - 仅平台：``node_id||platform``（空版本段占位，第三段仍可解析）；
     - 都无：纯 ``node_id``（M1 形态）。
     """
+    if machine_name:
+        return f"{node_id}|{version}|{platform}|{confirm_policy}|{machine_name}"
     if confirm_policy:
         return f"{node_id}|{version}|{platform}|{confirm_policy}"
     if platform:
@@ -63,6 +93,12 @@ def parse_confirm_policy(value: str) -> str:
     return parts[3] if len(parts) > 3 else ""
 
 
+def parse_machine_name(value: str) -> str:
+    """hash value 反解机器名（第五段）；段数不足（旧格式）返回空串。"""
+    parts = value.split("|")
+    return parts[4] if len(parts) > 4 else ""
+
+
 class SandboxClientRegistry:
     def _redis(self):
         return get_redis_client()
@@ -76,12 +112,19 @@ class SandboxClientRegistry:
         version: str = "",
         platform: str = "",
         confirm_policy: str = "",
+        machine_id: str = "",
+        machine_name: str = "",
     ) -> None:
+        """注册连接。带 machine_id 走多机路径（同机重连只替换自身字段，其他
+        机器不受影响）；缺 machine_id 走 legacy 路径（清空旧 hash 后连踢前连）。"""
+        value = encode_node_value(node_id, version, platform, confirm_policy, machine_name)
         redis = self._redis()
-        await redis.delete(_key(user_id))  # 后连踢前连
-        await redis.hset(
-            _key(user_id), client_id, encode_node_value(node_id, version, platform, confirm_policy)
-        )
+        if machine_id:
+            await redis.sadd(_machset_key(user_id), machine_id)
+            await redis.set(_machine_key(user_id, machine_id), value, ex=_TTL_SECONDS)
+            return
+        await redis.delete(_key(user_id))  # 后连踢前连（legacy 单机语义）
+        await redis.hset(_key(user_id), client_id, value)
         await redis.expire(_key(user_id), _TTL_SECONDS)
 
     async def heartbeat(
@@ -93,48 +136,172 @@ class SandboxClientRegistry:
         version: str = "",
         platform: str = "",
         confirm_policy: str = "",
+        machine_id: str = "",
+        machine_name: str = "",
     ) -> None:
+        value = encode_node_value(node_id, version, platform, confirm_policy, machine_name)
         redis = self._redis()
-        await redis.hset(
-            _key(user_id), client_id, encode_node_value(node_id, version, platform, confirm_policy)
-        )
+        if machine_id:
+            await redis.sadd(_machset_key(user_id), machine_id)
+            await redis.set(_machine_key(user_id, machine_id), value, ex=_TTL_SECONDS)
+            return
+        await redis.hset(_key(user_id), client_id, value)
         await redis.expire(_key(user_id), _TTL_SECONDS)
 
-    async def unregister(self, user_id: str, client_id: str) -> None:
+    async def unregister(self, user_id: str, client_id: str, machine_id: str = "") -> None:
         redis = self._redis()
+        if machine_id:
+            await redis.delete(_machine_key(user_id, machine_id))
+            await redis.srem(_machset_key(user_id), machine_id)
+            return
         await redis.hdel(_key(user_id), client_id)
         if not await redis.hgetall(_key(user_id)):
             await redis.delete(_key(user_id))
 
     async def is_online(self, user_id: str) -> bool:
-        return bool(await self._redis().exists(_key(user_id)))
+        """任一机器在线（多机或 legacy）即在线。"""
+        redis = self._redis()
+        if await redis.exists(_key(user_id)):
+            return True
+        for mid in await redis.smembers(_machset_key(user_id)):
+            if await redis.exists(_machine_key(user_id, mid)):
+                return True
+        return False
 
     async def get_active(self, user_id: str) -> tuple[str, str] | None:
+        """legacy 活跃连接（旧 hash 首字段）。多机路径不经过此方法。"""
         fields = await self._redis().hgetall(_key(user_id))
         if not fields:
             return None
         client_id = next(iter(fields))
         return client_id, fields[client_id]
 
-    async def get_platform(self, user_id: str) -> str:
-        """当前活跃 daemon 的上报平台（win32/linux/darwin）。
+    # ------------------------------------------------------------------
+    # 多机：列表 / 默认 / 重命名 / 移除 / 目标解析
+    # ------------------------------------------------------------------
+
+    async def list_machines(self, user_id: str) -> list[dict]:
+        """在线机器列表（TTL 过期即离线、从集合懒清理）。
+
+        返回 [{machine_id, name, platform, version, confirm_policy, online}]，
+        ``online`` 恒 True（列表只含在册在线机；离线机 TTL 后自然消失，
+        rename 覆盖层保留、机器重连时恢复展示）。
+        """
+        redis = self._redis()
+        names = await redis.hgetall(_machname_key(user_id))
+        machines: list[dict] = []
+        for mid in sorted(await redis.smembers(_machset_key(user_id))):
+            value = await redis.get(_machine_key(user_id, mid))
+            if value is None:
+                await redis.srem(_machset_key(user_id), mid)
+                continue
+            machines.append(
+                {
+                    "machine_id": mid,
+                    "name": names.get(mid) or parse_machine_name(value) or mid,
+                    "platform": parse_daemon_platform(value),
+                    "version": parse_daemon_version(value),
+                    "confirm_policy": parse_confirm_policy(value),
+                    "online": True,
+                }
+            )
+        active = await self.get_active(user_id)
+        if active is not None:
+            machines.append(
+                {
+                    "machine_id": LEGACY_MACHINE_ID,
+                    "name": parse_daemon_platform(active[1]) or "Daemon",
+                    "platform": parse_daemon_platform(active[1]),
+                    "version": parse_daemon_version(active[1]),
+                    "confirm_policy": parse_confirm_policy(active[1]),
+                    "online": True,
+                }
+            )
+        return machines
+
+    async def set_default_machine(self, user_id: str, machine_id: str) -> None:
+        await self._redis().set(_machdefault_key(user_id), machine_id)
+
+    async def get_default_machine(self, user_id: str) -> str | None:
+        return await self._redis().get(_machdefault_key(user_id))
+
+    async def rename_machine(self, user_id: str, machine_id: str, name: str) -> None:
+        await self._redis().hset(_machname_key(user_id), machine_id, name)
+
+    async def forget_machine(self, user_id: str, machine_id: str) -> bool:
+        """移除机器（仅离线可移除——在线机器先断连）。清默认机指向。"""
+        if machine_id == LEGACY_MACHINE_ID:
+            return False
+        redis = self._redis()
+        if await redis.exists(_machine_key(user_id, machine_id)):
+            return False
+        await redis.srem(_machset_key(user_id), machine_id)
+        await redis.hdel(_machname_key(user_id), machine_id)
+        if await redis.get(_machdefault_key(user_id)) == machine_id:
+            await redis.delete(_machdefault_key(user_id))
+        return True
+
+    def queue_key(self, user_id: str, machine_id: str) -> str:
+        """下发队列键：legacy 保持旧格式（无后缀），多机按机器分队列。"""
+        if machine_id == LEGACY_MACHINE_ID:
+            return f"sandbox:req:{user_id}"
+        return f"sandbox:req:{user_id}:{machine_id}"
+
+    async def resolve_target(self, user_id: str, machine_id: str | None = None) -> str | None:
+        """解析执行目标机：显式指定 → 校验在线；缺省 → 默认机 → 唯一在线机
+        → legacy。无可用机器返回 None（调用方按 DAEMON_OFFLINE 收敛）。"""
+        redis = self._redis()
+        if machine_id:
+            if machine_id == LEGACY_MACHINE_ID:
+                return machine_id if await redis.exists(_key(user_id)) else None
+            return machine_id if await redis.exists(_machine_key(user_id, machine_id)) else None
+        default = await self.get_default_machine(user_id)
+        if default and await self._machine_online(user_id, default):
+            return default
+        online = [
+            mid
+            for mid in await redis.smembers(_machset_key(user_id))
+            if await redis.exists(_machine_key(user_id, mid))
+        ]
+        if len(online) == 1:
+            return online[0]
+        if await redis.exists(_key(user_id)):
+            return LEGACY_MACHINE_ID
+        return None
+
+    async def _machine_online(self, user_id: str, machine_id: str) -> bool:
+        if machine_id == LEGACY_MACHINE_ID:
+            return await self._redis().exists(_key(user_id)) > 0
+        return await self._redis().exists(_machine_key(user_id, machine_id)) > 0
+
+    async def _machine_value(self, user_id: str, machine_id: str) -> str:
+        """目标机的注册 value（resolve 后调用；离线返回空串）。"""
+        redis = self._redis()
+        if machine_id == LEGACY_MACHINE_ID:
+            active = await self.get_active(user_id)
+            return active[1] if active else ""
+        value = await redis.get(_machine_key(user_id, machine_id))
+        return value or ""
+
+    async def get_platform(self, user_id: str, machine_id: str | None = None) -> str:
+        """目标机的上报平台（win32/linux/darwin）。
 
         离线或旧格式 value（段数不足）返回空串——调用方（local.py 文件命令
         生成平台分支）按空串归一 posix，即「无平台信息 → 现状零变化」。
         """
-        active = await self.get_active(user_id)
-        if active is None:
+        target = await self.resolve_target(user_id, machine_id)
+        if target is None:
             return ""
-        return parse_daemon_platform(active[1])
+        return parse_daemon_platform(await self._machine_value(user_id, target))
 
-    async def get_confirm_policy(self, user_id: str) -> str:
-        """当前活跃 daemon 上报的确认策略（all/commands/none）。
+    async def get_confirm_policy(self, user_id: str, machine_id: str | None = None) -> str:
+        """目标机的上报确认策略（all/commands/none）。
 
         离线或旧格式 value（段数不足）返回空串——调用方（local.py 确认门）
         按空串归一 all 保守确认。daemon 离线时门根本走不到（dispatch 先报
         DAEMON_OFFLINE），此查询只在在线会话的执行路径上发生。
         """
-        active = await self.get_active(user_id)
-        if active is None:
+        target = await self.resolve_target(user_id, machine_id)
+        if target is None:
             return ""
-        return parse_confirm_policy(active[1])
+        return parse_confirm_policy(await self._machine_value(user_id, target))

--- a/src/kernel/errors.py
+++ b/src/kernel/errors.py
@@ -90,6 +90,16 @@ class ErrorCode(Enum):
     PAT_EXPIRED = ("pat_expired", 401, "Personal access token expired")
     PAT_SCOPE_DENIED = ("pat_scope_denied", 403, "Token missing required scope '{{scope}}'")
     DAEMON_OFFLINE = ("daemon_offline", 409, "Local sandbox daemon is offline")
+    SANDBOX_MACHINE_OFFLINE = (
+        "sandbox_machine_offline",
+        409,
+        "Selected sandbox machine '{{machine}}' is offline",
+    )
+    SANDBOX_MACHINE_NOT_FOUND = (
+        "sandbox_machine_not_found",
+        404,
+        "Sandbox machine '{{machine}}' not found",
+    )
     SANDBOX_TIMEOUT = ("sandbox_timeout", 504, "Local sandbox call timed out after {{seconds}}s")
     SANDBOX_EXEC_FAILED = (
         "sandbox_exec_failed",

--- a/tests/agents/core/test_prompt_policy.py
+++ b/tests/agents/core/test_prompt_policy.py
@@ -1,6 +1,10 @@
 """Prompt policy 契约：归属纪律条目必须存在于所有主 agent 的共享 prompt。"""
 
-from src.agents.core.prompt_policy import SAFETY_POLICY, WORKFLOW_POLICY
+from src.agents.core.prompt_policy import (
+    SAFETY_POLICY,
+    WORKFLOW_POLICY,
+    sandbox_shell_platform_section,
+)
 from src.agents.core.subagent_prompts import MAIN_AGENT_PROMPT_SECTIONS
 
 
@@ -18,3 +22,30 @@ def test_attribution_discipline_reaches_all_main_agents():
     for phrase in ("explicitly", "unconfirmed", "possibly stale", "confirmed-current"):
         assert phrase in WORKFLOW_POLICY
         assert any(phrase in section for section in MAIN_AGENT_PROMPT_SECTIONS)
+
+
+def test_shell_platform_section_empty_for_posix_and_unknown():
+    """linux/空串（云端沙箱、未上报、查询失败）不加平台段：prompt 逐字节保持
+    现状，provider 前缀缓存零失效。"""
+    assert sandbox_shell_platform_section("") == ""
+    assert sandbox_shell_platform_section("linux") == ""
+    assert sandbox_shell_platform_section("winxp") == ""
+
+
+def test_shell_platform_section_win32_guides_cmdexe_syntax():
+    """win32 daemon：提示 cmd.exe 语法要点（%ERRORLEVEL%、%VAR%、无 POSIX 语法），
+    否则模型默认生成 POSIX 命令在 cmd.exe 全军覆没（生产实测根因之一）。"""
+    section = sandbox_shell_platform_section("win32")
+    assert "cmd.exe" in section
+    assert "%ERRORLEVEL%" in section
+    assert "%LAMBCHAT_WORKSPACE%" in section
+    # 反面约束：别把 POSIX 习惯带进 cmd.exe
+    assert "$?" not in section.replace("$LAMBCHAT", "")
+
+
+def test_shell_platform_section_darwin_guides_bsd_userland():
+    """darwin daemon：macOS 是 POSIX shell 但 BSD userland（无 /proc、无 free），
+    提示用 python3 做跨平台活。"""
+    section = sandbox_shell_platform_section("darwin")
+    assert "macOS" in section
+    assert "python3" in section

--- a/tests/agents/search_agent/test_sandbox_routing.py
+++ b/tests/agents/search_agent/test_sandbox_routing.py
@@ -112,3 +112,21 @@ async def test_cloud_platform_still_uses_lazy_backend_without_local_option(
     assert isinstance(backend, CompositeBackend)
     assert isinstance(sandbox, LazySandboxBackend)
     assert context.run_sandbox is sandbox
+
+
+async def test_local_option_forwards_machine_selection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """agent_options.sandbox_machine_id 透传 LocalSandboxBackend（会话级选机）。"""
+    _patch_store_and_sandbox(monkeypatch)
+
+    context = SearchAgentContext(session_id="session-1", user_id="user-1")
+    _, _, _, sandbox, _ = await search_nodes._create_backend_and_prompt(
+        state={"session_id": "session-1"},
+        context=context,
+        presenter=SimpleNamespace(),
+        assistant_id="assistant-user-1",
+        agent_options={"sandbox": "local", "sandbox_machine_id": "mac1"},
+    )
+    assert isinstance(sandbox, LocalSandboxBackend)
+    assert sandbox._machine_id == "mac1"

--- a/tests/api/routes/test_sandbox_machines_routes.py
+++ b/tests/api/routes/test_sandbox_machines_routes.py
@@ -1,0 +1,228 @@
+"""sandbox 多机路由测试：machines 列表/默认/重命名/移除、channel 机器身份、offline 定向注销。"""
+
+import pytest
+from fastapi import FastAPI, Request
+from httpx import ASGITransport, AsyncClient
+
+from src.api import deps as api_deps
+from src.api.error_handlers import register_error_handlers
+from src.api.routes import sandbox as sandbox_route
+
+
+def _fake_user():
+    from src.kernel.schemas.user import TokenPayload
+
+    return TokenPayload(sub="u1", username="t", roles=["user"], permissions=["sandbox:execute"])
+
+
+def _fake_pat_user(request: Request):
+    """PAT 通道：require_pat_only 链路要求 request.state 挂 scopes。"""
+    from src.kernel.schemas.user import TokenPayload
+
+    request.state.pat_scopes = ["sandbox:execute"]
+    return TokenPayload(sub="u1", username="t", roles=["user"], permissions=["sandbox:execute"])
+
+
+class _FakeRegistry:
+    def __init__(self):
+        self.calls: dict[str, list] = {
+            k: []
+            for k in (
+                "register",
+                "unregister",
+                "list_machines",
+                "set_default",
+                "rename",
+                "forget",
+                "get_default",
+                "resolve",
+            )
+        }
+        self.machines: list[dict] = []
+        self.default: str | None = None
+
+    async def register(
+        self,
+        user_id,
+        client_id,
+        node_id,
+        *,
+        version="",
+        platform="",
+        confirm_policy="",
+        machine_id="",
+        machine_name="",
+    ):
+        self.calls["register"].append((user_id, client_id, machine_id, machine_name))
+
+    async def unregister(self, user_id, client_id, machine_id=""):
+        self.calls["unregister"].append((user_id, client_id, machine_id))
+
+    async def list_machines(self, user_id):
+        self.calls["list_machines"].append(user_id)
+        return self.machines
+
+    async def set_default_machine(self, user_id, machine_id):
+        self.calls["set_default"].append(machine_id)
+        self.default = machine_id
+
+    async def get_default_machine(self, user_id):
+        return self.default
+
+    async def rename_machine(self, user_id, machine_id, name):
+        self.calls["rename"].append((machine_id, name))
+
+    def queue_key(self, user_id, machine_id):
+        return f"sandbox:req:{user_id}:{machine_id}"
+
+    async def forget_machine(self, user_id, machine_id):
+        self.calls["forget"].append(machine_id)
+        return True
+
+
+@pytest.fixture
+def fake_registry(monkeypatch):
+    reg = _FakeRegistry()
+    monkeypatch.setattr(sandbox_route, "_registry", lambda: reg)
+    return reg
+
+
+class _NoopRedis:
+    async def set(self, key, value, ex=None):
+        pass
+
+    async def get(self, key):
+        return None
+
+    async def delete(self, key):
+        pass
+
+
+@pytest.fixture
+async def client(monkeypatch, fake_registry):
+    monkeypatch.setattr(sandbox_route, "_redis", lambda: _NoopRedis())
+    app = FastAPI()
+    app.include_router(sandbox_route.router, prefix="/api/sandbox")
+    register_error_handlers(app)
+    app.dependency_overrides[api_deps.get_current_user_pat_or_jwt] = _fake_pat_user
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        yield c
+
+
+async def test_machines_endpoint_lists_registry(fake_registry, client):
+    fake_registry.machines = [
+        {
+            "machine_id": "mac1",
+            "name": "MacBook",
+            "platform": "darwin",
+            "version": "0.3.0",
+            "confirm_policy": "all",
+            "online": True,
+        },
+    ]
+    resp = await client.get("/api/sandbox/machines")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["machines"][0]["machine_id"] == "mac1"
+    assert fake_registry.calls["list_machines"] == ["u1"]
+
+
+async def test_machines_default_endpoint(fake_registry, client):
+    resp = await client.put("/api/sandbox/machines/mac1/default")
+    assert resp.status_code == 200
+    assert fake_registry.calls["set_default"] == ["mac1"]
+
+
+async def test_machines_rename_endpoint(fake_registry, client):
+    resp = await client.patch("/api/sandbox/machines/mac1", json={"name": "主力开发机"})
+    assert resp.status_code == 200
+    assert fake_registry.calls["rename"] == [("mac1", "主力开发机")]
+
+
+async def test_machines_rename_rejects_empty_name(fake_registry, client):
+    resp = await client.patch("/api/sandbox/machines/mac1", json={"name": "  "})
+    assert resp.status_code in (400, 422)
+
+
+async def test_machines_forget_endpoint(fake_registry, client):
+    resp = await client.delete("/api/sandbox/machines/old1")
+    assert resp.status_code == 200
+    assert fake_registry.calls["forget"] == ["old1"]
+
+
+async def test_channel_registers_machine_identity(fake_registry, monkeypatch):
+    """channel 带 machine_id/machine_name：注册与 hello 帧都携带机器身份。"""
+
+    class _NoopRedis:
+        async def lpop(self, key):
+            return None
+
+        async def set(self, key, value, ex=None):
+            pass
+
+        async def get(self, key):
+            return None
+
+        async def delete(self, key):
+            pass
+
+    captured: dict = {}
+
+    class _Reg(_FakeRegistry):
+        async def register(
+            self,
+            user_id,
+            client_id,
+            node_id,
+            *,
+            version="",
+            platform="",
+            confirm_policy="",
+            machine_id="",
+            machine_name="",
+        ):
+            captured.update(machine_id=machine_id, machine_name=machine_name)
+            await super().register(
+                user_id,
+                client_id,
+                node_id,
+                version=version,
+                platform=platform,
+                confirm_policy=confirm_policy,
+                machine_id=machine_id,
+                machine_name=machine_name,
+            )
+
+        async def unregister(self, user_id, client_id, machine_id=""):
+            await super().unregister(user_id, client_id, machine_id)
+
+    reg = _Reg()
+    monkeypatch.setattr(sandbox_route, "_registry", lambda: reg)
+    monkeypatch.setattr(sandbox_route, "_redis", lambda: _NoopRedis())
+
+    app = FastAPI()
+    app.include_router(sandbox_route.router, prefix="/api/sandbox")
+    register_error_handlers(app)
+    app.dependency_overrides[api_deps.get_current_user_pat_or_jwt] = _fake_pat_user
+    import asyncio
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        async with c.stream(
+            "GET",
+            "/api/sandbox/channel?version=0.3.0&machine_id=mac1&machine_name=MacBook",
+        ) as resp:
+            body = b""
+            async for chunk in resp.aiter_bytes():
+                body += chunk
+                if b"hello" in body:
+                    break
+        await asyncio.sleep(0.05)
+    assert captured["machine_id"] == "mac1"
+    assert captured["machine_name"] == "MacBook"
+    assert b'"machine_id": "mac1"' in body
+
+
+async def test_offline_unregisters_selected_machine(fake_registry, client):
+    resp = await client.post("/api/sandbox/offline?machine_id=mac1")
+    assert resp.status_code == 200
+    assert fake_registry.calls["unregister"] == [("u1", "", "mac1")]

--- a/tests/api/routes/test_sandbox_routes.py
+++ b/tests/api/routes/test_sandbox_routes.py
@@ -55,18 +55,36 @@ class _FakeRegistry:
         self.heartbeats: list[tuple[str, str, str, str, str, str]] = []
 
     async def register(
-        self, user_id, client_id, node_id, *, version="", platform="", confirm_policy=""
+        self,
+        user_id,
+        client_id,
+        node_id,
+        *,
+        version="",
+        platform="",
+        confirm_policy="",
+        machine_id="",
+        machine_name="",
     ):
         self.active = (client_id, node_id)
         self.registered.append((user_id, client_id, node_id, version, platform, confirm_policy))
 
     async def heartbeat(
-        self, user_id, client_id, node_id, *, version="", platform="", confirm_policy=""
+        self,
+        user_id,
+        client_id,
+        node_id,
+        *,
+        version="",
+        platform="",
+        confirm_policy="",
+        machine_id="",
+        machine_name="",
     ):
         self.beats += 1
         self.heartbeats.append((user_id, client_id, node_id, version, platform, confirm_policy))
 
-    async def unregister(self, user_id, client_id):
+    async def unregister(self, user_id, client_id, machine_id=""):
         self.unregistered.append((user_id, client_id))
 
     async def is_online(self, user_id):
@@ -379,7 +397,17 @@ async def test_channel_registers_confirm_policy_from_query(monkeypatch):
     seen: dict[str, object] = {}
 
     async def fake_frames(
-        redis, reg, user_id, client_id, *, stop, version="", platform="", confirm_policy=""
+        redis,
+        reg,
+        user_id,
+        client_id,
+        *,
+        stop,
+        version="",
+        platform="",
+        confirm_policy="",
+        machine_id="",
+        machine_name="",
     ):
         seen["confirm_policy"] = confirm_policy
         if False:  # pragma: no cover - 使其成为 async generator（空流即结束）
@@ -417,7 +445,17 @@ async def test_channel_registers_version_from_query(monkeypatch):
     seen: dict[str, object] = {}
 
     async def fake_frames(
-        redis, reg, user_id, client_id, *, stop, version="", platform="", confirm_policy=""
+        redis,
+        reg,
+        user_id,
+        client_id,
+        *,
+        stop,
+        version="",
+        platform="",
+        confirm_policy="",
+        machine_id="",
+        machine_name="",
     ):
         seen["version"] = version
         seen["platform"] = platform
@@ -452,7 +490,17 @@ async def test_channel_registers_platform_from_query(monkeypatch):
     seen: dict[str, object] = {}
 
     async def fake_frames(
-        redis, reg, user_id, client_id, *, stop, version="", platform="", confirm_policy=""
+        redis,
+        reg,
+        user_id,
+        client_id,
+        *,
+        stop,
+        version="",
+        platform="",
+        confirm_policy="",
+        machine_id="",
+        machine_name="",
     ):
         seen["platform"] = platform
         if False:  # pragma: no cover - 使其成为 async generator（空流即结束）
@@ -529,7 +577,17 @@ async def test_channel_allows_version_at_or_above_min(monkeypatch):
     seen: list[str] = []
 
     async def fake_frames(
-        redis, reg, user_id, client_id, *, stop, version="", platform="", confirm_policy=""
+        redis,
+        reg,
+        user_id,
+        client_id,
+        *,
+        stop,
+        version="",
+        platform="",
+        confirm_policy="",
+        machine_id="",
+        machine_name="",
     ):
         seen.append(version)
         if False:  # pragma: no cover - 空 async generator
@@ -549,7 +607,17 @@ async def test_channel_allows_equal_min_with_nonnumeric_suffix(monkeypatch):
     monkeypatch.setattr(sandbox_route.settings, "SANDBOX_MIN_DAEMON_VERSION", "0.2.0")
 
     async def fake_frames(
-        redis, reg, user_id, client_id, *, stop, version="", platform="", confirm_policy=""
+        redis,
+        reg,
+        user_id,
+        client_id,
+        *,
+        stop,
+        version="",
+        platform="",
+        confirm_policy="",
+        machine_id="",
+        machine_name="",
     ):
         if False:  # pragma: no cover - 空 async generator
             yield ""

--- a/tests/client/test_config.py
+++ b/tests/client/test_config.py
@@ -144,3 +144,50 @@ def test_save_omits_pat_id_when_unset(tmp_path):
     p = tmp_path / "sandbox.json"
     save_config(SandboxConfig(), p)
     assert "pat_id" not in json.loads(p.read_text())
+
+
+# ---------------------------------------------------------------------------
+# 机器身份（多机 daemon）：machine_id 持久化 + machine_name 展示名
+# ---------------------------------------------------------------------------
+
+
+def test_machine_id_generated_and_persisted_on_first_load(tmp_path):
+    """首启（无配置文件）生成 machine_id 并立即落盘——不落盘则每次进程重启
+    都换新身份，服务端注册表会堆积幽灵机器。"""
+    cfg = load_config(tmp_path / "sandbox.json")
+    assert cfg.machine_id, "首启必须生成非空 machine_id"
+    assert (tmp_path / "sandbox.json").exists(), "生成的 machine_id 必须立即持久化"
+    again = load_config(tmp_path / "sandbox.json")
+    assert again.machine_id == cfg.machine_id
+
+
+def test_machine_id_stable_across_loads(tmp_path):
+    p = tmp_path / "sandbox.json"
+    cfg = load_config(p)
+    save_config(cfg, p)
+    assert load_config(p).machine_id == cfg.machine_id
+
+
+def test_machine_name_defaults_empty_and_roundtrip(tmp_path):
+    p = tmp_path / "sandbox.json"
+    cfg = load_config(p)
+    assert cfg.machine_name == ""
+    cfg.machine_name = "工作台主机"
+    save_config(cfg, p)
+    assert load_config(p).machine_name == "工作台主机"
+
+
+def test_load_reads_machine_fields_written_externally(tmp_path):
+    """壳（Rust）或用户手写 machine 字段时 daemon 照读不覆盖。"""
+    p = tmp_path / "sandbox.json"
+    p.write_text('{"machine_id": "fixed123", "machine_name": "NAS"}', encoding="utf-8")
+    cfg = load_config(p)
+    assert cfg.machine_id == "fixed123"
+    assert cfg.machine_name == "NAS"
+
+
+def test_load_invalid_machine_id_type_rejected(tmp_path):
+    p = tmp_path / "sandbox.json"
+    p.write_text('{"machine_id": 123}', encoding="utf-8")
+    with pytest.raises(ConfigError):
+        load_config(p)

--- a/tests/client/test_selfupdate.py
+++ b/tests/client/test_selfupdate.py
@@ -82,7 +82,7 @@ def _fake_argv0(monkeypatch, tmp_path):
 
 def test_check_latest_finds_newer_platform_asset():
     resp = _api_response(
-        "v0.3.0",
+        "v0.4.0",
         [
             {"name": "lambchat-daemon-aarch64-apple-darwin"},
             {"name": _ASSET_NAME, "digest": "sha256:" + "0" * 64},
@@ -91,12 +91,12 @@ def test_check_latest_finds_newer_platform_asset():
     result = selfupdate.check_latest(
         "Yanyutin753/LambChat", current_version="0.2.0", transport=_transport(api_response=resp)
     )
-    assert result == ("0.3.0", f"https://dl.example/{_ASSET_NAME}")
+    assert result == ("0.4.0", f"https://dl.example/{_ASSET_NAME}")
 
 
 def test_check_latest_without_matching_asset_returns_none():
     """release 存在但无当前平台资产：无更新可用（None），不误报版本。"""
-    resp = _api_response("v0.3.0", [{"name": "lambchat-daemon-some-other-triple"}])
+    resp = _api_response("v0.4.0", [{"name": "lambchat-daemon-some-other-triple"}])
     assert (
         selfupdate.check_latest(
             "Yanyutin753/LambChat",
@@ -137,7 +137,7 @@ def test_check_latest_sends_github_token_when_present(monkeypatch):
     """GITHUB_TOKEN 存在时携带 Authorization 头（私有/限流场景），缺失不发。"""
     monkeypatch.setenv("GITHUB_TOKEN", "gh-token-1")
     log: list[httpx.Request] = []
-    resp = _api_response("v0.3.0", [{"name": _ASSET_NAME}])
+    resp = _api_response("v0.4.0", [{"name": _ASSET_NAME}])
     selfupdate.check_latest(
         "Yanyutin753/LambChat",
         current_version="0.2.0",
@@ -168,7 +168,7 @@ def _good_transport(
     asset_name: str = _ASSET_NAME,
 ):
     digest = "sha256:" + hashlib.sha256(content).hexdigest()
-    resp = _api_response("v0.3.0", [{"name": asset_name, "digest": digest}])
+    resp = _api_response("v0.4.0", [{"name": asset_name, "digest": digest}])
     return _transport(api_response=resp, asset_content=content, log=log)
 
 
@@ -184,7 +184,7 @@ def test_perform_update_replaces_target(tmp_path, _fake_argv0):
         "Yanyutin753/LambChat", transport=_good_transport(b"NEW-BINARY", log)
     )
 
-    assert "0.3.0" in message
+    assert "0.4.0" in message
     assert "重启" in message
     assert target.read_bytes() == b"NEW-BINARY"
     assert not (tmp_path / "lambchat-daemon.new").exists()  # 临时名无残留
@@ -210,7 +210,7 @@ def test_perform_update_already_latest_leaves_target(_fake_argv0):
 
 def test_perform_update_download_failure_raises(_fake_argv0):
     """下载失败：check 通过但资产端点 500 → SelfUpdateError，目标保持原样。"""
-    resp = _api_response("v0.3.0", [{"name": _ASSET_NAME}])
+    resp = _api_response("v0.4.0", [{"name": _ASSET_NAME}])
     with pytest.raises(selfupdate.SelfUpdateError, match="下载"):
         selfupdate.perform_update(
             "Yanyutin753/LambChat", transport=_transport(api_response=resp, asset_status=500)
@@ -221,7 +221,7 @@ def test_perform_update_download_failure_raises(_fake_argv0):
 def test_perform_update_digest_mismatch_raises(tmp_path, _fake_argv0):
     """digest 校验：资产内容与 release 声明的 sha256 不符 → 拒绝替换。"""
     bad_digest = "sha256:" + hashlib.sha256(b"DIFFERENT").hexdigest()
-    resp = _api_response("v0.3.0", [{"name": _ASSET_NAME, "digest": bad_digest}])
+    resp = _api_response("v0.4.0", [{"name": _ASSET_NAME, "digest": bad_digest}])
     with pytest.raises(selfupdate.SelfUpdateError, match="校验"):
         selfupdate.perform_update(
             "Yanyutin753/LambChat", transport=_transport(api_response=resp, asset_content=b"EVIL")
@@ -232,7 +232,7 @@ def test_perform_update_digest_mismatch_raises(tmp_path, _fake_argv0):
 
 def test_perform_update_without_digest_skips_verification(_fake_argv0):
     """资产未声明 digest：跳过校验并注明（不误伤无摘要的早期 release）。"""
-    resp = _api_response("v0.3.0", [{"name": _ASSET_NAME}])  # 无 digest 字段
+    resp = _api_response("v0.4.0", [{"name": _ASSET_NAME}])  # 无 digest 字段
 
     message = selfupdate.perform_update(
         "Yanyutin753/LambChat", transport=_transport(api_response=resp, asset_content=b"NEW")

--- a/tests/client/test_transport.py
+++ b/tests/client/test_transport.py
@@ -555,3 +555,36 @@ def test_channel_client_builds_heartbeat_aware_read_timeout():
     client = ChannelClient(SERVER, PAT)
     assert client._client.timeout.connect == 10.0
     assert client._client.timeout.read == 45.0
+
+
+# ---------------------------------------------------------------------------
+# 多机 daemon：channel URL 携带机器身份
+# ---------------------------------------------------------------------------
+
+
+async def test_channel_url_carries_machine_identity():
+    log: list[httpx.Request] = []
+    client = ChannelClient(
+        SERVER,
+        PAT,
+        machine_id="m123abc",
+        machine_name="My Linux Box",
+        client=_client(_sse_transport(log, GOOD_STREAM.encode("utf-8"))),
+    )
+    hello, _ = await client.connect()
+    assert hello["sandbox_id"]
+    req = log[0]
+    assert "machine_id=m123abc" in str(req.url)
+    assert "machine_name=My%20Linux%20Box" in str(req.url)
+
+
+async def test_channel_url_omits_machine_params_when_unset():
+    log: list[httpx.Request] = []
+    client = ChannelClient(
+        SERVER,
+        PAT,
+        client=_client(_sse_transport(log, GOOD_STREAM.encode("utf-8"))),
+    )
+    await client.connect()
+    assert "machine_id=" not in str(log[0].url)
+    assert "machine_name=" not in str(log[0].url)

--- a/tests/infra/agent/middleware/test_sandbox_confirm.py
+++ b/tests/infra/agent/middleware/test_sandbox_confirm.py
@@ -39,7 +39,7 @@ class _Recorder:
 def policy(monkeypatch):
     holder = {"value": "all"}
 
-    async def fake_lookup(user_id):
+    async def fake_lookup(user_id, machine_id=None):
         return holder["value"]
 
     monkeypatch.setattr(mw_pkg.sandbox_confirm, "_lookup_confirm_policy", fake_lookup)
@@ -283,3 +283,24 @@ async def test_programming_error_still_propagates(policy, interrupt, supported):
     mw = SandboxConfirmMiddleware(user_id="u1")
     with _pytest.raises(TypeError):
         await mw.awrap_tool_call(_request("execute", {"command": "ls"}), buggy_handler)
+
+
+# ---------------------------------------------------------------------------
+# 多机：确认门策略按目标机解析
+# ---------------------------------------------------------------------------
+
+
+async def test_registry_policy_resolver_passes_machine_id(monkeypatch):
+    from src.infra.agent.middleware import sandbox_confirm
+
+    calls: list[tuple[str, str | None]] = []
+
+    class _FakeRegistry:
+        async def get_confirm_policy(self, user_id, machine_id=None):
+            calls.append((user_id, machine_id))
+            return "none"
+
+    monkeypatch.setattr(sandbox_confirm, "SandboxClientRegistry", _FakeRegistry)
+    resolver = sandbox_confirm._RegistryPolicyResolver("u1", machine_id="mac1")
+    assert await resolver() == "none"
+    assert calls == [("u1", "mac1")]

--- a/tests/infra/agent/middleware/test_sandbox_confirm_integration.py
+++ b/tests/infra/agent/middleware/test_sandbox_confirm_integration.py
@@ -87,7 +87,7 @@ class ApprovalRecorder:
 def policy_all(monkeypatch: pytest.MonkeyPatch) -> None:
     from src.infra.agent.middleware import sandbox_confirm as mw
 
-    async def fake_lookup(user_id):
+    async def fake_lookup(user_id, machine_id=None):
         return "all"
 
     monkeypatch.setattr(mw, "_lookup_confirm_policy", fake_lookup)

--- a/tests/infra/agent/test_tool_events_error_format.py
+++ b/tests/infra/agent/test_tool_events_error_format.py
@@ -1,0 +1,34 @@
+"""工具错误事件格式化：AppError 必须走 display_message 插值。
+
+生产实测：本地沙箱命令失败上抛 AppError 后，模型与前端看到的都是
+``Local sandbox execution failed: {{detail}}`` 原文——``str(AppError)`` 返回
+未插值的默认模板，插值版在 ``AppError.display_message``。
+"""
+
+from src.infra.agent.events.tool_events import ToolEventMixin
+from src.kernel.errors import AppError, ErrorCode
+
+
+def _format(error) -> str:
+    return ToolEventMixin()._format_tool_error("execute", error)
+
+
+def test_app_error_interpolates_display_message():
+    err = AppError(ErrorCode.SANDBOX_EXEC_FAILED, args={"detail": "illegal cwd"})
+    text = _format(err)
+    assert "{{detail}}" not in text
+    assert "illegal cwd" in text
+
+
+def test_app_error_falls_back_to_error_name_when_args_missing():
+    """args 未提供占位值时保留 ``{{param}}`` 原文（display_message 语义），
+    但仍不应把异常类名拼错——格式保持 [AppError] 前缀链路可解析。"""
+    err = AppError(ErrorCode.SANDBOX_EXEC_FAILED)
+    text = _format(err)
+    assert "[AppError]" in text
+    assert "Local sandbox execution failed" in text
+
+
+def test_plain_exception_format_unchanged():
+    text = _format(RuntimeError("boom"))
+    assert text == "[MCP Tool Error] execute failed: [RuntimeError] boom"

--- a/tests/infra/backend/test_local_backend.py
+++ b/tests/infra/backend/test_local_backend.py
@@ -29,7 +29,7 @@ def _default_daemon_platform(monkeypatch):
     """
     state = {"platform": ""}
 
-    async def fake_lookup(user_id):
+    async def fake_lookup(user_id, machine_id=None):
         return state["platform"]
 
     monkeypatch.setattr(local_module, "_lookup_daemon_platform", fake_lookup)
@@ -46,7 +46,7 @@ def _real_exec_dispatch(cwd: Path):
     返回 dict 带 stdout/stderr/exit_code 独立字段——与 daemon executor 契约一致。
     """
 
-    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         proc = subprocess.run(payload["command"], shell=True, cwd=cwd, capture_output=True)
         return {
             "status": "ok",
@@ -59,7 +59,7 @@ def _real_exec_dispatch(cwd: Path):
 
 
 async def test_aexecute_maps_result(monkeypatch):
-    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         assert (user_id, op) == ("u1", "exec")
         assert payload["command"] == "echo hi"
         return _ok_response(stdout="hi", exit_code=0)
@@ -73,7 +73,7 @@ async def test_aexecute_maps_result(monkeypatch):
 
 
 async def test_aexecute_appends_stderr_to_output(monkeypatch):
-    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         if payload["command"] == "both":
             return _ok_response(stdout="out", stderr="err")
         return _ok_response(stderr="only-err")
@@ -87,7 +87,7 @@ async def test_aexecute_appends_stderr_to_output(monkeypatch):
 async def test_aexecute_passes_cwd_and_timeout(monkeypatch):
     captured = {}
 
-    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         captured.update(op=op, payload=payload, timeout=timeout)
         return _ok_response()
 
@@ -100,7 +100,7 @@ async def test_aexecute_passes_cwd_and_timeout(monkeypatch):
 
 
 async def test_offline_propagates(monkeypatch):
-    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         raise AppError(ErrorCode.DAEMON_OFFLINE)
 
     monkeypatch.setattr(local_module, "dispatch_local_call", fake_dispatch)
@@ -116,7 +116,7 @@ def test_id_contains_session():
 
 
 def test_execute_bridges_sync(monkeypatch):
-    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         return _ok_response(stdout="sync-hi")
 
     monkeypatch.setattr(local_module, "dispatch_local_call", fake_dispatch)
@@ -129,7 +129,7 @@ def test_execute_bridges_sync(monkeypatch):
 def test_download_files_decodes_base64(monkeypatch):
     content = "file-body"
 
-    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         b64 = base64.b64encode(content.encode()).decode()
         return _ok_response(stdout=b64)
 
@@ -150,7 +150,7 @@ def test_download_files_stderr_does_not_pollute_base64(monkeypatch):
     content = b"file-body"
     noisy = "grep: warning: something noisy on stderr"
 
-    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         assert payload["cwd"] == "/workspace/s1"  # 与 aexecute 同 cwd 契约
         b64 = base64.b64encode(content).decode()
         return _ok_response(stdout=b64, stderr=noisy)
@@ -167,7 +167,7 @@ async def test_adownload_files_stderr_does_not_pollute_base64(monkeypatch):
     content = b"async-body-1"
     noisy = "[PID 123] some daemon chatter"
 
-    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         b64 = base64.b64encode(content).decode()
         return _ok_response(stdout=b64, stderr=noisy)
 
@@ -182,7 +182,7 @@ def test_download_files_maps_missing_to_error(monkeypatch):
     # 真实 daemon 的 ENOENT 输出（python3 open() 抛出后经 stderr 回传）
     enoent = "[Errno 2] No such file or directory: '/workspace/s1/missing.txt'"
 
-    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         return _ok_response(stdout=enoent, exit_code=1)
 
     monkeypatch.setattr(local_module, "dispatch_local_call", fake_dispatch)
@@ -196,7 +196,7 @@ def test_download_files_maps_missing_to_error(monkeypatch):
 def test_download_files_maps_is_directory_error(monkeypatch):
     eisdir = "[Errno 21] Is a directory: '/workspace/s1'"
 
-    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         return _ok_response(stdout=eisdir, exit_code=1)
 
     monkeypatch.setattr(local_module, "dispatch_local_call", fake_dispatch)
@@ -215,7 +215,7 @@ def test_classify_file_error_real_daemon_strings():
 
 
 async def test_aexecute_missing_exit_code_is_undetermined(monkeypatch):
-    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         return {"status": "ok", "stdout": "partial"}
 
     monkeypatch.setattr(local_module, "dispatch_local_call", fake_dispatch)
@@ -229,7 +229,7 @@ async def test_aexecute_missing_exit_code_is_undetermined(monkeypatch):
 def test_upload_files_writes_via_exec(monkeypatch):
     captured = {}
 
-    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         captured.update(op=op, payload=payload)
         return _ok_response()
 
@@ -246,7 +246,7 @@ def test_upload_files_writes_via_exec(monkeypatch):
 
 
 async def test_upload_files_offline_propagates(monkeypatch):
-    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         raise AppError(ErrorCode.SANDBOX_TIMEOUT)
 
     monkeypatch.setattr(local_module, "dispatch_local_call", fake_dispatch)
@@ -296,7 +296,7 @@ async def test_alias_execute_rewrites_command_alias_with_boundary(monkeypatch):
     """shell 命令串里的 /workspace/s1 → .（cd /workspace/s1 && … 可用），且不误伤 s12。"""
     captured: list[str] = []
 
-    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         captured.append(payload["command"])
         return _ok_response()
 
@@ -314,7 +314,7 @@ async def test_alias_aread_passthrough_for_outside_absolute_path(monkeypatch, tm
     """别名之外的绝对路径（如 /etc/hostname）不改写——冒烟用例 4 的既有语义。"""
     captured: list[str] = []
 
-    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         captured.append(payload["cwd"])
         return _ok_response(stdout="{}")
 
@@ -339,7 +339,7 @@ async def test_aupload_files_large_content_chunked_end_to_end(monkeypatch, tmp_p
     commands: list[str] = []
     real = _real_exec_dispatch(tmp_path)
 
-    async def tracking_dispatch(user_id, op, payload, *, timeout=None):
+    async def tracking_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         commands.append(payload["command"])
         return await real(user_id, op, payload, timeout=timeout)
 
@@ -402,7 +402,7 @@ async def test_adownload_decode_failure_carries_original_output(monkeypatch):
     """b64decode 异常不得标成 file_not_found：错误带原始 stdout 片段供排查。"""
     garbage = "not!!valid!!b64!!"
 
-    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         return _ok_response(stdout=garbage)
 
     monkeypatch.setattr(local_module, "dispatch_local_call", fake_dispatch)
@@ -519,7 +519,7 @@ def test_upload_files_windows_via_registry_platform(monkeypatch, _default_daemon
     _default_daemon_platform["platform"] = "win32"
     commands: list[str] = []
 
-    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         commands.append(payload["command"])
         return _ok_response()
 
@@ -538,7 +538,7 @@ async def test_aupload_files_windows_chunked_commands(monkeypatch, _default_daem
     _default_daemon_platform["platform"] = "win32"
     commands: list[str] = []
 
-    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         commands.append(payload["command"])
         return _ok_response()
 
@@ -558,7 +558,7 @@ async def test_adownload_files_windows_command_shape(monkeypatch, _default_daemo
     _default_daemon_platform["platform"] = "win32"
     captured: dict[str, str] = {}
 
-    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         captured["command"] = payload["command"]
         return _ok_response(stdout=base64.b64encode(b"body").decode())
 
@@ -577,7 +577,7 @@ def test_platform_hint_overrides_registry(monkeypatch):
     async def failing_lookup(user_id):
         raise AssertionError("hint 在场时不应查注册表")
 
-    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         commands.append(payload["command"])
         return _ok_response()
 
@@ -603,7 +603,7 @@ def test_upload_files_default_platform_keeps_posix_commands(monkeypatch):
     """无平台信息（旧格式 value/查询失败）→ 命令串与现状逐字节一致。"""
     commands: list[str] = []
 
-    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         commands.append(payload["command"])
         return _ok_response()
 
@@ -634,7 +634,7 @@ def test_upload_windows_percent_path_maps_to_error(monkeypatch):
     不崩链路也不下发会被 cmd 改写的命令。"""
     commands: list[str] = []
 
-    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         commands.append(payload["command"])
         return _ok_response()
 
@@ -710,7 +710,7 @@ def _fs_dispatch(result: dict):
 
     calls: list[tuple[str, dict]] = []
 
-    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         assert (user_id, op) == ("u1", op)
         calls.append((op, dict(payload)))
         return {"status": "ok", "result": result}
@@ -776,7 +776,7 @@ async def test_posix_read_still_exec_pos_commands(monkeypatch, _default_daemon_p
     """posix（无平台信息）走 super() 的 exec 命令路径——现状零变化。"""
     captured: list[str] = []
 
-    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         captured.append(op)
         captured.append(payload["command"])
         return _ok_response(stdout='{"encoding": "utf-8", "content": "posix"}')
@@ -1001,7 +1001,7 @@ async def test_platform_hint_win32_triggers_fs_without_registry(monkeypatch):
 async def test_platform_hint_posix_keeps_exec_commands(monkeypatch):
     dispatch = _fs_dispatch({})
 
-    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         dispatch.calls.append((op, dict(payload)))
         return _ok_response(stdout="{}")
 
@@ -1033,7 +1033,7 @@ async def test_win32_fs_result_malformed_degrades_to_error(monkeypatch, _default
 async def test_aexecute_payload_carries_env_vars(monkeypatch):
     payloads = []
 
-    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         payloads.append(payload)
         return _ok_response()
 
@@ -1048,7 +1048,7 @@ async def test_aexecute_payload_carries_env_vars(monkeypatch):
 async def test_aexecute_payload_omits_env_when_empty(monkeypatch):
     payloads = []
 
-    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         payloads.append(payload)
         return _ok_response()
 

--- a/tests/infra/backend/test_local_backend.py
+++ b/tests/infra/backend/test_local_backend.py
@@ -219,7 +219,7 @@ async def test_aexecute_returns_failed_command_output(monkeypatch):
     不能在中继层被劫持成 AppError（Windows 实测：模型看不到 'free' is not
     recognized，无从换成正确命令）。"""
 
-    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         return {
             "status": "error",
             "stdout": "",
@@ -239,7 +239,7 @@ async def test_aexecute_appends_executor_error_marker(monkeypatch):
     """executor 超时结果（error="timeout"，exit_code=None）：error 字段并入
     output 作显式标记，模型能区分「命令超时」与「命令失败」。"""
 
-    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         return {
             "status": "error",
             "stdout": "partial",

--- a/tests/infra/backend/test_local_backend.py
+++ b/tests/infra/backend/test_local_backend.py
@@ -214,6 +214,48 @@ def test_classify_file_error_real_daemon_strings():
     assert classify("mkdir: cannot create directory '/x': Permission denied") == "permission_denied"
 
 
+async def test_aexecute_returns_failed_command_output(monkeypatch):
+    """非零退出码的命令结果必须回到模型（output 含 stderr、exit_code 透传）——
+    不能在中继层被劫持成 AppError（Windows 实测：模型看不到 'free' is not
+    recognized，无从换成正确命令）。"""
+
+    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+        return {
+            "status": "error",
+            "stdout": "",
+            "stderr": "'free' is not recognized as an internal or external command",
+            "exit_code": 1,
+            "error": None,
+        }
+
+    monkeypatch.setattr(local_module, "dispatch_local_call", fake_dispatch)
+    backend = LocalSandboxBackend(user_id="u1", session_id="s1")
+    resp = await backend.aexecute("free -h")
+    assert resp.exit_code == 1
+    assert "not recognized" in resp.output
+
+
+async def test_aexecute_appends_executor_error_marker(monkeypatch):
+    """executor 超时结果（error="timeout"，exit_code=None）：error 字段并入
+    output 作显式标记，模型能区分「命令超时」与「命令失败」。"""
+
+    async def fake_dispatch(user_id, op, payload, *, timeout=None):
+        return {
+            "status": "error",
+            "stdout": "partial",
+            "stderr": "",
+            "exit_code": None,
+            "error": "timeout",
+        }
+
+    monkeypatch.setattr(local_module, "dispatch_local_call", fake_dispatch)
+    backend = LocalSandboxBackend(user_id="u1", session_id="s1")
+    resp = await backend.aexecute("sleep 999")
+    assert resp.exit_code is None
+    assert "partial" in resp.output
+    assert "timeout" in resp.output
+
+
 async def test_aexecute_missing_exit_code_is_undetermined(monkeypatch):
     async def fake_dispatch(user_id, op, payload, *, timeout=None):
         return {"status": "ok", "stdout": "partial"}

--- a/tests/infra/sandbox/relay/test_dispatch.py
+++ b/tests/infra/sandbox/relay/test_dispatch.py
@@ -40,6 +40,13 @@ class _FakeRegistry:
     async def is_online(self, user_id: str) -> bool:
         return self.online
 
+    async def resolve_target(self, user_id: str, machine_id: str | None = None):
+        return "legacy" if self.online else None
+
+    def queue_key(self, user_id: str, machine_id: str) -> str:
+        # legacy 路由：旧断言的队列键（无机器后缀）
+        return f"sandbox:req:{user_id}"
+
 
 @pytest.fixture
 def fake(monkeypatch):
@@ -112,3 +119,55 @@ async def test_exec_timeout_raises_after_ack(fake, monkeypatch):
     await task
     assert exc.value.error_code == ErrorCode.SANDBOX_TIMEOUT
     assert exc.value.args_data == {"seconds": 0}  # int(0.05)，区别于 ack 超时路径
+
+
+# ---------------------------------------------------------------------------
+# 多机：machine_id 路由与离线语义
+# ---------------------------------------------------------------------------
+
+
+class _MachinesFakeRegistry:
+    """resolve_target/queue_key 可控行为：online_machine 控制 resolve 结果。"""
+
+    def __init__(self, resolved: str | None):
+        self.resolved = resolved
+
+    async def is_online(self, user_id: str) -> bool:
+        return self.resolved is not None
+
+    async def resolve_target(self, user_id: str, machine_id: str | None = None):
+        return self.resolved
+
+    def queue_key(self, user_id: str, machine_id: str) -> str:
+        return f"sandbox:req:{user_id}:{machine_id}"
+
+
+async def test_dispatch_routes_to_selected_machine_queue(monkeypatch):
+    redis = _FakeRedis()
+    monkeypatch.setattr(dispatch_module, "_redis", lambda: redis)
+    monkeypatch.setattr(dispatch_module, "_registry", lambda: _MachinesFakeRegistry("mac1"))
+    monkeypatch.setattr(dispatch_module, "_POLL_INTERVAL", 0.01)
+
+    async def fake_get(key):
+        return json.dumps({"user_id": "u1", "stage": "done", "status": "ok"})
+
+    monkeypatch.setattr(dispatch_module.settings, "SANDBOX_LOCAL_ACK_TIMEOUT", 1)
+    import contextlib
+
+    with contextlib.suppress(Exception):
+        # 只验证入队键：done 立即返回，不等待超时
+        async def fast_get(key):
+            return json.dumps({"user_id": "u1", "stage": "done", "status": "ok"})
+
+        redis.get = fast_get  # type: ignore[method-assign]
+        await dispatch_local_call("u1", "exec", {"command": "ls"}, machine_id="mac1")
+    assert list(redis.lists) == ["sandbox:req:u1:mac1"]
+
+
+async def test_dispatch_selected_machine_offline_raises_machine_error(monkeypatch):
+    redis = _FakeRedis()
+    monkeypatch.setattr(dispatch_module, "_redis", lambda: redis)
+    monkeypatch.setattr(dispatch_module, "_registry", lambda: _MachinesFakeRegistry(None))
+    with pytest.raises(AppError) as exc_info:
+        await dispatch_local_call("u1", "exec", {"command": "ls"}, machine_id="mac1")
+    assert exc_info.value.error_code == ErrorCode.SANDBOX_MACHINE_OFFLINE

--- a/tests/infra/sandbox/relay/test_dispatch.py
+++ b/tests/infra/sandbox/relay/test_dispatch.py
@@ -84,6 +84,75 @@ async def test_offline_fails_fast(fake, monkeypatch):
     assert not fake.lists  # rpush 之前快速失败，不产生孤儿请求
 
 
+async def test_exec_done_error_status_returns_command_outcome(fake, monkeypatch):
+    """exec 的非零退出码是命令结局而非中继故障：done 载荷带 executor 结果字段
+    （stdout/stderr/exit_code）时原样回传，由 aexecute 构造 ExecuteResponse 让
+    模型看到真实输出（Windows cmd.exe 上命令失败是常态，不能全部变成不透明
+    AppError——生产实测模型连续 6 条命令只见 "execution failed"，无从纠错）。"""
+    monkeypatch.setattr(dispatch_module, "_POLL_INTERVAL", 0.01)
+    monkeypatch.setattr(dispatch_module.settings, "SANDBOX_LOCAL_ACK_TIMEOUT", 2)
+    monkeypatch.setattr(dispatch_module.settings, "SANDBOX_LOCAL_EXEC_TIMEOUT", 5)
+
+    async def daemon():
+        await asyncio.sleep(0.02)
+        req = json.loads(await fake.lpop("sandbox:req:u1"))
+        await fake.set(
+            f"sandbox:resp:{req['call_id']}",
+            json.dumps(
+                {
+                    "user_id": "u1",
+                    "stage": "ack",
+                }
+            ),
+        )
+        await asyncio.sleep(0.02)
+        await fake.set(
+            f"sandbox:resp:{req['call_id']}",
+            json.dumps(
+                {
+                    "user_id": "u1",
+                    "stage": "done",
+                    "status": "error",
+                    "stdout": "",
+                    "stderr": "'free' is not recognized as an internal or external command",
+                    "exit_code": 1,
+                    "error": None,
+                }
+            ),
+        )
+
+    task = asyncio.create_task(daemon())
+    result = await dispatch_local_call("u1", "exec", {"command": "free -h"})
+    await task
+    assert result["exit_code"] == 1
+    assert "not recognized" in result["stderr"]
+
+
+async def test_fs_op_done_error_status_still_raises(fake, monkeypatch):
+    """fs_* op 的 status=error 是 daemon 内部异常（ExecutorError 等）：仍按
+    SANDBOX_EXEC_FAILED 上抛；detail 取 error 字段（None 不落成字面 "None"）。"""
+    monkeypatch.setattr(dispatch_module, "_POLL_INTERVAL", 0.01)
+    monkeypatch.setattr(dispatch_module.settings, "SANDBOX_LOCAL_ACK_TIMEOUT", 2)
+    monkeypatch.setattr(dispatch_module.settings, "SANDBOX_LOCAL_EXEC_TIMEOUT", 5)
+
+    async def daemon():
+        await asyncio.sleep(0.02)
+        req = json.loads(await fake.lpop("sandbox:req:u1"))
+        await fake.set(
+            f"sandbox:resp:{req['call_id']}",
+            json.dumps(
+                {"user_id": "u1", "stage": "done", "status": "error", "error": "illegal cwd"}
+            ),
+        )
+
+    task = asyncio.create_task(daemon())
+    with pytest.raises(AppError) as exc:
+        await dispatch_local_call("u1", "fs_read", {"path": "a.txt"})
+    await task
+    assert exc.value.error_code == ErrorCode.SANDBOX_EXEC_FAILED
+    assert exc.value.args_data == {"detail": "illegal cwd"}
+
+
 async def test_ack_timeout_raises(fake, monkeypatch):
     monkeypatch.setattr(dispatch_module, "_POLL_INTERVAL", 0.01)
     monkeypatch.setattr(dispatch_module.settings, "SANDBOX_LOCAL_ACK_TIMEOUT", 0.05)

--- a/tests/infra/sandbox/relay/test_registry.py
+++ b/tests/infra/sandbox/relay/test_registry.py
@@ -33,6 +33,22 @@ class _FakeRedis:
     async def hgetall(self, key: str) -> dict[str, str]:
         return dict(self.store.get(key, {}))
 
+    # 多机路径占位（legacy 测试不触及；注册表新分支按需调用）
+    async def smembers(self, key: str) -> set:
+        return set()
+
+    async def get(self, key: str):
+        return None
+
+    async def set(self, key: str, value: str, ex: int | None = None) -> None:
+        pass
+
+    async def sadd(self, key: str, member: str) -> None:
+        pass
+
+    async def srem(self, key: str, member: str) -> None:
+        pass
+
 
 @pytest.fixture
 def registry(monkeypatch) -> SandboxClientRegistry:

--- a/tests/infra/sandbox/relay/test_registry_machines.py
+++ b/tests/infra/sandbox/relay/test_registry_machines.py
@@ -1,0 +1,218 @@
+"""注册表多机化测试：每用户多台 daemon 机器共存、legacy 单机兼容、目标解析。
+
+Redis 布局（多机）::
+
+    sandbox:machine:{uid}:{mid}   string  node_id|version|platform|policy|name   TTL 35s
+    sandbox:machset:{uid}         set     在册 machine_id 集合
+    sandbox:machname:{uid}        hash    mid -> 自定义展示名（rename 覆盖层，重连保留）
+    sandbox:machdefault:{uid}     string  默认机 mid
+
+legacy（未上报 machine_id 的 0.2.0 daemon）沿用旧 ``sandbox:clients:{uid}``
+hash + ``sandbox:req:{uid}`` 队列，语义零变化；在机器列表中以 ``legacy``
+伪机器出现，选择它时路由回旧队列。
+"""
+
+import time
+
+import pytest
+
+from src.infra.sandbox.relay.registry import (
+    LEGACY_MACHINE_ID,
+    SandboxClientRegistry,
+)
+
+
+class _FakeRedis:
+    """覆盖 string/set/hash 三类操作的内存 Redis。TTL 由 expires_at 模拟。"""
+
+    def __init__(self):
+        self.strings: dict[str, str] = {}
+        self.sets: "dict[str, set[str]]" = {}
+        self.hashes: dict[str, dict[str, str]] = {}
+        self.expires_at: dict[str, float] = {}
+
+    def _alive(self, key: str) -> bool:
+        exp = self.expires_at.get(key)
+        return exp is None or exp > time.monotonic()
+
+    # string
+    async def get(self, key: str):
+        if key in self.strings and self._alive(key):
+            return self.strings[key]
+        return None
+
+    async def set(self, key: str, value: str, ex: int | None = None) -> None:
+        self.strings[key] = value
+        if ex is not None:
+            self.expires_at[key] = time.monotonic() + ex
+
+    # set
+    async def sadd(self, key: str, member: str) -> None:
+        self.sets.setdefault(key, set()).add(member)
+
+    async def srem(self, key: str, member: str) -> None:
+        self.sets.get(key, set()).discard(member)
+
+    async def smembers(self, key: str) -> "set[str]":
+        return set(self.sets.get(key, set()))
+
+    # hash
+    async def hset(self, key: str, field: str, value: str) -> None:
+        self.hashes.setdefault(key, {})[field] = value
+
+    async def hdel(self, key: str, field: str) -> None:
+        self.hashes.get(key, {}).pop(field, None)
+
+    async def hgetall(self, key: str) -> dict[str, str]:
+        if not self._alive(key):
+            return {}
+        return dict(self.hashes.get(key, {}))
+
+    # 通用
+    async def delete(self, key: str) -> None:
+        self.strings.pop(key, None)
+        self.sets.pop(key, None)
+        self.hashes.pop(key, None)
+        self.expires_at.pop(key, None)
+
+    async def expire(self, key: str, seconds: int) -> None:
+        self.expires_at[key] = time.monotonic() + seconds
+
+    async def exists(self, key: str) -> int:
+        return (
+            1
+            if self._alive(key) and (key in self.strings or key in self.sets or key in self.hashes)
+            else 0
+        )
+
+
+@pytest.fixture
+def registry(monkeypatch) -> SandboxClientRegistry:
+    fake = _FakeRedis()
+    reg = SandboxClientRegistry()
+    monkeypatch.setattr(reg, "_redis", lambda: fake)
+    reg.fake = fake  # type: ignore[attr-defined]
+    return reg
+
+
+async def test_machines_coexist_without_kicking_each_other(registry):
+    """多机并存：A 机注册后 B 机注册，A 仍在线（不再后连踢前连）。"""
+    await registry.register(
+        "u1", "c1", "n1", version="0.3.0", machine_id="mac1", machine_name="MacBook"
+    )
+    await registry.register(
+        "u1", "c2", "n2", version="0.3.0", machine_id="srv1", machine_name="Server"
+    )
+    machines = {m["machine_id"]: m for m in await registry.list_machines("u1")}
+    assert set(machines) == {"mac1", "srv1"}
+    assert machines["mac1"]["name"] == "MacBook"
+    assert machines["srv1"]["online"] is True
+
+
+async def test_same_machine_reconnect_replaces_only_own_entry(registry):
+    await registry.register(
+        "u1", "c1", "n1", version="0.3.0", machine_id="mac1", machine_name="MacBook"
+    )
+    await registry.register(
+        "u1", "c2", "n2", version="0.3.0", machine_id="srv1", machine_name="Server"
+    )
+    # 同机重连（新 client 连接）
+    await registry.register(
+        "u1", "c3", "n1b", version="0.3.1", machine_id="mac1", machine_name="MacBook"
+    )
+    machines = {m["machine_id"]: m for m in await registry.list_machines("u1")}
+    assert machines["mac1"]["version"] == "0.3.1"
+    assert machines["srv1"]["online"] is True  # 其他机不受影响
+
+
+async def test_list_machines_drops_expired_entries(registry):
+    await registry.register("u1", "c1", "n1", version="0.3.0", machine_id="mac1")
+    # 模拟 TTL 过期
+    for k in list(registry.fake.expires_at):
+        registry.fake.expires_at[k] = time.monotonic() - 1
+    assert await registry.list_machines("u1") == []
+
+
+async def test_rename_overrides_reported_name_and_survives_reconnect(registry):
+    await registry.register(
+        "u1", "c1", "n1", version="0.3.0", machine_id="mac1", machine_name="MacBook"
+    )
+    await registry.rename_machine("u1", "mac1", "主力机")
+    machines = {m["machine_id"]: m for m in await registry.list_machines("u1")}
+    assert machines["mac1"]["name"] == "主力机"
+    # 重连上报旧名，rename 覆盖层仍生效
+    await registry.register(
+        "u1", "c2", "n1", version="0.3.0", machine_id="mac1", machine_name="MacBook"
+    )
+    machines = {m["machine_id"]: m for m in await registry.list_machines("u1")}
+    assert machines["mac1"]["name"] == "主力机"
+
+
+async def test_legacy_daemon_appears_as_legacy_machine(registry):
+    """旧 daemon（无 machine_id）走 legacy 路径，仍出现在机器列表。"""
+    await registry.register("u1", "c1", "n1", version="0.2.0")
+    machines = {m["machine_id"]: m for m in await registry.list_machines("u1")}
+    assert LEGACY_MACHINE_ID in machines
+    assert machines[LEGACY_MACHINE_ID]["online"] is True
+
+
+async def test_forget_machine_clears_default_and_entry(registry):
+    await registry.register("u1", "c1", "n1", version="0.3.0", machine_id="old1")
+    await registry.set_default_machine("u1", "old1")
+    # 机器 TTL 过期离线后才可移除
+    for k in list(registry.fake.expires_at):
+        registry.fake.expires_at[k] = time.monotonic() - 1
+    assert await registry.forget_machine("u1", "old1") is True
+    assert await registry.list_machines("u1") == []
+    assert await registry.get_default_machine("u1") is None
+
+
+async def test_forget_machine_rejects_online_machine(registry):
+    await registry.register("u1", "c1", "n1", version="0.3.0", machine_id="mac1")
+    assert await registry.forget_machine("u1", "mac1") is False
+
+
+async def test_resolve_target_explicit_default_single(registry):
+    assert await registry.resolve_target("u1") is None  # 无任何机器
+
+    await registry.register("u1", "c1", "n1", version="0.3.0", machine_id="mac1")
+    # 唯一在线机：缺省解析到它
+    assert await registry.resolve_target("u1") == "mac1"
+
+    await registry.register("u1", "c2", "n2", version="0.3.0", machine_id="srv1")
+    # 多机无默认：显式指定仍可用
+    assert await registry.resolve_target("u1", "srv1") == "srv1"
+    # 设默认后缺省解析到默认
+    await registry.set_default_machine("u1", "mac1")
+    assert await registry.resolve_target("u1") == "mac1"
+    # 默认机离线：退回唯一在线机
+    for k in list(registry.fake.expires_at):
+        registry.fake.expires_at[k] = time.monotonic() - 1
+    await registry.register("u1", "c3", "n2", version="0.3.0", machine_id="srv1")
+    assert await registry.resolve_target("u1") == "srv1"
+
+
+async def test_resolve_target_legacy_compatible(registry):
+    """legacy 在线可被解析，且队列键保持旧格式（不带机器后缀）。"""
+    await registry.register("u1", "c1", "n1", version="0.2.0")  # 无 machine_id → legacy
+    assert await registry.resolve_target("u1") == LEGACY_MACHINE_ID
+    assert registry.queue_key("u1", LEGACY_MACHINE_ID) == "sandbox:req:u1"
+    assert registry.queue_key("u1", "mac1") == "sandbox:req:u1:mac1"
+
+
+async def test_get_confirm_policy_per_machine(registry):
+    await registry.register(
+        "u1",
+        "c1",
+        "n1",
+        version="0.3.0",
+        platform="linux",
+        confirm_policy="none",
+        machine_id="mac1",
+    )
+    await registry.register(
+        "u1", "c2", "n2", version="0.3.0", platform="win32", confirm_policy="all", machine_id="srv1"
+    )
+    assert await registry.get_confirm_policy("u1", "srv1") == "all"
+    assert await registry.get_confirm_policy("u1", "mac1") == "none"
+    assert await registry.get_platform("u1", "srv1") == "win32"


### PR DESCRIPTION
## 内容

- feat(sandbox) 多机 daemon 全栈：机器身份/多机注册表（legacy 兼容）/会话级选机/确认门同机/前端选择器与机器管理卡（#417）
- fix(sandbox) agentOptions 可空防护（mypy/tsc）

## 验证

- develop CI 全绿（#417 双架构镜像 + 前后端测试）
- staging（develop-20260906-030526）：服务健康，/api/sandbox/machines 路由已挂载并正确要求鉴权