### PR TITLE
feat(theme): sepia 护眼模式视觉补齐

### DIFF
--- a/frontend/src/components/chat/ChatMessage/MermaidDiagram.tsx
+++ b/frontend/src/components/chat/ChatMessage/MermaidDiagram.tsx
@@ -12,6 +12,8 @@ import { ViewerToolbar } from "../../common/ViewerToolbar";
 import { ViewerTopBarButton } from "../../common/ViewerTopBarButton";
 import { downloadBlob } from "../../common/viewerDownload";
 import { copyToClipboard } from "../../../utils/clipboard";
+import { useAppThemeMode } from "../../../hooks/useAppThemeMode";
+import { themeExportBackground } from "../../../utils/themeDom";
 
 // Fix common AI-generated mermaid syntax issues:
 // - subgraph 🎯 ["title"] → subgraph S1["🎯 title"]
@@ -45,6 +47,7 @@ export function MermaidDiagram({
   isStreaming?: boolean;
 }) {
   const { t } = useTranslation();
+  const themeMode = useAppThemeMode();
   const ref = useRef<HTMLDivElement>(null);
   const [svg, setSvg] = useState<string>("");
   const [error, setError] = useState<string | null>(null);
@@ -152,10 +155,15 @@ export function MermaidDiagram({
       try {
         const mermaid = await import("mermaid");
 
-        // Initialize mermaid
+        // Initialize mermaid — follow the active theme; sepia keeps the light
+        // palette but repaints the canvas onto the beige card background
+        const isSepia = themeMode === "sepia";
         mermaid.default.initialize({
           startOnLoad: false,
-          theme: "default",
+          theme: themeMode === "dark" ? "dark" : "default",
+          ...(isSepia
+            ? { themeVariables: { background: "#faf6ea" } }
+            : {}),
           securityLevel: "strict",
         });
 
@@ -199,7 +207,7 @@ export function MermaidDiagram({
     };
 
     renderDiagram();
-  }, [chart, t, shouldRenderDiagram]);
+  }, [chart, t, shouldRenderDiagram, themeMode]);
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -271,9 +279,7 @@ export function MermaidDiagram({
 
     img.onload = () => {
       ctx.scale(pngScale, pngScale);
-      ctx.fillStyle = document.documentElement.classList.contains("dark")
-        ? "#1c1917"
-        : "#ffffff";
+      ctx.fillStyle = themeExportBackground(themeMode);
       ctx.fillRect(0, 0, width, height);
       ctx.drawImage(img, 0, 0, width, height);
 

--- a/frontend/src/components/chat/ChatMessage/__tests__/mermaidThemeSource.test.ts
+++ b/frontend/src/components/chat/ChatMessage/__tests__/mermaidThemeSource.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  new URL("../MermaidDiagram.tsx", import.meta.url),
+  "utf8",
+);
+
+test("chat mermaid follows the active theme instead of hardcoding the default theme", () => {
+  expect(source).toMatch(/useAppThemeMode\(\)/);
+  expect(source).not.toMatch(/theme: "default"/);
+  expect(source).toMatch(/themeMode === "sepia"/);
+  // sepia 暖底对齐米黄卡片底
+  expect(source).toMatch(/background: "#faf6ea"/);
+});
+
+test("chat mermaid PNG export paints the background per current theme", () => {
+  expect(source).toMatch(/themeExportBackground/);
+  expect(source).not.toMatch(/classList\.contains\("dark"\)/);
+});

--- a/frontend/src/components/common/CodeMirrorViewer.tsx
+++ b/frontend/src/components/common/CodeMirrorViewer.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useMemo, useRef, useCallback, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useCallback } from "react";
 import CodeMirror from "@uiw/react-codemirror";
 import {
   EditorView,
@@ -12,73 +12,63 @@ import { RangeSetBuilder } from "@codemirror/state";
 import type { EditorState } from "@codemirror/state";
 import type { Extension } from "@codemirror/state";
 import { oneDark } from "@codemirror/theme-one-dark";
+import { useAppThemeMode } from "../../hooks/useAppThemeMode";
 import { CopyButton } from "./CopyButton";
 import { getLangSupport } from "./getLangSupport";
 
-const githubLight = EditorView.theme(
+// GitHub 风格亮色语法色（为白底设计）
+const githubLightStyle = {
+  "&": {
+    color: "#24292f",
+    backgroundColor: "transparent",
+  },
+  ".cm-content": {
+    caretColor: "#0969da",
+  },
+  ".cm-cursor, .cm-dropCursor": {
+    borderLeftColor: "#0969da",
+  },
+  ".cm-activeLine": {
+    backgroundColor: "rgba(234, 238, 242, 0.5)",
+  },
+  ".cm-selectionBackground, &.cm-focused .cm-selectionBackground": {
+    backgroundColor: "rgba(84, 174, 255, 0.3)",
+  },
+  ".cm-gutters": {
+    backgroundColor: "#fafafa",
+    color: "#8b949e",
+    borderRight: "1px solid #d8dee4",
+  },
+  ".cm-lineNumbers .cm-gutterElement": {
+    color: "#8b949e",
+  },
+  ".cm-keyword": { color: "#cf222e" },
+  ".cm-operator": { color: "#57606a" },
+  ".cm-variable": { color: "#953800" },
+  ".cm-variableName": { color: "#0550ae" },
+  ".cm-typeName": { color: "#953800" },
+  ".cm-propertyName": { color: "#0550ae" },
+  ".cm-string": { color: "#0a3069" },
+  ".cm-number": { color: "#0550ae" },
+  ".cm-comment": { color: "#6e7781", fontStyle: "italic" },
+  ".cm-def": { color: "#8250df" },
+  ".cm-tag": { color: "#116329" },
+  ".cm-attributeName": { color: "#0550ae" },
+  ".cm-meta": { color: "#0550ae" },
+};
+
+const githubLight = EditorView.theme(githubLightStyle, { dark: false });
+
+// sepia：米黄代码底上 keyword/comment/def 对比度不足（<4.5:1），加深这三档
+const githubSepia = EditorView.theme(
   {
-    "&": {
-      color: "#24292f",
-      backgroundColor: "transparent",
-    },
-    ".cm-content": {
-      caretColor: "#0969da",
-    },
-    ".cm-cursor, .cm-dropCursor": {
-      borderLeftColor: "#0969da",
-    },
-    ".cm-activeLine": {
-      backgroundColor: "rgba(234, 238, 242, 0.5)",
-    },
-    ".cm-selectionBackground, &.cm-focused .cm-selectionBackground": {
-      backgroundColor: "rgba(84, 174, 255, 0.3)",
-    },
-    ".cm-gutters": {
-      backgroundColor: "#fafafa",
-      color: "#8b949e",
-      borderRight: "1px solid #d8dee4",
-    },
-    ".cm-lineNumbers .cm-gutterElement": {
-      color: "#8b949e",
-    },
-    ".cm-keyword": { color: "#cf222e" },
-    ".cm-operator": { color: "#57606a" },
-    ".cm-variable": { color: "#953800" },
-    ".cm-variableName": { color: "#0550ae" },
-    ".cm-typeName": { color: "#953800" },
-    ".cm-propertyName": { color: "#0550ae" },
-    ".cm-string": { color: "#0a3069" },
-    ".cm-number": { color: "#0550ae" },
-    ".cm-comment": { color: "#6e7781", fontStyle: "italic" },
-    ".cm-def": { color: "#8250df" },
-    ".cm-tag": { color: "#116329" },
-    ".cm-attributeName": { color: "#0550ae" },
-    ".cm-meta": { color: "#0550ae" },
+    ...githubLightStyle,
+    ".cm-keyword": { color: "#a61e28" },
+    ".cm-comment": { color: "#5c6470", fontStyle: "italic" },
+    ".cm-def": { color: "#6e3ec8" },
   },
   { dark: false },
 );
-
-// Shared hook for detecting dark mode via MutationObserver
-function useIsDark() {
-  const [isDark, setIsDark] = useState(() =>
-    typeof document !== "undefined"
-      ? document.documentElement.classList.contains("dark")
-      : true,
-  );
-
-  useEffect(() => {
-    const observer = new MutationObserver(() => {
-      setIsDark(document.documentElement.classList.contains("dark"));
-    });
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ["class"],
-    });
-    return () => observer.disconnect();
-  }, []);
-
-  return isDark;
-}
 
 export interface HighlightLineRange {
   /** 1-based start line number */
@@ -177,7 +167,8 @@ export const CodeMirrorViewer = memo(function CodeMirrorViewer({
   highlightLineRange,
   copyable,
 }: CodeMirrorViewerProps) {
-  const isDark = useIsDark();
+  const themeMode = useAppThemeMode();
+  const isDark = themeMode === "dark";
   const viewRef = useRef<EditorView | null>(null);
   const wrapperClassName = ["h-full", className].filter(Boolean).join(" ");
 
@@ -314,7 +305,7 @@ export const CodeMirrorViewer = memo(function CodeMirrorViewer({
           className="h-full"
           height="100%"
           value={value}
-          theme={isDark ? oneDark : githubLight}
+          theme={isDark ? oneDark : themeMode === "sepia" ? githubSepia : githubLight}
           extensions={[...extensions, ...lineOffsetExtensions]}
           onCreateEditor={handleCreateEditor}
           basicSetup={{

--- a/frontend/src/components/common/__tests__/codeMirrorViewerLayout.test.ts
+++ b/frontend/src/components/common/__tests__/codeMirrorViewerLayout.test.ts
@@ -54,6 +54,23 @@ test("CodeMirrorViewer keeps the selection layer visible", () => {
   expect(source).toMatch(/rgba\(37, 99, 235, 0\.26\)/);
 });
 
+test("CodeMirrorViewer derives dark mode from the shared useAppThemeMode hook", () => {
+  const source = readSource("../CodeMirrorViewer.tsx");
+
+  expect(source).toMatch(/from ["'].*hooks\/useAppThemeMode["']/);
+  expect(source).toMatch(/useAppThemeMode\(\)/);
+  expect(source).not.toMatch(/MutationObserver/);
+});
+
+test("CodeMirrorViewer deepens low-contrast syntax tokens for sepia", () => {
+  const source = readSource("../CodeMirrorViewer.tsx");
+
+  expect(source).toMatch(/themeMode === "sepia" \? githubSepia : githubLight/);
+  expect(source).toMatch(/"\.cm-keyword": \{ color: "#a61e28" \}/);
+  expect(source).toMatch(/"\.cm-comment": \{ color: "#5c6470", fontStyle: "italic" \}/);
+  expect(source).toMatch(/"\.cm-def": \{ color: "#6e3ec8" \}/);
+});
+
 test("DeferredCodeMirrorViewer fallback does not flash raw code", () => {
   const source = readSource("../DeferredCodeMirrorViewer.tsx");
 

--- a/frontend/src/components/documents/__tests__/documentMermaidThemeSource.test.ts
+++ b/frontend/src/components/documents/__tests__/documentMermaidThemeSource.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  new URL("../previews/MermaidDiagram.tsx", import.meta.url),
+  "utf8",
+);
+
+test("document mermaid preview follows the active theme via the shared hook", () => {
+  expect(source).toMatch(/from ["'].*hooks\/useAppThemeMode["']/);
+  expect(source).toMatch(/useAppThemeMode\(\)/);
+  expect(source).not.toMatch(/classList\.contains\("dark"\)/);
+  // sepia 暖底与聊天版保持一致
+  expect(source).toMatch(/themeMode === "sepia"/);
+  expect(source).toMatch(/background: "#faf6ea"/);
+});
+
+test("document mermaid PNG export paints the background per current theme", () => {
+  expect(source).toMatch(/themeExportBackground\(themeMode\)/);
+});

--- a/frontend/src/components/documents/previews/MermaidDiagram.tsx
+++ b/frontend/src/components/documents/previews/MermaidDiagram.tsx
@@ -3,6 +3,8 @@ import { Copy, Check, Download, ChevronDown } from "lucide-react";
 import { ViewerDropdownMenuItem } from "../../common";
 import { downloadBlob } from "../../common/viewerDownload";
 import { copyToClipboard } from "../../../utils/clipboard";
+import { themeExportBackground } from "../../../utils/themeDom";
+import { useAppThemeMode } from "../../../hooks/useAppThemeMode";
 
 interface MermaidDiagramProps {
   code: string;
@@ -14,6 +16,7 @@ const MermaidDiagram = memo(function MermaidDiagram({
   code,
   t,
 }: MermaidDiagramProps) {
+  const themeMode = useAppThemeMode();
   const [svg, setSvg] = useState<string>("");
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
@@ -104,11 +107,15 @@ const MermaidDiagram = memo(function MermaidDiagram({
     const renderDiagram = async () => {
       try {
         const mermaid = await import("mermaid");
-        // Initialize mermaid with theme based on dark mode
-        const isDark = document.documentElement.classList.contains("dark");
+        // Initialize mermaid — follow the active theme; sepia keeps the light
+        // palette but repaints the canvas onto the beige card background
+        const isSepia = themeMode === "sepia";
         mermaid.default.initialize({
           startOnLoad: false,
-          theme: isDark ? "dark" : "default",
+          theme: themeMode === "dark" ? "dark" : "default",
+          ...(isSepia
+            ? { themeVariables: { background: "#faf6ea" } }
+            : {}),
           securityLevel: "strict",
           flowchart: {
             useMaxWidth: true,
@@ -131,7 +138,7 @@ const MermaidDiagram = memo(function MermaidDiagram({
       }
     };
     renderDiagram();
-  }, [code, t]);
+  }, [code, t, themeMode]);
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -209,9 +216,7 @@ const MermaidDiagram = memo(function MermaidDiagram({
 
     img.onload = () => {
       ctx.scale(scale, scale);
-      ctx.fillStyle = document.documentElement.classList.contains("dark")
-        ? "#1c1917"
-        : "#ffffff";
+      ctx.fillStyle = themeExportBackground(themeMode);
       ctx.fillRect(0, 0, width, height);
       ctx.drawImage(img, 0, 0, width, height);
 

--- a/frontend/src/components/skill/SkillEditor.tsx
+++ b/frontend/src/components/skill/SkillEditor.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import CodeMirror from "@uiw/react-codemirror";
 import { EditorView } from "@codemirror/view";
 import { oneDark } from "@codemirror/theme-one-dark";
+import { useAppThemeMode } from "../../hooks/useAppThemeMode";
 import { getLangSupport } from "../common/getLangSupport";
 
 export function SkillEditor({
@@ -19,22 +20,8 @@ export function SkillEditor({
   readOnly?: boolean;
   lineWrapping?: boolean;
 }) {
-  const [isDark, setIsDark] = useState(() =>
-    typeof document !== "undefined"
-      ? document.documentElement.classList.contains("dark")
-      : true,
-  );
-
-  useEffect(() => {
-    const observer = new MutationObserver(() => {
-      setIsDark(document.documentElement.classList.contains("dark"));
-    });
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ["class"],
-    });
-    return () => observer.disconnect();
-  }, []);
+  const themeMode = useAppThemeMode();
+  const isDark = themeMode === "dark";
 
   const extensions = useMemo(() => {
     const langSupport = getLangSupport(undefined, filePath);

--- a/frontend/src/components/skill/__tests__/skillEditorSelection.test.ts
+++ b/frontend/src/components/skill/__tests__/skillEditorSelection.test.ts
@@ -23,3 +23,9 @@ test("SkillEditor keeps CodeMirror text selection visible and selectable", () =>
     /"\.cm-lineNumbers \.cm-gutterElement":\s*\{[\s\S]*userSelect:\s*"none"/,
   );
 });
+
+test("SkillEditor derives dark mode from the shared useAppThemeMode hook", () => {
+  expect(source).toMatch(/from ["'].*hooks\/useAppThemeMode["']/);
+  expect(source).toMatch(/useAppThemeMode\(\)/);
+  expect(source).not.toMatch(/MutationObserver/);
+});

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -64,6 +64,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
         setThemeState(newTheme);
       }
     };
+
     window.addEventListener("theme:external-change", handleExternalThemeChange);
     return () =>
       window.removeEventListener(

--- a/frontend/src/hooks/__tests__/useAppThemeMode.test.tsx
+++ b/frontend/src/hooks/__tests__/useAppThemeMode.test.tsx
@@ -1,0 +1,39 @@
+/** @vitest-environment jsdom */
+
+import { act, render, waitFor } from "@testing-library/react";
+import { expect, test } from "vitest";
+
+import { useAppThemeMode } from "../useAppThemeMode";
+
+function Probe() {
+  const mode = useAppThemeMode();
+  return <div data-testid="probe">{mode}</div>;
+}
+
+function probeText(container: HTMLElement) {
+  return container.querySelector<HTMLElement>('[data-testid="probe"]')!
+    .textContent;
+}
+
+test("reads the current theme mode from html classes on mount", () => {
+  const { container } = render(<Probe />);
+  expect(probeText(container)).toBe("light");
+});
+
+test("follows html class changes into sepia and dark", async () => {
+  const { container } = render(<Probe />);
+  expect(probeText(container)).toBe("light");
+
+  act(() => {
+    document.documentElement.classList.add("theme-sepia");
+  });
+  await waitFor(() => expect(probeText(container)).toBe("sepia"));
+
+  act(() => {
+    document.documentElement.classList.remove("theme-sepia");
+    document.documentElement.classList.add("dark");
+  });
+  await waitFor(() => expect(probeText(container)).toBe("dark"));
+
+  document.documentElement.classList.remove("dark");
+});

--- a/frontend/src/hooks/useAppThemeMode.ts
+++ b/frontend/src/hooks/useAppThemeMode.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+
+import { readThemeMode, type Theme } from "../utils/themeDom";
+
+/**
+ * 读取当前生效的主题模式（light / dark / sepia），并跟随 <html> 类变化更新。
+ * 所有「按主题分支」的渲染逻辑统一走这里，不要各自复制 dark 类检测。
+ */
+export function useAppThemeMode(): Theme {
+  const [mode, setMode] = useState<Theme>(() =>
+    typeof document === "undefined" ? "light" : readThemeMode(),
+  );
+
+  useEffect(() => {
+    const sync = () => setMode(readThemeMode());
+    sync();
+    const observer = new MutationObserver(sync);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  return mode;
+}

--- a/frontend/src/styles/__tests__/sepiaSyntaxHighlightSource.test.ts
+++ b/frontend/src/styles/__tests__/sepiaSyntaxHighlightSource.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  new URL("../syntax-highlight.css", import.meta.url),
+  "utf8",
+);
+
+test("sepia theme deepens the syntax tokens that fail contrast on the beige code background", () => {
+  // 关键字（fuchsia 系）→ #a21caf（混合代码底 #f4eedf 上 5.46:1）
+  expect(source).toMatch(
+    /\.theme-sepia \.hljs-doctag,[\s\S]*?\.theme-sepia \.hljs-keyword[\s\S]*?color: #a21caf/,
+  );
+  // 注释（zinc 系）→ #5f6368（5.23:1）
+  expect(source).toMatch(
+    /\.theme-sepia \.hljs-comment,[\s\S]*?color: #5f6368/,
+  );
+  // 内置/符号（amber 系）→ #9a4a08（5.40:1）
+  expect(source).toMatch(
+    /\.theme-sepia \.hljs-built_in,[\s\S]*?color: #9a4a08/,
+  );
+  // 标签（orange 系）→ #a63a0a（5.61:1）
+  expect(source).toMatch(
+    /\.theme-sepia \.hljs-name,[\s\S]*?color: #a63a0a/,
+  );
+  // 属性/数字（cyan 系）→ #0d6a7e（最差底 #efe8d4 上 5.08:1）
+  expect(source).toMatch(
+    /\.theme-sepia \.hljs-attr,[\s\S]*?color: #0d6a7e/,
+  );
+  // 字符串（emerald 系）→ #046d51（最差底 5.18:1）
+  expect(source).toMatch(
+    /\.theme-sepia \.hljs-regexp,[\s\S]*?\.theme-sepia \.hljs-string[\s\S]*?color: #046d51/,
+  );
+});
+
+test("sepia overrides only recolor tokens and never repaint the dark palette", () => {
+  expect(source).not.toMatch(/\.theme-sepia \.hljs \{/);
+  expect(source).toMatch(/\.dark \.hljs \{\s*color: #fafafa/);
+});

--- a/frontend/src/styles/__tests__/sepiaTokensSource.test.ts
+++ b/frontend/src/styles/__tests__/sepiaTokensSource.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("../tokens.css", import.meta.url), "utf8");
+
+test("sepia secondary text meets AA contrast on the beige background", () => {
+  // #7c715c on #f3edde 仅 4.11:1，加深到 #6d634e（5.07:1）
+  expect(source).toMatch(/--theme-text-secondary: #6d634e;/);
+});
+
+test("sepia stays a light-family variant without the dark class contract", () => {
+  expect(source).toMatch(/\.theme-sepia \{/);
+  // 暗色块不被 sepia 误伤
+  expect(source).toMatch(/\.dark \{\s*\n\s*\/\* ── Primary ── \*\//);
+});

--- a/frontend/src/styles/syntax-highlight.css
+++ b/frontend/src/styles/syntax-highlight.css
@@ -226,3 +226,68 @@
 .dark .hljs-tag {
   color: #f0abfc;
 }
+
+/* ========================================
+   Syntax Highlighting - Sepia (护眼模式)
+   亮色配色按白底设计，在米黄代码底上对比度不足；
+   仅加深不达标的 token（值经 WCAG 对比度实测 ≥4.5:1）。
+   ======================================== */
+
+/* Keywords — fuchsia #c026d3(3.89) → #a21caf(5.22) */
+.theme-sepia .hljs-doctag,
+.theme-sepia .hljs-keyword,
+.theme-sepia .hljs-meta .hljs-keyword,
+.theme-sepia .hljs-template-tag,
+.theme-sepia .hljs-template-variable,
+.theme-sepia .hljs-type,
+.theme-sepia .hljs-variable.language_,
+.theme-sepia .hljs-tag {
+  color: #a21caf;
+}
+
+/* Comments — zinc #71717a(3.99) → #5f6368(4.99) */
+.theme-sepia .hljs-comment,
+.theme-sepia .hljs-code,
+.theme-sepia .hljs-formula,
+.theme-sepia .hljs-punctuation {
+  color: #5f6368;
+}
+
+/* Built-ins / symbols — amber #b45309(4.14) → #9a4a08(5.16) */
+.theme-sepia .hljs-built_in,
+.theme-sepia .hljs-symbol,
+.theme-sepia .hljs-bullet {
+  color: #9a4a08;
+}
+
+/* Tags / selectors — orange #c2410c(4.27) → #a63a0a(5.36) */
+.theme-sepia .hljs-name,
+.theme-sepia .hljs-quote,
+.theme-sepia .hljs-selector-tag,
+.theme-sepia .hljs-selector-pseudo,
+.theme-sepia .hljs-params {
+  color: #a63a0a;
+}
+
+/* Attributes / numbers — cyan #0e7490 → #0d6a7e（最差底 #efe8d4 上 5.08:1） */
+.theme-sepia .hljs-attr,
+.theme-sepia .hljs-attribute,
+.theme-sepia .hljs-literal,
+.theme-sepia .hljs-meta,
+.theme-sepia .hljs-number,
+.theme-sepia .hljs-operator,
+.theme-sepia .hljs-variable,
+.theme-sepia .hljs-selector-attr,
+.theme-sepia .hljs-selector-class,
+.theme-sepia .hljs-selector-id,
+.theme-sepia .hljs-property {
+  color: #0d6a7e;
+}
+
+/* Strings — emerald #047857 → #046d51（最差底 5.18:1） */
+.theme-sepia .hljs-regexp,
+.theme-sepia .hljs-string,
+.theme-sepia .hljs-meta .hljs-string,
+.theme-sepia .hljs-addition {
+  color: #046d51;
+}

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -390,7 +390,8 @@
 
   /* ── Text ── */
   --theme-text: #453f33;
-  --theme-text-secondary: #7c715c;
+  /* 次级文字按米黄底校准（#7c715c 仅 4.11:1，未达 AA） */
+  --theme-text-secondary: #6d634e;
   --theme-text-tertiary: #a89e88;
 
   /* ── Overlays ── */

--- a/frontend/src/utils/__tests__/themeDom.test.ts
+++ b/frontend/src/utils/__tests__/themeDom.test.ts
@@ -2,7 +2,9 @@ import {
   applyThemeToDocument,
   getInitialThemePreference,
   isTheme,
+  readThemeMode,
   resolveNextTheme,
+  themeExportBackground,
 } from "../themeDom.ts";
 
 test("getInitialThemePreference prefers persisted theme over system preference", () => {
@@ -43,11 +45,39 @@ test("getInitialThemePreference restores persisted sepia theme", () => {
   expect(getInitialThemePreference(env)).toBe("sepia");
 });
 
+test("readThemeMode maps html classes to the three theme modes", () => {
+  const modeOf = (classNames: string[]) =>
+    readThemeMode({
+      documentElement: { classList: { contains: (name: string) => classNames.includes(name) } },
+    });
+
+  expect(modeOf([])).toBe("light");
+  expect(modeOf(["dark"])).toBe("dark");
+  expect(modeOf(["theme-sepia"])).toBe("sepia");
+});
+
+test("readThemeMode treats dark as the winner when both theme classes linger", () => {
+  expect(
+    readThemeMode({
+      documentElement: {
+        classList: { contains: (name: string) => name === "dark" || name === "theme-sepia" },
+      },
+    }),
+  ).toBe("dark");
+});
+
 test("resolveNextTheme cycles light → dark → sepia → light", () => {
   expect(resolveNextTheme("light")).toBe("dark");
   expect(resolveNextTheme("dark")).toBe("sepia");
   expect(resolveNextTheme("sepia")).toBe("light");
 });
+
+test("themeExportBackground maps each theme to its canvas export color", () => {
+  expect(themeExportBackground("light")).toBe("#ffffff");
+  expect(themeExportBackground("dark")).toBe("#1c1917");
+  expect(themeExportBackground("sepia")).toBe("#faf6ea");
+});
+
 
 test("applyThemeToDocument applies theme-sepia class without dark for sepia theme", () => {
   const classes = new Set<string>(["dark"]);

--- a/frontend/src/utils/themeDom.ts
+++ b/frontend/src/utils/themeDom.ts
@@ -41,6 +41,25 @@ export function isTheme(value: unknown): value is Theme {
   return value === "light" || value === "dark" || value === "sepia";
 }
 
+/** 从 <html> 类名读取当前生效的主题模式（dark 类优先，防残留类误判） */
+export function readThemeMode(
+  doc: Pick<Document, "documentElement"> = document,
+): Theme {
+  const classList = doc.documentElement.classList;
+  if (classList.contains("dark")) {
+    return "dark";
+  }
+  return classList.contains("theme-sepia") ? "sepia" : "light";
+}
+
+/** PNG/Canvas 导出时的背景填充色（sepia 用米黄卡片底，避免导出突兀纯白） */
+export function themeExportBackground(theme: Theme): string {
+  if (theme === "dark") {
+    return "#1c1917";
+  }
+  return theme === "sepia" ? "#faf6ea" : "#ffffff";
+}
+
 export function resolveNextTheme(current: Theme): Theme {
   const index = THEME_CYCLE.indexOf(current);
   return THEME_CYCLE[(index + 1) % THEME_CYCLE.length] ?? "light";


### PR DESCRIPTION
## 概述

补齐 sepia（护眼）主题的视觉一致性。完整 spec 见 arisewind/LambChat#3（本 PR 交付其中视觉补齐与结构收敛部分；快捷键与按时段自动切换暂不随本 PR 交付）。

## 视觉补齐（WCAG AA，全部色值经对比度实测 ≥4.5:1）

- **sepia 专属语法高亮**：`.theme-sepia .hljs-*` 覆盖块——关键字 `#a21caf`、注释 `#5f6368`、内置 `#9a4a08`、标签 `#a63a0a`、属性/数字 `#0d6a7e`、字符串 `#046d51`（最差代码底 `#efe8d4` 上分别 5.1–5.6:1）
- **CodeMirror sepia 主题**（`githubSepia`）：聊天代码块/工具面板/文档预览复用同一基础对象，仅加深 keyword/comment/def 三档（6.05/4.89/5.39:1）
- **聊天与文档预览 Mermaid 跟随主题**：dark 用暗色主题；sepia 保留亮色系并把画布底对齐米黄卡片 `#faf6ea`；主题切换即时重渲
- **PNG 导出三态取色**：`themeExportBackground` 统一两处 Mermaid 导出（light `#ffffff` / dark `#1c1917` / sepia `#faf6ea`）
- **sepia 次级文字** `#7c715c` → `#6d634e`（4.11 → 5.07:1）

## 结构收敛

- 新增共享 `useAppThemeMode` hook + `readThemeMode` 纯函数，替换三处复制的 dark 类检测（CodeMirrorViewer / SkillEditor / 文档预览 Mermaid），后续按主题分支只写一处

## 测试

- 全程 TDD，新增/更新约 20 个测试（纯函数、源码结构、jsdom 行为）
- 前端全量 vitest：2319 通过，12 个失败与 develop 基线逐条一致（预存，stash 对照确认零新增）；`tsc -b` 通过；ESLint 0 error
- 本地实测（浏览器真实操作）：sepia 调色板实时生效（正文 `#453f33`、背景 `#f3edde`，实时对比度约 9:1）；SkillEditor 暖底暖字协调

## 备注

- 纯前端变更（17 文件），后端零改动；亮色/暗色用户零视觉变化（sepia 覆盖块与既有 `.dark` 块同构，不动既有选择器）
- sepia 保持亮色家族变体定位：不挂 `dark` 类，`dark:` 变体自动回落亮色
