### PR TITLE
fix(release): daemon 版本漏 bump——__version__ 入六处统一并纳入 preflight

### DIFF
--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -106,9 +106,10 @@ jobs:
           gradle_code="$(grep -E '^\s+versionCode' frontend/android/app/build.gradle | sed -E 's/.*versionCode ([0-9]+).*/\1/')"
           ios="$(grep -m1 'MARKETING_VERSION' frontend/ios/App/App.xcodeproj/project.pbxproj | sed -E 's/.*= ([^;]+);.*/\1/')"
           pyproject="$(grep -m1 '^version = ' pyproject.toml | sed -E 's/version = "([^"]+)"/\1/')"
+          daemon="$(grep -m1 '^__version__ = ' client/lambchat_sandbox/__init__.py | sed -E 's/__version__ = "([^"]+)"/\1/')"
           want_code="$(printf '%s' "$tag" | tr -d '.')"
           fail=0
-          for entry in "frontend/package.json=$pkg" "tauri.conf.json=$tauri" "android versionName=$gradle_name" "iOS MARKETING_VERSION=$ios" "pyproject.toml=$pyproject"; do
+          for entry in "frontend/package.json=$pkg" "tauri.conf.json=$tauri" "android versionName=$gradle_name" "iOS MARKETING_VERSION=$ios" "pyproject.toml=$pyproject" "daemon __version__=$daemon"; do
             k="${entry%%=*}"; v="${entry#*=}"
             if [ "$v" != "$tag" ]; then echo "✗ $k is $v, expected $tag"; fail=1; fi
           done
@@ -469,9 +470,10 @@ jobs:
           gradle_code="$(grep -E '^\s+versionCode' frontend/android/app/build.gradle | sed -E 's/.*versionCode ([0-9]+).*/\1/')"
           ios="$(grep -m1 'MARKETING_VERSION' frontend/ios/App/App.xcodeproj/project.pbxproj | sed -E 's/.*= ([^;]+);.*/\1/')"
           pyproject="$(grep -m1 '^version = ' pyproject.toml | sed -E 's/version = "([^"]+)"/\1/')"
+          daemon="$(grep -m1 '^__version__ = ' client/lambchat_sandbox/__init__.py | sed -E 's/__version__ = "([^"]+)"/\1/')"
           want_code="$(printf '%s' "$tag" | tr -d '.')"
           fail=0
-          for entry in "frontend/package.json=$pkg" "tauri.conf.json=$tauri" "android versionName=$gradle_name" "iOS MARKETING_VERSION=$ios" "pyproject.toml=$pyproject"; do
+          for entry in "frontend/package.json=$pkg" "tauri.conf.json=$tauri" "android versionName=$gradle_name" "iOS MARKETING_VERSION=$ios" "pyproject.toml=$pyproject" "daemon __version__=$daemon"; do
             k="${entry%%=*}"; v="${entry#*=}"
             if [ "$v" != "$tag" ]; then echo "✗ $k is $v, expected $tag"; fail=1; fi
           done
@@ -609,9 +611,10 @@ jobs:
           gradle_code="$(grep -E '^\s+versionCode' frontend/android/app/build.gradle | sed -E 's/.*versionCode ([0-9]+).*/\1/')"
           ios="$(grep -m1 'MARKETING_VERSION' frontend/ios/App/App.xcodeproj/project.pbxproj | sed -E 's/.*= ([^;]+);.*/\1/')"
           pyproject="$(grep -m1 '^version = ' pyproject.toml | sed -E 's/version = "([^"]+)"/\1/')"
+          daemon="$(grep -m1 '^__version__ = ' client/lambchat_sandbox/__init__.py | sed -E 's/__version__ = "([^"]+)"/\1/')"
           want_code="$(printf '%s' "$tag" | tr -d '.')"
           fail=0
-          for entry in "frontend/package.json=$pkg" "tauri.conf.json=$tauri" "android versionName=$gradle_name" "iOS MARKETING_VERSION=$ios" "pyproject.toml=$pyproject"; do
+          for entry in "frontend/package.json=$pkg" "tauri.conf.json=$tauri" "android versionName=$gradle_name" "iOS MARKETING_VERSION=$ios" "pyproject.toml=$pyproject" "daemon __version__=$daemon"; do
             k="${entry%%=*}"; v="${entry#*=}"
             if [ "$v" != "$tag" ]; then echo "✗ $k is $v, expected $tag"; fail=1; fi
           done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,7 @@ Conventional Commits + 中文描述：`类型(范围): 摘要`。
 
 **规矩：发版 tag 一律打在 `main` 的合并提交上——hotfix 或 develop 晋升合入 `main`、CI 全绿后再打 tag；禁止在 feature 分支或未晋升到 `main` 的提交上发版。**
 
-1. 打 tag 前先 bump 五处版本文件并保持一致：`frontend/package.json`、`frontend/src-tauri/tauri.conf.json`、android `versionName`/`versionCode`（数字串 = 版本去点）、iOS `MARKETING_VERSION`、`pyproject.toml`（服务端 `/api/version` 运行时读它，漏 bump 网页端版本号就不同步）——app-release.yml 的 preflight 会校验 tag 与版本一致，漂移直接红。
+1. 打 tag 前先 bump 六处版本文件并保持一致：`frontend/package.json`、`frontend/src-tauri/tauri.conf.json`、android `versionName`/`versionCode`（数字串 = 版本去点）、iOS `MARKETING_VERSION`、`pyproject.toml`（服务端 `/api/version` 运行时读它，漏 bump 网页端版本号就不同步）、`client/lambchat_sandbox/__init__.py` 的 `__version__`（daemon 自更新比版本，漏 bump daemon 永不更新）——app-release.yml 的 preflight 会校验 tag 与版本一致，漂移直接红。
 2. 在 `main` 合并提交上打 tag 并推送，触发 `app-release.yml`：六端矩阵构建（Linux x86_64/arm64、Windows、macOS Apple Silicon/Intel）+ Android/iOS，即发即传上传 GitHub Release。
 3. 收尾由 release job 权威重生成 `latest.json`（桌面端自更新清单，版本号取自 tag）；发版完成的判据是 latest.json 五个桌面平台条目齐全（含 `darwin-x86_64`）。
 4. 重打同一 tag：先删远端 tag 与旧 run，再在新提交上重推；资产同名 `--clobber` 原地替换。

--- a/client/lambchat_sandbox/__init__.py
+++ b/client/lambchat_sandbox/__init__.py
@@ -11,4 +11,4 @@ self-update 与服务端最低版本拒连打底。
 2.x/0.3.x 均放行，旧 daemon 经 self-update 平滑升到对齐版本。
 """
 
-__version__ = "2.8.6"
+__version__ = "2.8.7"

--- a/tests/client/test_packaging.py
+++ b/tests/client/test_packaging.py
@@ -251,6 +251,9 @@ def test_release_workflow_guards_version_drift_and_manifest_version_from_tag() -
         # 服务端版本（/api/version 运行时读 pyproject.toml）同入门禁：
         # 漏 bump 会让网页端展示的版本与客户端发版不同步
         assert "pyproject.toml=$pyproject" in preflight["run"], job
+        # daemon 版本（lambchat_sandbox.__version__，自 2.8.6 起随发版统一
+        # 递增）：漏 bump 会让 daemon self-update 比版本无变化、永不更新
+        assert "daemon __version__=$daemon" in preflight["run"], job
 
     # 闸 2：增量合并的 manifest.version 取自 tag（不再读 tauri.conf.json）
     merge_step = next(


### PR DESCRIPTION
## 问题

v2.8.7 的 daemon 仍报 2.8.6：`client/lambchat_sandbox/__init__.py` 的 `__version__` 漏 bump（自 2.8.6 起约定随发版统一递增）。daemon self-update 比版本无差异 → 永不更新；服务端 `daemon_version` 上报也停在 2.8.6。

## 修复

- `__version__` bump 至 2.8.7
- app-release 三处 preflight 增加 daemon `__version__` 校验（结构测试锁定）
- AGENTS.md 发版规矩更新为六处