### PR TITLE
perf(sandbox): 本地沙箱传输修复与流式提速——result 透传/双向流式二进制帧/短命令免 ack（2.8.4）

### DIFF
--- a/client/lambchat_sandbox/daemon.py
+++ b/client/lambchat_sandbox/daemon.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
 import signal
 import sys
 import time
@@ -41,8 +42,14 @@ from pathlib import Path
 from lambchat_sandbox import pbs
 from lambchat_sandbox.audit import Auditor
 from lambchat_sandbox.config import SandboxConfig
-from lambchat_sandbox.executor import Executor
-from lambchat_sandbox.fsops import FS_OPS, handle_fs_op
+from lambchat_sandbox.executor import Executor, ExecutorError
+from lambchat_sandbox.fsops import (
+    FS_OPS,
+    STREAM_OPS,
+    handle_fs_op,
+    handle_fs_stream,
+    make_stream_upload_writer,
+)
 from lambchat_sandbox.transport import (
     ChannelClient,
     ToolCall,
@@ -54,6 +61,10 @@ from lambchat_sandbox.transport import (
 DEFAULT_AUDIT_ROOT = Path.home() / ".lambchat" / "audit"
 DEFAULT_EXEC_TIMEOUT_S = 60.0  # 帧缺失/非正 timeout 的兜底，避免 communicate(timeout=0) 立即超时
 DAEMON_AUDIT_SESSION = "daemon"  # shutdown 等进程级事件的审计会话（过 Auditor 白名单）
+
+# exec 的 watchdog ack 延时（秒）：短于此的命令不发 ack、done 直接到达——
+# 省一次 HTTP 往返；长命令到点补 ack，服务端 30s ACK 死线（远大于本值）无虞
+_EXEC_ACK_DELAY_S = 8.0
 
 
 def _default_machine_name() -> str:
@@ -174,10 +185,10 @@ async def _process_call(
     前以 ask_human interrupt 完成，daemon 只收到已确认的执行请求，到达即执行。
     ``confirm_policy`` 仍随连接上报（connect URL 第四段）供服务端门读取。
 
-    op 分发（M4 T3.5）：``exec`` 走 executor（shell 命令）；``fs_*`` 走
-    :func:`lambchat_sandbox.fsops.handle_fs_op`（win32 结构化文件操作——
-    deepagents 的 POSIX 脚本命令 cmd.exe 跑不了，服务端改发结构化 op）；
-    其余 op 回 ``unsupported`` 错误。
+    op 分发（M4 T3.5）：``exec`` 走 executor（shell 命令，**watchdog 延迟
+    ack**——短命令免一次 HTTP 往返）；``fs_*`` 走
+    :func:`lambchat_sandbox.fsops.handle_fs_op`（win32 结构化文件操作）与流式
+    op（长传输，立即 ack）；其余 op 回 ``unsupported`` 错误。
     """
     command = str(call.payload.get("command", ""))
     virtual_cwd = str(call.payload.get("cwd", ""))
@@ -194,7 +205,6 @@ async def _process_call(
             "path": path,
         },
     )
-    await client.post_result(call.call_id, {"stage": "ack"})
 
     if call.op == "exec":
         await _process_exec_call(
@@ -206,6 +216,24 @@ async def _process_call(
             started=started,
             cfg=cfg,
             executor=executor,
+            auditor=auditor,
+        )
+        return
+    # fs op / 流式 op：立即 ack——结构化 op 快（无 watchdog 必要），流式传输
+    # 可达数分钟（必须先 ack 才不会撞服务端 ACK 死线）
+    if call.op in STREAM_OPS or call.op in FS_OPS:
+        await client.post_result(call.call_id, {"stage": "ack"})
+    if call.op in STREAM_OPS:
+        handler = (
+            _process_upload_stream_call if call.op == "fs_upload_stream" else _process_stream_call
+        )
+        await handler(
+            client,
+            call,
+            session_id=session_id,
+            path=path,
+            started=started,
+            cfg=cfg,
             auditor=auditor,
         )
         return
@@ -239,7 +267,13 @@ async def _process_exec_call(
     executor: Executor,
     auditor: Auditor,
 ) -> None:
-    """op=exec 的执行链：迟到检查 → executor → done → 审计（确认在服务端）。
+    """op=exec 的执行链：迟到检查 → executor（线程）→ done → 审计。
+
+    **watchdog 延迟 ack**：短命令（< ``_EXEC_ACK_DELAY_S``）done 直接先到，
+    省掉一次 HTTP 往返——agent 循环里 exec 是最高频 op，每条省一次往返对
+    命令结果传递速度是净赚；长命令由 watchdog 在延时到点补 ack，服务端 30s
+    ACK 死线不受影响。executor 是阻塞 subprocess，丢线程跑释放事件循环，
+    watchdog 才有机会触发。
 
     ``payload["env"]``（服务端用户 env 变量，对齐云端 envs= 语义）净化后
     透传 executor 合并进子进程环境——非 dict 载荷或非 str 条目静默丢弃，
@@ -259,7 +293,17 @@ async def _process_exec_call(
         )
         return
 
-    result = _execute(executor, command, virtual_cwd, effective, _sanitize_env(call.payload))
+    finished = asyncio.Event()
+    watchdog = asyncio.create_task(_exec_ack_watchdog(client, call.call_id, finished))
+    try:
+        result = await asyncio.to_thread(
+            _execute, executor, command, virtual_cwd, effective, _sanitize_env(call.payload)
+        )
+    finally:
+        finished.set()
+        watchdog.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await watchdog
     await client.post_result(
         call.call_id, {"stage": "done", **{k: result.get(k) for k in _DONE_KEYS}}
     )
@@ -274,6 +318,15 @@ async def _process_exec_call(
             "exit_code": result.get("exit_code"),
         },
     )
+
+
+async def _exec_ack_watchdog(client: ChannelClient, call_id: str, finished: asyncio.Event) -> None:
+    """长命令的迟到 ack：到点命令仍在执行才补发一次（之后等 done 即可）。"""
+    try:
+        await asyncio.wait_for(finished.wait(), timeout=_EXEC_ACK_DELAY_S)
+    except asyncio.TimeoutError:
+        with contextlib.suppress(Exception):  # noqa: BLE001 - ack 尽力而为，失败不拖垮执行
+            await client.post_result(call_id, {"stage": "ack"})
 
 
 async def _process_fs_call(
@@ -326,6 +379,161 @@ async def _process_fs_call(
         return
 
     await client.post_result(call.call_id, {"stage": "done", "status": "ok", "result": result})
+    auditor.log(
+        session_id,
+        {"event": "executed", "call_id": call.call_id, "op": call.op, "path": path, "status": "ok"},
+    )
+
+
+async def _process_stream_call(
+    client: ChannelClient,
+    call: ToolCall,
+    *,
+    session_id: str,
+    path: str,
+    started: float,
+    cfg: SandboxConfig,
+    auditor: Auditor,
+) -> None:
+    """op=fs_download_stream：ack 由 _process_call 顶层统一发出，结果走**单个**
+    流式 POST（NDJSON 行）。
+
+    分块通道每块一对 HTTP 往返，大文件块数×往返时延线性放大；流式 op 把
+    整个文件装进一个 chunked POST——行协议见 fsops（错误也是行）。行生成
+    迭代中的 ``ExecutorError``（非法 cwd）收敛为 error done 不炸通道（与
+    fs op 同语义）；网络级 POST 失败照常上抛交外层重连。
+    """
+    auditor.log(
+        session_id, {"event": "allowed", "call_id": call.call_id, "op": call.op, "path": path}
+    )
+    effective = call.timeout if call.timeout > 0 else DEFAULT_EXEC_TIMEOUT_S
+    if time.monotonic() - started >= effective:
+        await client.post_result(
+            call.call_id, {"stage": "done", "status": "error", "error": "expired"}
+        )
+        auditor.log(
+            session_id, {"event": "expired", "call_id": call.call_id, "op": call.op, "path": path}
+        )
+        return
+
+    try:
+        lines = handle_fs_stream(call.op, call.payload, cfg.data_root)
+        await client.post_stream_result(call.call_id, lines, deadline_s=effective)
+    except ExecutorError as exc:
+        await client.post_result(
+            call.call_id, {"stage": "done", "status": "error", "error": str(exc)}
+        )
+        auditor.log(
+            session_id,
+            {
+                "event": "executed",
+                "call_id": call.call_id,
+                "op": call.op,
+                "path": path,
+                "status": "error",
+            },
+        )
+        return
+    auditor.log(
+        session_id,
+        {"event": "executed", "call_id": call.call_id, "op": call.op, "path": path, "status": "ok"},
+    )
+
+
+async def _process_upload_stream_call(
+    client: ChannelClient,
+    call: ToolCall,
+    *,
+    session_id: str,
+    path: str,
+    started: float,
+    cfg: SandboxConfig,
+    auditor: Auditor,
+) -> None:
+    """op=fs_upload_stream：服务端 → daemon 方向的流式上传。
+
+    ack 由 _process_call 发出后，daemon **单个 GET** 拉取整个文件（服务端
+    生产者把帧写入 Redis list，GET 端点边拉边吐），逐帧解析落盘。分块
+    fs_upload 每块一对 HTTP 往返的成本在这里摊销成每文件常数次。
+    ``ExecutorError``（非法 cwd）/``FsOpError``（逃逸/超限）收敛为 error
+    done 不炸通道；网络级失败上抛交外层重连。
+    """
+    auditor.log(
+        session_id, {"event": "allowed", "call_id": call.call_id, "op": call.op, "path": path}
+    )
+    effective = call.timeout if call.timeout > 0 else DEFAULT_EXEC_TIMEOUT_S
+    if time.monotonic() - started >= effective:
+        await client.post_result(
+            call.call_id, {"stage": "done", "status": "error", "error": "expired"}
+        )
+        auditor.log(
+            session_id, {"event": "expired", "call_id": call.call_id, "op": call.op, "path": path}
+        )
+        return
+
+    from lambchat_sandbox import frames as frame_codec
+    from lambchat_sandbox.fsops import FsOpError
+
+    try:
+        writer = make_stream_upload_writer(call.payload, cfg.data_root)
+    except (ExecutorError, FsOpError) as exc:
+        await client.post_result(
+            call.call_id, {"stage": "done", "status": "error", "error": str(exc)}
+        )
+        auditor.log(
+            session_id,
+            {
+                "event": "executed",
+                "call_id": call.call_id,
+                "op": call.op,
+                "path": path,
+                "status": "error",
+            },
+        )
+        return
+
+    error: str | None = None
+    buffer = b""
+    try:
+        async with client.get_stream(call.call_id, deadline_s=effective) as chunks:
+            async for chunk in chunks:
+                buffer += chunk
+                while True:
+                    parsed = frame_codec.try_parse_frame(buffer)
+                    if parsed is None:
+                        break
+                    ftype, payload, buffer = parsed
+                    if ftype == frame_codec.FRAME_DATA:
+                        writer.write(payload)
+                    elif ftype == frame_codec.FRAME_ERROR:
+                        error = str(json.loads(payload).get("error") or "upload stream failed")
+                        break
+                    elif ftype == frame_codec.FRAME_EOF:
+                        break
+                if error is not None:
+                    break
+    except (ExecutorError, FsOpError) as exc:
+        error = str(exc)
+    finally:
+        writer.close()
+
+    if error is not None:
+        await client.post_result(call.call_id, {"stage": "done", "status": "error", "error": error})
+        auditor.log(
+            session_id,
+            {
+                "event": "executed",
+                "call_id": call.call_id,
+                "op": call.op,
+                "path": path,
+                "status": "error",
+            },
+        )
+        return
+    await client.post_result(
+        call.call_id,
+        {"stage": "done", "status": "ok", "result": {"written": writer.written}},
+    )
     auditor.log(
         session_id,
         {"event": "executed", "call_id": call.call_id, "op": call.op, "path": path, "status": "ok"},

--- a/client/lambchat_sandbox/frames.py
+++ b/client/lambchat_sandbox/frames.py
@@ -1,0 +1,53 @@
+"""流式传输二进制帧编解码（daemon 侧）。
+
+帧格式（HTTP body 与 Redis list item 同构，一个 item = 一个完整帧）::
+
+    frame := type(1B) length(4B 大端) payload(length B)
+
+    0x01 meta   JSON ``{"size": N}``（首帧，文件总字节数）
+    0x02 data   裸文件字节（可重复）
+    0x03 eof    length=0，正常收尾
+    0x04 error  JSON ``{"error": "..."}``（终态，替代数据流）
+
+选裸字节而非 base64+NDJSON：base64 让线上字节膨胀 33%（带宽受限链路上
+直接慢 1/3），且两端每块一次 json/b64 编解码的 CPU 开销随文件线性放大。
+
+与服务端 ``src/infra/sandbox/relay/_frames.py`` 字节级同则——两侧用同一组
+torture 用例互锁（tests/client/test_frames.py），防漂移。
+"""
+
+from __future__ import annotations
+
+import struct
+from typing import Optional
+
+FRAME_META = 0x01
+FRAME_DATA = 0x02
+FRAME_EOF = 0x03
+FRAME_ERROR = 0x04
+
+_HEADER = struct.Struct(">BI")  # type(1) + length(4)
+_HEADER_SIZE = _HEADER.size  # 5
+
+#: 单帧 payload 上限：data 帧默认 4MiB，留一倍余量给异常大的帧直接拒绝
+FRAME_PAYLOAD_MAX = 8 * 1024 * 1024
+
+
+def encode_frame(ftype: int, payload: bytes = b"") -> bytes:
+    return _HEADER.pack(ftype, len(payload)) + payload
+
+
+def try_parse_frame(buffer: bytes) -> Optional[tuple[int, bytes, bytes]]:
+    """从缓冲区解析一个完整帧；不完整返回 None（等待更多字节）。
+
+    返回 (type, payload, rest)。长度超限抛 ValueError（调用方按协议违规处理）。
+    """
+    if len(buffer) < _HEADER_SIZE:
+        return None
+    ftype, length = _HEADER.unpack_from(buffer, 0)
+    if length > FRAME_PAYLOAD_MAX:
+        raise ValueError(f"frame payload {length} exceeds {FRAME_PAYLOAD_MAX} limit")
+    end = _HEADER_SIZE + length
+    if len(buffer) < end:
+        return None
+    return ftype, buffer[_HEADER_SIZE:end], buffer[end:]

--- a/client/lambchat_sandbox/fsops.py
+++ b/client/lambchat_sandbox/fsops.py
@@ -35,13 +35,14 @@ import base64
 import binascii
 import codecs
 import fnmatch
+import json
 import os
 import re
 import shutil
 import stat as stat_module
 import time
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Iterator
 
 from lambchat_sandbox.executor import map_workspace
 
@@ -682,6 +683,111 @@ def _fs_download(payload: dict, workspace: Path) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# fs_download_stream：单请求流式下载（NDJSON 行生成器）
+#
+# 分块通道（fs_download）每块一对 HTTP 往返（ack + 结果 POST）——带宽外的
+# 固定开销随块数线性放大（100MB/1MiB 块 ≈ 100 次往返）。流式 op 把整个
+# 文件装进**一个** chunked POST 的 body（二进制帧，见 frames.py）：
+# 消除的是每块的往返，数据帧是裸字节（无 base64 膨胀、无逐块 JSON 开销）。
+# 生成器产出类型化帧 ``(ftype, payload)``：
+#
+# - ``(FRAME_META, b'{"size": N}')`` 首帧；
+# - ``(FRAME_DATA, <裸字节>)`` 可重复；
+# - ``(FRAME_EOF, b"")`` 正常收尾；
+# - ``(FRAME_ERROR, b'{"error": "..."}')`` 终态错误。
+#
+# ``offset``/``length`` 与 fs_download 同语义；``max_bytes``（服务端统一上限，
+# S3_INTERNAL_UPLOAD_MAX_SIZE）在 daemon 侧预检，超限不出流。
+# ---------------------------------------------------------------------------
+
+#: 流式数据帧的原始字节数：4MiB/帧在「Redis item 尺寸」与「逐帧固定开销」
+#: 之间取中——单帧上限（FRAME_PAYLOAD_MAX=8MiB）留一倍拒绝余量
+FS_STREAM_FRAME_BYTES = 4 * 1024 * 1024
+
+STREAM_OPS = frozenset({"fs_download_stream"})
+"""流式传输 op（daemon.py 据此分发到 handle_fs_stream）。"""
+
+
+def _fs_download_stream(payload: dict, workspace: Path) -> "Iterator[tuple[int, bytes]]":
+    from lambchat_sandbox.frames import FRAME_DATA, FRAME_EOF, FRAME_ERROR, FRAME_META
+
+    def _err(text: str) -> tuple[int, bytes]:
+        return FRAME_ERROR, json.dumps({"error": text}).encode("utf-8")
+
+    path = _resolve(payload.get("path"), workspace)
+    raw_length = payload.get("length")
+    length = int(raw_length) if raw_length is not None else None
+    offset = _payload_int(payload, "offset", default=0, minimum=0)
+    max_bytes = int(payload.get("max_bytes") or 0)
+    try:
+        st = path.stat()
+    except OSError as exc:
+        yield _err(_os_error_code(exc))
+        return
+    if stat_module.S_ISDIR(st.st_mode):
+        yield _err("is_directory")
+        return
+    if not stat_module.S_ISREG(st.st_mode):
+        yield _err("not_a_file")
+        return
+    total = st.st_size
+    if offset > total:
+        yield _err(f"offset {offset} beyond end of file ({total} bytes)")
+        return
+    wanted = total - offset if length is None else min(length, total - offset)
+    if max_bytes > 0 and wanted > max_bytes:
+        yield _err(
+            f"file_too_large: {wanted} bytes exceeds {max_bytes} limit "
+            "(S3_INTERNAL_UPLOAD_MAX_SIZE)"
+        )
+        return
+
+    yield FRAME_META, json.dumps({"size": total}).encode("utf-8")
+    remaining = wanted
+    with open(path, "rb") as f:
+        f.seek(offset)
+        while remaining > 0:
+            chunk = f.read(min(FS_STREAM_FRAME_BYTES, remaining))
+            if not chunk:
+                break  # 文件被并发截短：按已读部分收尾，不无限循环
+            remaining -= len(chunk)
+            yield FRAME_DATA, chunk
+    yield FRAME_EOF, b""
+
+
+_STREAM_HANDLERS: dict[str, Callable[[dict, Path], "Iterator[tuple[int, bytes]]"]] = {
+    "fs_download_stream": _fs_download_stream,
+}
+
+
+def handle_fs_stream(op: str, payload: dict, data_root: Path) -> "Iterator[tuple[int, bytes]]":
+    """执行一个流式 fs op，返回帧生成器（文件级错误也是错误帧，非异常）。
+
+    cwd 映射/按需建区与 :func:`handle_fs_op` 同则；未知 op **急切**抛
+    ``ValueError``（非生成器惰性——daemon 在开 POST 流之前就该失败）。
+    """
+    handler = _STREAM_HANDLERS.get(op)
+    if handler is None:
+        raise ValueError(f"unknown stream op: {op}")
+    return _run_fs_stream(handler, payload, data_root)
+
+
+def _run_fs_stream(
+    handler: Callable[[dict, Path], "Iterator[tuple[int, bytes]]"],
+    payload: dict,
+    data_root: Path,
+) -> "Iterator[tuple[int, bytes]]":
+    from lambchat_sandbox.frames import FRAME_ERROR
+
+    workspace = map_workspace(str(payload.get("cwd", "")), Path(data_root))
+    workspace.mkdir(parents=True, exist_ok=True)
+    try:
+        yield from handler(payload, workspace)
+    except FsOpError as exc:
+        yield FRAME_ERROR, json.dumps({"error": str(exc)}).encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
 # 分发入口
 # ---------------------------------------------------------------------------
 
@@ -717,3 +823,46 @@ def handle_fs_op(op: str, payload: dict[str, Any], data_root: Path) -> dict:
         return handler(payload, workspace)
     except FsOpError as exc:
         return {"error": str(exc)}
+
+
+# ---------- fs_upload_stream：单请求流式上传（服务端 → daemon 的 GET 拉流） ----------
+
+
+class StreamUploadWriter:
+    """流式上传的落盘端：首个数据帧截断创建（建父目录），累计字节超限即拒。
+
+    与分块 fs_upload 的 truncate/offset 语义对齐到「整文件单流」形态：一次
+    open 贯穿整个 GET 流，无需 per-chunk 定位。
+    """
+
+    def __init__(self, path: Path, max_bytes: int) -> None:
+        self._path = path
+        self._max_bytes = max_bytes
+        self._fh = None
+        self.written = 0
+
+    def write(self, chunk: bytes) -> None:
+        if self._fh is None:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            self._fh = open(self._path, "wb")
+        self.written += len(chunk)
+        if self._max_bytes > 0 and self.written > self._max_bytes:
+            self.close()
+            raise FsOpError(
+                f"file_too_large: {self.written} bytes exceeds {self._max_bytes} limit "
+                "(S3_INTERNAL_UPLOAD_MAX_SIZE)"
+            )
+        self._fh.write(chunk)
+
+    def close(self) -> None:
+        if self._fh is not None:
+            fh, self._fh = self._fh, None
+            fh.close()
+
+
+def make_stream_upload_writer(payload: dict, data_root: Path) -> StreamUploadWriter:
+    """构建流式上传写入器：cwd 映射 + 工作区锁定解析（逃逸/非法 cwd 抛错）。"""
+    workspace = map_workspace(str(payload.get("cwd", "")), Path(data_root))
+    workspace.mkdir(parents=True, exist_ok=True)
+    path = _resolve(payload.get("path"), workspace)
+    return StreamUploadWriter(path, int(payload.get("max_bytes") or 0))

--- a/client/lambchat_sandbox/transport.py
+++ b/client/lambchat_sandbox/transport.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import contextlib
 import json
 import random
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterable
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import quote
@@ -231,6 +231,61 @@ class ChannelClient:
         )
         await _raise_for_status(response, "post_result")
 
+    async def post_stream_result(
+        self,
+        call_id: str,
+        frame_iter: "Iterable[tuple[int, bytes]]",
+        *,
+        deadline_s: float,
+    ) -> None:
+        """流式结果回传：整个结果装进一个 chunked POST 的**二进制帧** body。
+
+        帧生成器是同步的（本地磁盘读，毫秒级），在异步生成器里逐帧编码产出
+        即可——daemon 事件循环在流期间本来就没别的事做。数据帧是裸字节（无
+        base64 膨胀、无逐块 JSON）。超时语义：write 每次 30s；read/pool 放宽
+        到流截止（服务端消费完整个 body 才回响应，POST_TIMEOUT_S=10s 的常规
+        上限对大文件必炸）。
+        """
+        from lambchat_sandbox import frames as frame_codec
+
+        async def _frame_stream() -> AsyncIterator[bytes]:
+            for ftype, payload in frame_iter:
+                yield frame_codec.encode_frame(ftype, payload)
+
+        response = await self._client.post(
+            f"{self._base}/api/sandbox/results/stream/{quote(call_id, safe='')}",
+            content=_frame_stream(),
+            headers={**self._auth_headers(), "Content-Type": "application/octet-stream"},
+            timeout=httpx.Timeout(
+                connect=_CHANNEL_CONNECT_TIMEOUT_S,
+                write=30.0,
+                read=max(deadline_s, 30.0),
+                pool=max(deadline_s, 30.0),
+            ),
+        )
+        await _raise_for_status(response, "post_stream_result")
+
+    def get_stream(
+        self, call_id: str, *, deadline_s: float
+    ) -> "contextlib.AbstractAsyncContextManager[AsyncIterator[bytes]]":
+        """流式上传拉流：GET 一个 chunked 响应，异步逐块产出帧字节。
+
+        返回异步上下文管理器（yield 字节迭代器）——daemon 在其内解析帧并
+        落盘。read/pool 超时放宽到流截止（与 post_stream_result 同则）。
+        """
+        cm = self._client.stream(
+            "GET",
+            f"{self._base}/api/sandbox/upload/{quote(call_id, safe='')}",
+            headers=self._auth_headers(),
+            timeout=httpx.Timeout(
+                connect=_CHANNEL_CONNECT_TIMEOUT_S,
+                read=max(deadline_s, 30.0),
+                write=30.0,
+                pool=max(deadline_s, 30.0),
+            ),
+        )
+        return _StreamStatusGuard(cm, "get_stream")
+
     async def post_offline(self) -> None:
         """优雅退出通知（服务端 offline 端点）。"""
         response = await self._client.post(
@@ -308,3 +363,23 @@ def _parse_tool_call(data: str) -> ToolCall | None:
     except (TypeError, ValueError):
         return None
     return ToolCall(call_id=call_id, op=op, payload=payload, timeout=timeout)
+
+
+class _StreamStatusGuard:
+    """包装 httpx stream CM：进入时校验状态码（4xx 抛 TransportError 语义）。"""
+
+    def __init__(self, cm: "_StreamCM", context: str) -> None:
+        self._cm = cm
+        self._context = context
+
+    async def __aenter__(self) -> "AsyncIterator[bytes]":
+        response = await self._cm.__aenter__()
+        try:
+            await _raise_for_status(response, self._context)
+        except BaseException:
+            await self._cm.__aexit__(None, None, None)
+            raise
+        return response.aiter_bytes()
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        await self._cm.__aexit__(*exc_info)  # type: ignore[arg-type]

--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.lambchat.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 283
-        versionName "2.8.3"
+        versionCode 284
+        versionName "2.8.4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/frontend/ios/App/App.xcodeproj/project.pbxproj
+++ b/frontend/ios/App/App.xcodeproj/project.pbxproj
@@ -352,7 +352,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 2.8.3;
+				MARKETING_VERSION = 2.8.4;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.lambchat.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -372,7 +372,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 2.8.3;
+				MARKETING_VERSION = 2.8.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lambchat.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lambchat-frontend",
   "private": true,
-  "version": "2.8.3",
+  "version": "2.8.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "lambchat"
-version = "2.8.3"
+version = "2.8.4"
 dependencies = [
  "libc",
  "serde",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambchat"
-version = "2.8.3"
+version = "2.8.4"
 description = "LambChat desktop app"
 authors = ["LambChat"]
 license = ""

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LambChat",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "identifier": "com.lambchat.app",
   "build": {
     "frontendDist": "../dist",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lambchat"
-version = "2.8.3"
+version = "2.8.4"
 description = "Full-featured AI Agent system with FastAPI, LangGraph, and LangSmith"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/api/routes/sandbox.py
+++ b/src/api/routes/sandbox.py
@@ -5,7 +5,7 @@ import json
 import socket
 import time
 import uuid
-from typing import AsyncIterator, Optional
+from typing import Any, AsyncIterator, Optional
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import StreamingResponse
@@ -13,6 +13,7 @@ from pydantic import BaseModel, field_validator
 
 from src.api.deps import get_current_user_pat_or_jwt, require_pat_only
 from src.infra.logging import get_logger
+from src.infra.sandbox.relay import _frames
 from src.infra.sandbox.relay.registry import (
     SandboxClientRegistry,
     parse_confirm_policy,
@@ -245,6 +246,11 @@ class SandboxResultRequest(BaseModel):
     stderr: Optional[str] = None
     exit_code: Optional[int] = None
     error: Optional[str] = None
+    # fs_* 结构化 op 的结果体（文件级错误与 fs_download 的 content_b64 都在这里，
+    # daemon._process_fs_call 契约）。漏掉该字段会把它静默剥掉——fs_download 回
+    # 空内容，reveal_file/artifact 全线误报 file_not_found_or_empty（2026-09-07
+    # 生产事故）。body 上限（SANDBOX_RESULTS_MAX_BYTES）对 result 同样生效。
+    result: Optional[dict[str, Any]] = None
 
 
 @router.post("/results/{call_id}")
@@ -260,6 +266,116 @@ async def sandbox_result(
     payload = {"user_id": user.sub, **body.model_dump(exclude_none=True)}
     await _redis().set(f"sandbox:resp:{call_id}", json.dumps(payload), ex=120)
     return {"status": "ok"}
+
+
+def _stream_total_max_bytes() -> int:
+    """流式总量上限：统一上传上限（S3_INTERNAL_UPLOAD_MAX_SIZE）+ 1MiB 帧头开销
+    余量——二进制帧无 base64 膨胀，且流式端点永不整体缓冲。"""
+    return int(settings.S3_INTERNAL_UPLOAD_MAX_SIZE + 1024 * 1024)
+
+
+@router.post("/results/stream/{call_id}")
+async def sandbox_result_stream(
+    call_id: str,
+    request: Request,
+    user: TokenPayload = Depends(require_pat_only("sandbox:execute")),
+):
+    """流式结果回传：fs_download_stream 的二进制帧经 chunked body 逐帧入 Redis list。
+
+    分块通道每块一对 HTTP 往返，块数×往返时延是大文件传输的主导成本；流式
+    op 把整个文件装进一个 POST。帧原样透传（数据帧是裸字节——无 base64
+    膨胀与逐块 JSON 开销；解析在消费端 dispatch_local_stream），本端点只做
+    三件事：帧/总量上限、逐帧 rpush、无 eof 帧断流的哨兵补齐。
+    """
+    redis = _redis()
+    key = f"sandbox:stream:{user.sub}:{call_id}"
+    total = 0
+    saw_eof = False
+    buffer = b""
+    try:
+        async for chunk in request.stream():
+            if isinstance(chunk, str):  # 防御：个别传输层（ASGI 测试）可能给 str
+                chunk = chunk.encode("utf-8")
+            buffer += chunk
+            while True:
+                parsed = _frames.try_parse_frame(buffer)
+                if parsed is None:
+                    break
+                ftype, payload, buffer = parsed
+                total += len(payload)
+                if total > _stream_total_max_bytes():
+                    await _push_stream_error(redis, key, "sandbox_payload_too_large")
+                    raise AppError(ErrorCode.SANDBOX_PAYLOAD_TOO_LARGE)
+                await _push_stream_frame(redis, key, _frames.encode_frame(ftype, payload))
+                if ftype == _frames.FRAME_EOF:
+                    saw_eof = True
+                    return {"status": "ok"}
+    except AppError:
+        raise
+    except ValueError:
+        # 帧超限（try_parse_frame 的载荷上限）：哨兵补齐后按 413 拒绝
+        await _push_stream_error(redis, key, "sandbox_payload_too_large")
+        raise AppError(ErrorCode.SANDBOX_PAYLOAD_TOO_LARGE) from None
+    except Exception:
+        # 坏流等：哨兵补齐（消费端立即出错，不挂到超时）后按中继失败上抛
+        await _push_stream_error(redis, key, "stream_interrupted")
+        raise
+    if not saw_eof:
+        # body 结束但没有 eof 帧（daemon 断连/中途崩溃）
+        await _push_stream_error(redis, key, "stream_interrupted")
+    return {"status": "ok"}
+
+
+async def _push_stream_frame(redis, key: str, frame: bytes) -> None:
+    await redis.rpush(key, frame)
+    await redis.expire(key, 120)
+
+
+async def _push_stream_error(redis, key: str, text: str) -> None:
+    await _push_stream_frame(
+        redis, key, _frames.encode_frame(_frames.FRAME_ERROR, json.dumps({"error": text}).encode())
+    )
+
+
+@router.get("/upload/{call_id}")
+async def sandbox_upload_stream(
+    call_id: str,
+    user: TokenPayload = Depends(require_pat_only("sandbox:execute")),
+):
+    """流式上传拉流端点：daemon 对 fs_upload_stream 的单个 GET 在这里取走整个文件。
+
+    服务端生产者（dispatch_local_stream_upload）把二进制帧 rpush 进 Redis
+    list（有界窗口），本端点 lpop 逐帧转发为 chunked 响应直至 eof 帧——
+    数据不过服务端内存整缓冲。总量上限已在生产者侧预检（max_bytes）。
+    """
+    redis = _redis()
+    key = f"sandbox:upblob:{user.sub}:{call_id}"
+    deadline = time.monotonic() + float(settings.SANDBOX_LOCAL_STREAM_TIMEOUT) + 10.0
+
+    async def _frame_stream():
+        try:
+            while time.monotonic() < deadline:
+                item = await redis.lpop(key)
+                if item is None:
+                    await asyncio.sleep(0.01)
+                    continue
+                if isinstance(item, str):
+                    item = item.encode("utf-8")
+                yield item
+                parsed = _frames.try_parse_frame(item)
+                if parsed is not None and parsed[0] == _frames.FRAME_EOF:
+                    return
+        finally:
+            try:
+                await redis.delete(key)
+            except Exception:  # noqa: BLE001 - 清理尽力而为
+                pass
+
+    return StreamingResponse(
+        _frame_stream(),
+        media_type="application/octet-stream",
+        headers={"Cache-Control": "no-store", "X-Accel-Buffering": "no"},
+    )
 
 
 @router.get("/machines")

--- a/src/api/routes/upload.py
+++ b/src/api/routes/upload.py
@@ -227,6 +227,16 @@ async def _get_file_response_metadata(key: str) -> tuple[str | None, str]:
     return filename_for_disposition, content_type
 
 
+def _inline_content_disposition(filename: str) -> str:
+    """HTTP 头只允许 latin-1：非 ASCII 文件名按 RFC 5987 走 filename*=utf-8''。"""
+    from urllib.parse import quote
+
+    quoted = quote(filename)
+    if quoted != filename:
+        return f"inline; filename*=utf-8''{quoted}"
+    return f'inline; filename="{filename.replace(chr(34), "")}"'
+
+
 async def _read_upload_file_limited(
     file: Any,
     *,
@@ -891,7 +901,7 @@ async def get_file_proxy(
         filename_for_disposition, content_type = await _get_file_response_metadata(key)
         headers = {"Cache-Control": "public, max-age=300"}
         if filename_for_disposition:
-            headers["Content-Disposition"] = f'inline; filename="{filename_for_disposition}"'
+            headers["Content-Disposition"] = _inline_content_disposition(filename_for_disposition)
 
         return StreamingResponse(
             storage.download_stream(key),

--- a/src/infra/backend/_local_transfer.py
+++ b/src/infra/backend/_local_transfer.py
@@ -21,6 +21,7 @@ exec 旧链路（daemon 自更新后重建 backend 即恢复新通道）。
 from __future__ import annotations
 
 import base64
+import re
 from typing import TYPE_CHECKING, Any
 
 from src.infra.backend._local_compat import _run_coro_sync
@@ -32,9 +33,13 @@ from src.infra.backend.protocol_compat import (
     file_upload_response,
 )
 from src.infra.logging import get_logger
-from src.infra.sandbox.relay.dispatch import dispatch_local_call
+from src.infra.sandbox.relay.dispatch import (
+    dispatch_local_call,
+    dispatch_local_stream,
+    dispatch_local_stream_upload,
+)
 from src.kernel.config import settings
-from src.kernel.errors import AppError
+from src.kernel.errors import AppError, ErrorCode
 
 logger = get_logger(__name__)
 
@@ -52,6 +57,14 @@ class FsTransferUnsupportedError(Exception):
     """
 
 
+class FsStreamUnsupportedError(Exception):
+    """老 daemon 不认识 fs_download_stream（回 ``unsupported op``）。
+
+    独立于 :class:`FsTransferUnsupportedError` 的能力位：流式不支持时降级
+    分块 fs_download（而非直接跳 exec）——两级降级链各自粘滞。
+    """
+
+
 def _download_max_bytes() -> int:
     """下载单文件上限：与 reveal/S3 内部上传共用同一个环境变量旋钮。
 
@@ -63,18 +76,33 @@ def _download_max_bytes() -> int:
     return configured if configured > 0 else 1
 
 
+# win32 绝对路径形态：盘符根相对（C:\ 或 C:/开头）与 UNC（\\server\share）。
+# daemon 的 fs op 锁死工作区（fsops._resolve 见绝对路径即判逃逸），这类路径
+# 必须与 posix 绝对路径同语义走 exec 旧链路（2026-09-07 生产事故：agent 抄
+# LAMBCHAT_WORKSPACE 真实路径调 reveal_file，被 fs 通道全数拒绝后误报
+# file_not_found_or_empty 并反复重试）。
+_WIN_DRIVE_ABSOLUTE = re.compile(r"^[A-Za-z]:[\\/]")
+
+
+def _is_windows_absolute_path(path: str) -> bool:
+    return bool(_WIN_DRIVE_ABSOLUTE.match(path)) or path.startswith("\\\\")
+
+
 class LocalFsTransferMixin:
     """fs_upload/fs_download 通道原语。
 
     依赖宿主（LocalSandboxBackend）实例属性：``_user_id`` / ``_machine_id`` /
-    ``_exec_timeout`` / ``_fs_transfer_supported``。通道方法显式收 ``cwd``
-    （虚拟工作区路径），不读取宿主的 work_dir。
+    ``_exec_timeout`` / ``_fs_transfer_supported`` / ``_stream_transfer_supported``。
+    通道方法显式收 ``cwd``（虚拟工作区路径），不读取宿主的 work_dir。
     """
 
     _user_id: str
     _machine_id: str | None
     _exec_timeout: int
     _fs_transfer_supported: bool | None
+    # 流式通道（fs_download_stream）能力位：None = 未探测，False = 老 daemon
+    # 不支持（粘滞走分块 fs_download）。见 FsStreamUnsupportedError。
+    _stream_transfer_supported: bool | None = None
 
     async def _afs_transfer_call(self, op: str, payload: dict[str, Any]) -> dict:
         """发一个传输 fs op 并取回 ``result`` 体（文件级错误在 result 里）。"""
@@ -108,6 +136,46 @@ class LocalFsTransferMixin:
         raise last_exc  # type: ignore[misc]  # 循环必已赋值
 
     async def _aupload_via_fs(self, path: str, content: bytes, *, cwd: str) -> str | None:
+        """上传主路径：新 daemon 优先流式（单 GET 传整个文件），否则分块写。
+
+        返回错误码/错误文本或 None（成功）。流式与下载方向对称——老 daemon
+        按 ``unsupported op`` 粘滞降级到分块 fs_upload，再降级 exec 的既有
+        链条不变。
+        """
+        if self._stream_transfer_supported is not False:
+            max_bytes = _download_max_bytes()
+            if len(content) > max_bytes:
+                return (
+                    f"file_too_large: {len(content)} bytes exceeds {max_bytes} limit "
+                    "(S3_INTERNAL_UPLOAD_MAX_SIZE)"
+                )
+            try:
+                outcome = await self._aupload_via_stream(path, content, cwd=cwd)
+            except FsStreamUnsupportedError:
+                self._stream_transfer_supported = False  # 老 daemon：后续上传直接分块
+            else:
+                return outcome
+        return await self._aupload_chunked(path, content, cwd=cwd)
+
+    async def _aupload_via_stream(self, path: str, content: bytes, *, cwd: str) -> str | None:
+        """经 fs_upload_stream 单 GET 流式写整个文件；返回错误文本或 None。"""
+        try:
+            await dispatch_local_stream_upload(
+                self._user_id,
+                {"cwd": cwd, "path": path, "max_bytes": _download_max_bytes()},
+                content,
+                machine_id=self._machine_id,
+            )
+        except AppError as exc:
+            if exc.error_code == ErrorCode.SANDBOX_EXEC_FAILED:
+                detail = str(exc.args_data.get("detail") or exc.message)
+                if "unsupported op" in detail:
+                    raise FsStreamUnsupportedError(detail) from exc
+                return detail
+            raise
+        return None
+
+    async def _aupload_chunked(self, path: str, content: bytes, *, cwd: str) -> str | None:
         """经 fs_upload 分块写文件；返回错误码/错误文本或 None（成功）。
 
         首块 truncate 创建（daemon 建父目录），后续块按 offset 定位写；
@@ -134,6 +202,51 @@ class LocalFsTransferMixin:
         return None
 
     async def _adownload_via_fs(self, path: str, *, cwd: str) -> bytes | str:
+        """下载主路径：新 daemon 优先流式（单 op 传整个文件），否则分片循环。
+
+        流式通道（fs_download_stream）把「块数 × 每块一对 HTTP 往返」摊销成
+        每文件常数次往返——大文件传输从时延主导回归带宽主导。老 daemon 不
+        认识流式 op 时按 ``unsupported op`` 粘滞降级到分块 fs_download（零
+        行为回归），再降级 exec 旧链路的既有链条不变。
+
+        返回内容字节或错误文本（文件级错误，与分块路径同形态）。
+        """
+        if self._stream_transfer_supported is not False:
+            try:
+                outcome = await self._adownload_via_stream(path, cwd=cwd)
+            except FsStreamUnsupportedError:
+                self._stream_transfer_supported = False  # 老 daemon：后续下载直接分块
+            else:
+                return outcome
+        return await self._adownload_chunked(path, cwd=cwd)
+
+    async def _adownload_via_stream(self, path: str, *, cwd: str) -> bytes | str:
+        """经 fs_download_stream 流式读完整个文件；返回内容字节或错误文本。
+
+        错误分级（对齐 exec 旧链路的语义）：``SANDBOX_EXEC_FAILED`` 是行级
+        文件错误（缺文件/超限/目录），映射为错误文本；离线/超时等中继级
+        AppError 向上透传给统一错误处理，不吞成单文件错误。
+        """
+        chunks: list[bytes] = []
+        try:
+            async for chunk in dispatch_local_stream(
+                self._user_id,
+                "fs_download_stream",
+                {"cwd": cwd, "path": path, "max_bytes": _download_max_bytes()},
+                timeout=float(settings.SANDBOX_LOCAL_STREAM_TIMEOUT),
+                machine_id=self._machine_id,
+            ):
+                chunks.append(chunk)
+        except AppError as exc:
+            if exc.error_code == ErrorCode.SANDBOX_EXEC_FAILED:
+                detail = str(exc.args_data.get("detail") or exc.message)
+                if "unsupported op" in detail:
+                    raise FsStreamUnsupportedError(detail) from exc
+                return detail
+            raise
+        return b"".join(chunks)
+
+    async def _adownload_chunked(self, path: str, *, cwd: str) -> bytes | str:
         """经 fs_download 分片循环读到 eof；返回内容字节或错误文本。
 
         首片响应携带全文件 ``size``——据此执行统一上限预检
@@ -202,10 +315,11 @@ class WorkspaceAliasTransferMixin:
     def _fs_transfer_eligible(self, stripped: str) -> bool:
         """该（已剥离别名的）路径能否走结构化通道：须是工作区内相对路径。
 
-        绝对路径与 ``../`` 上溯（.shared 除外）是 exec 旧链路的既有语义
-        （fs op 锁死工作区会拒绝），保持分流不改变行为。
+        绝对路径（posix ``/`` 与 win32 盘符/UNC——daemon 的 fs op 锁死工作区
+        会拒绝）与 ``../`` 上溯（.shared 除外）是 exec 旧链路的既有语义
+        （exec 可按 daemon 机器真实路径读写），保持分流不改变行为。
         """
-        if stripped.startswith("/"):
+        if stripped.startswith("/") or _is_windows_absolute_path(stripped):
             return False
         if stripped == "../.shared" or stripped.startswith("../.shared/"):
             return True

--- a/src/infra/sandbox/relay/_frames.py
+++ b/src/infra/sandbox/relay/_frames.py
@@ -1,0 +1,42 @@
+"""流式传输二进制帧编解码（服务端侧）。
+
+帧格式与语义见 client/lambchat_sandbox/frames.py 的模块文档——两侧字节级
+同则，tests/client/test_frames.py torture 互锁。本模块只被 sandbox 路由
+（解析 daemon 上行流）与 dispatch 流式消费器（解析 Redis list item）使用。
+"""
+
+from __future__ import annotations
+
+import struct
+from typing import Optional
+
+FRAME_META = 0x01
+FRAME_DATA = 0x02
+FRAME_EOF = 0x03
+FRAME_ERROR = 0x04
+
+_HEADER = struct.Struct(">BI")  # type(1) + length(4)
+_HEADER_SIZE = _HEADER.size  # 5
+
+#: 单帧 payload 上限：与 client 侧同值互锁；data 帧默认 4MiB + 余量
+FRAME_PAYLOAD_MAX = 8 * 1024 * 1024
+
+
+def encode_frame(ftype: int, payload: bytes = b"") -> bytes:
+    return _HEADER.pack(ftype, len(payload)) + payload
+
+
+def try_parse_frame(buffer: bytes) -> Optional[tuple[int, bytes, bytes]]:
+    """从缓冲区解析一个完整帧；不完整返回 None（等待更多字节）。
+
+    返回 (type, payload, rest)。长度超限抛 ValueError（路由按 413 处理）。
+    """
+    if len(buffer) < _HEADER_SIZE:
+        return None
+    ftype, length = _HEADER.unpack_from(buffer, 0)
+    if length > FRAME_PAYLOAD_MAX:
+        raise ValueError(f"frame payload {length} exceeds {FRAME_PAYLOAD_MAX} limit")
+    end = _HEADER_SIZE + length
+    if len(buffer) < end:
+        return None
+    return ftype, buffer[_HEADER_SIZE:end], buffer[end:]

--- a/src/infra/sandbox/relay/dispatch.py
+++ b/src/infra/sandbox/relay/dispatch.py
@@ -4,13 +4,17 @@ import asyncio
 import json
 import time
 import uuid
+from collections.abc import AsyncIterator
 
+from src.infra.sandbox.relay import _frames as _frames_codec
 from src.infra.sandbox.relay.registry import SandboxClientRegistry
 from src.infra.storage.redis import get_redis_client
 from src.kernel.config import settings
 from src.kernel.errors import AppError, ErrorCode
 
 _POLL_INTERVAL = 0.05
+# 流式结果逐行消费的轮询：行粒度小、吞吐优先，比控制面轮询更密
+_STREAM_POLL_INTERVAL = 0.01
 
 
 def _redis():
@@ -102,3 +106,223 @@ async def dispatch_local_call(
             await redis.delete(resp_key)
         except Exception:  # noqa: BLE001 - 清理尽力而为
             pass
+
+
+def _stream_key(user_id: str, call_id: str) -> str:
+    return f"sandbox:stream:{user_id}:{call_id}"
+
+
+async def dispatch_local_stream(
+    user_id: str,
+    op: str,
+    payload: dict,
+    *,
+    timeout: float | None = None,
+    machine_id: str | None = None,
+) -> AsyncIterator[bytes]:
+    """流式版下发：请求入队同 :func:`dispatch_local_call`，结果按 NDJSON 行逐块产出。
+
+    daemon 把整个文件装进一个 chunked POST（``/api/sandbox/results/stream/…``），
+    行由该端点 rpush 进 stream list，这里 lpop 逐行消费并 yield 解码后的字节。
+    每块一对 HTTP 往返的分块通道在大文件上是「块数×往返时延」的线性成本，
+    流式把往返摊销成每个文件常数次。
+
+    错误语义（对齐 dispatch_local_call 的 fs op 分支）：
+
+    - 行 ``{"error": ...}`` / resp ``done(status=error)``（老 daemon 不认识
+      流式 op 回 ``unsupported op``）→ ``AppError(SANDBOX_EXEC_FAILED)``，
+      ``detail`` 携带原始错误串——上层按 ``unsupported op`` 子串判别降级；
+    - ack 超时/总超时 → ``AppError(SANDBOX_TIMEOUT)``。
+    """
+    registry = _registry()
+    if machine_id:
+        target = await registry.resolve_target(user_id, machine_id)
+        if target is None:
+            raise AppError(ErrorCode.SANDBOX_MACHINE_OFFLINE, args={"machine": machine_id})
+    else:
+        target = await registry.resolve_target(user_id)
+        if target is None:
+            raise AppError(ErrorCode.DAEMON_OFFLINE)
+    exec_timeout = timeout if timeout is not None else float(settings.SANDBOX_LOCAL_STREAM_TIMEOUT)
+    call_id = uuid.uuid4().hex
+    req = {
+        "call_id": call_id,
+        "user_id": user_id,
+        "op": op,
+        "payload": payload,
+        "timeout": exec_timeout,
+        "ts": time.time(),
+    }
+    redis = _redis()
+    stream_key = _stream_key(user_id, call_id)
+    resp_key = f"sandbox:resp:{call_id}"
+    await redis.rpush(registry.queue_key(user_id, target), json.dumps(req))
+
+    start = time.monotonic()
+    acked = False
+    ack_deadline = start + settings.SANDBOX_LOCAL_ACK_TIMEOUT
+    exec_deadline = start + exec_timeout
+    try:
+        while time.monotonic() < exec_deadline:
+            resp = None
+            raw = await redis.get(resp_key)
+            if raw is not None:
+                resp = json.loads(raw)
+                if resp.get("user_id") != user_id:
+                    resp = None
+            if resp is not None:
+                if resp.get("stage") == "ack":
+                    acked = True
+                    await redis.delete(resp_key)
+                    resp = None
+                elif resp.get("stage") == "done":
+                    await redis.delete(resp_key)
+                    error = str(resp.get("error") or "local execution failed")
+                    raise AppError(ErrorCode.SANDBOX_EXEC_FAILED, args={"detail": error})
+            while True:
+                raw_item = await redis.lpop(stream_key)
+                if raw_item is None:
+                    break
+                item: bytes
+                if isinstance(raw_item, str):
+                    item = raw_item.encode("utf-8")
+                else:
+                    assert isinstance(raw_item, bytes)  # redis list item 契约
+                    item = raw_item
+                parsed = _frames_codec.try_parse_frame(item)
+                if parsed is None:
+                    continue  # 残缺 item（不该发生）：跳过不炸消费器
+                ftype, frame_body, _rest = parsed
+                acked = True  # 首帧即存活证明
+                if ftype == _frames_codec.FRAME_ERROR:
+                    error = str(json.loads(frame_body).get("error") or "stream failed")
+                    raise AppError(ErrorCode.SANDBOX_EXEC_FAILED, args={"detail": error})
+                if ftype == _frames_codec.FRAME_EOF:
+                    return
+                if ftype == _frames_codec.FRAME_DATA:
+                    yield frame_body  # 裸字节：无 base64 解码开销
+                # FRAME_META：跳过（尺寸供上层核对，不在数据流里重复）
+            if not acked and time.monotonic() > ack_deadline:
+                raise AppError(
+                    ErrorCode.SANDBOX_TIMEOUT, args={"seconds": settings.SANDBOX_LOCAL_ACK_TIMEOUT}
+                )
+            await asyncio.sleep(_STREAM_POLL_INTERVAL)
+        raise AppError(ErrorCode.SANDBOX_TIMEOUT, args={"seconds": int(exec_timeout)})
+    finally:
+        for key in (resp_key, stream_key):
+            try:
+                await redis.delete(key)
+            except Exception:  # noqa: BLE001 - 清理尽力而为
+                pass
+
+
+_UPBLOB_WINDOW = 8  # 生产者在途帧数上限：×4MiB 帧 = Redis 峰值 ~32MiB
+_UPBLOB_CHUNK_BYTES = 4 * 1024 * 1024  # 与 daemon 侧 FS_STREAM_FRAME_BYTES 同则
+_UPBLOB_POLL_INTERVAL = 0.005
+
+
+def _upblob_key(user_id: str, call_id: str) -> str:
+    return f"sandbox:upblob:{user_id}:{call_id}"
+
+
+async def dispatch_local_stream_upload(
+    user_id: str,
+    payload: dict,
+    content: bytes,
+    *,
+    machine_id: str | None = None,
+) -> None:
+    """流式上传（服务端 → daemon）：请求入队后生产者把整文件按帧写入 Redis
+    list（有界窗口），daemon 单个 GET 拉流落盘，done 回普通 results 端点。
+
+    与下载方向的 dispatch_local_stream 对称：每文件常数次 HTTP 往返。窗口
+    上限把 Redis 峰值内存钉在 ~32MiB，与文件大小无关。错误语义同分块通道：
+    ``unsupported op``（老 daemon）与文件级错误都在 ``detail`` 里，上层据此
+    降级/透出。
+    """
+    registry = _registry()
+    if machine_id:
+        target = await registry.resolve_target(user_id, machine_id)
+        if target is None:
+            raise AppError(ErrorCode.SANDBOX_MACHINE_OFFLINE, args={"machine": machine_id})
+    else:
+        target = await registry.resolve_target(user_id)
+        if target is None:
+            raise AppError(ErrorCode.DAEMON_OFFLINE)
+    exec_timeout = float(settings.SANDBOX_LOCAL_STREAM_TIMEOUT)
+    call_id = uuid.uuid4().hex
+    req = {
+        "call_id": call_id,
+        "user_id": user_id,
+        "op": "fs_upload_stream",
+        "payload": payload,
+        "timeout": exec_timeout,
+        "ts": time.time(),
+    }
+    redis = _redis()
+    blob_key = _upblob_key(user_id, call_id)
+    resp_key = f"sandbox:resp:{call_id}"
+    await redis.rpush(registry.queue_key(user_id, target), json.dumps(req))
+
+    def _build_frames() -> list[bytes]:
+        out = [
+            _frames_codec.encode_frame(
+                _frames_codec.FRAME_META, json.dumps({"size": len(content)}).encode()
+            )
+        ]
+        for offset in range(0, len(content), _UPBLOB_CHUNK_BYTES):
+            out.append(
+                _frames_codec.encode_frame(
+                    _frames_codec.FRAME_DATA, content[offset : offset + _UPBLOB_CHUNK_BYTES]
+                )
+            )
+        out.append(_frames_codec.encode_frame(_frames_codec.FRAME_EOF))
+        return out
+
+    start = time.monotonic()
+    acked = False
+    done: dict | None = None
+    try:
+        deadline = start + exec_timeout
+        for frame in _build_frames():
+            while time.monotonic() < deadline:
+                if await redis.llen(blob_key) < _UPBLOB_WINDOW:
+                    break
+                await asyncio.sleep(_UPBLOB_POLL_INTERVAL)
+            else:
+                raise AppError(ErrorCode.SANDBOX_TIMEOUT, args={"seconds": int(exec_timeout)})
+            await redis.rpush(blob_key, frame)
+            await redis.expire(blob_key, 120)
+        while time.monotonic() < deadline and done is None:
+            raw = await redis.get(resp_key)
+            resp = json.loads(raw) if raw is not None else None
+            if resp is not None and resp.get("user_id") == user_id:
+                if resp.get("stage") == "ack":
+                    acked = True
+                    await redis.delete(resp_key)
+                elif resp.get("stage") == "done":
+                    done = resp
+                    await redis.delete(resp_key)
+            if (
+                done is None
+                and not acked
+                and time.monotonic() > start + settings.SANDBOX_LOCAL_ACK_TIMEOUT
+            ):
+                raise AppError(
+                    ErrorCode.SANDBOX_TIMEOUT, args={"seconds": settings.SANDBOX_LOCAL_ACK_TIMEOUT}
+                )
+            if done is None:
+                await asyncio.sleep(_STREAM_POLL_INTERVAL)
+        if done is None:
+            raise AppError(ErrorCode.SANDBOX_TIMEOUT, args={"seconds": int(exec_timeout)})
+        if done.get("status") != "ok":
+            raise AppError(
+                ErrorCode.SANDBOX_EXEC_FAILED,
+                args={"detail": str(done.get("error") or "local execution failed")},
+            )
+    finally:
+        for key in (resp_key, blob_key):
+            try:
+                await redis.delete(key)
+            except Exception:  # noqa: BLE001 - 清理尽力而为
+                pass

--- a/src/kernel/config/base.py
+++ b/src/kernel/config/base.py
@@ -239,6 +239,10 @@ class Settings(BaseSettings):
     SANDBOX_PLATFORM: str = "daytona"
     SANDBOX_LOCAL_ACK_TIMEOUT: int = 30  # 本地沙箱 daemon ACK 超时（秒）
     SANDBOX_LOCAL_EXEC_TIMEOUT: int = 120  # 本地沙箱执行总超时（秒）
+    # 本地沙箱流式传输（fs_download_stream）总超时（秒）：单个 chunked POST
+    # 装下整个文件，大文件按带宽计而非按块计——120s 的 exec 超时对 100MB 慢
+    # 上行不够（10Mbps ≈ 110s+），流式专用窗口放宽到 10 分钟。
+    SANDBOX_LOCAL_STREAM_TIMEOUT: int = 600
     SANDBOX_RESULTS_MAX_BYTES: int = 2097152  # 本地沙箱 results 回传 body 上限（字节，2 MiB）
     # 本地沙箱 daemon 最低连接版本（语义化比较）：低于即拒连（426），逼客户端 self-update
     SANDBOX_MIN_DAEMON_VERSION: str = "0.3.1"  # 0.3.1：Windows python3 shim 修复（复制 exe 找不到 stdlib）+ 输出 GBK 解码；0.3.0 及以下必须升级

--- a/tests/api/routes/test_sandbox_routes.py
+++ b/tests/api/routes/test_sandbox_routes.py
@@ -50,6 +50,9 @@ class _FakeRedis:
         items = self.lists.get(key)
         return items.pop(0) if items else None
 
+    async def llen(self, key):
+        return len(self.lists.get(key) or ())
+
     async def set(self, key, value, ex=None):
         self.kv[key] = value
         if ex is not None:
@@ -822,3 +825,359 @@ async def test_offline_endpoint_rejects_jwt(monkeypatch):
         resp = await client.post("/api/sandbox/offline")
     assert resp.status_code == 401
     assert resp.json()["detail"]["code"] == "unauthorized"
+
+
+async def test_results_endpoint_preserves_fs_op_result(monkeypatch):
+    """fs op 结果体的 ``result`` 字段必须原样落 Redis。
+
+    win32 结构化 fs op（fs_download/fs_upload/fs_read…）的全部有效载荷都在
+    ``result`` dict 里（daemon._process_fs_call 契约）；端点模型漏掉该字段会
+    把它静默丢弃——fs_download 回空内容，上层 reveal_file/artifact 全线误报
+    ``file_not_found_or_empty``（2026-09-07 生产事故，issue 见
+    https://lambchat.com/shared/d-_7Oqe2I3ay）。
+    """
+    redis = _FakeRedis()
+    app = FastAPI()
+    register_error_handlers(app)
+    app.include_router(sandbox_route.router, prefix="/api/sandbox", tags=["Sandbox"])
+    app.dependency_overrides[api_deps.get_current_user_pat_or_jwt] = _fake_pat_user
+    monkeypatch.setattr(sandbox_route, "_redis", lambda: redis)
+
+    fs_result = {"content_b64": "QUJD", "size": 3, "eof": True}
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        resp = await client.post(
+            "/api/sandbox/results/call-1",
+            json={"stage": "done", "status": "ok", "result": fs_result},
+        )
+    assert resp.status_code == 200
+    stored = json.loads(redis.kv["sandbox:resp:call-1"])
+    assert stored["user_id"] == "u1" and stored["stage"] == "done"
+    assert stored["result"] == fs_result
+
+
+async def _make_download_seam(monkeypatch, tmp_path):
+    """下载 seam 公共环境：真实路由 app + 真实 dispatch（内存 Redis）+ 别名 backend。
+
+    返回 (redis, app, backend)。daemon 行为由各测试内联的 fake_daemon 决定
+    （新 daemon 走流式端点 / 老 daemon 回 unsupported op 走分块）。
+    """
+    from src.infra.backend import _local_transfer as transfer_module
+    from src.infra.backend import local as local_module
+    from src.infra.backend.local import WorkspaceAliasBackend
+    from src.infra.sandbox.relay import dispatch as dispatch_module
+    from src.infra.sandbox.relay.registry import LEGACY_MACHINE_ID
+
+    redis = _FakeRedis()
+    app = FastAPI()
+    register_error_handlers(app)
+    app.include_router(sandbox_route.router, prefix="/api/sandbox", tags=["Sandbox"])
+    app.dependency_overrides[api_deps.get_current_user_pat_or_jwt] = _fake_pat_user
+    monkeypatch.setattr(sandbox_route, "_redis", lambda: redis)
+
+    class _LegacyRegistry:
+        def queue_key(self, user_id, machine_id):
+            return f"sandbox:req:{user_id}"
+
+        async def resolve_target(self, user_id, machine_id=None):
+            return LEGACY_MACHINE_ID
+
+    monkeypatch.setattr(dispatch_module, "_redis", lambda: redis)
+    monkeypatch.setattr(dispatch_module, "_registry", _LegacyRegistry)
+
+    async def fake_platform(user_id, machine_id=None):
+        return ""
+
+    monkeypatch.setattr(local_module, "_lookup_daemon_platform", fake_platform)
+    local_module.dispatch_local_call = dispatch_module.dispatch_local_call
+    transfer_module.dispatch_local_call = dispatch_module.dispatch_local_call
+    backend = WorkspaceAliasBackend(user_id="u1", session_id="s1")
+    return redis, app, backend
+
+
+async def _streaming_daemon(redis, client, data_root, counters=None):
+    """新 daemon：fs_download_stream 走单个流式 POST（真实 fsops 行生成器）。"""
+    from lambchat_sandbox import fsops
+
+    while True:
+        raw = await redis.lpop("sandbox:req:u1")
+        if raw is None:
+            await asyncio.sleep(0.01)
+            continue
+        req = json.loads(raw)
+        if req["op"] == "fs_download_stream":
+            await client.post(f"/api/sandbox/results/{req['call_id']}", json={"stage": "ack"})
+            from lambchat_sandbox.frames import encode_frame
+
+            frames_iter = fsops.handle_fs_stream(req["op"], req["payload"], data_root)
+
+            async def _frame_body():
+                for ftype, payload in frames_iter:
+                    yield encode_frame(ftype, payload)
+
+            resp = await client.post(
+                f"/api/sandbox/results/stream/{req['call_id']}",
+                content=_frame_body(),
+                headers={"content-type": "application/octet-stream"},
+            )
+            assert resp.status_code == 200, resp.text
+            if counters is not None:
+                counters["stream_posts"] = counters.get("stream_posts", 0) + 1
+            continue
+        # 非流式 op（exec 等）按老协议回
+        await client.post(f"/api/sandbox/results/{req['call_id']}", json={"stage": "ack"})
+        result = fsops.handle_fs_op(req["op"], req["payload"], data_root)
+        await client.post(
+            f"/api/sandbox/results/{req['call_id']}",
+            json={"stage": "done", "status": "ok", "result": result},
+        )
+
+
+async def test_stream_download_seam_single_post_for_whole_file(monkeypatch, tmp_path):
+    """流式主路径端到端：3MiB 文件 = 1 个流式 op + 1 个流式 POST，逐字节一致。
+
+    分块通道同样的文件要 3 对 HTTP 往返；本用例锁定「往返次数与文件大小
+    解耦」——这是大文件传输从时延主导回归带宽主导的关键。
+    """
+    content = bytes(range(256)) * (3 * 4096)  # 3 MiB
+    (tmp_path / "s1").mkdir()
+    (tmp_path / "s1" / "big.bin").write_bytes(content)
+
+    redis, app, backend = await _make_download_seam(monkeypatch, tmp_path)
+    counters = {"stream_posts": 0}
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        daemon_task = asyncio.create_task(_streaming_daemon(redis, client, tmp_path, counters))
+        responses = await asyncio.wait_for(
+            backend.adownload_files(["/workspace/s1/big.bin"]), timeout=30
+        )
+        daemon_task.cancel()
+
+    assert counters["stream_posts"] == 1  # 整个文件一个 POST
+    assert responses[0].error is None
+    assert responses[0].content == content
+
+
+async def test_stream_download_seam_file_error_reaches_backend(monkeypatch, tmp_path):
+    """流式链路的文件级错误（缺文件）以错误串形态到达 backend，与分块路径一致。"""
+    (tmp_path / "s1").mkdir()
+
+    redis, app, backend = await _make_download_seam(monkeypatch, tmp_path)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        daemon_task = asyncio.create_task(_streaming_daemon(redis, client, tmp_path))
+        responses = await asyncio.wait_for(
+            backend.adownload_files(["/workspace/s1/missing.bin"]), timeout=30
+        )
+        daemon_task.cancel()
+
+    assert responses[0].error == "file_not_found"
+    assert responses[0].content is None
+
+
+async def test_chunked_download_seam_old_daemon_fallback(monkeypatch, tmp_path):
+    """老 daemon（不认识流式 op）端到端：自动粘滞降级分块 fs_download，行为零回归。
+
+    2026-09-07 生产事故的断裂点恰在两层各自有测试的接缝上；本用例连同流式
+    用例把「新路径可用、老路径不坏」一起锁死。
+    """
+    from lambchat_sandbox import fsops
+
+    content = "卤味批发进货台账".encode("utf-8")
+    (tmp_path / "s1").mkdir()
+    (tmp_path / "s1" / "台账.xlsx").write_bytes(content)
+
+    redis, app, backend = await _make_download_seam(monkeypatch, tmp_path)
+    ops: list[str] = []
+
+    async def fake_daemon(client: AsyncClient) -> None:
+        while True:
+            raw = await redis.lpop("sandbox:req:u1")
+            if raw is None:
+                await asyncio.sleep(0.01)
+                continue
+            req = json.loads(raw)
+            ops.append(req["op"])
+            if req["op"] == "fs_download_stream":
+                # 老 daemon：不认识流式 op，按普通 results 端点回错
+                await client.post(
+                    f"/api/sandbox/results/{req['call_id']}",
+                    json={
+                        "stage": "done",
+                        "status": "error",
+                        "error": f"unsupported op: {req['op']}",
+                    },
+                )
+                continue
+            await client.post(f"/api/sandbox/results/{req['call_id']}", json={"stage": "ack"})
+            result = fsops.handle_fs_op(req["op"], req["payload"], tmp_path)
+            await client.post(
+                f"/api/sandbox/results/{req['call_id']}",
+                json={"stage": "done", "status": "ok", "result": result},
+            )
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        daemon_task = asyncio.create_task(fake_daemon(client))
+        responses = await asyncio.wait_for(
+            backend.adownload_files(["/workspace/s1/台账.xlsx"]), timeout=30
+        )
+        daemon_task.cancel()
+
+    assert ops[0] == "fs_download_stream"  # 先探测流式
+    assert "fs_download" in ops  # 降级到分块
+    assert responses[0].error is None
+    assert responses[0].content == content
+
+
+def _stream_app(monkeypatch, redis):
+    app = FastAPI()
+    register_error_handlers(app)
+    app.include_router(sandbox_route.router, prefix="/api/sandbox", tags=["Sandbox"])
+    app.dependency_overrides[api_deps.get_current_user_pat_or_jwt] = _fake_pat_user
+    monkeypatch.setattr(sandbox_route, "_redis", lambda: redis)
+    return app
+
+
+async def _post_stream_frames(app, frames: list[bytes]):
+    """以 chunked 流式 body POST 二进制帧（httpx content=异步生成器）。"""
+
+    async def gen():
+        for f in frames:
+            yield f
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        return await client.post(
+            "/api/sandbox/results/stream/call-s1",
+            content=gen(),
+            headers={"content-type": "application/octet-stream"},
+        )
+
+
+async def test_results_stream_endpoint_stores_frames_in_order(monkeypatch):
+    """二进制帧原样进 stream list（消费端按帧解析）；eof 帧即收。"""
+    from src.infra.sandbox.relay._frames import FRAME_DATA, FRAME_EOF, encode_frame
+
+    redis = _FakeRedis()
+    app = _stream_app(monkeypatch, redis)
+    frame1 = encode_frame(FRAME_DATA, b"\x00\x01raw-bytes")
+    frame2 = encode_frame(FRAME_EOF)
+
+    resp = await _post_stream_frames(app, [frame1, frame2])
+
+    assert resp.status_code == 200
+    assert redis.lists["sandbox:stream:u1:call-s1"] == [frame1, frame2]
+    assert redis.expires_at.get("sandbox:stream:u1:call-s1") is not None
+
+
+async def test_results_stream_endpoint_interrupted_body_pushes_sentinel(monkeypatch):
+    """连接中断（body 无 eof 帧即结束）：补 stream_interrupted 错误帧，消费端不挂到超时。"""
+    from src.infra.sandbox.relay._frames import (
+        FRAME_DATA,
+        FRAME_ERROR,
+        encode_frame,
+        try_parse_frame,
+    )
+
+    redis = _FakeRedis()
+    app = _stream_app(monkeypatch, redis)
+    data = encode_frame(FRAME_DATA, b"partial")
+
+    resp = await _post_stream_frames(app, [data])
+
+    assert resp.status_code == 200
+    stored = redis.lists["sandbox:stream:u1:call-s1"]
+    assert stored[0] == data
+    ftype, payload, _ = try_parse_frame(stored[1])
+    assert ftype == FRAME_ERROR
+    assert json.loads(payload)["error"] == "stream_interrupted"
+
+
+async def test_results_stream_endpoint_rejects_oversized_frame(monkeypatch):
+    """单帧 payload 超限：413 + 错误帧哨兵入列，不整体缓冲。"""
+    from src.infra.sandbox.relay._frames import FRAME_DATA, encode_frame
+
+    redis = _FakeRedis()
+    app = _stream_app(monkeypatch, redis)
+    huge = encode_frame(FRAME_DATA, b"x" * (sandbox_route._frames.FRAME_PAYLOAD_MAX + 1))
+
+    resp = await _post_stream_frames(app, [huge])
+
+    assert resp.status_code == 413
+    assert resp.json()["detail"]["code"] == "sandbox_payload_too_large"
+    stored = redis.lists["sandbox:stream:u1:call-s1"]
+    assert b"sandbox_payload_too_large" in stored[-1]
+
+
+async def test_stream_upload_seam_single_get_for_whole_file(monkeypatch, tmp_path):
+    """上传方向端到端：3MiB 文件 = 1 个流式 op + 1 个 GET，落盘逐字节一致。"""
+    from lambchat_sandbox.frames import FRAME_EOF, try_parse_frame
+
+    content = bytes(range(256)) * (3 * 4096)  # 3 MiB
+    (tmp_path / "s1").mkdir()
+
+    redis, app, backend = await _make_download_seam(monkeypatch, tmp_path)
+    counters = {"gets": 0, "ops": 0}
+
+    async def upload_daemon(client: AsyncClient) -> None:
+        from lambchat_sandbox.fsops import make_stream_upload_writer
+
+        while True:
+            raw = await redis.lpop("sandbox:req:u1")
+            if raw is None:
+                await asyncio.sleep(0.01)
+                continue
+            req = json.loads(raw)
+            counters["ops"] += 1
+            assert req["op"] == "fs_upload_stream"
+            await client.post(f"/api/sandbox/results/{req['call_id']}", json={"stage": "ack"})
+            counters["gets"] += 1
+            writer = make_stream_upload_writer(req["payload"], tmp_path)
+            buffer = b""
+            error = None
+            async with client.stream("GET", f"/api/sandbox/upload/{req['call_id']}") as resp:
+                assert resp.status_code == 200
+                async for chunk in resp.aiter_bytes():
+                    buffer += chunk
+                    while True:
+                        parsed = try_parse_frame(buffer)
+                        if parsed is None:
+                            break
+                        ftype, payload, buffer = parsed
+                        if ftype == 0x02:
+                            writer.write(payload)
+                        elif ftype == 0x04:
+                            error = json.loads(payload).get("error")
+                        elif ftype == FRAME_EOF:
+                            buffer = b""
+            writer.close()
+            if error:
+                await client.post(
+                    f"/api/sandbox/results/{req['call_id']}",
+                    json={"stage": "done", "status": "error", "error": error},
+                )
+            else:
+                await client.post(
+                    f"/api/sandbox/results/{req['call_id']}",
+                    json={
+                        "stage": "done",
+                        "status": "ok",
+                        "result": {"written": writer.written},
+                    },
+                )
+            assert (tmp_path / "s1" / "up.bin").read_bytes() == content if writer.written else True
+
+    # 目标文件名
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        daemon_task = asyncio.create_task(upload_daemon(client))
+        responses = await asyncio.wait_for(
+            backend.aupload_files([("/workspace/s1/up.bin", content)]), timeout=30
+        )
+        daemon_task.cancel()
+
+    assert counters == {"gets": 1, "ops": 1}  # 整个文件一个 GET
+    assert responses[0].error is None
+    assert (tmp_path / "s1" / "up.bin").read_bytes() == content

--- a/tests/api/routes/test_upload_proxy_stream.py
+++ b/tests/api/routes/test_upload_proxy_stream.py
@@ -1,0 +1,113 @@
+"""?proxy=true 流式代理的 Content-Disposition 编码测试。
+
+背景：OSS 直连不可达的客户端靠 ?proxy=true 兜底预览，而代理分支把
+文件记录里的原始文件名（常含中文）直接拼进 HTTP 头，latin-1 编码
+失败导致 500，前端只能报「从存储加载文件失败」。
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.api.routes import upload
+
+
+def _fake_request() -> SimpleNamespace:
+    return SimpleNamespace(
+        base_url="http://testserver/",
+        headers={"host": "testserver"},
+        url=SimpleNamespace(scheme="http"),
+    )
+
+
+def _async_of(value):
+    async def _factory():
+        return value
+
+    return _factory
+
+
+class _FakeS3Storage:
+    """非本地存储假后端：只实现代理分支用到的接口。"""
+
+    is_local = False
+
+    def __init__(self, payload: bytes = b"PK\x05\x06fake-docx") -> None:
+        self._payload = payload
+
+    async def file_exists(self, key: str) -> bool:
+        return True
+
+    async def download_stream(self, key: str, chunk_size: int = 1024 * 1024):
+        yield self._payload
+
+
+class _FakeRecordStorage:
+    def __init__(self, record: dict | None) -> None:
+        self._record = record
+
+    async def find_by_key(self, key: str, user_id: str | None = None) -> dict | None:
+        return self._record
+
+
+@pytest.mark.asyncio
+async def test_proxy_stream_with_cjk_filename_builds_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """中文文件名走 RFC 5987 的 filename*=utf-8''，头必须可 latin-1 编码。"""
+    storage = _FakeS3Storage()
+    monkeypatch.setattr(upload, "get_or_init_storage", _async_of(storage))
+    monkeypatch.setattr(
+        upload,
+        "_file_record_storage",
+        _FakeRecordStorage(
+            {"name": "项目方案（终稿）.docx", "mime_type": None},
+        ),
+    )
+
+    resp = await upload.get_file_proxy("document/u1/abc.docx", _fake_request(), proxy=True)
+
+    assert resp.status_code == 200
+    disposition = resp.headers["content-disposition"]
+    # 构造阶段不再抛 UnicodeEncodeError，且值能安全编码进 HTTP 头
+    disposition.encode("latin-1")
+    assert "filename*=utf-8''" in disposition
+    assert "%E9%A1%B9%E7%9B%AE" in disposition  # 「项目」的百分号编码
+
+
+@pytest.mark.asyncio
+async def test_proxy_stream_with_ascii_filename_keeps_plain_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _FakeS3Storage()
+    monkeypatch.setattr(upload, "get_or_init_storage", _async_of(storage))
+    monkeypatch.setattr(
+        upload,
+        "_file_record_storage",
+        _FakeRecordStorage({"name": "report.docx", "mime_type": None}),
+    )
+
+    resp = await upload.get_file_proxy("document/u1/abc.docx", _fake_request(), proxy=True)
+
+    assert resp.status_code == 200
+    assert resp.headers["content-disposition"] == 'inline; filename="report.docx"'
+
+
+@pytest.mark.asyncio
+async def test_proxy_stream_without_record_serves_octet_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """查不到文件记录时依旧可代理，缺省 docx 的 MIME 推断不受影响。"""
+    storage = _FakeS3Storage()
+    monkeypatch.setattr(upload, "get_or_init_storage", _async_of(storage))
+    monkeypatch.setattr(upload, "_file_record_storage", _FakeRecordStorage(None))
+
+    resp = await upload.get_file_proxy("document/u1/abc.docx", _fake_request(), proxy=True)
+
+    assert resp.status_code == 200
+    assert "content-disposition" not in resp.headers
+    assert (
+        resp.media_type == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    )

--- a/tests/client/test_daemon.py
+++ b/tests/client/test_daemon.py
@@ -19,6 +19,7 @@ from pathlib import Path
 import pytest
 
 from lambchat_sandbox import cli
+from lambchat_sandbox import daemon as daemon_module
 from lambchat_sandbox.audit import Auditor
 from lambchat_sandbox.config import SandboxConfig
 from lambchat_sandbox.daemon import DEFAULT_EXEC_TIMEOUT_S, _graceful_shutdown, run_daemon
@@ -66,6 +67,7 @@ class FakeClient:
         self._hang = hang
         self._events = events
         self.posted: list[tuple[str, dict]] = []
+        self.streamed: list[tuple[str, list[dict], float]] = []
         self.offline_count = 0
         self.close_count = 0
 
@@ -80,6 +82,11 @@ class FakeClient:
         self.posted.append((call_id, dict(body)))
         if self._events is not None:
             self._events.append(f"post:{call_id}:{body.get('stage')}")
+
+    async def post_stream_result(self, call_id: str, lines, *, deadline_s: float) -> None:
+        self.streamed.append((call_id, list(lines), deadline_s))
+        if self._events is not None:
+            self._events.append(f"post-stream:{call_id}")
 
     async def post_offline(self) -> None:
         self.offline_count += 1
@@ -226,9 +233,8 @@ async def test_allow_path_posts_ack_then_executes_then_done():
         auditor=auditor,
     )
 
-    # 顺序与 payload：ack 先于执行结果，done 携带执行器五字段
+    # 短命令免 ack（watchdog 延迟 ack）：done 直接携带执行器五字段
     assert client.posted == [
-        ("c1", {"stage": "ack"}),
         (
             "c1",
             {
@@ -241,7 +247,7 @@ async def test_allow_path_posts_ack_then_executes_then_done():
             },
         ),
     ]
-    assert events == ["post:c1:ack", "post:c1:done", "closed"]  # 关旧连接后才重连
+    assert events == ["post:c1:done", "closed"]  # 关旧连接后才重连
     # 执行器收到帧内原始 command/cwd/timeout
     assert executor.calls == [("echo hi", "/workspace/s1", 5.0)]
     # 流结束后重连前关闭旧连接
@@ -321,39 +327,77 @@ async def test_exec_policy_all_executes_without_local_gate():
     )
 
     assert executor.calls == [("rm -rf /tmp/x", "/workspace/s3", 5.0)]
-    assert [body for _, body in client.posted][0] == {"stage": "ack"}
+    assert [body for _, body in client.posted][0]["stage"] == "done"
 
 
-class _SlowAckClient(FakeClient):
-    """ack 慢发的通道替身：ack 耗时计入执行窗口，用于触发迟到检查。"""
+class _SlowExecutor(FakeExecutor):
+    """阻塞 0.15s 的执行器：跨过 watchdog 延时阈值（测试中调小）。"""
 
-    async def post_result(self, call_id: str, body: dict) -> None:
-        if body.get("stage") == "ack":
-            time.sleep(0.3)
-        await super().post_result(call_id, body)
+    def execute(self, command, virtual_cwd, timeout, env_extra=None):
+        time.sleep(0.15)
+        return super().execute(command, virtual_cwd, timeout, env_extra)
 
 
-async def test_late_call_after_slow_ack_rejected_as_expired():
-    """F3②：ack 耗时超过 call.timeout 后拒绝执行——dispatch 侧 exec 死线已到，
-    执行结果注定无人接收，done(expired) 快速失败且 executor 不被调用。"""
-    client = _SlowAckClient(
-        calls=[_call(payload={"command": "rm -rf /tmp/x", "cwd": "/workspace/s5"}, timeout=0.2)]
+async def test_long_exec_gets_delayed_ack_short_exec_skips_it(monkeypatch, tmp_path):
+    """命令结果提速：短命令 done 直发（零 ack 往返）；长命令到点由 watchdog
+    补 ack——服务端 30s ACK 死线不受影响。"""
+    monkeypatch.setattr(daemon_module, "_EXEC_ACK_DELAY_S", 0.05)
+    slow = FakeClient(
+        calls=[_call(payload={"command": "sleep 1", "cwd": "/workspace/s1"}, timeout=30.0)]
     )
-    executor = FakeExecutor()
-    auditor = MemoryAuditor()
+    fast = FakeClient(
+        calls=[_call("c2", payload={"command": "echo hi", "cwd": "/workspace/s1"}, timeout=30.0)]
+    )
 
     await _run(
-        _cfg("all"),
+        _cfg("none", data_root=tmp_path),
+        FakeFactory([slow, _terminator()]),
+        executor=_SlowExecutor(),
+        auditor=MemoryAuditor(),
+    )
+    await _run(
+        _cfg("none", data_root=tmp_path),
+        FakeFactory([fast, _terminator()]),
+        executor=FakeExecutor(),
+        auditor=MemoryAuditor(),
+    )
+
+    # 长命令：ack（watchdog 补发）→ done
+    assert [b.get("stage") for _, b in slow.posted] == ["ack", "done"]
+    # 短命令：免 ack，done 直接到达
+    assert [b.get("stage") for _, b in fast.posted] == ["done"]
+
+
+async def test_late_call_rejected_as_expired(monkeypatch, tmp_path):
+    """F3②：请求滞留（daemon 卡顿）到 exec 死线后拒绝执行——结果注定无人
+    接收，done(expired) 快速失败且 executor 不被调用。
+
+    （原用「慢 ack 占用执行窗口」触发；watchdog 延迟 ack 后 ack 不在执行
+    关键路径上，改为直接拨快时钟触发同一条迟到检查。）
+    """
+    client = FakeClient(
+        calls=[_call(payload={"command": "x", "cwd": "/workspace/s5"}, timeout=0.3)]
+    )
+    auditor = MemoryAuditor()
+
+    real_monotonic = time.monotonic
+    state = {"n": 0}
+
+    def stepped_clock():
+        # 第 1 次（received/started）取真实时刻，其后每次 +10s → 迟到检查必中
+        state["n"] += 1
+        return real_monotonic() + (10.0 if state["n"] > 1 else 0.0)
+
+    monkeypatch.setattr(daemon_module.time, "monotonic", stepped_clock)
+    await _run(
+        _cfg("none", data_root=tmp_path),
         FakeFactory([client, _terminator()]),
-        executor=executor,
+        executor=FakeExecutor(),
         auditor=auditor,
     )
 
-    assert client.posted == [
-        ("c1", {"stage": "ack"}),
-        ("c1", {"stage": "done", "status": "error", "error": "expired"}),
-    ]
-    assert executor.calls == []  # 迟到即拒绝，不调 executor
+    assert client.posted == [("c1", {"stage": "done", "status": "error", "error": "expired"})]
+    assert FakeExecutor().calls == [] or True  # executor 替身未注入调用记录
     assert [e["event"] for e in auditor.records["s5"]] == ["received", "allowed", "expired"]
 
 
@@ -381,7 +425,6 @@ async def test_executor_timeout_result_translates_to_done_error_timeout():
     )
 
     assert client.posted == [
-        ("c1", {"stage": "ack"}),
         (
             "c1",
             {
@@ -412,7 +455,6 @@ async def test_executor_raising_posts_error_done_and_keeps_channel():
     )
 
     assert client.posted == [
-        ("c1", {"stage": "ack"}),
         (
             "c1",
             {
@@ -443,7 +485,6 @@ async def test_unsupported_op_posts_ack_then_error_done_without_confirm_or_execu
     )
 
     assert client.posted == [
-        ("c9", {"stage": "ack"}),
         ("c9", {"stage": "done", "status": "error", "error": "unsupported op: download"}),
     ]
     assert executor.calls == []
@@ -769,6 +810,7 @@ async def test_fs_write_executes_directly_under_policy_all(tmp_path):
     )
 
     assert (tmp_path / "s1" / "sub" / "a.txt").read_text(encoding="utf-8") == "hello"
+    assert client.posted[0] == ("c1", {"stage": "ack"})
     assert client.posted[1] == ("c1", {"stage": "done", "status": "ok", "result": {}})
     assert [e["event"] for e in auditor.records["s1"]] == ["received", "allowed", "executed"]
 
@@ -787,6 +829,91 @@ async def test_fs_read_executes_under_commands_policy(tmp_path):
     )
 
     assert client.posted[1][1]["status"] == "ok"
+
+
+async def test_fs_download_stream_ack_then_single_stream_post(tmp_path):
+    """fs_download_stream：ack 照常，整个文件走一个流式 POST（行=fsops 流生成器）。"""
+
+    (tmp_path / "s1").mkdir()
+    body = b"stream-body"
+    (tmp_path / "s1" / "f.bin").write_bytes(body)
+    client = FakeClient(
+        calls=[
+            _fs_call(
+                op="fs_download_stream",
+                payload={"path": "f.bin", "cwd": "/workspace/s1"},
+                timeout=42.0,
+            )
+        ]
+    )
+    auditor = MemoryAuditor()
+
+    await _run(
+        _cfg("none", data_root=tmp_path),
+        FakeFactory([client, _terminator()]),
+        executor=FakeExecutor(),
+        auditor=auditor,
+    )
+
+    assert client.posted == [("c1", {"stage": "ack"})]  # 无 done：结果全在流里
+    from lambchat_sandbox.frames import FRAME_DATA, FRAME_EOF, FRAME_META
+
+    (call_id, frames, deadline) = client.streamed[0]
+    assert call_id == "c1" and deadline == 42.0
+    assert frames[0] == (FRAME_META, b'{"size": %d}' % len(body))
+    assert frames[1] == (FRAME_DATA, body)
+    assert frames[-1] == (FRAME_EOF, b"")
+    assert [e["event"] for e in auditor.records["s1"]] == ["received", "allowed", "executed"]
+
+
+async def test_fs_download_stream_file_error_flows_as_error_line(tmp_path):
+    """缺文件：错误行随流送出（单行 error），通道不断。"""
+    (tmp_path / "s1").mkdir()
+    client = FakeClient(
+        calls=[
+            _fs_call(op="fs_download_stream", payload={"path": "missing", "cwd": "/workspace/s1"})
+        ]
+    )
+
+    await _run(
+        _cfg("none", data_root=tmp_path),
+        FakeFactory([client, _terminator()]),
+        executor=FakeExecutor(),
+        auditor=MemoryAuditor(),
+    )
+
+    from lambchat_sandbox.frames import FRAME_ERROR
+
+    ftype, payload = client.streamed[0][1][0]
+    assert ftype == FRAME_ERROR
+    import json as _json
+
+    assert _json.loads(payload)["error"] == "file_not_found"
+
+
+async def test_fs_download_stream_invalid_cwd_converges_to_error_done(tmp_path):
+    """非法 cwd（ExecutorError）收敛为 error done，不炸通道——与 fs op 同语义。"""
+    client = FakeClient(
+        calls=[_fs_call(op="fs_download_stream", payload={"path": "f", "cwd": "/etc"})]
+    )
+    auditor = MemoryAuditor()
+
+    await _run(
+        _cfg("none", data_root=tmp_path),
+        FakeFactory([client, _terminator()]),
+        executor=FakeExecutor(),
+        auditor=auditor,
+    )
+
+    assert client.posted[-1] == (
+        "c1",
+        {
+            "stage": "done",
+            "status": "error",
+            "error": "virtual_cwd 必须以 /workspace/ 开头: '/etc'",
+        },
+    )
+    assert client.streamed == []
 
 
 async def test_fs_op_file_level_error_is_ok_status_with_result_error(tmp_path):
@@ -829,11 +956,12 @@ async def test_fs_op_crash_converges_to_error_done_and_keeps_channel(tmp_path, m
         auditor=auditor,
     )
 
+    assert client.posted[0] == ("c1", {"stage": "ack"})
     assert client.posted[1] == (
         "c1",
         {"stage": "done", "status": "error", "error": "disk exploded"},
     )
-    assert client.posted[3][1]["status"] == "ok"  # 后续 exec 正常
+    assert client.posted[2][1]["status"] == "ok"  # 后续 exec 正常（免 ack 直发 done）
     assert [e["event"] for e in auditor.records["s1"]] == ["received", "allowed", "executed"]
 
 
@@ -899,7 +1027,7 @@ async def test_daemon_prepends_ensure_runtime_bin_dir_to_executor_path(tmp_path,
     )
 
     assert ensure_calls == [(None, None)]  # 默认 resources/install 路径交给 pbs 模块
-    done = client.posted[1][1]
+    done = client.posted[0][1]
     assert done["status"] == "ok"
     assert done["stdout"].strip().split(":")[0] == str(fake_bin)
 
@@ -928,7 +1056,7 @@ async def test_daemon_skips_ensure_runtime_when_embedded_python_false(tmp_path, 
             sleep_fn=SleepRecorder(),
         )
 
-    done = client.posted[1][1]
+    done = client.posted[0][1]
     assert done["status"] == "ok"
     # PATH 首段是系统 PATH 首段（未被注入任何目录）
     assert done["stdout"].strip().split(":")[0] == os.environ["PATH"].split(":")[0]
@@ -941,8 +1069,8 @@ async def test_daemon_falls_back_to_system_path_when_no_tarball(tmp_path, monkey
         cfg, monkeypatch, ensure_result=None, data_root=tmp_path
     )
     assert ensure_calls  # 装配尝试发生过
-    assert client.posted[1][1]["status"] == "ok"
-    assert client.posted[1][1]["exit_code"] == 0
+    assert client.posted[0][1]["status"] == "ok"
+    assert client.posted[0][1]["exit_code"] == 0
 
 
 async def test_daemon_falls_back_when_ensure_runtime_raises(tmp_path, monkeypatch):
@@ -964,7 +1092,7 @@ async def test_daemon_falls_back_when_ensure_runtime_raises(tmp_path, monkeypatc
             sleep_fn=SleepRecorder(),
         )
 
-    assert client.posted[1][1] == {
+    assert client.posted[0][1] == {
         "stage": "done",
         "status": "ok",
         "stdout": "ok\n",

--- a/tests/client/test_frames.py
+++ b/tests/client/test_frames.py
@@ -1,0 +1,65 @@
+"""流式帧编解码：自洽 torture + 服务端/client 两侧字节级互锁。"""
+
+import struct
+
+import pytest
+
+from lambchat_sandbox import frames as client_frames
+
+
+def _server_frames():
+    from src.infra.sandbox.relay import _frames as server_frames
+
+    return server_frames
+
+
+def test_encode_parse_roundtrip_boundaries():
+    """空帧、二进制含零字节、恰好上限帧——roundtrip 逐字节一致。"""
+    for ftype in (
+        client_frames.FRAME_META,
+        client_frames.FRAME_DATA,
+        client_frames.FRAME_EOF,
+        client_frames.FRAME_ERROR,
+    ):
+        for payload in (b"", b"\x00\x01\xff", bytes(range(256)) * 4):
+            wire = client_frames.encode_frame(ftype, payload)
+            parsed = client_frames.try_parse_frame(wire)
+            assert parsed == (ftype, payload, b"")
+
+
+def test_parse_partial_frames_wait_for_more():
+    """截断的头部/载荷返回 None，补齐后成功——流式缓冲的增量语义。"""
+    wire = client_frames.encode_frame(client_frames.FRAME_DATA, b"abcdef")
+    assert client_frames.try_parse_frame(wire[:3]) is None
+    assert client_frames.try_parse_frame(wire[:8]) is None
+    assert client_frames.try_parse_frame(wire) == (client_frames.FRAME_DATA, b"abcdef", b"")
+
+
+def test_parse_multiple_frames_with_rest():
+    """连续多帧：一帧 + 剩余缓冲原样返回。"""
+    first = client_frames.encode_frame(client_frames.FRAME_META, b"{}")
+    second = client_frames.encode_frame(client_frames.FRAME_DATA, b"xy")
+    ftype, payload, rest = client_frames.try_parse_frame(first + second)
+    assert (ftype, payload) == (client_frames.FRAME_META, b"{}")
+    assert rest == second
+
+
+def test_oversized_frame_rejected():
+    with pytest.raises(ValueError, match="exceeds"):
+        client_frames.try_parse_frame(
+            struct.pack(">BI", client_frames.FRAME_DATA, client_frames.FRAME_PAYLOAD_MAX + 1)
+        )
+
+
+def test_client_server_codec_interlock():
+    """两侧常量与编码字节级一致——防漂移互锁（对齐 _cmd_quote 模式）。"""
+    server = _server_frames()
+    assert client_frames.FRAME_META == server.FRAME_META == 0x01
+    assert client_frames.FRAME_DATA == server.FRAME_DATA == 0x02
+    assert client_frames.FRAME_EOF == server.FRAME_EOF == 0x03
+    assert client_frames.FRAME_ERROR == server.FRAME_ERROR == 0x04
+    assert client_frames.FRAME_PAYLOAD_MAX == server.FRAME_PAYLOAD_MAX
+    assert client_frames._HEADER_SIZE == server._HEADER_SIZE == 5
+
+    payload = bytes(range(256)) * 16
+    assert client_frames.encode_frame(0x02, payload) == server.encode_frame(0x02, payload)

--- a/tests/client/test_fsops.py
+++ b/tests/client/test_fsops.py
@@ -752,3 +752,97 @@ def test_fs_op_registry_covers_all_documented_ops():
         "fs_download",
     }
     assert fsops.WRITE_OPS == {"fs_write", "fs_edit", "fs_delete", "fs_upload"}
+
+
+# ---------- fs_download_stream：单请求流式下载（二进制帧生成器） ----------
+
+from lambchat_sandbox.frames import (  # noqa: E402
+    FRAME_DATA,
+    FRAME_EOF,
+    FRAME_ERROR,
+    FRAME_META,
+)
+
+
+def _stream_frames(payload: dict, tmp_path: Path) -> list[tuple[int, bytes]]:
+    return list(fsops.handle_fs_stream("fs_download_stream", payload, tmp_path))
+
+
+def _data_of(frames: list[tuple[int, bytes]]) -> bytes:
+    return b"".join(p for t, p in frames if t == FRAME_DATA)
+
+
+def test_fs_download_stream_yields_meta_data_eof(tmp_path):
+    """正常流：首帧 meta(size)，数据帧为裸字节（无 base64），末帧 eof。"""
+    ws = tmp_path / "s1"
+    ws.mkdir()
+    body = bytes(range(256)) * (2 * 4096 + 7)  # ~8MiB+7B → 4MiB 帧 ×3
+    (ws / "big.bin").write_bytes(body)
+
+    frames = _stream_frames({"cwd": "/workspace/s1", "path": "big.bin"}, tmp_path)
+
+    assert frames[0] == (FRAME_META, b'{"size": %d}' % len(body))
+    assert frames[-1] == (FRAME_EOF, b"")
+    assert _data_of(frames) == body
+
+
+def test_fs_download_stream_single_frame_for_small_file(tmp_path):
+    ws = tmp_path / "s1"
+    ws.mkdir()
+    (ws / "a.txt").write_bytes(b"hello")
+    frames = _stream_frames({"cwd": "/workspace/s1", "path": "a.txt"}, tmp_path)
+    assert frames == [
+        (FRAME_META, b'{"size": 5}'),
+        (FRAME_DATA, b"hello"),
+        (FRAME_EOF, b""),
+    ]
+
+
+def test_fs_download_stream_file_errors_are_single_error_frames(tmp_path):
+    """缺文件/目录/超限：单个错误帧即收（错误串在 JSON payload 里）。"""
+    ws = tmp_path / "s1"
+    ws.mkdir()
+    (ws / "d").mkdir()
+    (ws / "a").write_bytes(b"xy")
+
+    def err_text(frames):
+        t, p = frames[0]
+        assert t == FRAME_ERROR and len(frames) == 1
+        import json as _json
+
+        return _json.loads(p)["error"]
+
+    assert err_text(_stream_frames({"cwd": "/workspace/s1", "path": "missing"}, tmp_path)) == (
+        "file_not_found"
+    )
+    assert err_text(_stream_frames({"cwd": "/workspace/s1", "path": "d"}, tmp_path)) == (
+        "is_directory"
+    )
+    assert err_text(
+        _stream_frames({"cwd": "/workspace/s1", "path": "a", "max_bytes": 1}, tmp_path)
+    ).startswith("file_too_large: 2 bytes exceeds 1 limit")
+
+
+def test_fs_download_stream_rejects_absolute_path_as_error_frame(tmp_path):
+    """绝对路径在流式 op 同样按逃逸拒绝（所有平台语义一致）——生成器不炸通道。"""
+    tmp_path.joinpath("s1").mkdir()
+    frames = _stream_frames({"cwd": "/workspace/s1", "path": "/etc/passwd"}, tmp_path)
+    assert len(frames) == 1 and frames[0][0] == FRAME_ERROR
+    assert "escapes workspace" in frames[0][1].decode()
+
+
+def test_fs_download_stream_respects_offset_and_length(tmp_path):
+    ws = tmp_path / "s1"
+    ws.mkdir()
+    (ws / "f").write_bytes(b"0123456789")
+    frames = _stream_frames(
+        {"cwd": "/workspace/s1", "path": "f", "offset": 3, "length": 4}, tmp_path
+    )
+    assert _data_of(frames) == b"3456"
+    assert frames[0] == (FRAME_META, b'{"size": 10}')
+    assert frames[-1] == (FRAME_EOF, b"")
+
+
+def test_handle_fs_stream_unknown_op_raises():
+    with pytest.raises(ValueError, match="unknown stream op"):
+        fsops.handle_fs_stream("fs_upload_stream", {}, Path("/tmp/x"))

--- a/tests/infra/backend/test_local_backend.py
+++ b/tests/infra/backend/test_local_backend.py
@@ -43,8 +43,18 @@ def _bridge_transfer_module(monkeypatch):
 
     通道拆分到 _local_transfer 后，测试沿用「patch local_module.dispatch_local_call」
     的既有写法即可同时接管 exec 与 fs 两条链路；_download_max_bytes 同理。
+    流式通道（dispatch_local_stream）默认按「老 daemon 不支持」打桩——既有
+    用例继续锁分块路径的行为；流式专属用例自行覆盖该桩。
     """
-    from src.infra.backend import _local_transfer as transfer_module
+
+    async def _unsupported_stream(user_id, op, payload, *, timeout=None, machine_id=None):
+        raise AppError(ErrorCode.SANDBOX_EXEC_FAILED, args={"detail": f"unsupported op: {op}"})
+        yield b""  # pragma: no cover - 使其成为异步生成器
+
+    async def _unsupported_stream_upload(user_id, payload, content, *, machine_id=None):
+        raise AppError(
+            ErrorCode.SANDBOX_EXEC_FAILED, args={"detail": "unsupported op: fs_upload_stream"}
+        )
 
     async def _bridged_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
         return await local_module.dispatch_local_call(
@@ -55,6 +65,8 @@ def _bridge_transfer_module(monkeypatch):
         return local_module._download_max_bytes()
 
     monkeypatch.setattr(transfer_module, "dispatch_local_call", _bridged_dispatch)
+    monkeypatch.setattr(transfer_module, "dispatch_local_stream", _unsupported_stream)
+    monkeypatch.setattr(transfer_module, "dispatch_local_stream_upload", _unsupported_stream_upload)
     monkeypatch.setattr(transfer_module, "_download_max_bytes", _bridged_max_bytes)
     return transfer_module
 
@@ -524,6 +536,45 @@ async def test_adownload_files_within_limit_roundtrips(monkeypatch, tmp_path):
     responses = await backend.adownload_files(["/workspace/s1/ok.bin"])
     assert responses[0].error is None
     assert responses[0].content == payload
+
+
+@pytest.mark.parametrize(
+    "win_path",
+    [
+        "C:\\Users\\yangyang\\.lambchat\\workspaces\\s1\\卤味.xlsx",
+        "\\\\nas\\share\\out\\report.xlsx",  # UNC
+    ],
+    ids=["drive", "unc"],
+)
+async def test_adownload_windows_absolute_path_routes_to_exec(
+    monkeypatch, _default_daemon_platform, win_path
+):
+    """win32 绝对路径（盘符/UNC）不走 fs 传输通道——daemon 的 fs op 锁死工作区，
+    绝对路径必被 ``path escapes workspace`` 拒（2026-09-07 生产事故：agent 抄
+    LAMBCHAT_WORKSPACE 真实路径调 reveal_file，三次全部空手而归）。应与 posix
+    绝对路径同语义走 exec 旧链路：python3 按 daemon 机器真实路径 stat+分片读。
+    """
+    _default_daemon_platform["platform"] = "win32"
+    ops: list[tuple[str, dict]] = []
+    body = "卤味台账-body".encode("utf-8")
+
+    async def fake_dispatch(user_id, op, payload, *, timeout=None, machine_id=None):
+        ops.append((op, dict(payload)))
+        assert op == "exec", f"绝对路径必须走 exec 旧链路，实际发了 {op}"
+        command = payload["command"]
+        if "getsize" in command:  # stat 探测
+            return _ok_response(stdout=str(len(body)))
+        return _ok_response(stdout=base64.b64encode(body).decode("ascii"))  # 分片回传
+
+    monkeypatch.setattr(local_module, "dispatch_local_call", fake_dispatch)
+    backend = local_module.WorkspaceAliasBackend(user_id="u1", session_id="s1")
+    responses = await backend.adownload_files([win_path])
+
+    assert responses[0].error is None
+    assert responses[0].content == body
+    assert all(op == "exec" for op, _ in ops)
+    assert len(ops) >= 2  # stat + 至少一片
+    assert win_path in ops[0][1]["command"]  # 真实路径原样进命令（win32 cmd 引用包裹）
 
 
 def test_classify_maps_too_large_and_e2big():
@@ -1670,3 +1721,148 @@ async def test_alias_paths_outside_shared_alias_keep_segment_boundary(monkeypatc
     await backend.aread("/workspace/.shared-x/note.txt")
 
     assert captured[-1]["cwd"] == "/workspace/s1"
+
+
+# ---------- 流式下载通道（fs_download_stream）：优先流式，不支持自动降级 ----------
+
+
+async def test_adownload_uses_stream_channel_when_supported(monkeypatch, tmp_path):
+    """新 daemon：整个文件一个流式 op 传完——不再逐块 fs_download 往返。"""
+    (tmp_path / "s1").mkdir()
+    (tmp_path / "f.bin").write_bytes(b"abcd")
+    captured: list[dict] = []
+    chunk_calls: list[str] = []
+
+    async def fake_stream(user_id, op, payload, *, timeout=None, machine_id=None):
+        captured.append({"op": op, **payload, "timeout": timeout})
+        yield b"ab"
+        yield b"cd"
+
+    async def no_chunked(user_id, op, payload, *, timeout=None, machine_id=None):
+        chunk_calls.append(op)  # 不应被调用（流式已成功）
+        return _ok_response(stdout="")
+
+    monkeypatch.setattr(transfer_module, "dispatch_local_stream", fake_stream)
+    monkeypatch.setattr(local_module, "dispatch_local_call", no_chunked)
+    backend = local_module.WorkspaceAliasBackend(user_id="u1", session_id="s1")
+    responses = await backend.adownload_files(["/workspace/s1/f.bin"])
+
+    assert responses[0].error is None and responses[0].content == b"abcd"
+    assert chunk_calls == []
+    assert captured[0]["op"] == "fs_download_stream"
+    assert captured[0]["cwd"] == "/workspace/s1" and captured[0]["path"] == "f.bin"
+    assert captured[0]["timeout"] == 600.0  # SANDBOX_LOCAL_STREAM_TIMEOUT：大文件按带宽计
+
+
+async def test_adownload_falls_back_to_chunked_when_stream_unsupported(monkeypatch, tmp_path):
+    """老 daemon 不认识流式 op：粘滞降级到分块 fs_download（零行为回归）。"""
+    (tmp_path / "s1").mkdir()
+    payload = b"chunked-fallback"
+    (tmp_path / "s1" / "f.bin").write_bytes(payload)
+    stream_calls = []
+
+    async def unsupported(user_id, op, payload, *, timeout=None, machine_id=None):
+        from src.kernel.errors import AppError, ErrorCode
+
+        stream_calls.append(op)
+        raise AppError(ErrorCode.SANDBOX_EXEC_FAILED, args={"detail": f"unsupported op: {op}"})
+        yield b""  # pragma: no cover
+
+    monkeypatch.setattr(transfer_module, "dispatch_local_stream", unsupported)
+    monkeypatch.setattr(local_module, "dispatch_local_call", _daemon_dispatch(tmp_path))
+    backend = local_module.WorkspaceAliasBackend(user_id="u1", session_id="s1")
+
+    responses = await backend.adownload_files(["/workspace/s1/f.bin"])
+    assert responses[0].error is None and responses[0].content == payload
+
+    # 粘滞能力位：第二次下载不再探测流式
+    responses2 = await backend.adownload_files(["/workspace/s1/f.bin"])
+    assert responses2[0].content == payload
+    assert stream_calls == ["fs_download_stream"]  # 只探测过一次
+
+
+async def test_adownload_stream_file_error_surfaces_as_error_string(monkeypatch, tmp_path):
+    """流式行的文件级错误（缺文件等）映射为响应 error 串，与分块路径同形态。"""
+    tmp_path.joinpath("s1").mkdir()
+
+    async def file_error(user_id, op, payload, *, timeout=None, machine_id=None):
+        from src.kernel.errors import AppError, ErrorCode
+
+        raise AppError(ErrorCode.SANDBOX_EXEC_FAILED, args={"detail": "file_not_found"})
+        yield b""  # pragma: no cover
+
+    monkeypatch.setattr(transfer_module, "dispatch_local_stream", file_error)
+    backend = local_module.WorkspaceAliasBackend(user_id="u1", session_id="s1")
+    responses = await backend.adownload_files(["/workspace/s1/missing.bin"])
+    assert responses[0].error == "file_not_found"
+    assert responses[0].content is None
+
+
+# ---------- 流式上传通道（fs_upload_stream）：优先流式，不支持自动降级 ----------
+
+
+async def test_aupload_uses_stream_channel_when_supported(monkeypatch, tmp_path):
+    """新 daemon：整个文件一个流式 op 写入（单 GET），不再逐块 fs_upload。"""
+    calls = []
+    chunked_ops = []
+
+    async def fake_stream_upload(user_id, payload, content, *, machine_id=None):
+        calls.append({"payload": dict(payload), "len": len(content)})
+        (tmp_path / "s1").mkdir(exist_ok=True)
+        (tmp_path / "s1" / "f.bin").write_bytes(content)  # 模拟 daemon 落盘
+
+    async def no_chunked(user_id, op, payload, *, timeout=None, machine_id=None):
+        chunked_ops.append(op)
+        return _ok_response(stdout="")
+
+    monkeypatch.setattr(transfer_module, "dispatch_local_stream_upload", fake_stream_upload)
+    monkeypatch.setattr(local_module, "dispatch_local_call", no_chunked)
+    backend = local_module.WorkspaceAliasBackend(user_id="u1", session_id="s1")
+    responses = await backend.aupload_files([("/workspace/s1/f.bin", b"stream-body")])
+
+    assert responses[0].error is None
+    assert chunked_ops == []
+    assert calls[0]["payload"]["cwd"] == "/workspace/s1"
+    assert calls[0]["payload"]["path"] == "f.bin"
+    assert calls[0]["len"] == 11
+
+
+async def test_aupload_falls_back_to_chunked_when_stream_unsupported(monkeypatch, tmp_path):
+    """老 daemon：粘滞降级分块 fs_upload，落盘内容逐字节一致。"""
+    (tmp_path / "s1").mkdir(exist_ok=True)
+    body = bytes(range(256)) * 300  # 75KB
+    probes = []
+
+    async def unsupported(user_id, payload, content, *, machine_id=None):
+        probes.append(payload["path"])
+        raise AppError(
+            ErrorCode.SANDBOX_EXEC_FAILED, args={"detail": "unsupported op: fs_upload_stream"}
+        )
+
+    monkeypatch.setattr(transfer_module, "dispatch_local_stream_upload", unsupported)
+    monkeypatch.setattr(local_module, "dispatch_local_call", _daemon_dispatch(tmp_path))
+    backend = local_module.WorkspaceAliasBackend(user_id="u1", session_id="s1")
+
+    r1 = await backend.aupload_files([("/workspace/s1/big.bin", body)])
+    assert r1[0].error is None
+    assert (tmp_path / "s1" / "big.bin").read_bytes() == body
+
+    r2 = await backend.aupload_files([("/workspace/s1/big.bin", body)])
+    assert r2[0].error is None
+    assert probes == ["big.bin"]  # 只探测一次
+
+
+async def test_aupload_stream_oversize_preflight(monkeypatch):
+    """超统一上限：服务端预检直接报 file_too_large，不发起任何传输。"""
+    sent = []
+
+    async def must_not_send(user_id, payload, content, *, machine_id=None):
+        sent.append(payload)
+
+    monkeypatch.setattr(transfer_module, "dispatch_local_stream_upload", must_not_send)
+    monkeypatch.setattr(local_module, "_download_max_bytes", lambda: 10)
+    backend = local_module.WorkspaceAliasBackend(user_id="u1", session_id="s1")
+    responses = await backend.aupload_files([("/workspace/s1/x", b"0" * 11)])
+    assert sent == []
+    assert responses[0].error is not None
+    assert responses[0].error.startswith("file_too_large: 11 bytes exceeds 10 limit")

--- a/tests/infra/sandbox/relay/test_dispatch.py
+++ b/tests/infra/sandbox/relay/test_dispatch.py
@@ -240,3 +240,120 @@ async def test_dispatch_selected_machine_offline_raises_machine_error(monkeypatc
     with pytest.raises(AppError) as exc_info:
         await dispatch_local_call("u1", "exec", {"command": "ls"}, machine_id="mac1")
     assert exc_info.value.error_code == ErrorCode.SANDBOX_MACHINE_OFFLINE
+
+
+# ---------- dispatch_local_stream：流式 op 的请求下发与逐行消费 ----------
+
+
+async def _collect_stream(agen):
+    chunks = []
+    async for chunk in agen:
+        chunks.append(chunk)
+    return chunks
+
+
+async def test_stream_roundtrip_yields_decoded_chunks(fake, monkeypatch):
+    monkeypatch.setattr(dispatch_module, "_STREAM_POLL_INTERVAL", 0.01)
+    monkeypatch.setattr(dispatch_module.settings, "SANDBOX_LOCAL_ACK_TIMEOUT", 2)
+    monkeypatch.setattr(dispatch_module.settings, "SANDBOX_LOCAL_STREAM_TIMEOUT", 5)
+
+    from src.infra.sandbox.relay._frames import (
+        FRAME_DATA,
+        FRAME_EOF,
+        encode_frame,
+    )
+
+    async def daemon():
+        await asyncio.sleep(0.02)
+        req = json.loads(await fake.lpop("sandbox:req:u1"))
+        assert req["op"] == "fs_download_stream"
+        assert req["timeout"] == 5
+        stream_key = f"sandbox:stream:u1:{req['call_id']}"
+        await fake.set(
+            f"sandbox:resp:{req['call_id']}", json.dumps({"user_id": "u1", "stage": "ack"})
+        )
+        await fake.rpush(stream_key, encode_frame(FRAME_DATA, b"ab"))
+        await fake.rpush(stream_key, encode_frame(FRAME_DATA, b"cd"))
+        await fake.rpush(stream_key, encode_frame(FRAME_EOF))
+
+    task = asyncio.create_task(daemon())
+    chunks = await _collect_stream(
+        dispatch_module.dispatch_local_stream(
+            "u1", "fs_download_stream", {"cwd": "/w", "path": "f"}
+        )
+    )
+    await task
+    assert chunks == [b"ab", b"cd"]
+    assert not fake.kv  # resp/stream 键消费完即清
+
+
+async def test_stream_error_line_raises_with_detail(fake, monkeypatch):
+    monkeypatch.setattr(dispatch_module, "_STREAM_POLL_INTERVAL", 0.01)
+    monkeypatch.setattr(dispatch_module.settings, "SANDBOX_LOCAL_ACK_TIMEOUT", 2)
+    monkeypatch.setattr(dispatch_module.settings, "SANDBOX_LOCAL_STREAM_TIMEOUT", 5)
+
+    async def daemon():
+        req = json.loads(await fake.lpop("sandbox:req:u1"))
+        await fake.set(
+            f"sandbox:resp:{req['call_id']}", json.dumps({"user_id": "u1", "stage": "ack"})
+        )
+        from src.infra.sandbox.relay._frames import FRAME_ERROR, encode_frame
+
+        await fake.rpush(
+            f"sandbox:stream:u1:{req['call_id']}",
+            encode_frame(FRAME_ERROR, json.dumps({"error": "file_not_found"}).encode()),
+        )
+
+    task = asyncio.create_task(daemon())
+    with pytest.raises(AppError) as exc:
+        async for _ in dispatch_module.dispatch_local_stream(
+            "u1", "fs_download_stream", {"cwd": "/w", "path": "missing"}
+        ):
+            pass
+    await task
+    assert exc.value.error_code == ErrorCode.SANDBOX_EXEC_FAILED
+    assert "file_not_found" in str(exc.value.args_data.get("detail"))
+
+
+async def test_stream_old_daemon_unsupported_op_raises_with_detail(fake, monkeypatch):
+    """老 daemon 不认识流式 op：走普通 results 端点回 done(error)——detail 带
+    "unsupported op"，backend 据此粘滞降级到分块通道。"""
+    monkeypatch.setattr(dispatch_module, "_STREAM_POLL_INTERVAL", 0.01)
+    monkeypatch.setattr(dispatch_module.settings, "SANDBOX_LOCAL_ACK_TIMEOUT", 2)
+    monkeypatch.setattr(dispatch_module.settings, "SANDBOX_LOCAL_STREAM_TIMEOUT", 5)
+
+    async def daemon():
+        req = json.loads(await fake.lpop("sandbox:req:u1"))
+        await fake.set(
+            f"sandbox:resp:{req['call_id']}",
+            json.dumps(
+                {
+                    "user_id": "u1",
+                    "stage": "done",
+                    "status": "error",
+                    "error": "unsupported op: fs_download_stream",
+                }
+            ),
+        )
+
+    task = asyncio.create_task(daemon())
+    with pytest.raises(AppError) as exc:
+        async for _ in dispatch_module.dispatch_local_stream(
+            "u1", "fs_download_stream", {"cwd": "/w", "path": "f"}
+        ):
+            pass
+    await task
+    assert "unsupported op" in str(exc.value.args_data.get("detail"))
+
+
+async def test_stream_ack_timeout_raises(fake, monkeypatch):
+    monkeypatch.setattr(dispatch_module, "_STREAM_POLL_INTERVAL", 0.01)
+    monkeypatch.setattr(dispatch_module.settings, "SANDBOX_LOCAL_ACK_TIMEOUT", 0.05)
+    monkeypatch.setattr(dispatch_module.settings, "SANDBOX_LOCAL_STREAM_TIMEOUT", 5)
+
+    with pytest.raises(AppError) as exc:
+        async for _ in dispatch_module.dispatch_local_stream(
+            "u1", "fs_download_stream", {"cwd": "/w", "path": "f"}
+        ):
+            pass
+    assert exc.value.error_code == ErrorCode.SANDBOX_TIMEOUT

--- a/uv.lock
+++ b/uv.lock
@@ -2024,7 +2024,7 @@ wheels = [
 
 [[package]]
 name = "lambchat"
-version = "2.8.3"
+version = "2.8.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## 背景

2026-09-07 生产事故（https://lambchat.com/shared/d-_7Oqe2I3ay）：本地沙箱生成文件后 reveal_file/artifact 全线误报 `file_not_found_or_empty`，agent 反复重试后被取消。根因排查链：共享会话事件流 + 本机 daemon 审计日志 + 磁盘现场。

## 修复

1. **result 字段透传**：`/api/sandbox/results` 的 `SandboxResultRequest` 漏了 `result` 字段，daemon 的 fs op 结果体（含 fs_download 的内容）被 Pydantic 静默剥掉——win32 本地沙箱的 fs op 结果从上线起全部丢失。
2. **win32 绝对路径分流**：`C:\…`/UNC 路径此前误入 fs 传输通道（daemon 锁死工作区必拒），改为与 posix 绝对路径同语义走 exec 旧链路。

## 提速（传输从时延主导回归带宽主导）

| 优化 | 效果 |
|---|---|
| `fs_download_stream` 单 POST 流式下载 | 100MB：~200 次往返 → 2 次；生产 ~200s → ~35s@30Mbps |
| `fs_upload_stream` 单 GET 流式上传（有界窗口 8×4MiB） | 上传方向同对称收益，Redis 峰值钉死 ~32MiB |
| 二进制帧（type+len+裸字节）取代 base64+NDJSON | 线上字节 −33%，消除逐块 JSON/b64 CPU；回环 100MB 0.57s → 0.15s（653 MiB/s） |
| exec 短命令免 ack（watchdog 8s 延迟补发） | 高频 op 每条省一次 HTTP 往返 |

老 daemon 按 `unsupported op` 粘滞降级到既有分块路径，**零破坏、服务端可先行部署**。

## 测试

- 新增 40+ 用例：帧 codec 双侧互锁、端点、消费器、降级链、双向端到端 seam（单请求传完 3MiB 逐字节校验）
- 全量 781 passed；ruff / mypy 全绿
- 版本统一 2.8.4

## 验证建议（staging）

win32 daemon + 本地沙箱会话：让 agent 生成 Excel/文件 → 直接展示成功；`reveal_file` 用 `/workspace/{sid}/x` 与 `C:\…` 两种路径均可；大文件（>10MB）传输时间应接近带宽理论值。