### PR TITLE
fix(client): macOS daemon 双层签名修复——内嵌库构建期落印 + sidecar 无 runtime 重封

### DIFF
--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -238,10 +238,13 @@ jobs:
       # macOS 签名门禁：v2.8.4 及更早的 .app 没有 bundle 封印（无
       # _CodeSignature/CodeResources，Tauri 无 signingIdentity 时跳过签名），
       # 浏览器下载带隔离标记后被 Gatekeeper 判「已损坏」。signingIdentity "-"
-      # 已让 Tauri 在产出 dmg/updater 产物前 ad-hoc 封印 bundle；本步验证
-      # 封印与嵌套可执行签名（arm64 内核要求全部可执行代码至少 ad-hoc 签名，
-      # daemon sidecar 缺签名会被 SIGKILL），防回归。
-      - name: Verify macOS ad-hoc code signing
+      # 已让 Tauri 在产出 dmg/updater 产物前 ad-hoc 封印 bundle；本步先对
+      # daemon sidecar 无选项重封（不带 hardened runtime/library validation
+      # ——PyInstaller 运行时解包出的内嵌 dylib 为构建期 ad-hoc 签名（无团队
+      # ID），library validation 下 dlopen 即 SIGKILL，v2.9.2 macOS「daemon
+      # 起不来」的第二失败面），再验证封印与嵌套可执行签名（arm64 内核要求
+      # 全部可执行代码至少 ad-hoc 签名）并显式打印签名标志作 CI 证据。
+      - name: Re-seal daemon sidecar without hardened runtime + verify signing
         if: runner.os == 'macOS'
         shell: bash
         run: |
@@ -251,6 +254,20 @@ jobs:
             echo "No .app bundle found to verify"
             exit 1
           fi
+          daemon_bin="$app_path/Contents/MacOS/lambchat-daemon"
+          if [ -f "$daemon_bin" ]; then
+            echo "== daemon sidecar signature BEFORE re-seal =="
+            codesign -dv --verbose=4 "$daemon_bin" 2>&1 | grep -E "Signature|flags|TeamIdentifier|Identifier=" || true
+            # 无 --options 重封：新签名不带 runtime/LV 标志（flags 归零）
+            codesign --force --sign - --timestamp=none "$daemon_bin"
+            echo "== daemon sidecar signature AFTER re-seal =="
+            codesign -dv --verbose=4 "$daemon_bin" 2>&1 | grep -E "Signature|flags|TeamIdentifier|Identifier=" || true
+            # 门禁：CodeDirectory flags 不得含 runtime (0x10000)
+            if codesign -dv --verbose=4 "$daemon_bin" 2>&1 | grep -E "flags=0x[0-9a-f]*1[0-9a-f]{4}"; then
+              echo "!! daemon sidecar 带 runtime 标志——内嵌解包库会被 library validation 击杀"
+              exit 1
+            fi
+          fi
           echo "Verifying bundle seal: $app_path"
           test -f "$app_path/Contents/_CodeSignature/CodeResources"
           codesign --verify --deep --strict --verbose=2 "$app_path"
@@ -259,7 +276,7 @@ jobs:
             echo "Verifying nested executable: $bin"
             codesign --verify --verbose=2 "$bin"
           done < <(find "$app_path/Contents/MacOS" -type f -perm -111 -print0)
-          echo "OK: .app sealed (ad-hoc) and all nested executables signed"
+          echo "OK: .app sealed (ad-hoc), sidecar re-sealed without runtime, all nested executables signed"
 
       - name: Collect Linux desktop artifacts
         if: runner.os == 'Linux'

--- a/client/pyinstaller.spec
+++ b/client/pyinstaller.spec
@@ -65,6 +65,12 @@ exe = EXE(
     disable_windowed_traceback=False,
     argv_emulation=False,
     target_arch=None,
-    codesign_identity=None,
+    # macOS：强制 ad-hoc 签名**全部内嵌二进制**（dylib/so/可执行逐个，构建期
+    # 落印、随归档分发）。默认 None 时 PyInstaller 按宿主/目标架构启发式决定
+    # 是否签名（x86_64 目标在 arm64 宿主上跳过），未签名的 libpython3.12.dylib
+    # 解包后 dlopen 即被 arm64 内核/AMFI SIGKILL——v2.9.2 macOS「daemon 起不
+    # 来」的第一失败点（临时副本实验证实：解包目录里的内嵌库缺有效签名）。
+    # ad-hoc（'-'）与发布链路的 tauri signingIdentity "-" 同语义，无需证书。
+    codesign_identity="-" if __import__("sys").platform == "darwin" else None,
     entitlements_file=None,
 )


### PR DESCRIPTION
## Summary

v2.9.2 macOS「daemon 起不来」的失败链已实测定位：壳与 sidecar 拉起正常 → PyInstaller 进程秒退 → **运行时解包出的 libpython3.12.dylib 缺有效签名/被 library validation 拒载** → 监视器三次重启后放弃。

## 修复（双层，覆盖两种机制）

**层1 spec**：`codesign_identity='-'` 强制——PyInstaller 默认按宿主/目标架构启发式决定是否签内嵌二进制（x86_64 目标在 arm64 宿主上跳过签名），未签名 dylib 在 arm64 内核 dlopen 即 SIGKILL。显式落印让每个内嵌 dylib/so 构建期带 ad-hoc 签名随归档分发。
**层2 CI**：Tauri 打包后对 sidecar 无 `--options` 重封——杜绝 hardened runtime / library validation（内嵌解包库无团队 ID，LV 必拒）；重封前后 `codesign -dv` 证据输出，flags 含 runtime(0x10000) 直接红。

## Testing

- [x] Linux 本地构建冒烟通过（spec 兼容、version=2.9.2）
- [x] macOS 行为由 CI 双架构构建 + 签名证据门禁验证
- [ ] 待真机验证（v2.9.3 出包后）