### PR TITLE
fix(agents): 视觉消息文本摘要保留图片 URL，模型可按需下载附件

### DIFF
--- a/src/agents/core/node_utils.py
+++ b/src/agents/core/node_utils.py
@@ -560,7 +560,9 @@ def build_human_message(
                     "image_url": {"url": image_url},
                 }
             )
-            if data_url and url:
+            # URL 必须写进文本摘要：模型读不出 image 块里的 URL，
+            # 没有链接就无法用 upload_url_to_sandbox 按需取字节
+            if url:
                 text_summary_attachments.append({**attachment, "image_index": image_index})
         elif url:
             text_summary_attachments.append(attachment)

--- a/tests/agents/core/test_node_utils_multimodal.py
+++ b/tests/agents/core/test_node_utils_multimodal.py
@@ -61,11 +61,27 @@ def test_vision_model_sends_image_attachment_as_multimodal_block():
 
     assert isinstance(message, HumanMessage)
     assert isinstance(message.content, list)
-    assert message.content[0] == {"type": "text", "text": "what is this?"}
+    assert message.content[0]["type"] == "text"
+    assert "what is this?" in message.content[0]["text"]
     assert message.content[1] == {
         "type": "image_url",
         "image_url": {"url": "/api/upload/file/uploads/img.png"},
     }
+
+
+def test_vision_model_keeps_image_url_in_text_summary_for_url_mode():
+    """URL 模式下视觉模型的文本摘要必须保留图片链接。
+
+    模型无法从 image 块里读回 URL；文本里没有链接时，模型拿不到文件字节
+    （无法调用 upload_url_to_sandbox 按需下载），只能要求用户重新上传。
+    """
+    message = build_human_message("what is this?", [image_attachment()], supports_vision=True)
+
+    assert isinstance(message.content, list)
+    assert "User Uploaded Attachments" in message.content[0]["text"]
+    assert "/api/upload/file/uploads/img.png" in message.content[0]["text"]
+    assert "Corresponding image: #1" in message.content[0]["text"]
+    assert message.content[1]["image_url"]["url"] == "/api/upload/file/uploads/img.png"
 
 
 def test_non_vision_model_keeps_image_attachment_as_text_summary():

--- a/tests/infra/tool/test_image_analysis_tool.py
+++ b/tests/infra/tool/test_image_analysis_tool.py
@@ -250,10 +250,14 @@ async def test_image_analyze_uses_configured_vlm_model_and_prompt(monkeypatch):
     }
     assert len(captured["messages"]) == 1
     assert isinstance(captured["messages"][0], HumanMessage)
-    assert captured["messages"][0].content == [
-        {"type": "text", "text": "Describe the animal."},
-        {"type": "image_url", "image_url": {"url": "/api/upload/file/uploads/lamb.png"}},
-    ]
+    # 文本摘要保留附件链接（URL 模式），图片块仍为原图 URL
+    assert captured["messages"][0].content[0]["type"] == "text"
+    assert "Describe the animal." in captured["messages"][0].content[0]["text"]
+    assert "/api/upload/file/uploads/lamb.png" in captured["messages"][0].content[0]["text"]
+    assert captured["messages"][0].content[1] == {
+        "type": "image_url",
+        "image_url": {"url": "/api/upload/file/uploads/lamb.png"},
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 问题

生产反馈（https://lambchat.com/shared/suZepyrnS_UZ）：用户上传 4 张图片让 Agent 做像素级裁剪/压缩，模型回复"截图没有落到沙箱文件系统里，需要重新提供文件"；用户重传后依旧失败。

## 根因

- 图片附件以 URL 模式传给视觉模型时，`build_human_message` 仅在 `data_url and url` 同时存在时才把链接写进文本摘要（image 块 + `Corresponding image: #N` 映射）。
- 模型读不出 image 块里携带的 URL 字符串；文本里没有链接，就无法调用已有的 `upload_url_to_sandbox` 按需下载进沙箱，沙箱工作区又不会自动落附件文件，于是只能要求用户重传。

## 修复

- `src/agents/core/node_utils.py`：条件由 `if data_url and url:` 放宽为 `if url:`——附件带 URL 即写入文本摘要，模型拿到链接即可自行下载，无需重传（覆盖 fast/search/team 所有走 `build_human_message` 的 Agent）。

## 测试

- [x] 新增 `test_vision_model_keeps_image_url_in_text_summary_for_url_mode`（先 RED 后 GREEN）
- [x] `uv run pytest tests/agents`：236 passed
- [x] `ruff check` / `ruff format --check` 通过

## 后续

合并部署后按 hotfix 规范将同一修复回合（PR）到 `develop`，保持双分支不漂移。
