### PR TITLE
docs(agents): 开发起点规矩——开工前基于最新 origin/develop 拉分支/rebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,21 @@ feat/fix 分支 ──PR──▶ develop ──PR──▶ main ──▶ yang 
 |------|------|------|
 | `main` | 生产分支，每次合并出 `main-<时间戳>` 镜像 | 必须 PR；Merge Gate 只放行 `develop` 与 `hotfix/*` 来源 |
 | `develop` | 集成分支（默认分支），所有 feature/fix PR 的目标，每次合并出 `develop-<时间戳>` 镜像 | 必须 PR（0 approvals，自合留痕即可） |
-| `feat/*` `fix/*` `perf/*` `docs/*` `chore/*` | 短生命周期工作分支，从 `develop` 拉 | 无 |
+| `feat/*` `fix/*` `perf/*` `docs/*` `chore/*` | 短生命周期工作分支，从最新 `origin/develop` 拉 | 无 |
+
+### 开发起点（基于最新 origin/develop）
+
+**规矩：任何开发开工前，先同步远端并基于最新的 `origin/develop` 进行——新分支直接从 `origin/develop` 拉，已有分支先 rebase 到 `origin/develop` 再继续；禁止基于过期的本地 `develop` 或其他工作分支开工。**
+
+```bash
+git fetch origin
+
+# 开新工作分支：直接基于最新 origin/develop
+git checkout -b feat/xxx origin/develop
+
+# 已有分支继续开发 / 开 PR 前：先 rebase 到最新 origin/develop
+git rebase origin/develop
+```
 
 ### 提交信息规范
 


### PR DESCRIPTION
## Summary

把「开发一律基于最新 `origin/develop`」定为规矩写进 AGENTS.md：新分支直接从最新 `origin/develop` 拉，已有分支先 `rebase origin/develop` 再继续，禁止基于过期的本地 `develop` 或其他工作分支开工。

## Changes

- 「分支与发布流程」新增「开发起点（基于最新 origin/develop）」小节：规矩说明 + `git fetch origin` / `git checkout -b <branch> origin/develop` / `git rebase origin/develop` 命令示例
- 分支模型表格中工作分支的基线描述同步改为「从最新 `origin/develop` 拉」，与新规矩保持一致

## Testing

- 纯文档变更；已核对 Markdown 结构、命令与路径正确
- 本分支即按新规矩执行：`git fetch origin` 后直接从 `origin/develop` 拉出 `docs/dev-baseline`
