### PR TITLE
feat(app): Android 更新包原生下载——DownloadManager 优先，WebView 流式兜底

### DIFF
--- a/frontend/android/app/src/main/java/com/lambchat/app/MainActivity.java
+++ b/frontend/android/app/src/main/java/com/lambchat/app/MainActivity.java
@@ -22,6 +22,7 @@ public class MainActivity extends BridgeActivity {
         // 必须在 super.onCreate 之前注册：BridgeActivity.onCreate 末尾 load()
         // 即消费 bridgeBuilder 创建 bridge，晚于此注册插件不会生效
         registerPlugin(ApkInstallerPlugin.class);
+        registerPlugin(UpdateDownloaderPlugin.class);
         super.onCreate(savedInstanceState);
 
         WebView webView = getBridge().getWebView();

--- a/frontend/android/app/src/main/java/com/lambchat/app/UpdateDownloaderPlugin.java
+++ b/frontend/android/app/src/main/java/com/lambchat/app/UpdateDownloaderPlugin.java
@@ -1,0 +1,118 @@
+package com.lambchat.app;
+
+import android.app.DownloadManager;
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Environment;
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+/**
+ * 更新包原生下载桥（系统 DownloadManager）。
+ *
+ * WebView fetch 流式代理是 CORS/内存约束下的兜底；原生下载无 CORS、
+ * 不占 WebView 内存、系统级断点续传与下载通知。目标为应用专属外部目录
+ * （免存储权限），FileProvider 的 external-path 已覆盖，完成后 localUri
+ * 直接交给 ApkInstaller 覆盖安装。
+ *
+ * downloadId 以字符串往返（Long.parseLong），避开各 Capacitor 版本
+ * PluginCall 数值取值 API 差异。
+ */
+@CapacitorPlugin(name = "UpdateDownloader")
+public class UpdateDownloaderPlugin extends Plugin {
+
+    @PluginMethod
+    public void start(PluginCall call) {
+        String url = call.getString("url");
+        String fileName = call.getString("fileName");
+        if (url == null || url.isEmpty() || fileName == null || fileName.isEmpty()) {
+            call.reject("url and fileName are required");
+            return;
+        }
+        try {
+            DownloadManager.Request request = new DownloadManager.Request(Uri.parse(url));
+            request.setDestinationInExternalFilesDir(
+                    getContext(), Environment.DIRECTORY_DOWNLOADS, fileName);
+            // 可见通知：免 DOWNLOAD_WITHOUT_NOTIFICATION 权限，大文件下载进度
+            // 对用户可见，完成后保留
+            request.setNotificationVisibility(
+                    DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
+            request.setTitle(fileName);
+            DownloadManager dm = (DownloadManager) getContext()
+                    .getSystemService(Context.DOWNLOAD_SERVICE);
+            if (dm == null) {
+                call.reject("DownloadManager unavailable");
+                return;
+            }
+            long id = dm.enqueue(request);
+            JSObject ret = new JSObject();
+            ret.put("downloadId", Long.toString(id));
+            call.resolve(ret);
+        } catch (Exception e) {
+            call.reject("enqueue failed: " + e.getMessage());
+        }
+    }
+
+    @PluginMethod
+    public void progress(PluginCall call) {
+        String idRaw = call.getString("downloadId", "");
+        long id;
+        try {
+            id = Long.parseLong(idRaw);
+        } catch (NumberFormatException e) {
+            call.reject("invalid downloadId");
+            return;
+        }
+        DownloadManager dm = (DownloadManager) getContext()
+                .getSystemService(Context.DOWNLOAD_SERVICE);
+        if (dm == null) {
+            call.reject("DownloadManager unavailable");
+            return;
+        }
+        try (Cursor c = dm.query(new DownloadManager.Query().setFilterById(id))) {
+            if (c == null || !c.moveToFirst()) {
+                call.reject("download not found");
+                return;
+            }
+            int status = c.getInt(c.getColumnIndex(DownloadManager.COLUMN_STATUS));
+            long soFar = c.getLong(c.getColumnIndex(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR));
+            long total = c.getLong(c.getColumnIndex(DownloadManager.COLUMN_TOTAL_SIZE_BYTES));
+
+            JSObject ret = new JSObject();
+            ret.put("status", mapStatus(status));
+            ret.put("bytesSoFar", soFar);
+            ret.put("totalBytes", total); // 服务端不回 content-length 时为 -1
+            if (status == DownloadManager.STATUS_SUCCESSFUL) {
+                int uriIdx = c.getColumnIndex(DownloadManager.COLUMN_LOCAL_URI);
+                if (uriIdx >= 0) {
+                    ret.put("localUri", c.getString(uriIdx));
+                }
+            }
+            if (status == DownloadManager.STATUS_FAILED) {
+                int reasonIdx = c.getColumnIndex(DownloadManager.COLUMN_REASON);
+                ret.put("reason", reasonIdx >= 0 ? c.getInt(reasonIdx) : 0);
+            }
+            call.resolve(ret);
+        }
+    }
+
+    private static String mapStatus(int status) {
+        if (status == DownloadManager.STATUS_SUCCESSFUL) {
+            return "success";
+        }
+        if (status == DownloadManager.STATUS_FAILED) {
+            return "failed";
+        }
+        if (status == DownloadManager.STATUS_PAUSED) {
+            return "paused";
+        }
+        if (status == DownloadManager.STATUS_PENDING) {
+            return "pending";
+        }
+        return "running";
+    }
+}

--- a/frontend/src/hooks/__tests__/useAutoUpdateSource.test.ts
+++ b/frontend/src/hooks/__tests__/useAutoUpdateSource.test.ts
@@ -85,3 +85,54 @@ test("install permission hint copy exists in all five locales", () => {
     expect(data.update.installPermissionHint, locale).toBeTruthy();
   }
 });
+
+test("installAndroidUpdate tries native downloader before WebView fallback", () => {
+  const hook = readRepoFile("frontend/src/hooks/useAutoUpdate.ts");
+  const nativeCall = hook.indexOf("installAndroidUpdateViaNative(");
+  const webviewCall = hook.indexOf("installAndroidUpdateViaWebViewStream(");
+  // 原生优先、WebView 兜底——旧壳/系统裁剪下原生桥不可用时兼容网仍在
+  expect(nativeCall).toBeGreaterThan(-1);
+  expect(webviewCall).toBeGreaterThan(nativeCall);
+  // 两条链路共用同一自托管代理 URL（保住服务端可达 GitHub 的转发语义）
+  expect(
+    hook.match(/buildReleaseAssetDownloadUrl\(/g)?.length,
+  ).toBeGreaterThanOrEqual(2);
+});
+
+test("UpdateDownloader bridge polls progress with string downloadId", () => {
+  const bridge = readRepoFile(
+    "frontend/src/services/capacitor/updateDownloader.ts",
+  );
+  expect(bridge).toMatch(/registerPlugin/);
+  expect(bridge).toMatch(/"UpdateDownloader"/);
+  // downloadId 字符串往返：规避各 Capacitor 版本 PluginCall 数值取值差异
+  expect(bridge).toMatch(/downloadId: string/);
+
+  const hook = readRepoFile("frontend/src/hooks/useAutoUpdate.ts");
+  expect(hook).toMatch(/UpdateDownloader\.progress\(\{ downloadId \}\)/);
+});
+
+test("MainActivity registers UpdateDownloaderPlugin before the bridge loads", () => {
+  const main = readRepoFile(
+    "frontend/android/app/src/main/java/com/lambchat/app/MainActivity.java",
+  );
+  expect(main).toMatch(/registerPlugin\(UpdateDownloaderPlugin\.class\);/);
+  const registerIdx = main.indexOf(
+    "registerPlugin(UpdateDownloaderPlugin.class);",
+  );
+  const superIdx = main.indexOf("super.onCreate(");
+  expect(registerIdx).toBeGreaterThan(-1);
+  expect(superIdx).toBeGreaterThan(registerIdx);
+});
+
+test("UpdateDownloaderPlugin downloads to app-private external dir via DownloadManager", () => {
+  const plugin = readRepoFile(
+    "frontend/android/app/src/main/java/com/lambchat/app/UpdateDownloaderPlugin.java",
+  );
+  // 应用专属外部目录：免存储权限，且 FileProvider external-path 已覆盖
+  expect(plugin).toMatch(/setDestinationInExternalFilesDir/);
+  expect(plugin).toMatch(/DownloadManager\.COLUMN_STATUS/);
+  expect(plugin).toMatch(/COLUMN_LOCAL_URI/);
+  // 原生侧 Long.parseLong 消费字符串 id
+  expect(plugin).toMatch(/Long\.parseLong/);
+});

--- a/frontend/src/hooks/useAutoUpdate.ts
+++ b/frontend/src/hooks/useAutoUpdate.ts
@@ -325,9 +325,87 @@ export function useAutoUpdate(): UseAutoUpdateReturn {
       const apkAsset = findApkAsset(state.releaseAssets);
       if (!apkAsset) throw new Error("No APK found in release assets");
 
+      // 原生 DownloadManager 优先：无 CORS、不占 WebView 内存、系统断点续传
+      try {
+        await installAndroidUpdateViaNative(apkAsset.name);
+        return;
+      } catch {
+        // 原生桥不可用/下载失败（旧壳、系统裁剪、瞬时网络）：
+        // 回落 WebView 流式代理路径——两条链路同一代理 URL，行为一致
+      }
+      await installAndroidUpdateViaWebViewStream(apkAsset.name);
+    } catch (err) {
+      setState((prev) => ({
+        ...prev,
+        downloading: false,
+        error:
+          err instanceof TypeError
+            ? i18n.t("updateDownloadNetworkError", {
+                defaultValue: "下载失败，请检查网络后重试",
+              })
+            : err instanceof Error
+              ? err.message
+              : i18n.t("updateError", "更新失败"),
+      }));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.releaseAssets]);
+
+  /** 原生 DownloadManager 下载 + 拉起安装器（progress 轮询驱动进度条） */
+  const installAndroidUpdateViaNative = useCallback(
+    async (assetName: string) => {
+      const { UpdateDownloader } = await import(
+        "../services/capacitor/updateDownloader"
+      );
+      const { downloadId } = await UpdateDownloader.start({
+        // 同一自托管代理 URL：原生无 CORS 约束，但保住「服务端可达 GitHub」
+        // 的转发语义（国内直连 GitHub release 不稳）
+        url: buildReleaseAssetDownloadUrl(assetName),
+        fileName: assetName,
+      });
+
+      // 轮询驱动 UI：binder 调用极轻量，400ms 粒度足够
+      for (;;) {
+        await new Promise((r) => setTimeout(r, 400));
+        const p = await UpdateDownloader.progress({ downloadId });
+        const pct = p.totalBytes > 0 ? (p.bytesSoFar / p.totalBytes) * 100 : 0;
+        setState((prev) => ({
+          ...prev,
+          downloaded: p.bytesSoFar,
+          progress: pct,
+          contentLength: p.totalBytes,
+        }));
+        if (p.status === "success" && p.localUri) {
+          const { ApkInstaller } = await import(
+            "../services/capacitor/apkInstaller"
+          );
+          const res = await ApkInstaller.installApk({ path: p.localUri });
+          if (res.status === "settings") {
+            const { toast } = await import("react-hot-toast");
+            toast(
+              i18n.t("update.installPermissionHint", {
+                defaultValue:
+                  "请先允许 LambChat 安装未知应用，授权后重新点击升级",
+              }),
+            );
+          }
+          setState((prev) => ({ ...prev, downloading: false, progress: 100 }));
+          return;
+        }
+        if (p.status === "failed") {
+          throw new Error(`Native download failed (reason=${p.reason ?? "?"})`);
+        }
+      }
+    },
+    [],
+  );
+
+  /** WebView 流式代理下载（兜底）：逐块 base64 落盘避免整包驻留内存 */
+  const installAndroidUpdateViaWebViewStream = useCallback(
+    async (assetName: string) => {
       // 直连 GitHub browser_download_url 会被 WebView CORS 拦截
       // （Failed to fetch）：走自托管后端同源代理流式下载。
-      const response = await fetch(buildReleaseAssetDownloadUrl(apkAsset.name));
+      const response = await fetch(buildReleaseAssetDownloadUrl(assetName));
       if (!response.ok) throw new Error(`Download failed: ${response.status}`);
       const contentLength = Number(response.headers.get("content-length") ?? 0);
       const reader = response.body?.getReader();
@@ -336,7 +414,7 @@ export function useAutoUpdate(): UseAutoUpdateReturn {
       // 逐块 base64 落盘（writeFile + appendFile），避免整包 APK 在
       // WebView 内存里 Blob+base64 双份驻留导致低端机 OOM。
       const { Filesystem, Directory } = await import("@capacitor/filesystem");
-      const fileName = apkAsset.name || "LambChat-update.apk";
+      const fileName = assetName || "LambChat-update.apk";
       let wroteAny = false;
       let writtenUri: string | undefined;
       let downloaded = 0;
@@ -393,21 +471,9 @@ export function useAutoUpdate(): UseAutoUpdateReturn {
         downloading: false,
         progress: 100,
       }));
-    } catch (err) {
-      setState((prev) => ({
-        ...prev,
-        downloading: false,
-        error:
-          err instanceof TypeError
-            ? i18n.t("updateDownloadNetworkError", {
-                defaultValue: "下载失败，请检查网络后重试",
-              })
-            : err instanceof Error
-              ? err.message
-              : i18n.t("updateError", "更新失败"),
-      }));
-    }
-  }, [state.releaseAssets]);
+    },
+    [],
+  );
 
   /** Open release page in browser (iOS) */
   const openReleasePage = useCallback(() => {

--- a/frontend/src/services/capacitor/updateDownloader.ts
+++ b/frontend/src/services/capacitor/updateDownloader.ts
@@ -1,0 +1,26 @@
+import { registerPlugin } from "@capacitor/core";
+
+/**
+ * Android 系统下载器桥（MainActivity 注册的 UpdateDownloaderPlugin）。
+ *
+ * 更新包 APK 走 DownloadManager 原生下载：无 CORS、不占 WebView 内存、
+ * 系统级断点续传与下载通知。downloadId 以字符串往返（原生侧 Long.parseLong），
+ * 规避各 Capacitor 版本 PluginCall 数值取值 API 差异。
+ */
+export interface UpdateDownloaderPlugin {
+  start(options: {
+    url: string;
+    fileName: string;
+  }): Promise<{ downloadId: string }>;
+
+  progress(options: { downloadId: string }): Promise<{
+    status: "pending" | "running" | "paused" | "success" | "failed";
+    bytesSoFar: number;
+    totalBytes: number; // 服务端不回 content-length 时为 -1
+    localUri?: string;
+    reason?: number;
+  }>;
+}
+
+export const UpdateDownloader =
+  registerPlugin<UpdateDownloaderPlugin>("UpdateDownloader");


### PR DESCRIPTION
## 背景

Android 更新包下载目前走「同源代理 + WebView fetch 流式 + 逐块 base64 落盘」：CORS 与低端机 OOM 都已解决，但 WebView 网络栈本身仍是瓶颈与单点。本次把下载主路径升级为**系统 DownloadManager 原生下载**。

## 方案

- 新增 `UpdateDownloaderPlugin`（纯 Java，镜像 ApkInstaller 范式）：`start` 入队、`progress` 轮询（binder 调用，400ms 粒度驱动进度条）
- 目标为应用专属外部目录——**免存储权限**，FileProvider `external-path` 已覆盖，完成后 `localUri` 直接交给现有 ApkInstaller 覆盖安装
- **原生不可用/失败自动回落现有 WebView 流式路径**（旧壳兼容网，两条链路同一代理 URL，行为一致）
- 代理 URL 保留（服务端可达 GitHub 的转发语义不变——国内直连 GitHub release 不稳）
- downloadId 以字符串往返（`Long.parseLong`），规避各 Capacitor 版本 PluginCall 数值取值 API 差异

## 验证

- 前端全量 2517 tests passed（含 4 个新增源码结构用例：原生优先次序、兜底存在、插件注册时序、免权限落盘）
- ESLint / build 全绿
- Java 编译由 App Release 的 APK 构建验证（下个版本发布时生效）