### PR TITLE
docs: 发版规矩——App Release 只走 main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,7 +137,16 @@ Conventional Commits + 中文描述：`类型(范围): 摘要`。
 |-----|------|------|
 | `develop-YYYYMMDD-HHmmss` | push `develop` | staging 验证 |
 | `main-YYYYMMDD-HHmmss` | push `main` | 生产部署 |
-| `v*` | 发版 tag | 归档 |
+| `v*` | 发版 tag（只打在 `main`） | 归档 + App Release 触发 |
+
+### 发版流程（App Release / `v*` tag）
+
+**规矩：发版 tag 一律打在 `main` 的合并提交上——hotfix 或 develop 晋升合入 `main`、CI 全绿后再打 tag；禁止在 feature 分支或未晋升到 `main` 的提交上发版。**
+
+1. 打 tag 前先 bump 四处版本文件并保持一致：`frontend/package.json`、`frontend/src-tauri/tauri.conf.json`、android `versionName`/`versionCode`（数字串 = 版本去点）、iOS `MARKETING_VERSION`——app-release.yml 的 prelight 会校验 tag 与版本一致，漂移直接红。
+2. 在 `main` 合并提交上打 tag 并推送，触发 `app-release.yml`：六端矩阵构建（Linux x86_64/arm64、Windows、macOS Apple Silicon/Intel）+ Android/iOS，即发即传上传 GitHub Release。
+3. 收尾由 release job 权威重生成 `latest.json`（桌面端自更新清单，版本号取自 tag）；发版完成的判据是 latest.json 五个桌面平台条目齐全（含 `darwin-x86_64`）。
+4. 重打同一 tag：先删远端 tag 与旧 run，再在新提交上重推；资产同名 `--clobber` 原地替换。
 
 ### 晋升 checklist（develop → main）
 

--- a/frontend/src/components/chat/__tests__/chatInputSandboxPanel.test.tsx
+++ b/frontend/src/components/chat/__tests__/chatInputSandboxPanel.test.tsx
@@ -327,8 +327,13 @@ test("sandbox panel online hides the download entry", async () => {
   mocks.getStatus.mockResolvedValue({ online: true });
   renderSelectors("sandbox");
 
-  await screen.findByText("Local");
-  expect(screen.queryByText("Download local sandbox")).not.toBeInTheDocument();
+  // 等下载入口消失而非等"Local"出现：档位 chip 首帧即渲染，getStatus
+  // 异步落地前离线引导仍在，同步断言会竞态（CI 高负载下抖动）
+  await waitFor(() =>
+    expect(
+      screen.queryByText("Download local sandbox"),
+    ).not.toBeInTheDocument(),
+  );
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
AGENTS.md 新增发版流程小节：v* tag 一律打在 main 合并提交上（CI 绿后），禁止在未晋升提交上发版；打 tag 前四处版本文件一致；重打先删旧 tag 与旧 run。