### PR TITLE
feat(app): 桌面更新器清单加自托管代理回退端点

### DIFF
--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -41,7 +41,8 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDY3REJCNjQ1NTgzN0NGNTkKUldSWnp6ZFlSYmJiWjRHb1lJRFhVOXl5cW93OWlnK0hhS25pdE5lWC9xaVpiL0svTzV0em5ydVIK",
       "endpoints": [
-        "https://github.com/Yanyutin753/LambChat/releases/latest/download/latest.json"
+        "https://github.com/Yanyutin753/LambChat/releases/latest/download/latest.json",
+        "https://lambchat.com/api/version/assets/latest.json/download"
       ]
     }
   }

--- a/frontend/src/hooks/__tests__/useAutoUpdateSource.test.ts
+++ b/frontend/src/hooks/__tests__/useAutoUpdateSource.test.ts
@@ -136,3 +136,16 @@ test("UpdateDownloaderPlugin downloads to app-private external dir via DownloadM
   // 原生侧 Long.parseLong 消费字符串 id
   expect(plugin).toMatch(/Long\.parseLong/);
 });
+
+test("tauri updater keeps proxy fallback endpoint for manifest fetch", () => {
+  // 桌面更新器清单拉取：GitHub 直连不稳（国内）时回退自托管同源代理。
+  // 端点按序尝试是 tauri-plugin-updater 的内建语义。
+  const conf = readRepoFile("frontend/src-tauri/tauri.conf.json");
+  const endpoints = /"endpoints":\s*\[([\s\S]*?)\]/.exec(conf)?.[1] ?? "";
+  expect(endpoints).toMatch(
+    /github\.com\/Yanyutin753\/LambChat\/releases\/latest\/download\/latest\.json/,
+  );
+  expect(endpoints).toMatch(
+    /lambchat\.com\/api\/version\/assets\/latest\.json\/download/,
+  );
+});


### PR DESCRIPTION
## 背景

多端更新链路审计发现：桌面（Windows/macOS/Linux）更新器的清单端点只有 GitHub 直连——国内网络下拉取 latest.json 不稳，自动更新静默失败。

## 修复

`tauri.conf.json` updater endpoints 增加自托管同源代理为**第二端点**（tauri-plugin-updater 内建按序回退）：

1. `https://github.com/.../latest.json`（主）
2. `https://lambchat.com/api/version/assets/latest.json/download`（回退，生产实测 200）

更新包下载 URL 仍为清单内带签名的 GitHub 资产 URL——签名链不变，官方分发通道不变。

## 多端审计结论（本 PR 收尾）

| 端 | 链路 | 状态 |
|---|---|---|
| Web/PWA | /api/version 展示性检查 | ✅ has_update 语义正确 |
| Android | 原生 DownloadManager(#450) + WebView 流式兜底 + 代理(401 已修) | ✅ APK 200/35MB 实测 |
| iOS | 跳发布页 | ✅ 302 正常 |
| 桌面×3 | Tauri updater + latest.json(5 平台签名齐全) | ✅ +本 PR 补回退端点 |
| daemon×4 | release 二进制 + self-update + 服务端版本门 | ✅ 产物齐备 |

测试：新增端点回退源码用例，前端全量 2518 passed（唯一失败为在途 UI 工作的既有中间态，与本 PR 无关）。