### PR TITLE
ci(release): 发布 job 的 checkout 挪到 artifact 下载之前——修复 latest.json 生成 ENOENT

### DIFF
--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -458,6 +458,13 @@ jobs:
     if: always()
 
     steps:
+      # checkout 必须先于 artifact 下载：actions/checkout@v4.2+ 在 init 前
+      # "Deleting the contents of <workspace>"——放下载之后会把已下载的
+      # release-assets/ 整目录清掉（v0.2.0-rc1 首发实测：latest.json 步骤
+      # ENOENT + 全平台 sig glob 落空）。
+      - name: Checkout repository (app version for updater manifest)
+        uses: actions/checkout@v4
+
       - name: Download release artifacts
         uses: actions/download-artifact@v4
         with:
@@ -473,9 +480,6 @@ jobs:
           fi
           find release-assets -type f -print
           test "$(find release-assets -type f | wc -l)" -gt 0
-
-      - name: Checkout repository (app version for updater manifest)
-        uses: actions/checkout@v4
 
       - name: Generate latest.json updater manifest
         # Tauri v2 CLI 只产出 .sig 签名文件，不再自动生成更新清单（v1 行为已


### PR DESCRIPTION
## 问题

v0.2.0-rc1 重新打包（run 34007955813）：六个平台打包全部成功，发布 job 在 "Generate latest.json updater manifest" 步骤失败：

```
WARN: no sig file matches *_x64_en-US.msi.sig, platform windows-x86_64 omitted
FileNotFoundError: 'release-assets/latest.json'
```

## 根因

actions/checkout@v4.2+ 在 `git init` 前 **"Deleting the contents of /home/runner/work/LambChat/LambChat"**（run 日志实锤）。#416 把 checkout 放在 download-artifact 之后，刚下载的 `release-assets/`（含全部安装包与 sig）被整目录清掉——manifest 的 glob 全落空，写文件 ENOENT。

sig 文件与资产名本身都对得上（日志可见 `LambChat_2.8.0_x64_en-US.msi.sig`、`LambChat_2.8.0_amd64/aarch64.AppImage.sig` 均在下载清单里），纯步骤顺序问题。

## 修复

把 "Checkout repository (app version for updater manifest)" 挪到 "Download release artifacts" 之前。checkout 只为读 `tauri.conf.json` 的 version，放最前不受下载影响；Ensure 步骤仍兜底目录存在性。