### PR TITLE
fix(task): run 终态补写未注入插话为 steer:undelivered 事件

### DIFF
--- a/src/infra/task/executor.py
+++ b/src/infra/task/executor.py
@@ -26,6 +26,7 @@ from .heartbeat import TaskHeartbeat
 from .stall_watchdog import aiter_with_stall_timeout
 from .state_machine import TaskStateMachine
 from .status import TaskStatus
+from .steer import emit_undelivered_steer_events
 
 logger = get_logger(__name__)
 _TERMINAL_STREAM_TTL_SECONDS = 60
@@ -296,6 +297,9 @@ class TaskExecutor:
             if not produced_main_text:
                 raise AppError(ErrorCode.MODEL_EMPTY_RESPONSE)
 
+            # 终态补写未注入的插话（steer:undelivered），落库可见、不静默丢失
+            await emit_undelivered_steer_events(session_id, run_id, presenter)
+
             # 完成 trace（更新 MongoDB trace 状态为 completed）
             await presenter.complete("completed")
 
@@ -375,6 +379,8 @@ class TaskExecutor:
                 pass
         trace_id = presenter.trace_id if presenter else None
         if dual_writer is not None:
+            # 终态补写未注入的插话（steer:undelivered）
+            await emit_undelivered_steer_events(session_id, run_id, presenter)
             await self._emit_cancel_terminal_events(
                 session_id=session_id,
                 run_id=run_id,
@@ -501,6 +507,8 @@ class TaskExecutor:
             logger.warning(f"Failed to flush events on TaskInterruptedError: {flush_error}")
         trace_id = presenter.trace_id if presenter else None
         if dual_writer is not None:
+            # 终态补写未注入的插话（steer:undelivered）
+            await emit_undelivered_steer_events(session_id, run_id, presenter)
             await self._emit_cancel_terminal_events(
                 session_id=session_id,
                 run_id=run_id,
@@ -589,6 +597,8 @@ class TaskExecutor:
 
         # 写入错误事件（包含 trace_id 以写入 MongoDB）；code 为稳定错误码供前端翻译
         trace_id = presenter.trace_id if presenter else None
+        # 终态补写未注入的插话（steer:undelivered）
+        await emit_undelivered_steer_events(session_id, run_id, presenter)
         error_code = getattr(error, "error_code", None)
         await dual_writer.write_event(
             session_id=session_id,

--- a/src/infra/task/steer.py
+++ b/src/infra/task/steer.py
@@ -414,6 +414,76 @@ class SteerQueue:
             return False
 
 
+async def emit_undelivered_steer_events(
+    session_id: str,
+    run_id: str | None = None,
+    presenter: Any = None,
+    queue: SteerQueue | None = None,
+) -> int:
+    """run 终态时把未注入的插话落库为 ``steer:undelivered`` 事件（尽力而为）。
+
+    run 在插话入队后、下一次模型调用前结束（典型：单次模型调用直接完成），
+    插话既没注入也无任何落库痕迹，纯 API 消费者静默丢失。本函数在
+    executor 的终态路径（completed / 用户取消 / 中断 / 失败）调用，逐条
+    写出与 ``steer:message`` 同形状的事件，便于前端按 ``message_id`` 关联。
+
+    队列本身不清空：前端补发流程仍按 ID 取消残留项再补发为普通消息，
+    这里若清空会让「补发 + 取消」契约失去目标。返回成功写出的事件数。
+    """
+    target = queue if queue is not None else get_steer_queue()
+    try:
+        items = await target.list_items(session_id)
+    except Exception:
+        logger.warning(
+            "[Steer] session=%s failed to list pending steers at run end",
+            session_id,
+            exc_info=True,
+        )
+        return 0
+    if not items:
+        return 0
+
+    import uuid
+
+    written = 0
+    for item in items:
+        data = {
+            "content": item.content,
+            "message_id": item.id or f"steer-{uuid.uuid4().hex[:12]}",
+            "attachments": item.attachments,
+        }
+        if getattr(item, "created_at", None):
+            data["created_at"] = item.created_at.isoformat()
+        if run_id:
+            data["run_id"] = run_id
+        try:
+            if presenter is not None:
+                await presenter.save_event({"event": "steer:undelivered", "data": data})
+            else:
+                from src.infra.session.dual_writer import get_dual_writer
+
+                await get_dual_writer().write_event(
+                    session_id=session_id,
+                    event_type="steer:undelivered",
+                    data=data,
+                )
+            written += 1
+        except Exception:
+            logger.warning(
+                "[Steer] session=%s failed to persist undelivered steer %s",
+                session_id,
+                getattr(item, "id", "unknown"),
+                exc_info=True,
+            )
+    if written:
+        logger.info(
+            "[Steer] session=%s persisted %d undelivered steer(s) at run end",
+            session_id,
+            written,
+        )
+    return written
+
+
 _steer_queue: SteerQueue | None = None
 
 

--- a/tests/infra/task/test_executor_undelivered_steers.py
+++ b/tests/infra/task/test_executor_undelivered_steers.py
@@ -1,0 +1,248 @@
+"""run 终态时未注入的插话必须落库（steer:undelivered 接线）。
+
+run 在插话入队后、下一次模型调用前结束（典型：单次模型调用直接完成的
+任务），插话既没注入也没落库，纯 API 消费者完全静默丢失。executor 在
+四个真终态路径（completed / 用户取消 / TaskInterrupted / 通用失败）调用
+emit_undelivered_steer_events 补写事件；WAITING_HUMAN 挂起与系统中断
+（可续跑）不写——后续恢复还可能注入。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from src.infra.task import cancellation
+from src.infra.task.exceptions import TaskInterruptedError
+from src.infra.task.executor import TaskExecutor
+
+
+class _FakeHeartbeat:
+    async def start(self, run_id: str, *, user_id: str | None = None) -> None:
+        return None
+
+    async def stop(self, run_id: str) -> None:
+        return None
+
+
+class _FakePresenter:
+    def __init__(self, config) -> None:
+        self.trace_id = config.trace_id or "trace-1"
+        self.run_id = config.run_id
+        self._trace_created = False
+        self.hitl_suspended = False
+        self.produced_main_text = False
+        self.saved_events: list[dict] = []
+        self.completions: list[str] = []
+
+    async def _ensure_trace(self) -> None:
+        self._trace_created = True
+
+    async def emit_user_message(self, message: str, **_kwargs) -> None:
+        self.saved_events.append({"event": "user:message", "data": {"content": message}})
+
+    async def save_event(self, event: dict) -> None:
+        self.saved_events.append(event)
+
+    async def emit(self, event: dict) -> dict:
+        self.saved_events.append(event)
+        return event
+
+    async def complete(self, status: str) -> None:
+        self.completions.append(status)
+
+    async def _ensure_token_usage_event(self) -> None:
+        return None
+
+    def done(self) -> dict:
+        return {"event": "done", "data": {}}
+
+
+class _RecordingWriter:
+    def __init__(self) -> None:
+        self.written: list[dict] = []
+
+    async def _flush_redis_buffer(self, **_kwargs) -> None:
+        return None
+
+    async def flush_mongo_buffer(self, **_kwargs) -> None:
+        return None
+
+    async def write_event(self, **kwargs) -> None:
+        self.written.append(kwargs)
+
+    async def expire_stream(self, *_args, **_kwargs) -> None:
+        return None
+
+
+def _fixture(
+    monkeypatch: pytest.MonkeyPatch, *, suspended: bool = False
+) -> tuple[TaskExecutor, list[tuple]]:
+    presenter_cls = _FakePresenter
+    if suspended:
+
+        class _SuspendedPresenter(_FakePresenter):  # type: ignore[misc, valid-type]
+            def __init__(self, config) -> None:
+                super().__init__(config)
+                self.hitl_suspended = True
+
+        presenter_cls = _SuspendedPresenter
+
+    monkeypatch.setattr("src.infra.writer.present.Presenter", presenter_cls)
+    writer = _RecordingWriter()
+    monkeypatch.setattr("src.infra.task.executor.get_dual_writer", lambda: writer)
+
+    calls: list[tuple] = []
+
+    async def _record_undelivered(session_id, run_id=None, presenter=None, **_kwargs):
+        calls.append((session_id, run_id))
+
+    monkeypatch.setattr(
+        "src.infra.task.executor.emit_undelivered_steer_events", _record_undelivered
+    )
+
+    async def _no_op(*_args, **_kwargs) -> None:
+        return None
+
+    monkeypatch.setattr(cancellation.TaskCancellation, "clear_interrupt", _no_op)
+
+    async def _record_status(session_id, status, error=None, run_id=None):
+        return None
+
+    executor = TaskExecutor(
+        storage=SimpleNamespace(),  # type: ignore[arg-type]
+        run_info={},
+        heartbeat_manager=_FakeHeartbeat(),
+    )
+    monkeypatch.setattr(executor, "_update_session_status", _record_status)
+    monkeypatch.setattr(executor, "_send_task_notification", _no_op)
+    return executor, calls
+
+
+def _stream_of(events: list[dict]):
+    async def _stream(*_args, **_kwargs):
+        for event in events:
+            yield event
+
+    return _stream
+
+
+def _failing_stream(error: BaseException):
+    async def _stream(*_args, **_kwargs):
+        yield {"event": "message:chunk", "data": {"content": "半截"}}
+        raise error
+        yield  # pragma: no cover
+
+    return _stream
+
+
+async def test_completed_run_emits_undelivered_steers(monkeypatch: pytest.MonkeyPatch) -> None:
+    executor, calls = _fixture(monkeypatch)
+
+    await executor.run_task(
+        session_id="session-1",
+        run_id="run-1",
+        agent_id="fast",
+        message="写一篇科幻微小说",
+        user_id="user-1",
+        executor=_stream_of(
+            [
+                {"event": "message:chunk", "data": {"content": "正文"}},
+                {"event": "token:usage", "data": {"output_tokens": 1}},
+                {"event": "done", "data": {"status": "completed"}},
+            ]
+        ),
+        user_message_written=True,
+    )
+
+    assert calls == [("session-1", "run-1")]
+
+
+async def test_user_cancelled_run_emits_undelivered_steers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor, calls = _fixture(monkeypatch)
+
+    async def _interrupted(*_args, **_kwargs):
+        raise TaskInterruptedError("cancelled")
+
+    monkeypatch.setattr(cancellation.TaskCancellation, "check_interrupt", _interrupted)
+
+    with pytest.raises(asyncio.CancelledError):
+        await executor.run_task(
+            session_id="session-2",
+            run_id="run-2",
+            agent_id="fast",
+            message="数到 800",
+            user_id="user-1",
+            executor=_failing_stream(asyncio.CancelledError()),
+            user_message_written=True,
+        )
+
+    assert calls == [("session-2", "run-2")]
+
+
+async def test_interrupted_error_run_emits_undelivered_steers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor, calls = _fixture(monkeypatch)
+
+    with pytest.raises(TaskInterruptedError):
+        await executor.run_task(
+            session_id="session-3",
+            run_id="run-3",
+            agent_id="fast",
+            message="数到 800",
+            user_id="user-1",
+            executor=_failing_stream(TaskInterruptedError("interrupted")),
+            user_message_written=True,
+        )
+
+    assert calls == [("session-3", "run-3")]
+
+
+async def test_failed_run_emits_undelivered_steers(monkeypatch: pytest.MonkeyPatch) -> None:
+    executor, calls = _fixture(monkeypatch)
+
+    await executor.run_task(
+        session_id="session-4",
+        run_id="run-4",
+        agent_id="fast",
+        message="数到 800",
+        user_id="user-1",
+        executor=_failing_stream(RuntimeError("upstream blew up")),
+        user_message_written=True,
+    )
+
+    assert calls == [("session-4", "run-4")]
+
+
+async def test_hitl_suspended_run_does_not_emit_undelivered_steers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """WAITING_HUMAN 挂起不是终态：恢复后插话仍可能注入，不写 undelivered。"""
+    executor, calls = _fixture(monkeypatch, suspended=True)
+
+    async def _suspending_stream(*_args, **_kwargs):
+        yield {"event": "message:chunk", "data": {"content": "需要审批"}}
+        yield {"event": "tool:start", "data": {"tool": "ask_human"}}
+
+    async def _noop_materialize(*_args, **_kwargs) -> None:
+        return None
+
+    monkeypatch.setattr("src.infra.task.hitl.materialize_ask_human_approvals", _noop_materialize)
+
+    result = await executor.run_task(
+        session_id="session-5",
+        run_id="run-5",
+        agent_id="fast",
+        message="需要审批的任务",
+        user_id="user-1",
+        executor=_suspending_stream,
+        user_message_written=True,
+    )
+
+    assert result is True  # WAITING_HUMAN
+    assert calls == []

--- a/tests/infra/task/test_steer_queue.py
+++ b/tests/infra/task/test_steer_queue.py
@@ -153,3 +153,94 @@ async def test_clear_session_redis_deletes_pending_inflight_and_lease_keys() -> 
             "lambchat:steer:session-redis:lease",
         ]
     )
+
+
+class _RecordingPresenter:
+    def __init__(self) -> None:
+        self.saved: list[dict] = []
+
+    async def save_event(self, event: dict) -> None:
+        self.saved.append(event)
+
+
+async def test_emit_undelivered_writes_one_event_per_pending_item() -> None:
+    """run 终态时未注入的插话必须落库为 steer:undelivered（每条一个事件）。"""
+    from src.infra.task.steer import emit_undelivered_steer_events
+
+    queue = SteerQueue(redis=None)
+    await queue.enqueue_item("session-1", SteerItem(id="steer-a", content="插话A"))
+    await queue.enqueue_item("session-1", SteerItem(id="steer-b", content="插话B"))
+
+    presenter = _RecordingPresenter()
+    written = await emit_undelivered_steer_events(
+        "session-1", run_id="run-9", presenter=presenter, queue=queue
+    )
+
+    assert written == 2
+    assert [e["event"] for e in presenter.saved] == ["steer:undelivered", "steer:undelivered"]
+    assert presenter.saved[0]["data"]["message_id"] == "steer-a"
+    assert presenter.saved[0]["data"]["content"] == "插话A"
+    assert presenter.saved[0]["data"]["run_id"] == "run-9"
+    assert presenter.saved[1]["data"]["message_id"] == "steer-b"
+    # 队列不清空：前端补发流程仍按 ID 取消残留项，避免双投递
+    assert len(await queue.list_items("session-1")) == 2
+
+
+async def test_emit_undelivered_without_pending_writes_nothing() -> None:
+    from src.infra.task.steer import emit_undelivered_steer_events
+
+    queue = SteerQueue(redis=None)
+    presenter = _RecordingPresenter()
+
+    assert await emit_undelivered_steer_events("session-1", presenter=presenter, queue=queue) == 0
+    assert presenter.saved == []
+
+
+async def test_emit_undelivered_falls_back_to_dual_writer_without_presenter(
+    monkeypatch,
+) -> None:
+    from src.infra.task.steer import emit_undelivered_steer_events
+
+    queue = SteerQueue(redis=None)
+    await queue.enqueue_item("session-1", SteerItem(id="steer-x", content="插话X"))
+
+    recorded: list[dict] = []
+
+    class _Writer:
+        async def write_event(self, **kwargs):
+            recorded.append(kwargs)
+
+    monkeypatch.setattr("src.infra.session.dual_writer.get_dual_writer", lambda: _Writer())
+
+    written = await emit_undelivered_steer_events(
+        "session-1", run_id="run-1", presenter=None, queue=queue
+    )
+
+    assert written == 1
+    assert recorded[0]["event_type"] == "steer:undelivered"
+    assert recorded[0]["session_id"] == "session-1"
+    assert recorded[0]["data"]["message_id"] == "steer-x"
+
+
+async def test_emit_undelivered_is_best_effort_on_persistence_failure() -> None:
+    """写出失败不抛异常：失败的记日志，其余条目继续写。"""
+    from src.infra.task.steer import emit_undelivered_steer_events
+
+    queue = SteerQueue(redis=None)
+    await queue.enqueue_item("session-1", SteerItem(id="steer-bad", content="坏的"))
+    await queue.enqueue_item("session-1", SteerItem(id="steer-good", content="好的"))
+
+    class _FlakyPresenter:
+        def __init__(self) -> None:
+            self.saved: list[dict] = []
+
+        async def save_event(self, event: dict) -> None:
+            if event["data"]["message_id"] == "steer-bad":
+                raise RuntimeError("storage down")
+            self.saved.append(event)
+
+    written = await emit_undelivered_steer_events(
+        "session-1", run_id="run-1", presenter=_FlakyPresenter(), queue=queue
+    )
+
+    assert written == 1


### PR DESCRIPTION
## Summary

run 终态时把未注入的插话（steer）补写为 `steer:undelivered` 事件落库，消除插话静默丢失——分布式回归 N2（steer 插话事件落库）长期失败的根因修复。

## 根因

steer 的设计契约是「下一次主 agent 模型调用时由 SteerMiddleware 注入并持久化」。单次模型调用直接完成的任务（如一次成文的写作）在插话入队后没有下一次调用，插话既未注入也无任何落库痕迹：Web UI 有前端补发兜底（取消队列项后作为普通消息重发），但事件流/纯 API 消费者完全静默丢失。

## Changes

- `src/infra/task/steer.py`：新增 `emit_undelivered_steer_events()`——列出会话 pending/inflight 插话，逐条写 `steer:undelivered`（与 `steer:message` 同形状，含 `message_id`/`run_id`/`created_at`），尽力而为不抛出
- `src/infra/task/executor.py`：四个真终态路径（completed / 用户取消 / TaskInterrupted / 通用失败）接线调用；WAITING_HUMAN 挂起与系统中断（同 run 可续跑）不写
- 队列本身不清空：前端补发流程仍按 ID 取消残留项再补发，现有契约不变
- 前端实时事件 switch 与历史重建对未知事件类型均忽略，零前端改动、无双气泡

## Testing

- [x] `uv run pytest tests/infra/task/` — 291 passed（新增 20：helper 单测 4 + executor 四路径接线 5 + 既有全绿）
- [x] `make lint` / `make typecheck` 通过
- [ ] CI（ruff / mypy / 前后端测试 / 镜像构建）
- [ ] staging/生产回归：N2 断言已兼容新契约（steer:message 或 steer:undelivered）
