### PR TITLE
fix(frontend): 桌面端更新后旧 chunk 404 白屏自愈——拦截 vite:preloadError 带缓存参数重载一次

### DIFF
--- a/frontend/src/__tests__/chunkRecoverySource.test.ts
+++ b/frontend/src/__tests__/chunkRecoverySource.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { expect, test } from "vitest";
+
+test("main.tsx installs chunk load recovery before rendering the app", () => {
+  const source = readFileSync(
+    resolve(import.meta.dirname, "../main.tsx"),
+    "utf8",
+  );
+
+  // 桌面端 updater 更新重启后 WebView2 可能仍用缓存的旧 index.html，
+  // 引用的旧 hash chunk 已不存在 → 动态 import 失败。入口必须安装
+  // vite:preloadError 恢复：吞掉错误并带 cache-bust 参数重载一次
+  const installIndex = source.indexOf("installChunkLoadRecovery()");
+  expect(installIndex).toBeGreaterThan(-1);
+  expect(source.indexOf("createRoot(")).toBeGreaterThan(installIndex);
+});

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,11 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import "katex/dist/katex.min.css";
 import "./fonts.css";
+// 动态 import chunk 拉取失败自愈（桌面端更新重启后 WebView2 缓存旧
+// index.html 引用已删除 chunk）：吞错并带 cache-bust 参数重载一次。
+// 必须先于任何动态 import 安装。
+import { installChunkLoadRecovery } from "./utils/chunkLoadRecovery";
+installChunkLoadRecovery();
 // CJK 字体异步加载（约 940 条 @font-face 拆独立 chunk，不阻塞首屏，
 // 也不占 PWA 预缓存预算），见 src/fonts-cjk.ts。
 void import("./fonts-cjk");

--- a/frontend/src/utils/__tests__/chunkLoadRecovery.test.ts
+++ b/frontend/src/utils/__tests__/chunkLoadRecovery.test.ts
@@ -1,0 +1,145 @@
+import { expect, test, vi } from "vitest";
+import {
+  CHUNK_RELOAD_COOLDOWN_MS,
+  CHUNK_RELOAD_STORAGE_KEY,
+  buildCacheBustedUrl,
+  installChunkLoadRecovery,
+  isChunkLoadError,
+  shouldReloadAfterChunkError,
+} from "../chunkLoadRecovery";
+
+/** 用户实报的桌面端错误：updater 更新重启后 WebView2 缓存的旧 index.html
+ *  仍引用已不存在的旧 hash chunk，动态 import 404。 */
+const TAURI_STALE_CHUNK_ERROR = new TypeError(
+  "Failed to fetch dynamically imported module: http://tauri.localhost/assets/RichChatComposer-6TNnBJWu.js",
+);
+
+test("isChunkLoadError matches stale-chunk fetch failures across engines", () => {
+  expect(isChunkLoadError(TAURI_STALE_CHUNK_ERROR)).toBe(true);
+  expect(
+    isChunkLoadError(new Error("Importing a module script failed")),
+  ).toBe(true);
+  expect(
+    isChunkLoadError(new Error("error loading dynamically imported module")),
+  ).toBe(true);
+  expect(
+    isChunkLoadError(new Error("Unable to preload CSS for http://tauri.localhost/assets/x.css")),
+  ).toBe(true);
+});
+
+test("isChunkLoadError rejects unrelated and missing errors", () => {
+  expect(isChunkLoadError(new ReferenceError("x is not defined"))).toBe(false);
+  expect(isChunkLoadError(undefined)).toBe(false);
+  expect(isChunkLoadError(null)).toBe(false);
+  expect(isChunkLoadError("random string")).toBe(false);
+});
+
+test("buildCacheBustedUrl appends chunk_reload nonce keeping existing query", () => {
+  expect(buildCacheBustedUrl("http://tauri.localhost/", 1234)).toBe(
+    "http://tauri.localhost/?chunk_reload=1234",
+  );
+  const busted = buildCacheBustedUrl(
+    "https://app.example.com/chat?id=7&tab=2",
+    1234,
+  );
+  expect(busted).toContain("id=7");
+  expect(busted).toContain("tab=2");
+  expect(busted).toContain("chunk_reload=1234");
+});
+
+test("buildCacheBustedUrl replaces a previous nonce", () => {
+  const once = buildCacheBustedUrl("http://tauri.localhost/?chunk_reload=1", 2);
+  expect(once).toBe("http://tauri.localhost/?chunk_reload=2");
+});
+
+test("shouldReloadAfterChunkError allows first attempt and blocks within cooldown", () => {
+  const now = 1_000_000;
+  expect(shouldReloadAfterChunkError(null, now)).toBe(true);
+  expect(shouldReloadAfterChunkError(now - 1_000, now)).toBe(false);
+  expect(
+    shouldReloadAfterChunkError(now - CHUNK_RELOAD_COOLDOWN_MS, now),
+  ).toBe(true);
+});
+
+interface FakeWindow {
+  addEventListener: (
+    type: string,
+    listener: (event: Event) => void,
+  ) => void;
+  sessionStorage: { getItem(k: string): string | null; setItem(k: string, v: string): void };
+  location: { href: string; replace(url: string): void };
+}
+
+function createHarness(href = "http://tauri.localhost/") {
+  const listeners: Record<string, Array<(event: Event) => void>> = {};
+  const store = new Map<string, string>();
+  const replace = vi.fn();
+  const win: FakeWindow = {
+    addEventListener(type, listener) {
+      (listeners[type] ??= []).push(listener);
+    },
+    sessionStorage: {
+      getItem: (k) => store.get(k) ?? null,
+      setItem: (k, v) => void store.set(k, v),
+    },
+    location: { href, replace },
+  };
+  const dispatchPreloadError = (payload: unknown): boolean => {
+    const event = new Event("vite:preloadError", { cancelable: true });
+    Object.assign(event, { payload });
+    for (const listener of listeners["vite:preloadError"] ?? []) {
+      listener(event);
+    }
+    return event.defaultPrevented;
+  };
+  return { win, dispatchPreloadError, replace, store };
+}
+
+test("installChunkLoadRecovery prevents default and reloads with cache-busted url", () => {
+  const { win, dispatchPreloadError, replace, store } = createHarness();
+  installChunkLoadRecovery(win);
+
+  const prevented = dispatchPreloadError(TAURI_STALE_CHUNK_ERROR);
+
+  expect(prevented).toBe(true);
+  expect(store.get(CHUNK_RELOAD_STORAGE_KEY)).toBeTruthy();
+  expect(replace).toHaveBeenCalledTimes(1);
+  expect(replace).toHaveBeenCalledWith(
+    expect.stringContaining("chunk_reload="),
+  );
+});
+
+test("installChunkLoadRecovery swallows repeat failures without reload loop", () => {
+  const { win, dispatchPreloadError, replace } = createHarness();
+  installChunkLoadRecovery(win);
+
+  // Vite 的 __vitePreload 在同一页面内会先后派发 preload 失败与 import 失败
+  // 两个事件，冷却期内只允许触发一次导航
+  dispatchPreloadError(TAURI_STALE_CHUNK_ERROR);
+  const preventedAgain = dispatchPreloadError(TAURI_STALE_CHUNK_ERROR);
+
+  expect(preventedAgain).toBe(true);
+  expect(replace).toHaveBeenCalledTimes(1);
+});
+
+test("installChunkLoadRecovery allows another reload after cooldown", () => {
+  const { win, dispatchPreloadError, replace } = createHarness();
+  let now = 1_000_000;
+  installChunkLoadRecovery(win, { now: () => now });
+
+  dispatchPreloadError(TAURI_STALE_CHUNK_ERROR);
+  now += CHUNK_RELOAD_COOLDOWN_MS + 1;
+  dispatchPreloadError(TAURI_STALE_CHUNK_ERROR);
+
+  expect(replace).toHaveBeenCalledTimes(2);
+});
+
+test("installChunkLoadRecovery ignores non-chunk preload errors", () => {
+  const { win, dispatchPreloadError, replace } = createHarness();
+  installChunkLoadRecovery(win);
+
+  const prevented = dispatchPreloadError(new Error("some random failure"));
+
+  expect(prevented).toBe(false);
+  expect(replace).not.toHaveBeenCalled();
+});

--- a/frontend/src/utils/chunkLoadRecovery.ts
+++ b/frontend/src/utils/chunkLoadRecovery.ts
@@ -1,0 +1,82 @@
+/**
+ * 动态 import chunk 加载失败的自愈恢复。
+ *
+ * 桌面端 updater 更新重启后，WebView2 可能仍从磁盘缓存返回旧版
+ * index.html，其中引用的旧 hash chunk（如 RichChatComposer-xxx.js）
+ * 在新安装目录里已不存在，React.lazy 的动态 import 随即 404 报
+ * "Failed to fetch dynamically imported module"。没有恢复路径时用户
+ * 只能重装。Vite 生产构建的所有动态 import 都经 __vitePreload 包裹，
+ * 失败时派发可取消的 vite:preloadError 事件：这里吞掉错误并带
+ * cache-bust 参数 replace 一次（换 URL 绕过文档缓存拿新 index.html），
+ * 冷却期内只允许一次，避免真坏掉时无限重载。
+ */
+
+const CHUNK_LOAD_ERROR_PATTERNS = [
+  // Chromium / WebView2
+  "Failed to fetch dynamically imported module",
+  // Firefox
+  "Importing a module script failed",
+  // WebKit
+  "error loading dynamically imported module",
+  // Vite __vitePreload 的 CSS 依赖预载失败
+  "Unable to preload CSS for",
+];
+
+export const CHUNK_RELOAD_STORAGE_KEY = "lambchat:chunk-reload-at";
+export const CHUNK_RELOAD_COOLDOWN_MS = 30_000;
+
+export function isChunkLoadError(error: unknown): boolean {
+  if (!error) return false;
+  const message = error instanceof Error ? error.message : String(error);
+  return CHUNK_LOAD_ERROR_PATTERNS.some((pattern) =>
+    message.includes(pattern),
+  );
+}
+
+/** 同一 URL 加上/更新 chunk_reload 随机数，强制 webview 重新拉取文档 */
+export function buildCacheBustedUrl(href: string, nonce: number): string {
+  const url = new URL(href);
+  url.searchParams.set("chunk_reload", String(nonce));
+  return url.toString();
+}
+
+export function shouldReloadAfterChunkError(
+  lastReloadAt: number | null,
+  now: number,
+  cooldownMs: number = CHUNK_RELOAD_COOLDOWN_MS,
+): boolean {
+  if (lastReloadAt === null) return true;
+  return now - lastReloadAt >= cooldownMs;
+}
+
+interface ChunkLoadRecoveryWindow {
+  addEventListener(type: string, listener: (event: Event) => void): void;
+  sessionStorage: Pick<Storage, "getItem" | "setItem">;
+  location: { href: string; replace(url: string): void };
+}
+
+interface InstallOptions {
+  /** 可注入时钟，便于测试冷却期 */
+  now?: () => number;
+}
+
+export function installChunkLoadRecovery(
+  win: ChunkLoadRecoveryWindow = window as typeof window,
+  { now = Date.now }: InstallOptions = {},
+): void {
+  win.addEventListener("vite:preloadError", (event) => {
+    const payload = (event as Event & { payload?: unknown }).payload;
+    if (!isChunkLoadError(payload)) return;
+
+    // 吞掉错误，避免它冒泡到 React lazy 边界崩成白屏
+    event.preventDefault();
+
+    const at = now();
+    const storedAt = Number(win.sessionStorage.getItem(CHUNK_RELOAD_STORAGE_KEY));
+    if (!shouldReloadAfterChunkError(Number.isFinite(storedAt) ? storedAt : null, at)) {
+      return;
+    }
+    win.sessionStorage.setItem(CHUNK_RELOAD_STORAGE_KEY, String(at));
+    win.location.replace(buildCacheBustedUrl(win.location.href, at));
+  });
+}


### PR DESCRIPTION
## 问题

桌面端（Windows / WebView2）报错：

```
Failed to fetch dynamically imported module: http://tauri.localhost/assets/RichChatComposer-6TNnBJWu.js
```

## 根因

桌面端 updater 自更新（下载 → 安装 → relaunch）重启后，WebView2 仍可能从磁盘缓存返回**旧版 `index.html`**，其中引用的旧 hash chunk 在新安装目录里已不存在（`ChatInput.tsx` 对 RichChatComposer 是 `lazy(() => import(...))`，正好对上报错的 chunk 名）。动态 import 404 后没有任何恢复路径，React lazy 边界崩掉，用户只能重装。

## 修复

新增 `frontend/src/utils/chunkLoadRecovery.ts`，在 `main.tsx` 于任何动态 import 之前安装：

- 监听 Vite 生产构建为所有动态 import 统一派发的可取消事件 `vite:preloadError`（Vite 6.4 实测可用）
- 识别跨引擎 chunk 拉取失败文案（Chromium / Firefox / WebKit / Vite CSS preload）
- `preventDefault()` 吞掉错误，避免冒泡到 lazy 边界白屏
- 带 `chunk_reload` 时间戳参数 `location.replace` 一次——URL 变化绕过 webview 文档缓存，拿到新 `index.html` 与一致的资源 hash
- `sessionStorage` 冷却 30s：同一页面 Vite 会先后派发 preload 失败与 import 失败两个事件，且若资源真缺失则不再重载，杜绝无限重载循环

## 验证

- ✅ 新增测试 10 项（`chunkLoadRecovery.test.ts` 单测 + `chunkRecoverySource.test.ts` 入口接线校验），先 RED 后 GREEN
- ✅ 前端全量测试：533 files / 2589 tests 全绿
- ✅ `pnpm run lint`、`pnpm run build`（含 PWA）通过
- 真机 WebView2 缓存行为本环境无法复现，需 staging / 真实发版后观察（该修复为业界处理此类问题的标准模式，Vite 官方文档同荐）