### PR TITLE
fix(frontend): Tooltip 四向智能定位与气泡样式优化

### DIFF
--- a/frontend/src/components/common/Tooltip.tsx
+++ b/frontend/src/components/common/Tooltip.tsx
@@ -1,4 +1,5 @@
 import {
+  type CSSProperties,
   type ReactNode,
   useState,
   useCallback,
@@ -8,7 +9,8 @@ import {
 import { createPortal } from "react-dom";
 import { useStickyDropdownPosition } from "../../hooks/useStickyDropdownPosition";
 
-type Placement = "top" | "bottom" | "auto";
+type Placement = "top" | "bottom" | "left" | "right" | "auto";
+type ResolvedPlacement = Exclude<Placement, "auto">;
 
 interface TooltipProps {
   content: ReactNode;
@@ -34,6 +36,151 @@ const TOUCH_MOVE_CANCEL_PX = 10;
  * tooltip on a mere tap instead of a deliberate long press.
  */
 const TOUCH_MOUSE_GATE_MS = 600;
+/** Gap between trigger and bubble (px) */
+const TOOLTIP_GAP = 10;
+/** Minimum distance between bubble and viewport edge (px) */
+const VIEWPORT_PADDING = 8;
+const TOOLTIP_MAX_WIDTH = 240;
+/** Arrow is a 10px (border-[5px]) triangle; keep it clear of the rounded corners */
+const ARROW_SIZE = 10;
+const ARROW_MARGIN = 6;
+
+/** Rough bubble size from content, used to pick a placement before measuring */
+function estimateTooltipSize(content: ReactNode) {
+  const text =
+    typeof content === "string" || typeof content === "number"
+      ? String(content)
+      : "";
+  const estimatedWidth = Math.min(
+    TOOLTIP_MAX_WIDTH,
+    Math.max(72, text.length * 7 + 20),
+  );
+  const estimatedLines = Math.max(
+    1,
+    Math.ceil((text.length * 7 + 20) / TOOLTIP_MAX_WIDTH),
+  );
+
+  return {
+    width: estimatedWidth,
+    height: estimatedLines * 24 + 12,
+  };
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), Math.max(min, max));
+}
+
+function resolvePlacement(
+  requested: Placement,
+  rect: DOMRect,
+  width: number,
+  height: number,
+): ResolvedPlacement {
+  if (requested !== "auto") return requested;
+
+  const spaceLeft = rect.left - VIEWPORT_PADDING;
+  const spaceRight = window.innerWidth - rect.right - VIEWPORT_PADDING;
+  const spaceAbove = rect.top - VIEWPORT_PADDING;
+  const spaceBelow = window.innerHeight - rect.bottom - VIEWPORT_PADDING;
+  const horizontalFitsLeft = spaceLeft >= width + TOOLTIP_GAP;
+  const horizontalFitsRight = spaceRight >= width + TOOLTIP_GAP;
+
+  // Triggers hugging a viewport edge (e.g. the left rail) read better sideways
+  if (rect.left <= VIEWPORT_PADDING + 48 && horizontalFitsRight) return "right";
+  if (
+    window.innerWidth - rect.right <= VIEWPORT_PADDING + 48 &&
+    horizontalFitsLeft
+  )
+    return "left";
+  // Only one side fits horizontally: use it
+  if (horizontalFitsRight && !horizontalFitsLeft && spaceRight >= spaceBelow)
+    return "right";
+  if (horizontalFitsLeft && !horizontalFitsRight && spaceLeft > spaceAbove)
+    return "left";
+
+  return spaceAbove >= height + TOOLTIP_GAP && spaceAbove >= spaceBelow
+    ? "top"
+    : "bottom";
+}
+
+function getTooltipPosition(
+  rect: DOMRect,
+  requested: Placement,
+  content: ReactNode,
+) {
+  const { width, height } = estimateTooltipSize(content);
+  const resolved = resolvePlacement(requested, rect, width, height);
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+  const centerX = rect.left + rect.width / 2;
+  const centerY = rect.top + rect.height / 2;
+
+  if (resolved === "right" || resolved === "left") {
+    const idealLeft =
+      resolved === "right"
+        ? rect.right + TOOLTIP_GAP
+        : rect.left - TOOLTIP_GAP - width;
+    const idealTop = centerY - height / 2;
+    const clampedTop = clamp(
+      idealTop,
+      VIEWPORT_PADDING,
+      viewportHeight - height - VIEWPORT_PADDING,
+    );
+
+    return {
+      resolved,
+      style: {
+        position: "fixed",
+        left: clamp(
+          idealLeft,
+          VIEWPORT_PADDING,
+          viewportWidth - width - VIEWPORT_PADDING,
+        ),
+        top: clampedTop,
+        transform: "none",
+      } satisfies CSSProperties,
+      arrowStyle: {
+        top: clamp(
+          centerY - clampedTop,
+          ARROW_MARGIN,
+          height - ARROW_MARGIN - ARROW_SIZE,
+        ),
+      } satisfies CSSProperties,
+    };
+  }
+
+  const idealLeft = centerX - width / 2;
+  const left = clamp(
+    idealLeft,
+    VIEWPORT_PADDING,
+    viewportWidth - width - VIEWPORT_PADDING,
+  );
+  const idealTop =
+    resolved === "top"
+      ? rect.top - TOOLTIP_GAP - height
+      : rect.bottom + TOOLTIP_GAP;
+
+  return {
+    resolved,
+    style: {
+      position: "fixed",
+      left,
+      top: clamp(
+        idealTop,
+        VIEWPORT_PADDING,
+        viewportHeight - height - VIEWPORT_PADDING,
+      ),
+      transform: "none",
+    } satisfies CSSProperties,
+    arrowStyle: {
+      left: clamp(
+        centerX - left,
+        ARROW_MARGIN,
+        width - ARROW_MARGIN - ARROW_SIZE,
+      ),
+    } satisfies CSSProperties,
+  };
+}
 
 export function Tooltip({
   content,
@@ -51,7 +198,8 @@ export function Tooltip({
   const touchStartPosRef = useRef<{ x: number; y: number } | null>(null);
   const wrapperRef = useRef<HTMLSpanElement>(null);
   const childElRef = useRef<HTMLElement | null>(null);
-  const resolvedPlacement = useRef<"top" | "bottom">("top");
+  const resolvedPlacement = useRef<ResolvedPlacement>("top");
+  const arrowStyle = useRef<CSSProperties>({});
 
   // Get the actual child element (not the display:contents wrapper)
   const getChild = useCallback(
@@ -171,33 +319,25 @@ export function Tooltip({
   const visible = open === true || show;
 
   const tipStyle = useStickyDropdownPosition(childElRef, visible, (rect) => {
-    const textLen =
-      typeof content === "string"
-        ? content.length
-        : content?.toString().length ?? 0;
-    const estimatedHeight = Math.min(textLen * 0.6, 120) + 24;
-    const spaceAbove = rect.top;
-    const spaceBelow = window.innerHeight - rect.bottom;
-
-    let showAbove = spaceAbove > estimatedHeight + 8;
-    if (placement === "top") showAbove = true;
-    else if (placement === "bottom") showAbove = false;
-    else showAbove = spaceAbove > spaceBelow;
-
-    resolvedPlacement.current = showAbove ? "top" : "bottom";
-
+    const position = getTooltipPosition(rect, placement, content);
+    resolvedPlacement.current = position.resolved;
+    arrowStyle.current = position.arrowStyle;
     return {
-      position: "fixed",
-      left: rect.left + rect.width / 2,
-      top: showAbove ? rect.top - 8 : rect.bottom + 8,
-      transform: showAbove ? "translate(-50%, -100%)" : "translate(-50%, 0)",
+      ...position.style,
       zIndex,
     };
   });
 
   if (typeof content !== "string" && typeof content !== "number") return null;
 
-  const arrowTop = resolvedPlacement.current === "top";
+  const arrowClassName = {
+    top: "absolute left-0 top-full border-[5px] border-transparent border-t-stone-700 dark:border-t-stone-900",
+    bottom:
+      "absolute left-0 bottom-full border-[5px] border-transparent border-b-stone-700 dark:border-b-stone-900",
+    left: "absolute right-0 top-0 border-[5px] border-transparent border-l-stone-700 dark:border-l-stone-900",
+    right:
+      "absolute left-0 top-0 border-[5px] border-transparent border-r-stone-700 dark:border-r-stone-900",
+  }[resolvedPlacement.current];
 
   return (
     <>
@@ -208,7 +348,8 @@ export function Tooltip({
       {visible &&
         createPortal(
           <span
-            className={`fixed max-w-[240px] w-max rounded-lg bg-stone-700 dark:bg-stone-900 px-2.5 py-1.5 text-12 leading-relaxed text-white shadow-lg whitespace-normal pointer-events-none ${
+            data-placement={resolvedPlacement.current}
+            className={`fixed z-50 max-w-[min(240px,calc(100vw-16px))] w-max rounded-md border border-white/10 bg-stone-700/95 px-2.5 py-1.5 text-12 font-medium leading-relaxed text-white shadow-xl shadow-black/20 backdrop-blur-sm whitespace-normal pointer-events-none ${
               className ?? ""
             }`}
             style={{
@@ -217,11 +358,11 @@ export function Tooltip({
             }}
           >
             {content}
-            {arrowTop ? (
-              <span className="absolute left-1/2 -translate-x-1/2 top-full border-[5px] border-transparent border-t-stone-700 dark:border-t-stone-900" />
-            ) : (
-              <span className="absolute left-1/2 -translate-x-1/2 bottom-full border-[5px] border-transparent border-b-stone-700 dark:border-b-stone-900" />
-            )}
+            <span
+              data-tooltip-arrow
+              className={arrowClassName}
+              style={arrowStyle.current}
+            />
           </span>,
           document.body,
         )}

--- a/frontend/src/components/common/__tests__/tooltipControlledOpen.test.tsx
+++ b/frontend/src/components/common/__tests__/tooltipControlledOpen.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from "vitest";
-import { fireEvent, render, within } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, waitFor, within } from "@testing-library/react";
 import { Tooltip } from "../Tooltip";
 
 describe("Tooltip controlled open", () => {
@@ -23,5 +23,139 @@ describe("Tooltip controlled open", () => {
     expect(within(document.body).queryByText("运行中")).not.toBeInTheDocument();
     fireEvent.mouseEnter(view.getByTestId("icon"));
     expect(within(document.body).getByText("运行中")).toBeInTheDocument();
+  });
+
+  it("places a left-edge tooltip to the right of its trigger", async () => {
+    vi.spyOn(window, "innerWidth", "get").mockReturnValue(800);
+    vi.spyOn(window, "innerHeight", "get").mockReturnValue(600);
+    const view = render(
+      <Tooltip content="侧边栏提示">
+        <span data-testid="icon" />
+      </Tooltip>,
+    );
+    const trigger = view.getByTestId("icon");
+    vi.spyOn(trigger, "getBoundingClientRect").mockReturnValue({
+      left: 8,
+      top: 260,
+      right: 32,
+      bottom: 284,
+      width: 24,
+      height: 24,
+    } as DOMRect);
+    fireEvent.mouseEnter(trigger);
+
+    await waitFor(() => {
+      expect(within(document.body).getByText("侧边栏提示")).toHaveAttribute(
+        "data-placement",
+        "right",
+      );
+    });
+  });
+
+  it("keeps a bottom tooltip inside the viewport and shifts its arrow", async () => {
+    vi.spyOn(window, "innerWidth", "get").mockReturnValue(320);
+    vi.spyOn(window, "innerHeight", "get").mockReturnValue(240);
+    const view = render(
+      <Tooltip content="这是一个很长的提示内容" placement="bottom">
+        <span data-testid="icon" />
+      </Tooltip>,
+    );
+    const trigger = view.getByTestId("icon");
+    vi.spyOn(trigger, "getBoundingClientRect").mockReturnValue({
+      left: 4,
+      top: 180,
+      right: 28,
+      bottom: 204,
+      width: 24,
+      height: 24,
+    } as DOMRect);
+    fireEvent.mouseEnter(trigger);
+
+    const bubble = within(document.body).getByText("这是一个很长的提示内容");
+    await waitFor(() => {
+      expect(bubble).toHaveAttribute("data-placement", "bottom");
+      expect(bubble).toHaveStyle({ left: "8px" });
+      expect(bubble.querySelector("[data-tooltip-arrow]")).toHaveStyle({
+        left: "8px",
+      });
+    });
+  });
+
+  it("places a right-edge tooltip to the left of its trigger", async () => {
+    vi.spyOn(window, "innerWidth", "get").mockReturnValue(800);
+    vi.spyOn(window, "innerHeight", "get").mockReturnValue(600);
+    const view = render(
+      <Tooltip content="右侧提示">
+        <span data-testid="icon" />
+      </Tooltip>,
+    );
+    const trigger = view.getByTestId("icon");
+    vi.spyOn(trigger, "getBoundingClientRect").mockReturnValue({
+      left: 760,
+      top: 260,
+      right: 784,
+      bottom: 284,
+      width: 24,
+      height: 24,
+    } as DOMRect);
+    fireEvent.mouseEnter(trigger);
+
+    await waitFor(() => {
+      expect(within(document.body).getByText("右侧提示")).toHaveAttribute(
+        "data-placement",
+        "left",
+      );
+    });
+  });
+
+  it("flips vertically to the side with more space when away from edges", async () => {
+    vi.spyOn(window, "innerWidth", "get").mockReturnValue(800);
+    vi.spyOn(window, "innerHeight", "get").mockReturnValue(600);
+    const nearTop = render(
+      <Tooltip content="靠上提示">
+        <span data-testid="icon" />
+      </Tooltip>,
+    );
+    const topTrigger = nearTop.getByTestId("icon");
+    vi.spyOn(topTrigger, "getBoundingClientRect").mockReturnValue({
+      left: 300,
+      top: 40,
+      right: 324,
+      bottom: 64,
+      width: 24,
+      height: 24,
+    } as DOMRect);
+    fireEvent.mouseEnter(topTrigger);
+
+    await waitFor(() => {
+      expect(within(document.body).getByText("靠上提示")).toHaveAttribute(
+        "data-placement",
+        "bottom",
+      );
+    });
+    nearTop.unmount();
+
+    const nearBottom = render(
+      <Tooltip content="靠下提示">
+        <span data-testid="icon" />
+      </Tooltip>,
+    );
+    const bottomTrigger = nearBottom.getByTestId("icon");
+    vi.spyOn(bottomTrigger, "getBoundingClientRect").mockReturnValue({
+      left: 300,
+      top: 500,
+      right: 324,
+      bottom: 524,
+      width: 24,
+      height: 24,
+    } as DOMRect);
+    fireEvent.mouseEnter(bottomTrigger);
+
+    await waitFor(() => {
+      expect(within(document.body).getByText("靠下提示")).toHaveAttribute(
+        "data-placement",
+        "top",
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary

统一 Tooltip 组件由仅上下两向升级为四向智能定位，并优化气泡视觉样式。贴近视口左边缘的触发器（如左侧栏）气泡显示在右侧，贴近右边缘的显示在左侧，其余场景按上下可用空间自动选择方向，全部方向做视口夹紧，不再溢出屏幕。

## Changes

- `frontend/src/components/common/Tooltip.tsx`
  - `placement` 扩展为 `top | bottom | left | right | auto`（默认 auto），auto 模式按触发器在视口中的位置智能选择四向
  - 气泡整体视口夹紧（8px 安全边距），窄屏下最大宽度随 `100vw` 收缩
  - 箭头精确指向触发器中心，气泡被夹紧时箭头跟随偏移并避开圆角区域
  - 视觉升级：`rounded-md`、半透明背景 + `backdrop-blur`、细边框、更深阴影层级，暗色模式同步适配
  - hover 延迟隐藏、触摸长按 500ms 显示、受控 `open`、滚动/缩放实时跟随等既有行为保持不变；所有调用点（侧边栏、会话/项目列表、技能卡片等）自动受益，无需改动
- `frontend/src/components/common/__tests__/tooltipControlledOpen.test.tsx`
  - 新增 4 个定位回归用例：左缘→右侧、右缘→左侧、远离边缘时上下自动翻转、底部夹紧 + 箭头偏移

## Testing

- [x] 新增用例先在旧实现上确认失败（RED），再以新实现全部通过
- [x] Tooltip 相关套件 22 文件 / 121 测试通过
- [x] 前端全量 492 文件 / 2283 测试通过
- [x] `pnpm run lint` 0 错误（现存警告均为无关历史遗留）
- [x] `pnpm run build` 成功
