### PR TITLE
fix(frontend): App 客户端回复完成通知——首条消息后请求权限 + 回前台补发后台期间完成的任务

### DIFF
--- a/frontend/src/components/layout/AppContent/ChatAppContent.tsx
+++ b/frontend/src/components/layout/AppContent/ChatAppContent.tsx
@@ -14,6 +14,7 @@ import { personaPresetApi } from "../../../services/api";
 import { usePersonaPresets } from "../../../hooks/usePersonaPresets";
 import { useProjectManager } from "../../../hooks/useProjectManager";
 import { appNotificationService } from "../../../services/notifications/appNotificationService";
+import { promptAppNotificationPermissionOnce } from "./appNotificationPermissionPrompt";
 import { useSessionConfig } from "../../../hooks/useSessionConfig";
 import {
   Permission,
@@ -868,15 +869,24 @@ export function ChatAppContent({
             sendAttachments,
             runOptions,
             submissionCallbacks,
-          ) =>
-            void sendMessage(
+          ) => {
+            // 第一次发消息后请求原生通知权限（仅 App 客户端，一次性）：
+            // 此刻用户最需要「回复完成提醒」，且 Android 只允许前台请求
+            void promptAppNotificationPermissionOnce({
+              appRuntime: appNotificationService.getRuntime(),
+              storage:
+                typeof localStorage !== "undefined" ? localStorage : null,
+              requestPermission: () =>
+                appNotificationService.requestPermission(),
+            });
+            return void sendMessage(
               content,
               undefined,
               sendAttachments,
               runOptions,
               submissionCallbacks,
-            )
-          }
+            );
+          }}
           onStopGeneration={stopGeneration}
           onSteerMessage={steerMessage}
           steerMessages={steerMessages}

--- a/frontend/src/components/layout/AppContent/__tests__/appNotificationPermissionPrompt.test.ts
+++ b/frontend/src/components/layout/AppContent/__tests__/appNotificationPermissionPrompt.test.ts
@@ -1,0 +1,48 @@
+import {
+  APP_NOTIFICATION_PERMISSION_PROMPT_STORAGE_KEY,
+  shouldPromptForAppNotificationPermission,
+  type PromptStorage,
+} from "../appNotificationPermissionPrompt";
+
+function storage(initial?: string): PromptStorage {
+  const map = new Map<string, string>(
+    initial ? [[APP_NOTIFICATION_PERMISSION_PROMPT_STORAGE_KEY, initial]] : [],
+  );
+  return {
+    getItem: (key: string) => map.get(key) ?? null,
+    setItem: (key: string, value: string) => void map.set(key, value),
+  };
+}
+
+test("prompts in packaged app runtimes after the first message", () => {
+  expect(
+    shouldPromptForAppNotificationPermission({
+      appRuntime: "capacitor-android",
+      storage: storage(),
+    }),
+  ).toBe(true);
+  expect(
+    shouldPromptForAppNotificationPermission({
+      appRuntime: "tauri",
+      storage: storage(),
+    }),
+  ).toBe(true);
+});
+
+test("does not prompt in plain browser runtimes", () => {
+  expect(
+    shouldPromptForAppNotificationPermission({
+      appRuntime: "unsupported",
+      storage: storage(),
+    }),
+  ).toBe(false);
+});
+
+test("never prompts twice", () => {
+  expect(
+    shouldPromptForAppNotificationPermission({
+      appRuntime: "capacitor-android",
+      storage: storage("requested"),
+    }),
+  ).toBe(false);
+});

--- a/frontend/src/components/layout/AppContent/__tests__/taskCatchUp.test.ts
+++ b/frontend/src/components/layout/AppContent/__tests__/taskCatchUp.test.ts
@@ -1,0 +1,154 @@
+import {
+  selectCatchUpCandidates,
+  type CatchUpSessionSnapshot,
+} from "../taskCatchUp";
+
+const HIDDEN_AT = Date.parse("2026-09-06T10:00:00.000Z");
+const COMPLETED_WHILE_HIDDEN = "2026-09-06T10:05:00.000Z";
+const COMPLETED_LONG_BEFORE = "2026-09-06T09:00:00.000Z";
+
+function snapshot(
+  overrides: Partial<CatchUpSessionSnapshot>,
+): CatchUpSessionSnapshot {
+  return {
+    id: "s1",
+    task_status: "completed",
+    updated_at: COMPLETED_WHILE_HIDDEN,
+    name: "Session One",
+    unread_count: 1,
+    metadata: {},
+    ...overrides,
+  };
+}
+
+test("selects sessions that finished while the app was hidden", () => {
+  const candidates = selectCatchUpCandidates({
+    sessions: [snapshot({ id: "s1" })],
+    hiddenAt: HIDDEN_AT,
+    currentSessionId: "other",
+    hasNotified: () => false,
+  });
+
+  expect(candidates).toHaveLength(1);
+  expect(candidates[0]).toMatchObject({
+    session_id: "s1",
+    status: "completed",
+  });
+});
+
+test("skips sessions whose last update predates going hidden", () => {
+  const candidates = selectCatchUpCandidates({
+    sessions: [snapshot({ id: "stale", updated_at: COMPLETED_LONG_BEFORE })],
+    hiddenAt: HIDDEN_AT,
+    currentSessionId: "other",
+    hasNotified: () => false,
+  });
+
+  expect(candidates).toHaveLength(0);
+});
+
+test("tolerates minor client clock skew around the hidden timestamp", () => {
+  // 设备时钟略慢于服务器：完成时间略早于本地记录的 hiddenAt，仍应通知
+  const slightlyEarly = new Date(HIDDEN_AT - 60_000).toISOString();
+  const candidates = selectCatchUpCandidates({
+    sessions: [snapshot({ id: "skew", updated_at: slightlyEarly })],
+    hiddenAt: HIDDEN_AT,
+    currentSessionId: "other",
+    hasNotified: () => false,
+  });
+
+  expect(candidates).toHaveLength(1);
+});
+
+test("skips the session the user is currently viewing", () => {
+  const candidates = selectCatchUpCandidates({
+    sessions: [snapshot({ id: "current" })],
+    hiddenAt: HIDDEN_AT,
+    currentSessionId: "current",
+    hasNotified: () => false,
+  });
+
+  expect(candidates).toHaveLength(0);
+});
+
+test("skips runs already notified through live websocket delivery", () => {
+  const candidates = selectCatchUpCandidates({
+    sessions: [snapshot({ id: "s1", metadata: { current_run_id: "run-1" } })],
+    hiddenAt: HIDDEN_AT,
+    currentSessionId: "other",
+    hasNotified: (key) => key === "task:run-1:completed",
+  });
+
+  expect(candidates).toHaveLength(0);
+});
+
+test("skips running sessions and statuses that do not warrant a notification", () => {
+  const candidates = selectCatchUpCandidates({
+    sessions: [
+      snapshot({ id: "running", task_status: "running" }),
+      snapshot({ id: "queued", task_status: "queued" }),
+      snapshot({ id: "cancelled", task_status: "cancelled" }),
+      snapshot({ id: "idle", task_status: null }),
+    ],
+    hiddenAt: HIDDEN_AT,
+    currentSessionId: "other",
+    hasNotified: () => false,
+  });
+
+  expect(candidates).toHaveLength(0);
+});
+
+test("notifies failed and waiting-human completions too", () => {
+  const candidates = selectCatchUpCandidates({
+    sessions: [
+      snapshot({ id: "failed", task_status: "failed" }),
+      snapshot({ id: "waiting", task_status: "waiting_human" }),
+    ],
+    hiddenAt: HIDDEN_AT,
+    currentSessionId: "other",
+    hasNotified: () => false,
+  });
+
+  expect(candidates.map((c) => c.status).sort()).toEqual([
+    "failed",
+    "waiting_human",
+  ]);
+});
+
+test("derives the websocket dedupe key from the run id when present", () => {
+  const [candidate] = selectCatchUpCandidates({
+    sessions: [snapshot({ id: "s1", metadata: { current_run_id: "run-9" } })],
+    hiddenAt: HIDDEN_AT,
+    currentSessionId: "other",
+    hasNotified: () => false,
+  });
+
+  expect(candidate?.dedupeKey).toBe("task:run-9:completed");
+});
+
+test("falls back to a session-scoped dedupe key when run id is missing", () => {
+  const [candidate] = selectCatchUpCandidates({
+    sessions: [snapshot({ id: "s1", metadata: {} })],
+    hiddenAt: HIDDEN_AT,
+    currentSessionId: "other",
+    hasNotified: () => false,
+  });
+
+  expect(candidate?.dedupeKey).toBe(
+    `task:catchup:s1:${COMPLETED_WHILE_HIDDEN}:completed`,
+  );
+});
+
+test("caps the number of catch-up notifications to avoid spam", () => {
+  const sessions = Array.from({ length: 8 }, (_, i) =>
+    snapshot({ id: `s${i}` }),
+  );
+  const candidates = selectCatchUpCandidates({
+    sessions,
+    hiddenAt: HIDDEN_AT,
+    currentSessionId: "other",
+    hasNotified: () => false,
+  });
+
+  expect(candidates.length).toBeLessThanOrEqual(5);
+});

--- a/frontend/src/components/layout/AppContent/__tests__/taskCatchUpIntegrationSource.test.ts
+++ b/frontend/src/components/layout/AppContent/__tests__/taskCatchUpIntegrationSource.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const notificationsSource = readFileSync(
+  join(
+    process.cwd(),
+    "src/components/layout/AppContent/useWebSocketNotifications.tsx",
+  ),
+  "utf8",
+);
+
+const chatAppContentSource = readFileSync(
+  join(process.cwd(), "src/components/layout/AppContent/ChatAppContent.tsx"),
+  "utf8",
+);
+
+test("task notifications dedupe across websocket and catch-up delivery", () => {
+  expect(notificationsSource).toMatch(/hasTaskNotified/);
+  expect(notificationsSource).toMatch(/markTaskNotified/);
+});
+
+test("websocket notifications re-check finished tasks when the app resumes", () => {
+  expect(notificationsSource).toMatch(/visibilitychange/);
+  expect(notificationsSource).toMatch(/selectCatchUpCandidates/);
+  expect(notificationsSource).toMatch(/document\.visibilityState === "hidden"/);
+});
+
+test("first chat submission prompts for native notification permission once", () => {
+  expect(chatAppContentSource).toMatch(/promptAppNotificationPermissionOnce/);
+  expect(chatAppContentSource).toMatch(
+    /appNotificationService\.getRuntime\(\)/,
+  );
+});

--- a/frontend/src/components/layout/AppContent/__tests__/taskNotificationDedupe.test.ts
+++ b/frontend/src/components/layout/AppContent/__tests__/taskNotificationDedupe.test.ts
@@ -1,0 +1,17 @@
+import {
+  clearTaskNotificationDedupe,
+  hasTaskNotified,
+  markTaskNotified,
+} from "../taskNotificationDedupe";
+
+test("unmarked keys are considered unnotified", () => {
+  clearTaskNotificationDedupe();
+  expect(hasTaskNotified("task:run-1:completed")).toBe(false);
+});
+
+test("marks a key as notified so later deliveries can dedupe", () => {
+  clearTaskNotificationDedupe();
+  markTaskNotified("task:run-1:completed");
+  expect(hasTaskNotified("task:run-1:completed")).toBe(true);
+  expect(hasTaskNotified("task:run-1:failed")).toBe(false);
+});

--- a/frontend/src/components/layout/AppContent/appNotificationPermissionPrompt.ts
+++ b/frontend/src/components/layout/AppContent/appNotificationPermissionPrompt.ts
@@ -1,0 +1,76 @@
+/**
+ * One-time native notification permission prompt.
+ *
+ * Android 13+ (targetSdk 35) denies POST_NOTIFICATIONS by default and runtime
+ * requests only work while the app is foregrounded — requesting lazily at
+ * delivery time (exactly when the app may be hidden) fails silently. Prompt
+ * once right after the user's first message, when the value of "reply done"
+ * notifications is obvious.
+ */
+
+import type { AppNotificationRuntime } from "../../../services/notifications/appNotificationService";
+
+export const APP_NOTIFICATION_PERMISSION_PROMPT_STORAGE_KEY =
+  "lambchat.app_notification_permission_prompted";
+
+export interface PromptStorage {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+}
+
+export function shouldPromptForAppNotificationPermission({
+  appRuntime,
+  storage,
+}: {
+  appRuntime: AppNotificationRuntime;
+  storage: PromptStorage;
+}): boolean {
+  if (appRuntime === "unsupported") return false;
+  return (
+    storage.getItem(APP_NOTIFICATION_PERMISSION_PROMPT_STORAGE_KEY) !==
+    "requested"
+  );
+}
+
+/**
+ * 请求一次原生通知权限（App 客户端）。无论用户授予与否都记录已请求，
+ * 避免反复骚扰；被拒后仍可在 设置 → 通知 里重试。
+ */
+export async function promptAppNotificationPermissionOnce({
+  appRuntime,
+  storage,
+  requestPermission,
+}: {
+  appRuntime: AppNotificationRuntime;
+  storage: PromptStorage | null;
+  requestPermission: () => Promise<string>;
+}): Promise<boolean> {
+  const safeStorage: PromptStorage =
+    storage ??
+    (typeof localStorage === "undefined"
+      ? {
+          getItem: () => null,
+          setItem: () => {},
+        }
+      : localStorage);
+
+  if (
+    !shouldPromptForAppNotificationPermission({
+      appRuntime,
+      storage: safeStorage,
+    })
+  ) {
+    return false;
+  }
+
+  safeStorage.setItem(
+    APP_NOTIFICATION_PERMISSION_PROMPT_STORAGE_KEY,
+    "requested",
+  );
+  try {
+    await requestPermission();
+  } catch (error) {
+    console.warn("[AppNotification] Permission prompt failed:", error);
+  }
+  return true;
+}

--- a/frontend/src/components/layout/AppContent/taskCatchUp.ts
+++ b/frontend/src/components/layout/AppContent/taskCatchUp.ts
@@ -1,0 +1,121 @@
+/**
+ * Resume-time catch-up selection for task completion notifications.
+ *
+ * Mobile clients lose their websocket soon after backgrounding, so
+ * `task:complete` never arrives while the user is away. When the app comes
+ * back to the foreground we diff the session list against the moment the app
+ * went hidden and re-notify for runs that finished in the meantime.
+ */
+
+import type { BackendSession } from "../../../services/api/session";
+
+export const CATCH_UP_NOTIFIABLE_STATUSES = [
+  "completed",
+  "failed",
+  "waiting_human",
+] as const;
+
+type CatchUpStatus = (typeof CATCH_UP_NOTIFIABLE_STATUSES)[number];
+
+/** 客户端与服务器时钟偏差容忍窗口：完成时间略早于本地 hiddenAt 仍算后台期间完成 */
+const CATCH_UP_CLOCK_SKEW_MS = 2 * 60 * 1000;
+
+/** 单次回前台最多补发的通知条数，防止长时间离开后通知轰炸 */
+const CATCH_UP_MAX_NOTIFICATIONS = 5;
+
+export interface CatchUpSessionSnapshot {
+  id: string;
+  task_status?: string | null;
+  updated_at: string;
+  name?: string;
+  unread_count?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CatchUpCandidate {
+  session_id: string;
+  run_id?: string;
+  status: CatchUpStatus;
+  dedupeKey: string;
+  sessionName?: string;
+  unreadCount?: number;
+}
+
+function isNotifiableStatus(status?: string | null): status is CatchUpStatus {
+  return (
+    !!status &&
+    (CATCH_UP_NOTIFIABLE_STATUSES as readonly string[]).includes(status)
+  );
+}
+
+function currentRunId(metadata?: Record<string, unknown>): string | undefined {
+  const value = metadata?.current_run_id;
+  return typeof value === "string" && value ? value : undefined;
+}
+
+/**
+ * 与 websocket 即时通知共享的 dedupe key（`task:<run_id>:<status>`）；
+ * 没有 run_id 时退化为会话 + 完成时间戳，保证同一完成事件只补发一次。
+ */
+export function buildCatchUpDedupeKey(
+  session: CatchUpSessionSnapshot,
+  status: CatchUpStatus,
+): string {
+  const runId = currentRunId(session.metadata);
+  if (runId) {
+    return `task:${runId}:${status}`;
+  }
+  return `task:catchup:${session.id}:${session.updated_at}:${status}`;
+}
+
+export function selectCatchUpCandidates({
+  sessions,
+  hiddenAt,
+  currentSessionId,
+  hasNotified,
+}: {
+  sessions: CatchUpSessionSnapshot[];
+  hiddenAt: number;
+  currentSessionId: string | null;
+  hasNotified: (dedupeKey: string) => boolean;
+}): CatchUpCandidate[] {
+  const candidates: CatchUpCandidate[] = [];
+
+  for (const session of sessions) {
+    if (!isNotifiableStatus(session.task_status)) continue;
+    if (session.id === currentSessionId) continue;
+
+    const updatedAt = Date.parse(session.updated_at);
+    if (!Number.isFinite(updatedAt)) continue;
+    if (updatedAt < hiddenAt - CATCH_UP_CLOCK_SKEW_MS) continue;
+
+    const status = session.task_status;
+    const dedupeKey = buildCatchUpDedupeKey(session, status);
+    if (hasNotified(dedupeKey)) continue;
+
+    candidates.push({
+      session_id: session.id,
+      run_id: currentRunId(session.metadata),
+      status,
+      dedupeKey,
+      sessionName: session.name,
+      unreadCount: session.unread_count,
+    });
+    if (candidates.length >= CATCH_UP_MAX_NOTIFICATIONS) break;
+  }
+
+  return candidates;
+}
+
+export function toCatchUpSnapshot(
+  session: BackendSession,
+): CatchUpSessionSnapshot {
+  return {
+    id: session.id,
+    task_status: session.task_status,
+    updated_at: session.updated_at,
+    name: session.name,
+    unread_count: session.unread_count,
+    metadata: session.metadata,
+  };
+}

--- a/frontend/src/components/layout/AppContent/taskNotificationDedupe.ts
+++ b/frontend/src/components/layout/AppContent/taskNotificationDedupe.ts
@@ -1,0 +1,21 @@
+/**
+ * Cross-channel task notification dedupe.
+ *
+ * Live websocket delivery (`task:complete`) and resume-time catch-up both
+ * surface the same run; the shared key space keeps users from getting
+ * double-notified for one completion.
+ */
+
+const notifiedKeys = new Set<string>();
+
+export function markTaskNotified(dedupeKey: string): void {
+  notifiedKeys.add(dedupeKey);
+}
+
+export function hasTaskNotified(dedupeKey: string): boolean {
+  return notifiedKeys.has(dedupeKey);
+}
+
+export function clearTaskNotificationDedupe(): void {
+  notifiedKeys.clear();
+}

--- a/frontend/src/components/layout/AppContent/useWebSocketNotifications.tsx
+++ b/frontend/src/components/layout/AppContent/useWebSocketNotifications.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { toast } from "react-hot-toast";
@@ -17,6 +17,8 @@ import {
   shouldSurfaceTaskNotification,
 } from "./taskNotificationGuards";
 import { buildTaskNotificationCopy } from "./taskNotificationContent";
+import { hasTaskNotified, markTaskNotified } from "./taskNotificationDedupe";
+import { selectCatchUpCandidates, toCatchUpSnapshot } from "./taskCatchUp";
 import { ImageWithSkeleton } from "../../chat/ChatMessage/ImageWithSkeleton";
 import { isMobileDevice } from "../../../utils/mobile";
 
@@ -37,6 +39,20 @@ interface UseWebSocketNotificationsOptions {
   }) => void;
 }
 
+interface TaskCompleteDelivery {
+  data: {
+    session_id: string;
+    run_id?: string;
+    status: string;
+    message?: string;
+    unread_count?: number;
+    project_id?: string | null;
+    scheduled_task_id?: string | null;
+    is_favorite?: boolean;
+    dedupeKey?: string;
+  };
+}
+
 export function useWebSocketNotifications({
   sessionId,
   enabled = true,
@@ -54,31 +70,8 @@ export function useWebSocketNotifications({
   const onSessionTaskStatusRef = useRef(onSessionTaskStatus);
   onSessionTaskStatusRef.current = onSessionTaskStatus;
 
-  // WebSocket for task completion notifications
-  useWebSocket({
-    enabled,
-    onUsageUpdated: () => {
-      // 后端 usage_logs 落库后推送，直接触发各处当日用量刷新
-      window.dispatchEvent(new Event(TODAY_USAGE_REFRESH_EVENT));
-    },
-    onSessionTaskStatus: (data) => {
-      onSessionTaskStatusRef.current?.(data);
-    },
-    onRecommendQuestions: (notification) => {
-      onRecommendQuestionsRef.current?.(notification);
-    },
-    onTaskComplete: async (notification: {
-      data: {
-        session_id: string;
-        run_id: string;
-        status: string;
-        message?: string;
-        unread_count?: number;
-        project_id?: string | null;
-        scheduled_task_id?: string | null;
-        is_favorite?: boolean;
-      };
-    }) => {
+  const deliverTaskCompletion = useCallback(
+    async (notification: TaskCompleteDelivery) => {
       const {
         session_id,
         run_id,
@@ -89,6 +82,15 @@ export function useWebSocketNotifications({
         scheduled_task_id,
         is_favorite,
       } = notification.data;
+
+      // 跨通道去重：websocket 即时通知与回前台补发共用同一 key 空间
+      const dedupeKey =
+        notification.data.dedupeKey ??
+        (run_id ? `task:${run_id}:${status}` : undefined);
+      if (dedupeKey) {
+        if (hasTaskNotified(dedupeKey)) return;
+        markTaskNotified(dedupeKey);
+      }
 
       // 通知侧边栏更新 unread_count（仅非当前 session）
       if (session_id !== sessionId && unread_count !== undefined) {
@@ -269,6 +271,86 @@ export function useWebSocketNotifications({
           },
         },
       );
+    },
+    [sessionId, t, navigate, notify, isSupported, permission],
+  );
+
+  const deliverTaskCompletionRef = useRef(deliverTaskCompletion);
+  deliverTaskCompletionRef.current = deliverTaskCompletion;
+  const sessionIdRef = useRef(sessionId);
+  sessionIdRef.current = sessionId;
+
+  // 回前台补发：移动端退后台后 WebSocket 被系统挂断，`task:complete`
+  // 送达不了；回到前台时对比「切走时刻 vs 会话列表最新状态」，把后台
+  // 期间完成的 run 补一条通知（与即时通知共用 dedupe，不会重复）。
+  useEffect(() => {
+    if (!enabled) return;
+
+    const hiddenAtRef: { current: number | null } = { current: null };
+    let catchUpInFlight = false;
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        hiddenAtRef.current = Date.now();
+        return;
+      }
+
+      const hiddenAt = hiddenAtRef.current;
+      hiddenAtRef.current = null;
+      if (!hiddenAt || catchUpInFlight) return;
+
+      catchUpInFlight = true;
+      void (async () => {
+        try {
+          const response = await sessionApi.list({ limit: 100 });
+          const sessions = Array.isArray(response)
+            ? response
+            : response?.sessions ?? [];
+          const candidates = selectCatchUpCandidates({
+            sessions: sessions.map(toCatchUpSnapshot),
+            hiddenAt,
+            currentSessionId: sessionIdRef.current,
+            hasNotified: hasTaskNotified,
+          });
+          for (const candidate of candidates) {
+            await deliverTaskCompletionRef.current({
+              data: {
+                session_id: candidate.session_id,
+                run_id: candidate.run_id,
+                status: candidate.status,
+                unread_count: candidate.unreadCount,
+                dedupeKey: candidate.dedupeKey,
+              },
+            });
+          }
+        } catch (err) {
+          console.warn("[AppContent] Task catch-up check failed:", err);
+        } finally {
+          catchUpInFlight = false;
+        }
+      })();
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () =>
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+  }, [enabled]);
+
+  // WebSocket for task completion notifications
+  useWebSocket({
+    enabled,
+    onUsageUpdated: () => {
+      // 后端 usage_logs 落库后推送，直接触发各处当日用量刷新
+      window.dispatchEvent(new Event(TODAY_USAGE_REFRESH_EVENT));
+    },
+    onSessionTaskStatus: (data) => {
+      onSessionTaskStatusRef.current?.(data);
+    },
+    onRecommendQuestions: (notification) => {
+      onRecommendQuestionsRef.current?.(notification);
+    },
+    onTaskComplete: (notification) => {
+      void deliverTaskCompletionRef.current(notification);
     },
   });
 }


### PR DESCRIPTION
## 背景

App 客户端（Android/iOS/桌面）在「等 LLM 回复」场景下收不到完成通知：

1. 移动端退后台后系统挂断 WebSocket，`task:complete` 送达不了；后端 Web Push 兜底依赖 Service Worker + PushManager，在 Capacitor/Tauri WebView 中不存在
2. Android 13+（targetSdk 35）`POST_NOTIFICATIONS` 默认拒绝，且只能在前景请求——现有「送达时懒请求」恰好都发生在后台，必败
3. 权限只在 设置→通知 手动开启时请求，没去过设置页的用户永远收不到系统通知

## 改动

- **首条消息发送后一次性请求原生通知权限**（仅 App 客户端）：此刻用户最需要「回复完成提醒」，且满足 Android 前景请求约束；localStorage 记忆一次性，被拒后仍可在 设置→通知 重试
- **回前台 catch-up 补发**：App 切后台记时刻，回到前台拉会话列表，把后台期间转为 `completed` / `failed` / `waiting_human` 的 run 补发系统通知 + Toast + 未读角标
  - 与 WebSocket 即时通知**共享 dedupe key**（`task:<run_id>:<status>`，无 run_id 退化为会话+时间戳），桌面端 WS 已弹过的不重复
  - 排除当前会话：既有 SSE 重连机制（`useSSEReconnect`）回前台会自动补全回复流，不打扰
  - 单次上限 5 条防轰炸；容忍 2 分钟客户端时钟偏差；早已完成的旧会话、用户取消的不误报
- `onTaskComplete` 主体抽为 `deliverTaskCompletion` 复用，WS 路径行为不变

## 已知边界

App 被杀死 / 深度后台期间的实时推送仍需 FCM/APNs 基建（需 Firebase 项目凭据 + 服务器可访问 Google + 用户设备有 GMS），另行决策。

## 验证

- 新增 18 个测试（catch-up 纯函数 10、跨通道去重 2、权限时机 3、接线 source test 3），TDD 红-绿流程
- 前端全量 `pnpm test`：500 文件 / 2326 测试全过
- `pnpm run lint` 0 errors；`pnpm run build` 成功，eager 预算内