### PR TITLE
fix(upload): proxy=true 流式代理头中文文件名按 RFC 5987 编码

### DIFF
--- a/src/api/routes/upload.py
+++ b/src/api/routes/upload.py
@@ -227,6 +227,16 @@ async def _get_file_response_metadata(key: str) -> tuple[str | None, str]:
     return filename_for_disposition, content_type
 
 
+def _inline_content_disposition(filename: str) -> str:
+    """HTTP 头只允许 latin-1：非 ASCII 文件名按 RFC 5987 走 filename*=utf-8''。"""
+    from urllib.parse import quote
+
+    quoted = quote(filename)
+    if quoted != filename:
+        return f"inline; filename*=utf-8''{quoted}"
+    return f'inline; filename="{filename.replace(chr(34), "")}"'
+
+
 async def _read_upload_file_limited(
     file: Any,
     *,
@@ -891,7 +901,7 @@ async def get_file_proxy(
         filename_for_disposition, content_type = await _get_file_response_metadata(key)
         headers = {"Cache-Control": "public, max-age=300"}
         if filename_for_disposition:
-            headers["Content-Disposition"] = f'inline; filename="{filename_for_disposition}"'
+            headers["Content-Disposition"] = _inline_content_disposition(filename_for_disposition)
 
         return StreamingResponse(
             storage.download_stream(key),

--- a/tests/api/routes/test_upload_proxy_stream.py
+++ b/tests/api/routes/test_upload_proxy_stream.py
@@ -1,0 +1,113 @@
+"""?proxy=true 流式代理的 Content-Disposition 编码测试。
+
+背景：OSS 直连不可达的客户端靠 ?proxy=true 兜底预览，而代理分支把
+文件记录里的原始文件名（常含中文）直接拼进 HTTP 头，latin-1 编码
+失败导致 500，前端只能报「从存储加载文件失败」。
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.api.routes import upload
+
+
+def _fake_request() -> SimpleNamespace:
+    return SimpleNamespace(
+        base_url="http://testserver/",
+        headers={"host": "testserver"},
+        url=SimpleNamespace(scheme="http"),
+    )
+
+
+def _async_of(value):
+    async def _factory():
+        return value
+
+    return _factory
+
+
+class _FakeS3Storage:
+    """非本地存储假后端：只实现代理分支用到的接口。"""
+
+    is_local = False
+
+    def __init__(self, payload: bytes = b"PK\x05\x06fake-docx") -> None:
+        self._payload = payload
+
+    async def file_exists(self, key: str) -> bool:
+        return True
+
+    async def download_stream(self, key: str, chunk_size: int = 1024 * 1024):
+        yield self._payload
+
+
+class _FakeRecordStorage:
+    def __init__(self, record: dict | None) -> None:
+        self._record = record
+
+    async def find_by_key(self, key: str, user_id: str | None = None) -> dict | None:
+        return self._record
+
+
+@pytest.mark.asyncio
+async def test_proxy_stream_with_cjk_filename_builds_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """中文文件名走 RFC 5987 的 filename*=utf-8''，头必须可 latin-1 编码。"""
+    storage = _FakeS3Storage()
+    monkeypatch.setattr(upload, "get_or_init_storage", _async_of(storage))
+    monkeypatch.setattr(
+        upload,
+        "_file_record_storage",
+        _FakeRecordStorage(
+            {"name": "项目方案（终稿）.docx", "mime_type": None},
+        ),
+    )
+
+    resp = await upload.get_file_proxy("document/u1/abc.docx", _fake_request(), proxy=True)
+
+    assert resp.status_code == 200
+    disposition = resp.headers["content-disposition"]
+    # 构造阶段不再抛 UnicodeEncodeError，且值能安全编码进 HTTP 头
+    disposition.encode("latin-1")
+    assert "filename*=utf-8''" in disposition
+    assert "%E9%A1%B9%E7%9B%AE" in disposition  # 「项目」的百分号编码
+
+
+@pytest.mark.asyncio
+async def test_proxy_stream_with_ascii_filename_keeps_plain_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _FakeS3Storage()
+    monkeypatch.setattr(upload, "get_or_init_storage", _async_of(storage))
+    monkeypatch.setattr(
+        upload,
+        "_file_record_storage",
+        _FakeRecordStorage({"name": "report.docx", "mime_type": None}),
+    )
+
+    resp = await upload.get_file_proxy("document/u1/abc.docx", _fake_request(), proxy=True)
+
+    assert resp.status_code == 200
+    assert resp.headers["content-disposition"] == 'inline; filename="report.docx"'
+
+
+@pytest.mark.asyncio
+async def test_proxy_stream_without_record_serves_octet_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """查不到文件记录时依旧可代理，缺省 docx 的 MIME 推断不受影响。"""
+    storage = _FakeS3Storage()
+    monkeypatch.setattr(upload, "get_or_init_storage", _async_of(storage))
+    monkeypatch.setattr(upload, "_file_record_storage", _FakeRecordStorage(None))
+
+    resp = await upload.get_file_proxy("document/u1/abc.docx", _fake_request(), proxy=True)
+
+    assert resp.status_code == 200
+    assert "content-disposition" not in resp.headers
+    assert (
+        resp.media_type == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    )


### PR DESCRIPTION
## 问题

线上预览中文名文件（如 docx）报「从存储加载文件失败」：

- 前端先 302 直连 OSS 香港签名 URL，网络不稳时失败
- 兜底重试 `?proxy=true` 应用内流式代理，但该端点对中文文件名**必 500**

生产 `lambchat-b` Pod 日志：

```
File "/app/src/api/routes/upload.py", line 896, in get_file_proxy
    return StreamingResponse(
UnicodeEncodeError: 'latin-1' codec can't encode characters in position 36-45
```

## 根因

`proxy=true` 分支把文件记录里的原始文件名直接拼进 `Content-Disposition` 头，HTTP 头只允许 latin-1，中文名编码抛 `UnicodeEncodeError` → 500，兜底通道整体不可用。本地存储分支走 `FileResponse(filename=...)` 由 Starlette 正确处理，唯独此处手拼头漏了编码。

## 修复

- 新增 `_inline_content_disposition()`：非 ASCII 文件名按 RFC 5987 输出 `filename*=utf-8''<百分号编码>`，ASCII 名保持 `inline; filename="..."`（与 FileResponse 行为对齐）
- 新增 `tests/api/routes/test_upload_proxy_stream.py` 3 个用例：中文文件名（修复前以与线上一致的 UnicodeEncodeError 失败）、ASCII 文件名、无文件记录

## 验证

- 新测试 3 passed；upload/file 相关 81 passed 无回归
- ruff / mypy 干净
- curl 复核线上：OSS 文件完好（200 / 377KB / 正确 MIME），302 签名正常——部署后预览即恢复