### PR TITLE
fix(settings): S3_INTERNAL_UPLOAD_MAX_SIZE 设置页可见——浏览器可直接改统一上限

### DIFF
--- a/src/kernel/config/_definitions_extra.py
+++ b/src/kernel/config/_definitions_extra.py
@@ -238,6 +238,7 @@ EXTRA_SETTING_DEFINITIONS: dict[str, dict] = {
         "subcategory": "limits",
         "description": "settingDesc.S3_INTERNAL_UPLOAD_MAX_SIZE",
         "default": 1073741824,
+        "frontend_visible": True,
         "depends_on": "S3_ENABLED",
     },
     "S3_PRESIGNED_URL_EXPIRES": {


### PR DESCRIPTION
## Summary

`S3_INTERNAL_UPLOAD_MAX_SIZE`（reveal/本地沙箱下载/S3 内部上传统一上限，默认 1GB）此前 `frontend_visible=false`，被设置页过滤藏掉——#430 落地的「浏览器直接改」因此不可达。置 `frontend_visible: true`：设置页 S3 → limits 下直接渲染，PUT 走既有热更新链路双 Pod 即时生效。

## Testing

- [x] tests/kernel 76 passed