### PR TITLE
fix(api): release 资产代理下载 401——公开路径挂错精确匹配集合

### DIFF
--- a/src/api/middleware/auth.py
+++ b/src/api/middleware/auth.py
@@ -34,8 +34,6 @@ class AuthMiddleware(BaseHTTPMiddleware):
         "/sw.js",
         "/offline.html",
         "/api/version",
-        # release 资产下载代理：与 /api/version 同为公开端点（移动端更新链路）
-        "/api/version/assets/",
         "/robots.txt",
         "/sitemap.xml",
         "/index.html",
@@ -50,6 +48,10 @@ class AuthMiddleware(BaseHTTPMiddleware):
         "/api/auth/verify-email",
         "/api/auth/resend-verification",
         "/api/upload/file/",  # 文件访问端点 - 设计为公开以支持文件分享和前端访问
+        # release 资产下载代理：与 /api/version 同为公开端点（移动端更新链路）。
+        # 必须挂前缀列表——PUBLIC_PATHS 是精确匹配集合，挡不住
+        # /api/version/assets/<name>/download 实际路径（2026-09-07 生产 401 事故）。
+        "/api/version/assets/",
         "/assets/",
         "/icons/",
         "/images/",

--- a/tests/api/test_auth_middleware_public_paths.py
+++ b/tests/api/test_auth_middleware_public_paths.py
@@ -39,3 +39,29 @@ async def test_static_font_paths_are_public_without_authorization() -> None:
         response = await client.get("/fonts/source-sans-3-400-latin.woff2")
 
     assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_release_asset_download_path_is_public_without_authorization() -> None:
+    """release 资产代理下载必须匿名可访问（移动端更新链路）。
+
+    PUBLIC_PATHS 是精确匹配集合——``/api/version/assets/`` 挂在那里挡不住
+    ``/api/version/assets/<name>/download`` 实际路径，移动端「立即更新」
+    全部 401（2.8.3 引入，2026-09-07 用户报告）。
+    """
+    app = FastAPI()
+    app.add_middleware(AuthMiddleware)
+
+    @app.get("/api/version/assets/{asset_name}/download")
+    async def asset_download(asset_name: str) -> dict[str, str]:
+        return {"ok": "asset", "name": asset_name}
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            "/api/version/assets/LambChat-android-v2.8.4-signed.apk/download",
+            headers={"accept": "*/*"},  # WebView fetch 非 text/html，不走浏览器导航豁免
+        )
+
+    assert response.status_code == 200
+    assert response.json()["ok"] == "asset"


### PR DESCRIPTION
## 问题

移动端「立即更新」下载 APK 报 `Download failed: 401`（2026-09-07 用户报告，生产 curl 复现：`/api/version/assets/<name>/download` → 401 unauthorized）。

## 根因

`/api/version/assets/` 在 AuthMiddleware 里被加进了 `PUBLIC_PATHS`——那是**精确匹配**集合；实际请求路径 `/api/version/assets/<asset>/download` 匹配不上，又不在 `PUBLIC_PREFIXES`，WebView fetch（`Accept: */*`）也不走浏览器导航豁免 → 中间件 401。2.8.3（246d3821 引入代理下载）起即存在，更新检查 `/api/version` 精确匹配能过、下载必挂。

## 修复

移入 `PUBLIC_PREFIXES`（前缀匹配），补非浏览器导航请求的回归测试。本地 api 套件 523 passed，ruff 全绿。

## 验证

合并部署后：`curl -I https://lambchat.com/api/version/assets/LambChat-android-v2.8.4-signed.apk/download` 应 200。