### PR TITLE
chore: 晋升 develop——darwin updater 签名确定性命名修复

### DIFF
--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -75,7 +75,7 @@ jobs:
             asset_suffix: macOS-Apple-Silicon
             pbs_platform: macos-arm64
             updater_key: darwin-aarch64
-            updater_sig: "*_aarch64.app.tar.gz.sig"
+            updater_sig: "*-macOS-Apple-Silicon.app.tar.gz.sig"
             updater_asset_suffix: macOS-Apple-Silicon.app.tar.gz
           - label: macOS Intel
             runner: macos-14
@@ -85,7 +85,7 @@ jobs:
             asset_suffix: macOS-Intel
             pbs_platform: macos-x64
             updater_key: darwin-x86_64
-            updater_sig: "*_x64.app.tar.gz.sig"
+            updater_sig: "*-macOS-Intel.app.tar.gz.sig"
             updater_asset_suffix: macOS-Intel.app.tar.gz
 
     steps:
@@ -355,6 +355,7 @@ jobs:
             exit 1
           fi
           cp "$app_tgz" "release-assets/LambChat-${RELEASE_TAG}-${{ matrix.updater_asset_suffix }}"
+          cp "$app_tgz".sig "release-assets/LambChat-${RELEASE_TAG}-${{ matrix.updater_asset_suffix }}.sig"
           # 稳定名副本（一键安装脚本按 releases/latest/download/<稳定名> 直链
           # 下载，免版本号解析、免 API 限流）。双架构各一份稳定名。
           cp "$app_tgz" "release-assets/LambChat-${{ matrix.asset_suffix }}-latest.app.tar.gz"
@@ -776,8 +777,8 @@ jobs:
               ("linux-x86_64", "*_amd64.AppImage.sig", f"LambChat-{tag}-Linux-x86_64.AppImage"),
               ("linux-aarch64", "*_aarch64.AppImage.sig", f"LambChat-{tag}-Linux-arm64.AppImage"),
               # 双 darwin：sig 按 Tauri updater 产物名的 arch 段区分
-              ("darwin-aarch64", "*_aarch64.app.tar.gz.sig", f"LambChat-{tag}-macOS-Apple-Silicon.app.tar.gz"),
-              ("darwin-x86_64", "*_x64.app.tar.gz.sig", f"LambChat-{tag}-macOS-Intel.app.tar.gz"),
+              ("darwin-aarch64", "*-macOS-Apple-Silicon.app.tar.gz.sig", f"LambChat-{tag}-macOS-Apple-Silicon.app.tar.gz"),
+              ("darwin-x86_64", "*-macOS-Intel.app.tar.gz.sig", f"LambChat-{tag}-macOS-Intel.app.tar.gz"),
           ]
           platforms = {}
           for key, pattern, asset in mapping:

--- a/frontend/src/services/api/__tests__/releasePackagingSource.test.ts
+++ b/frontend/src/services/api/__tests__/releasePackagingSource.test.ts
@@ -38,6 +38,22 @@ test("release workflow publishes branded desktop and mobile artifacts", () => {
   expect(workflow).toMatch(/rustup target add \$\{\{ matrix\.target \}\}/);
   expect(workflow).toMatch(/asset_suffix: macOS-Apple-Silicon/);
   expect(workflow).toMatch(/asset_suffix: macOS-Intel/);
+  // darwin updater 签名用确定性命名（跟 updater 资产名走）：Tauri 原始
+  // sig 名不带架构段（双 mac job 互踩 clobber），按 arch 段 glob 匹配会
+  // 静默丢 darwin 条目、Mac 收不到自动更新
+  expect(workflow).toMatch(
+    /updater_sig: "\*-macOS-Apple-Silicon\.app\.tar\.gz\.sig"/,
+  );
+  expect(workflow).toMatch(/updater_sig: "\*-macOS-Intel\.app\.tar\.gz\.sig"/);
+  expect(workflow).toMatch(
+    /cp "\$app_tgz"\.sig "release-assets\/LambChat-\$\{RELEASE_TAG\}-\$\{\{ matrix\.updater_asset_suffix \}\}\.sig"/,
+  );
+  expect(workflow).toMatch(
+    /"darwin-aarch64", "\*-macOS-Apple-Silicon\.app\.tar\.gz\.sig"/,
+  );
+  expect(workflow).toMatch(
+    /"darwin-x86_64", "\*-macOS-Intel\.app\.tar\.gz\.sig"/,
+  );
   expect(workflow).toMatch(/frontend\/src-tauri\/target\/release\/bundle/);
   expect(workflow).toMatch(
     /LambChat-\$\{RELEASE_TAG\}-Linux-\$\{arch\}\.AppImage/,

--- a/tests/client/test_packaging.py
+++ b/tests/client/test_packaging.py
@@ -207,12 +207,12 @@ def test_release_workflow_publishes_assets_immediately_per_platform() -> None:
     # macOS updater 走 .app.tar.gz（dmg 不能原地更新）；双架构各有平台键，
     # sig 按 Tauri updater 产物名的 arch 段区分（_aarch64 / _x64）
     assert by_label["macOS Apple Silicon"]["updater_key"] == "darwin-aarch64"
-    assert by_label["macOS Apple Silicon"]["updater_sig"] == "*_aarch64.app.tar.gz.sig"
+    assert by_label["macOS Apple Silicon"]["updater_sig"] == "*-macOS-Apple-Silicon.app.tar.gz.sig"
     assert by_label["macOS Apple Silicon"]["updater_asset_suffix"] == (
         "macOS-Apple-Silicon.app.tar.gz"
     )
     assert by_label["macOS Intel"]["updater_key"] == "darwin-x86_64"
-    assert by_label["macOS Intel"]["updater_sig"] == "*_x64.app.tar.gz.sig"
+    assert by_label["macOS Intel"]["updater_sig"] == "*-macOS-Intel.app.tar.gz.sig"
     assert by_label["macOS Intel"]["updater_asset_suffix"] == "macOS-Intel.app.tar.gz"
     merge_step = next(
         s
@@ -267,8 +267,8 @@ def test_release_workflow_guards_version_drift_and_manifest_version_from_tag() -
     )
     assert 'version = tag.lstrip("v")' in regen["run"]
     assert "read_text()" not in regen["run"] or "tauri.conf" not in regen["run"]
-    assert '("darwin-aarch64", "*_aarch64.app.tar.gz.sig"' in regen["run"]
-    assert '("darwin-x86_64", "*_x64.app.tar.gz.sig"' in regen["run"]
+    assert '("darwin-aarch64", "*-macOS-Apple-Silicon.app.tar.gz.sig"' in regen["run"]
+    assert '("darwin-x86_64", "*-macOS-Intel.app.tar.gz.sig"' in regen["run"]
 
 
 def test_release_workflow_macos_collect_requires_app_tar_gz() -> None:


### PR DESCRIPTION
回合 #467：修 latest.json 静默丢 darwin 条目（Tauri sig 名不带架构段，按 arch glob 匹配落空）。含 develop 上的全部内容，合入后 main/develop 零偏移。