### PR TITLE
fix(sandbox): 修复本地沙箱跨事件循环 Redis 池污染与 Windows daemon 内嵌 Python 损坏

### DIFF
--- a/client/lambchat_sandbox/__init__.py
+++ b/client/lambchat_sandbox/__init__.py
@@ -7,4 +7,4 @@ value（``node_id|version``），经 ``GET /api/sandbox/status`` 的
 self-update 与服务端最低版本拒连打底。发版时同步递增本值。
 """
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/client/lambchat_sandbox/executor.py
+++ b/client/lambchat_sandbox/executor.py
@@ -239,10 +239,14 @@ class Executor:
         workspace: Path | None = None,
         env_extra: dict[str, str] | None = None,
     ) -> dict[str, str] | None:
-        """构建子进程环境，落笔顺序固定：用户 env → PATH shim 前置 →
-        LAMBCHAT_WORKSPACE（契约变量最后写，不被用户 env 覆盖——PATH 被
-        覆盖会破坏内嵌 python3 shim 的解析）。
+        """构建子进程环境，落笔顺序固定：PYTHONIOENCODING 默认 → 用户 env →
+        PATH shim 前置 → LAMBCHAT_WORKSPACE（契约变量最后写，不被用户 env
+        覆盖——PATH 被覆盖会破坏内嵌 python3 shim 的解析）。
 
+        - ``PYTHONIOENCODING`` 默认钉 utf-8（用户 env / 继承环境显式给出时
+          尊重原值）：子进程 Python 的 stdio 输出 UTF-8，executor 的解码链
+          原样命中，脚本 print 中文不再吐 GBK（cmd.exe 自身消息仍是 GBK，
+          由解码链兜底）；
         - ``env_extra``：服务端下发的用户 env 变量（对齐云端 envs= 语义，
           来自用户加密存储，EnvVarStorage 已限 50 个/单值 16k/总量 64k）；
         - ``extra_path`` 前置进 PATH（内嵌 Python shim 目录）；
@@ -254,6 +258,7 @@ class Executor:
         if self._extra_path is None and workspace is None and not env_extra:
             return None
         env = dict(os.environ)
+        env.setdefault("PYTHONIOENCODING", "utf-8")
         if env_extra:
             env.update(env_extra)
         if self._extra_path is not None:
@@ -407,8 +412,29 @@ def _partial(data: bytes | str | None) -> bytes:
     return data
 
 
+# 输出解码链（2026-09-06 Windows 真机事故）：cmd.exe 与本地工具在中文
+# Windows 输出 GBK（CP936），一律按 UTF-8 容错解码会把「信息: ...」变成
+# 乱码喂给模型。先按 UTF-8 严格解码（绝大多数子进程输出），失败再试 GBK
+# （中文 Windows 控制台码页），最终退化为 UTF-8 replace（二进制垃圾）。
+_DECODE_FALLBACKS = ("gbk",)
+
+
+def _decode_output(data: bytes) -> str:
+    """按解码链把子进程输出字节转文本：UTF-8 → GBK → UTF-8 replace。"""
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError:
+        pass
+    for encoding in _DECODE_FALLBACKS:
+        try:
+            return data.decode(encoding)
+        except (UnicodeDecodeError, LookupError):
+            continue
+    return data.decode("utf-8", errors="replace")
+
+
 def _tail(data: bytes) -> str:
-    """超过 MAX_OUTPUT_BYTES 时保留尾部并加头部标记；UTF-8 容错解码。"""
+    """超过 MAX_OUTPUT_BYTES 时保留尾部并加头部标记；经解码链容错解码。"""
     if len(data) <= MAX_OUTPUT_BYTES:
-        return data.decode("utf-8", errors="replace")
-    return TRUNCATED_MARK + data[-MAX_OUTPUT_BYTES:].decode("utf-8", errors="replace")
+        return _decode_output(data)
+    return TRUNCATED_MARK + _decode_output(data[-MAX_OUTPUT_BYTES:])

--- a/client/lambchat_sandbox/pbs.py
+++ b/client/lambchat_sandbox/pbs.py
@@ -17,10 +17,15 @@ daemon 执行环境不依赖用户系统的 python3：壳把 PBS ``install_only`
     内解释器，``python3 -c "import sys;print(sys.executable)"`` 因此命中
     ``~/.lambchat/python/<tag>/``（符号链接做不到：``sys.executable`` 会停在
     链接自身路径）；
-  - Windows：复制语义（``python.exe`` → ``python3.exe``；wrapper/符号链接在
-    win 无益）。Linux 全测，win 分支按此语义实现、真机验证见 M4 任务报告；
-- **回退**：无归档 / 归档缺解释器 / 装配异常 → 打印警告返回 ``None``，调用方
-  （daemon）回退系统 PATH，绝不阻断启动。
+  - Windows：``python3.cmd`` 批处理 wrapper（``@echo off`` + 转发到归档内
+    真实 ``python.exe``）。**不能复制 exe**（2026-09-06 Windows 真机事故）：
+    CPython 按可执行文件自身位置定位标准库，bin/ 下没有 Lib/，副本启动即
+    ``Could not find platform independent libraries <prefix>``、import 全灭；
+    wrapper 让 ``sys.executable`` 命中归档原位解释器，stdlib/DLL 正常发现。
+    旧版本残留的 ``python3.exe`` 副本必须清除——PATHEXT 里 .EXE 优先于
+    .CMD，残留副本会重新赢走命令解析；
+  - **回退**：无归档 / 归档缺解释器 / 装配异常 → 打印警告返回 ``None``，调用方
+    （daemon）回退系统 PATH，绝不阻断启动。
 
 PBS tag / CPython 版本在本模块锁定（``PBS_TAG`` / ``PBS_PYTHON_VERSION``），
 ``client/scripts/fetch-pbs.py`` 构建期同源引用，升版本两处一起动。
@@ -108,16 +113,26 @@ def _extract(tarball: Path, install_root: Path) -> Path | None:
 def _install_shim(interp: Path, bin_dir: Path) -> Path:
     """在 bin_dir 建 python3 shim，返回 shim 路径。
 
-    - Windows：复制解释器为 ``python3.exe``；
+    - Windows：``python3.cmd`` 批处理 wrapper（CRLF 行尾），转发到归档内真实
+      解释器——复制 exe 会让 CPython 按副本位置找不到标准库（见模块
+      docstring）；旧实现残留的 ``python3.exe`` 副本清除（PATHEXT .EXE 优先
+      于 .CMD，不清会重新赢走解析）。
     - POSIX：exec wrapper（``#!/bin/sh\\nexec <解释器> "$@"``），陈旧 shim
       （普通文件/错误指向）先清再写。
     """
     bin_dir.mkdir(parents=True, exist_ok=True)
-    shim = bin_dir / ("python3.exe" if plat.is_windows() else "python3")
     if plat.is_windows():
-        shutil.copyfile(interp, shim)
+        legacy = bin_dir / "python3.exe"
+        if legacy.exists():
+            legacy.unlink()
+        shim = bin_dir / "python3.cmd"
+        # 解释器绝对路径进双引号（PBS 落位在用户目录，路径可含空格）
+        body = f'@echo off\r\n"{interp.resolve()}" %*\r\n'
+        if not (shim.exists() and shim.read_text(encoding="utf-8") == body):
+            shim.write_text(body, encoding="utf-8", newline="")
         os.chmod(shim, 0o755)
         return shim
+    shim = bin_dir / "python3"
     if shim.is_symlink() or shim.exists():
         shim.unlink()
     target = shlex.quote(str(interp.resolve()))

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -388,6 +388,11 @@ async def lifespan(app: FastAPI):
     # 启动时初始化
     logger.info("%s v%s starting...", settings.APP_NAME, settings.APP_VERSION)
 
+    # 登记主事件循环：本地沙箱同步文件操作的协程桥接统一投递到该循环，
+    # 共享 redis.asyncio 连接池不再跨循环复用（2026-09-06 生产事故修复）
+    from src.infra.async_utils import loop_bridge
+
+    loop_bridge.set_main_loop(asyncio.get_running_loop())
     # 复位进程关闭标志（进程复用/热重载场景），随后才允许扫描/恢复入口工作
     from src.infra.task.lifecycle import clear_shutting_down
 
@@ -547,8 +552,10 @@ async def lifespan(app: FastAPI):
     finally:
         # 关闭时清理
         from src.agents import AgentFactory
+        from src.infra.async_utils import loop_bridge
         from src.infra.sandbox import SandboxFactory
 
+        loop_bridge.clear_main_loop()
         # 第一时间置进程关闭标志：此后周期扫描/孤儿接管不再发起新的恢复，
         # 否则依赖逐个断开期间，垂死实例会把恢复任务塞给自己并随即被杀掉。
         from src.infra.task.lifecycle import mark_shutting_down

--- a/src/infra/async_utils/loop_bridge.py
+++ b/src/infra/async_utils/loop_bridge.py
@@ -1,0 +1,61 @@
+"""同步→异步桥接的主循环登记处。
+
+背景（生产事故 2026-09-06，会话 a5fd351a）：本地沙箱的同步文件操作经
+``asyncio.run`` 临时建循环执行协程，协程内部使用进程级共享的
+``redis.asyncio`` 连接池。redis 连接绑定首次使用它的事件循环，临时循环
+复用主循环创建的连接直接 ``RuntimeError: got Future attached to a
+different loop``；临时循环关闭后残留的 pending Task 持续污染池，主循环上
+的 /api/sandbox/* 端点连锁 500、daemon SSE 通道反复断连。
+
+修复：进程启动时（FastAPI lifespan / arq worker startup）登记主循环，
+:func:`run_coro_sync` 一律 ``run_coroutine_threadsafe`` 投递到该循环——
+全部 Redis 池使用收敛到同一个循环。未登记（脚本/测试）退回 ``asyncio.run``
+维持旧行为。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Coroutine, TypeVar
+
+T = TypeVar("T")
+
+_main_loop: asyncio.AbstractEventLoop | None = None
+
+
+def set_main_loop(loop: asyncio.AbstractEventLoop) -> None:
+    """登记进程主事件循环（lifespan / worker startup 调用）。"""
+    global _main_loop
+    _main_loop = loop
+
+
+def get_main_loop() -> asyncio.AbstractEventLoop | None:
+    return _main_loop
+
+
+def clear_main_loop() -> None:
+    global _main_loop
+    _main_loop = None
+
+
+def run_coro_sync(coro: Coroutine[object, object, T]) -> T:
+    """在同步上下文中运行协程：优先投递到已登记的主循环。
+
+    - 当前线程已有运行中的循环：报错（要求改用异步 API），与旧行为一致；
+    - 已登记主循环且仍在运行：``run_coroutine_threadsafe`` 投递执行——
+      共享 Redis 池的全部使用都发生在该循环上，杜绝跨循环污染；
+    - 未登记主循环（脚本/测试/未走 lifespan 的进程）：``asyncio.run`` 兜底。
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        pass
+    else:
+        coro.close()
+        raise RuntimeError(
+            "LocalSandboxBackend.execute() cannot run inside an active event loop; use aexecute()."
+        )
+    loop = _main_loop
+    if loop is not None and loop.is_running():
+        return asyncio.run_coroutine_threadsafe(coro, loop).result()
+    return asyncio.run(coro)

--- a/src/infra/backend/_local_compat.py
+++ b/src/infra/backend/_local_compat.py
@@ -9,12 +9,12 @@ local.py 命名空间解析这些名字，测试打桩路径不变；本模块�
 
 from __future__ import annotations
 
-import asyncio
 import posixpath
 import shlex
 from dataclasses import dataclass
 from typing import Any, Coroutine, TypeVar, cast
 
+from src.infra.async_utils import loop_bridge
 from src.infra.backend.protocol_compat import ExtendedFileError, FileInfo
 
 T = TypeVar("T")
@@ -108,19 +108,16 @@ def _platform_ctx(platform: str) -> _PlatformCmdCtx:
 
 
 def _run_coro_sync(coro: Coroutine[Any, Any, T]) -> T:
-    """在同步上下文中运行异步协程（照 _skills_path_utils._run_async 模式）。
+    """在同步上下文中运行异步协程：经 loop_bridge 投递到进程主循环。
 
-    没有运行中的事件循环（如 asyncio.to_thread 的 worker 线程）时用
-    asyncio.run；若在运行中的事件循环内被同步调用则报错，要求改用异步 API。
+    直接 ``asyncio.run`` 会为每次调用新建临时事件循环，而协程内部使用的
+    ``redis.asyncio`` 共享连接池绑定首个使用它的循环——跨循环复用报
+    ``got Future attached to a different loop`` 并污染池（2026-09-06 生产
+    事故：/api/sandbox/* 连锁 500、daemon 通道反复断连）。lifespan 已登记
+    主循环，统一投递执行；未登记（脚本/测试）时 loop_bridge 内部退回
+    ``asyncio.run``。活动循环内同步调用仍报错，要求改用异步 API。
     """
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        return asyncio.run(coro)
-    coro.close()
-    raise RuntimeError(
-        "LocalSandboxBackend.execute() cannot run inside an active event loop; use aexecute()."
-    )
+    return loop_bridge.run_coro_sync(coro)
 
 
 def _classify_file_error(text: str) -> ExtendedFileError:

--- a/src/infra/backend/local.py
+++ b/src/infra/backend/local.py
@@ -133,12 +133,24 @@ class LocalSandboxBackend(BaseSandbox):
         # 构造时由 wiring 经 sync_sandbox_env_vars 注入；env_var 工具运行中
         # 改动时同一 helper 经 hasattr 探测写入，后续 exec 即时生效。
         self.env_vars: dict[str, str] = dict(env_vars) if env_vars else {}
+        # 平台粘滞缓存：注册表查询瞬断（redis 抖动等）时复用最近一次成功值，
+        # 不让已确认 win32 的会话翻回 posix 分支（多行 POSIX 脚本在 cmd.exe
+        # 上产出垃圾输出——2026-09-06 生产事故的连锁之一）。None = 从未解析。
+        self._sticky_platform: str | None = None
 
     async def _resolve_platform(self) -> str:
-        """本次命令生成所用平台：显式 hint 优先，否则查注册表（容错 posix）。"""
+        """本次命令生成所用平台：显式 hint 优先，否则查注册表（容错 posix）。
+
+        查询失败（空串）时回退粘滞缓存；从未成功解析过的会话才按空串归一
+        posix（现状零变化）。
+        """
         if self._platform_hint is not None:
             return self._platform_hint
-        return await _lookup_daemon_platform(self._user_id, self._machine_id)
+        platform = await _lookup_daemon_platform(self._user_id, self._machine_id)
+        if platform:
+            self._sticky_platform = platform
+            return platform
+        return self._sticky_platform or ""
 
     @property
     def id(self) -> str:

--- a/src/infra/task/arq_worker.py
+++ b/src/infra/task/arq_worker.py
@@ -67,12 +67,21 @@ async def worker_startup(ctx: dict[str, Any]) -> None:
     del ctx
     validate_distributed_runtime_settings(settings)
 
+    # 登记本进程事件循环：本地沙箱同步文件操作的协程桥接统一投递到该循环，
+    # 共享 redis.asyncio 连接池不再跨循环复用（对齐 API 进程 lifespan 的登记）
+    from src.infra.async_utils import loop_bridge
+
+    loop_bridge.set_main_loop(asyncio.get_running_loop())
+
 
 async def worker_shutdown(ctx: dict[str, Any]) -> None:
     """Mark the worker process as shutting down so recovery entrypoints go quiet."""
     del ctx
+    from src.infra.async_utils import loop_bridge
+
     from .lifecycle import mark_shutting_down
 
+    loop_bridge.clear_main_loop()
     mark_shutting_down()
 
 

--- a/src/infra/tool/image_analysis_tool.py
+++ b/src/infra/tool/image_analysis_tool.py
@@ -369,6 +369,8 @@ async def image_analyze(
             }
         )
     except Exception as exc:
+        # 只记异常类型不记正文：LLM 异常消息可能内嵌请求体（图片 data URL），
+        # 全量落日志会泄露用户内容（test_image_analyze_model_error_omits_request_content 守卫）。
         logger.warning(
             "[image_analyze] failed: error_type=%s",
             type(exc).__name__,

--- a/src/kernel/config/base.py
+++ b/src/kernel/config/base.py
@@ -241,9 +241,7 @@ class Settings(BaseSettings):
     SANDBOX_LOCAL_EXEC_TIMEOUT: int = 120  # 本地沙箱执行总超时（秒）
     SANDBOX_RESULTS_MAX_BYTES: int = 2097152  # 本地沙箱 results 回传 body 上限（字节，2 MiB）
     # 本地沙箱 daemon 最低连接版本（语义化比较）：低于即拒连（426），逼客户端 self-update
-    SANDBOX_MIN_DAEMON_VERSION: str = (
-        "0.2.0"  # 0.2.0：确认门搬服务端 + 策略上报；旧版带 daemon 侧门，拒连防双重确认
-    )
+    SANDBOX_MIN_DAEMON_VERSION: str = "0.3.1"  # 0.3.1：Windows python3 shim 修复（复制 exe 找不到 stdlib）+ 输出 GBK 解码；0.3.0 及以下必须升级
     DAYTONA_API_KEY: str = ""
     DAYTONA_SERVER_URL: str = ""
     DAYTONA_TIMEOUT: int = 180

--- a/tests/api/routes/test_sandbox_machines_routes.py
+++ b/tests/api/routes/test_sandbox_machines_routes.py
@@ -209,7 +209,7 @@ async def test_channel_registers_machine_identity(fake_registry, monkeypatch):
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
         async with c.stream(
             "GET",
-            "/api/sandbox/channel?version=0.3.0&machine_id=mac1&machine_name=MacBook",
+            "/api/sandbox/channel?version=0.3.1&machine_id=mac1&machine_name=MacBook",
         ) as resp:
             body = b""
             async for chunk in resp.aiter_bytes():

--- a/tests/api/routes/test_sandbox_routes.py
+++ b/tests/api/routes/test_sandbox_routes.py
@@ -548,12 +548,12 @@ async def test_channel_registers_confirm_policy_from_query(monkeypatch):
     async with AsyncClient(transport=transport, base_url="http://testserver") as client:
         resp = await client.get(
             "/api/sandbox/channel",
-            params={"version": "0.2.0", "platform": "linux", "confirm_policy": "none"},
+            params={"version": "0.3.1", "platform": "linux", "confirm_policy": "none"},
         )
         assert resp.status_code == 200
         resp2 = await client.get(
             "/api/sandbox/channel",
-            params={"version": "0.2.0", "confirm_policy": "yolo"},
+            params={"version": "0.3.1", "confirm_policy": "yolo"},
         )
         assert resp2.status_code == 200
     assert registry.registered[0][5] == "none"
@@ -596,12 +596,12 @@ async def test_channel_registers_version_from_query(monkeypatch):
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://testserver") as client:
-        resp = await client.get("/api/sandbox/channel?version=0.2.0")
+        resp = await client.get("/api/sandbox/channel?version=0.3.1")
     assert resp.status_code == 200
-    assert seen["version"] == "0.2.0"
+    assert seen["version"] == "0.3.1"
     assert len(registry.registered) == 1
     user_id, _client_id, node_id, version, platform, _confirm_policy = registry.registered[0]
-    assert (user_id, version) == ("u1", "0.2.0")
+    assert (user_id, version) == ("u1", "0.3.1")
     assert node_id == sandbox_route._NODE_ID
     assert platform == ""  # 未上报平台：保持空（旧 daemon 兼容）
 
@@ -639,12 +639,12 @@ async def test_channel_registers_platform_from_query(monkeypatch):
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://testserver") as client:
-        resp = await client.get("/api/sandbox/channel?version=0.2.0&platform=win32")
+        resp = await client.get("/api/sandbox/channel?version=0.3.1&platform=win32")
     assert resp.status_code == 200
     assert seen["platform"] == "win32"
     assert len(registry.registered) == 1
     user_id, _client_id, node_id, version, platform, _confirm_policy = registry.registered[0]
-    assert (user_id, version, platform) == ("u1", "0.2.0", "win32")
+    assert (user_id, version, platform) == ("u1", "0.3.1", "win32")
     assert node_id == sandbox_route._NODE_ID
 
 

--- a/tests/client/test_executor.py
+++ b/tests/client/test_executor.py
@@ -304,3 +304,62 @@ def test_spawn_env_user_only_without_extras(tmp_path):
     assert env is not None
     assert env["LC_ONLY"] == "1"
     assert "PATH" in env  # 基于父环境扩展
+
+
+# ---------------------------------------------------------------------------
+# 输出解码（2026-09-06 Windows 真机事故）：cmd.exe 及本地工具在中文 Windows
+# 输出 GBK（CP936），一律按 UTF-8 容错解码会把「信息: ...」变成乱码。
+# 解码链：UTF-8 严格 → GBK（中文 Windows 控制台常用码页）→ UTF-8 replace。
+# ---------------------------------------------------------------------------
+
+
+def test_decode_output_utf8_bytes_pass_through():
+    from lambchat_sandbox.executor import _decode_output
+
+    text = "信息: 操作完成"
+    assert _decode_output(text.encode("utf-8")) == text
+
+
+def test_decode_output_gbk_bytes_fallback():
+    from lambchat_sandbox.executor import _decode_output
+
+    text = "信息: 用提供的模式无法找到文件。"
+    gbk_bytes = text.encode("gbk")
+    assert _decode_output(gbk_bytes) == text
+
+
+def test_decode_output_binary_garbage_never_raises():
+    from lambchat_sandbox.executor import _decode_output
+
+    garbage = bytes(range(256)) * 8
+    decoded = _decode_output(garbage)
+    assert isinstance(decoded, str)  # 任意字节不抛异常，退化为替换字符
+
+
+def test_tail_uses_decode_chain():
+    from lambchat_sandbox.executor import _tail
+
+    text = "当前卷的目录中没有标签。"
+    assert _tail(text.encode("gbk")) == text
+
+
+def test_spawn_env_defaults_pythonioencoding_utf8(tmp_path):
+    """子进程 Python 的 stdio 编码默认钉死 UTF-8：executor 按解码链吃回输出，
+    python 子进程不再吐 GBK（cmd.exe 自身消息仍 GBK，由解码链兜底）。"""
+    monkey_env = None
+    import os as _os
+
+    saved = _os.environ.get("PYTHONIOENCODING")
+    _os.environ.pop("PYTHONIOENCODING", None)
+    try:
+        env = Executor(tmp_path)._spawn_env(Path("/w"))
+        assert env is not None
+        assert env["PYTHONIOENCODING"] == "utf-8"
+    finally:
+        if saved is not None:
+            _os.environ["PYTHONIOENCODING"] = saved
+
+
+def test_spawn_env_user_overrides_pythonioencoding(tmp_path):
+    env = Executor(tmp_path)._spawn_env(Path("/w"), env_extra={"PYTHONIOENCODING": "cp936"})
+    assert env["PYTHONIOENCODING"] == "cp936"

--- a/tests/client/test_pbs.py
+++ b/tests/client/test_pbs.py
@@ -11,8 +11,9 @@ install_root 全部落 tmp_path，绝不碰真实 ``~/.lambchat``：
   ``~/.lambchat/python/<tag>/`` 而非 shim 自身路径；符号链接做不到这一点）；
 - 幂等：首次解压后删掉 tar.gz 再调一次，不重解压（标记文件为门）且仍返回
   bin 目录；重复调用不炸；
-- Windows 分支（``platform._sys_platform`` 注入 win32）：shim 是 ``python3.exe``
-  **复制**（非 wrapper）；
+- Windows 分支（``platform._sys_platform`` 注入 win32）：shim 是 ``python3.cmd``
+  **wrapper**（转发到归档内真实解释器；复制 exe 会让 CPython 找不到 stdlib，
+  2026-09-06 Windows 真机事故后弃用）；
 - 回退：无 tar.gz → None + stderr 警告；归档里找不到解释器 → None + 警告；
 - 陈旧 shim（已存在的普通文件/错误指向）被替换成正确 wrapper。
 """
@@ -129,26 +130,54 @@ def test_ensure_runtime_replaces_stale_shim(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Windows 分支：shim 是 python3.exe 复制（Linux 宿主注入 win32 可全测）
+# Windows 分支：shim 是 python3.cmd wrapper（Linux 宿主注入 win32 可全测）
+#
+# 生产事故（2026-09-06，Windows 真机）：旧实现的「复制 python.exe 到 bin/」
+# 让 CPython 按副本自身位置找标准库——bin/ 下没有 Lib/，解释器能启动但
+# ``Could not find platform independent libraries <prefix>``，import 全灭，
+# 本地沙箱的上传/下载（python3 -c 单命令往返）与 agent 的 python3 调用
+# 全部失败。改写 .cmd wrapper：argv[0] 命中归档内真实解释器，stdlib/DLL
+# 按原位布局正常发现。
 # ---------------------------------------------------------------------------
 
 
-def test_ensure_runtime_windows_shim_is_exe_copy(tmp_path, monkeypatch):
+def test_ensure_runtime_windows_shim_is_cmd_wrapper(tmp_path, monkeypatch):
     monkeypatch.setattr(plat, "_sys_platform", "win32")
     resources, install_root = _setup(
         tmp_path, {"python/bin/python.exe": "MZ fake exe"}, {"python/bin/python.exe"}
     )
     bin_dir = pbs.ensure_runtime(resources, install_root)
 
-    shim = bin_dir / "python3.exe"
+    shim = bin_dir / "python3.cmd"
     assert shim.exists()
-    # 复制语义：内容与解释器一致（非 wrapper 文本）
-    assert shim.read_text(encoding="utf-8") == "MZ fake exe"
+    body = shim.read_text(encoding="utf-8")
+    # wrapper 语义：转发到归档内真实解释器（绝对路径），参数原样透传
+    assert body.startswith("@echo off")
+    interp = (install_root / pbs.PBS_TAG / "python" / "bin" / "python.exe").resolve()
+    assert f'"{interp}" %*' in body
+    # 不再产生 exe 副本（PATHEXT 下 .exe 优先于 .cmd，残留副本会重新赢走解析）
+    assert not (bin_dir / "python3.exe").exists()
+
+
+def test_ensure_runtime_windows_removes_legacy_exe_copy(tmp_path, monkeypatch):
+    """旧版本留下的坏 python3.exe 副本必须被清掉（自愈升级路径）。"""
+    monkeypatch.setattr(plat, "_sys_platform", "win32")
+    resources, install_root = _setup(
+        tmp_path, {"python/bin/python.exe": "MZ fake exe"}, {"python/bin/python.exe"}
+    )
+    bin_dir = install_root.parent / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    (bin_dir / "python3.exe").write_bytes(b"broken legacy copy")
+
+    pbs.ensure_runtime(resources, install_root)
+
+    assert not (bin_dir / "python3.exe").exists()
+    assert (bin_dir / "python3.cmd").exists()
 
 
 def test_ensure_runtime_windows_install_only_layout(tmp_path, monkeypatch):
     """PBS Windows install_only 真实布局：解释器在 ``python/python.exe``
-    （顶层 python 目录直接放 exe，无 bin 子目录）——同样认（M4 T4 审查）。"""
+    （顶层 python 目录直接放 exe，无 bin 子目录）——wrapper 指向该布局。"""
     monkeypatch.setattr(plat, "_sys_platform", "win32")
     resources, install_root = _setup(
         tmp_path, {"python/python.exe": "MZ root exe"}, {"python/python.exe"}
@@ -156,9 +185,10 @@ def test_ensure_runtime_windows_install_only_layout(tmp_path, monkeypatch):
     bin_dir = pbs.ensure_runtime(resources, install_root)
 
     assert bin_dir == tmp_path / "bin"
-    shim = bin_dir / "python3.exe"
+    shim = bin_dir / "python3.cmd"
     assert shim.exists()
-    assert shim.read_text(encoding="utf-8") == "MZ root exe"
+    interp = (install_root / pbs.PBS_TAG / "python" / "python.exe").resolve()
+    assert f'"{interp}" %*' in shim.read_text(encoding="utf-8")
 
 
 def test_find_interpreter_prefers_python_bin_over_root_level(tmp_path, monkeypatch):

--- a/tests/infra/async_utils/test_loop_bridge.py
+++ b/tests/infra/async_utils/test_loop_bridge.py
@@ -1,0 +1,116 @@
+"""loop_bridge：同步桥接统一投递到注册的主事件循环。
+
+背景（生产事故 2026-09-06）：LocalSandboxBackend 的同步文件操作经
+``_run_coro_sync`` 用 ``asyncio.run`` 临时建循环执行协程，而协程内部使用
+进程级共享的 ``redis.asyncio`` 连接池——连接绑定首次使用它的循环，跨循环
+复用直接 ``RuntimeError: got Future attached to a different loop``，且循环
+关闭后残留的 pending Task 污染连接池，后续主循环上的 /api/sandbox/* 全部
+500、daemon SSE 通道反复断连（read_file 报 daemon offline 的连锁根源）。
+
+修复语义：注册主循环后，同步桥接一律 ``run_coroutine_threadsafe`` 投递到
+该循环执行——全部 Redis 池使用收敛到同一个循环。
+"""
+
+import asyncio
+import threading
+
+import pytest
+
+from src.infra.async_utils.loop_bridge import (
+    clear_main_loop,
+    get_main_loop,
+    run_coro_sync,
+    set_main_loop,
+)
+
+
+def test_get_main_loop_initially_none():
+    clear_main_loop()
+    assert get_main_loop() is None
+
+
+def test_set_and_clear_main_loop():
+    loop = asyncio.new_event_loop()
+    try:
+        set_main_loop(loop)
+        assert get_main_loop() is loop
+        clear_main_loop()
+        assert get_main_loop() is None
+    finally:
+        loop.close()
+
+
+def test_run_coro_sync_runs_on_registered_main_loop():
+    """工作线程内同步桥接：协程在注册的主循环上执行（而非临时 asyncio.run 循环）。"""
+    main_loop = asyncio.new_event_loop()
+    set_main_loop(main_loop)
+    try:
+        thread = threading.Thread(target=main_loop.run_forever, daemon=True)
+        thread.start()
+
+        async def probe() -> object:
+            return asyncio.get_running_loop()
+
+        result: dict[str, object] = {}
+
+        def run_sync() -> None:
+            result["loop"] = run_coro_sync(probe())
+
+        worker = threading.Thread(target=run_sync)
+        worker.start()
+        worker.join(timeout=10)
+        assert not worker.is_alive(), "sync bridge did not return"
+        assert result["loop"] is main_loop
+    finally:
+        main_loop.call_soon_threadsafe(main_loop.stop)
+        thread.join(timeout=10)
+        clear_main_loop()
+        main_loop.close()
+
+
+def test_run_coro_sync_without_registered_loop_falls_back_to_asyncio_run():
+    clear_main_loop()
+
+    async def value() -> int:
+        await asyncio.sleep(0)
+        return 42
+
+    assert run_coro_sync(value()) == 42
+
+
+def test_run_coro_sync_inside_running_loop_still_rejected():
+    """活动循环内同步调用必须报错（要求改用异步 API），语义与旧实现一致。"""
+
+    async def value() -> int:
+        return 1
+
+    async def attempt() -> object:
+        try:
+            run_coro_sync(value())
+        except RuntimeError as exc:
+            return exc
+        return None
+
+    clear_main_loop()
+    exc = asyncio.run(attempt())
+    assert isinstance(exc, RuntimeError)
+    assert "cannot run inside an active event loop" in str(exc)
+
+
+def test_run_coro_sync_propagates_exception_from_main_loop():
+    main_loop = asyncio.new_event_loop()
+    set_main_loop(main_loop)
+    try:
+        thread = threading.Thread(target=main_loop.run_forever, daemon=True)
+        thread.start()
+
+        async def boom() -> None:
+            raise ValueError("relay failure")
+
+        with pytest.raises(ValueError, match="relay failure"):
+            run_coro_sync(boom())
+    finally:
+        main_loop.call_soon_threadsafe(main_loop.stop)
+        thread.join(timeout=10)
+        clear_main_loop()
+        main_loop.close()

--- a/tests/infra/async_utils/test_main_loop_wiring.py
+++ b/tests/infra/async_utils/test_main_loop_wiring.py
@@ -1,0 +1,37 @@
+"""源码接线校验：主循环登记必须出现在两个进程入口。
+
+本地沙箱同步桥接的跨循环修复依赖 lifespan / arq worker startup 显式登记
+主事件循环（loop_bridge.set_main_loop）；漏掉任何一处，对应进程里的同步
+文件操作就会退回 asyncio.run 临时循环，重新引入 redis 连接池跨循环污染
+（2026-09-06 生产事故）。源码扫描锁死接线不被顺手删掉。
+"""
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_api_lifespan_registers_main_loop():
+    main_py = _REPO_ROOT / "src" / "api" / "main.py"
+    text = main_py.read_text(encoding="utf-8")
+    lifespan_body = text.split("async def lifespan", 1)[1].split("\nasync def", 1)[0]
+    assert "loop_bridge.set_main_loop(asyncio.get_running_loop())" in lifespan_body
+    assert "loop_bridge.clear_main_loop()" in lifespan_body
+
+
+def test_arq_worker_registers_main_loop():
+    worker_py = _REPO_ROOT / "src" / "infra" / "task" / "arq_worker.py"
+    text = worker_py.read_text(encoding="utf-8")
+    startup_body = text.split("async def worker_startup", 1)[1].split("\nasync def", 1)[0]
+    shutdown_body = text.split("async def worker_shutdown", 1)[1].split("\ndef ", 1)[0]
+    assert "loop_bridge.set_main_loop(asyncio.get_running_loop())" in startup_body
+    assert "loop_bridge.clear_main_loop()" in shutdown_body
+
+
+def test_local_compat_delegates_to_loop_bridge():
+    compat_py = _REPO_ROOT / "src" / "infra" / "backend" / "_local_compat.py"
+    text = compat_py.read_text(encoding="utf-8")
+    body = text.split("def _run_coro_sync", 1)[1]
+    assert "loop_bridge.run_coro_sync(coro)" in body
+    # 旧实现特征（asyncio.run 直跑）不应再出现在函数体里
+    assert "return asyncio.run(coro)" not in body

--- a/tests/infra/backend/test_local_backend.py
+++ b/tests/infra/backend/test_local_backend.py
@@ -1114,3 +1114,47 @@ async def test_sync_sandbox_env_vars_writes_local_backend(monkeypatch):
     backend = LocalSandboxBackend(user_id="u1", session_id="s1")
     await sync_sandbox_env_vars(backend, "u1")
     assert backend.env_vars == {"FOO": "bar"}
+
+
+async def test_resolve_platform_sticky_after_transient_lookup_failure(monkeypatch):
+    """平台查询瞬断（redis 异常）不回退 posix：复用最近一次成功解析值。
+
+    生产事故（2026-09-06）：一次查询失败把 win32 会话翻回 posix 分支，
+    daemon 收到多行 POSIX python3 脚本产出垃圾输出（ls 全空、read 报
+    unexpected server response）。粘滞缓存保证一次成功解析后不再漂移。
+    """
+    state = {"fail": False}
+
+    async def fake_lookup(user_id, machine_id=None):
+        if state["fail"]:
+            return ""  # 真实 _lookup_daemon_platform 故障时回落空串（不抛异常）
+        return "win32"
+
+    monkeypatch.setattr(local_module, "_lookup_daemon_platform", fake_lookup)
+    backend = LocalSandboxBackend(user_id="u1", session_id="s1")
+    assert await backend._resolve_platform() == "win32"
+
+    state["fail"] = True
+    assert await backend._resolve_platform() == "win32"
+
+
+async def test_resolve_platform_posix_when_never_resolved(monkeypatch):
+    """从未成功解析过平台的会话，查询失败仍按空串（posix 现状）处理。"""
+
+    async def fake_lookup(user_id, machine_id=None):
+        return ""  # 持续故障：真实契约回落空串
+
+    monkeypatch.setattr(local_module, "_lookup_daemon_platform", fake_lookup)
+    backend = LocalSandboxBackend(user_id="u1", session_id="s1")
+    assert await backend._resolve_platform() == ""
+
+
+async def test_resolve_platform_prefers_hint_over_sticky_cache(monkeypatch):
+    """显式 platform_hint 优先级最高，粘滞缓存不影响既有构造期提示语义。"""
+
+    async def fake_lookup(user_id, machine_id=None):
+        return "win32"
+
+    monkeypatch.setattr(local_module, "_lookup_daemon_platform", fake_lookup)
+    backend = LocalSandboxBackend(user_id="u1", session_id="s1", platform_hint="linux")
+    assert await backend._resolve_platform() == "linux"


### PR DESCRIPTION
## 背景

生产事故（2026-09-06，会话 `a5fd351a`，Windows 本地沙箱）：转移文件失败、截图展示不了、/api/sandbox/* 大量 500、read_file 误报 daemon offline、命令输出乱码。经 yang 生产日志 + MongoDB trace + pod 日志取证，定位两个根因，均已按 TDD 修复。

## 根因 1：跨事件循环 Redis 连接池污染（服务端）

`LocalSandboxBackend` 的同步文件操作经 `_run_coro_sync` 用 `asyncio.run` 临时建事件循环，协程内部复用绑定主循环的共享 `redis.asyncio` 连接池 → `got Future attached to a different loop`，且临时循环关闭后残留 pending Task 污染池：`/api/sandbox/status|machines|channel|results` 连锁 500、daemon SSE 通道反复断连、read_file 误报 daemon offline、artifact 转移全部 `failed:`。

**修复**：新增 `async_utils.loop_bridge`（进程主循环登记处），`run_coro_sync` 统一 `run_coroutine_threadsafe` 投递到主循环；API lifespan 与 arq worker startup 登记主循环；平台解析加粘滞缓存（注册表查询瞬断不再翻回 posix 分支）。

## 根因 2：Windows 内嵌 python3 shim 损坏（daemon 客户端）

`pbs.py` 在 Windows 把 `python.exe` 复制成 `~/.lambchat/bin/python3.exe`——CPython 按副本位置找不到标准库，启动即 `Could not find platform independent libraries <prefix>`。而文件上传/下载（`python3 -c` 单命令往返）、reveal_file 展示全依赖它 → 转移文件必失败、截图展示不了。

**修复**：shim 改为 `python3.cmd` 批处理 wrapper 转发到归档内真实解释器（自动清理旧坏 exe 副本）；executor 输出解码链 UTF-8 → GBK → replace（修中文 Windows 乱码）；子进程默认 `PYTHONIOENCODING=utf-8`；daemon 0.3.1 + 版本门提升（旧 daemon 426 拒连提示升级，升级重启即自愈）。

## 验证

- 沙箱相关 428+ 测试全绿（新增 17 个），ruff / mypy 通过
- 全量套件与 develop 基线对比零新增失败（基线上 ask_human / sandbox_confirm 等 12 个失败为既有问题，与本 PR 无关）

## 部署注意

- 服务端走正常 develop → main 晋升流程
- **用户 Windows 机器 daemon 需升级到 0.3.1**（版本门会拒绝 0.3.0 并打印 `lambchat_sandbox update` 指引），升级重启后自动清除坏 shim