### PR TITLE
chore(release): 版本 2.8.7 → 2.9.0——六处统一 bump

### DIFF
--- a/client/lambchat_sandbox/__init__.py
+++ b/client/lambchat_sandbox/__init__.py
@@ -11,4 +11,4 @@ self-update 与服务端最低版本拒连打底。
 2.x/0.3.x 均放行，旧 daemon 经 self-update 平滑升到对齐版本。
 """
 
-__version__ = "2.8.7"
+__version__ = "2.9.0"

--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.lambchat.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 287
-        versionName "2.8.7"
+        versionCode 290
+        versionName "2.9.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/frontend/ios/App/App.xcodeproj/project.pbxproj
+++ b/frontend/ios/App/App.xcodeproj/project.pbxproj
@@ -352,7 +352,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 2.8.7;
+				MARKETING_VERSION = 2.9.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.lambchat.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -372,7 +372,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 2.8.7;
+				MARKETING_VERSION = 2.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lambchat.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lambchat-frontend",
   "private": true,
-  "version": "2.8.7",
+  "version": "2.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LambChat",
-  "version": "2.8.7",
+  "version": "2.9.0",
   "identifier": "com.lambchat.app",
   "build": {
     "frontendDist": "../dist",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lambchat"
-version = "2.8.7"
+version = "2.9.0"
 description = "Full-featured AI Agent system with FastAPI, LangGraph, and LangSmith"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2024,7 +2024,7 @@ wheels = [
 
 [[package]]
 name = "lambchat"
-version = "2.8.7"
+version = "2.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

版本 `2.8.7 → 2.9.0`（minor：含功能与多项生产修复）。六处版本文件统一 bump，app-release preflight 校验项齐全。

## 变更点

| 位置 | 值 |
|------|-----|
| `frontend/package.json` | 2.9.0 |
| `frontend/src-tauri/tauri.conf.json` | 2.9.0 |
| android `versionName` / `versionCode` | 2.9.0 / 290（版本去点） |
| iOS `MARKETING_VERSION`（×2 target） | 2.9.0 |
| `pyproject.toml`（服务端 `/api/version` 运行时源） | 2.9.0 |
| `client/lambchat_sandbox/__init__.py`（daemon 自更新比版本） | 2.9.0 |

uv.lock 的 lambchat 条目同步（手工改版本行，避免整锁重生成引入镜像 URL 污染）。

## 2.9.0 相对 2.8.7 的主体内容

- **feat(sandbox)**：daemon 连接全链路优化（presence 秒级推送、BLPOP 阻塞中继、多机体验与 command-group 进程管理）+ WRONGTYPE 滚动窗口兼容与 ack 队列语义修复（#475）
- **fix(sandbox)**：流式传输五连修——fs_upload_stream 分发注册、请求体门限豁免（>8MiB 下载 413）、空文件落盘、上传中断 600s→0.4s、uv.lock 镜像清理（#476）
- **feat(sandbox)**：`SANDBOX_LOCAL_EXEC_TIMEOUT` 入设置表，前端可动态更新、调用时读取
- **test(sandbox)**：本地链路 E2E 常驻化 33 项硬性门禁（AGENTS.md 写死）

## Testing

- [x] 六处版本一致性核验通过（含 android versionCode=290、iOS 双 target）
- [x] `lambchat_sandbox.__version__` 导入验证 = 2.9.0
- [x] CI（复用既有套件，无代码变更）
