### PR TITLE
ci(release): 发版流程三重优化——打包冒烟门禁 + latest.json 烘焙态 + 手动发布

### DIFF
--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -389,6 +389,43 @@ jobs:
           find frontend/src-tauri/target -name "*.sig" -exec cp {} release-assets/ \; 2>/dev/null || true
           ls -la release-assets/ 2>/dev/null || true
 
+      # 打包产物冒烟门禁：v2.9.0~v2.9.2 的三次生产事故（sidecar 路径、Windows
+      # 弹终端/卡死、macOS 内嵌库签名击杀）全部只在用户装包后才暴露——CI 从
+      # 未真正运行过打包产物里的 daemon。本步在**真实打包产物**上跑 daemon
+      # version：macOS 直接执行 .app 内的 sidecar（签名/dylib 击杀当场红）、
+      # Linux 解包 deb 后执行（同时锁布局：sidecar 与主程序同级且去 triple）、
+      # Windows 执行构建产物 sidecar。输出必须等于 tag 版本。
+      - name: Packaged daemon smoke (version assert)
+        if: runner.os != 'Linux' || matrix.arch == 'amd64'
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected="${RELEASE_TAG#v}"
+          run_daemon() {
+            local bin="$1"
+            echo "== smoke: $bin =="
+            actual="$("$bin" version | tail -1 | tr -d '\r')"
+            echo "version -> $actual (expect $expected)"
+            [ "$actual" = "$expected" ]
+          }
+          case "${{ runner.os }}" in
+            macOS)
+              app_path="$(find frontend/src-tauri/target -path '*/release/bundle/macos/*.app' -type d | head -1)"
+              run_daemon "$app_path/Contents/MacOS/lambchat-daemon"
+              ;;
+            Linux)
+              deb="$(find frontend/src-tauri/target -name '*.deb' -type f | head -1)"
+              mkdir -p /tmp/deb-x && dpkg-deb -x "$deb" /tmp/deb-x
+              # 布局断言：externalBin 落位主程序同目录且去 triple（v2.9.0 路径事故锚点）
+              test -x /tmp/deb-x/usr/bin/lambchat
+              run_daemon /tmp/deb-x/usr/bin/lambchat-daemon
+              ;;
+            Windows)
+              run_daemon "frontend/src-tauri/binaries/lambchat-daemon-x86_64-pc-windows-msvc.exe"
+              ;;
+          esac
+          echo "OK: packaged daemon smoke passed"
+
       - name: Upload desktop artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -773,57 +810,24 @@ jobs:
           test "$(find release-assets -type f | wc -l)" -gt 0
 
       - name: Generate latest.json updater manifest
-        # Tauri v2 CLI 只产出 .sig 签名文件，不再自动生成更新清单（v1 行为已
-        # 移除）；这里按平台 sig 组装 latest.json（端点见 tauri.conf.json
-        # updater.endpoints）。版本取自 tag（preflight 已校验与各端版本文件
-        # 一致）；macOS updater 走 .app.tar.gz，dmg 仅用于首装。
+        # 公共生成器（scripts/generate_updater_manifest.py，与手动 publish
+        # 工作流共用）。烘焙门控：仓库变量 DESKTOP_UPDATER_AUTO_PUBLISH != true
+        # 时 latest.json 不随出包上传——资产在 Release 上可供手工验证，但
+        # 桌面端自更新不感知，待人工/真机抽检后跑 Publish Updater 工作流才
+        # 真正推送（v2.9.0~v2.9.2 三连热修的流程性根治）。
         env:
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
+          ASSET_DIR: release-assets
         run: |
-          python3 - <<'EOF'
-          import datetime
-          import glob
-          import json
-          import os
-          import pathlib
-
-          tag = os.environ["RELEASE_TAG"]
-          base = f"https://github.com/Yanyutin753/LambChat/releases/download/{tag}"
-          version = tag.lstrip("v")
-
-          def sig(pattern: str) -> str | None:
-              files = sorted(glob.glob(f"release-assets/{pattern}"))
-              return pathlib.Path(files[0]).read_text().strip() if files else None
-
-          mapping = [
-              ("windows-x86_64", "*_x64_en-US.msi.sig", f"LambChat-{tag}-Windows.msi"),
-              ("linux-x86_64", "*_amd64.AppImage.sig", f"LambChat-{tag}-Linux-x86_64.AppImage"),
-              ("linux-aarch64", "*_aarch64.AppImage.sig", f"LambChat-{tag}-Linux-arm64.AppImage"),
-              # 双 darwin：sig 按 Tauri updater 产物名的 arch 段区分
-              ("darwin-aarch64", "*-macOS-Apple-Silicon.app.tar.gz.sig", f"LambChat-{tag}-macOS-Apple-Silicon.app.tar.gz"),
-              ("darwin-x86_64", "*-macOS-Intel.app.tar.gz.sig", f"LambChat-{tag}-macOS-Intel.app.tar.gz"),
-          ]
-          platforms = {}
-          for key, pattern, asset in mapping:
-              signature = sig(pattern)
-              if signature:
-                  platforms[key] = {"signature": signature, "url": f"{base}/{asset}"}
-              else:
-                  print(f"WARN: no sig file matches {pattern}, platform {key} omitted")
-
-          manifest = {
-              "version": version,
-              "notes": f"LambChat {tag}",
-              "pub_date": datetime.datetime.now(datetime.timezone.utc).strftime(
-                  "%Y-%m-%dT%H:%M:%SZ"
-              ),
-              "platforms": platforms,
-          }
-          pathlib.Path("release-assets/latest.json").write_text(
-              json.dumps(manifest, indent=2)
-          )
-          print(f"latest.json platforms: {sorted(platforms)}")
-          EOF
+          set -euo pipefail
+          python3 scripts/generate_updater_manifest.py || {
+            echo "!! latest.json 平台不齐——见上方 WARN"; exit 1; }
+          if [ "${{ vars.DESKTOP_UPDATER_AUTO_PUBLISH }}" != "true" ]; then
+            rm -f release-assets/latest.json
+            echo "::notice::出包完成（烘焙态）：latest.json 未上传。真机抽检后到 Actions 跑 Desktop Updater Publish（tag: ${RELEASE_TAG}）推给桌面端。"
+          else
+            echo "::notice::DESKTOP_UPDATER_AUTO_PUBLISH=true——latest.json 随包发布"
+          fi
 
       - name: Publish release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -238,10 +238,13 @@ jobs:
       # macOS 签名门禁：v2.8.4 及更早的 .app 没有 bundle 封印（无
       # _CodeSignature/CodeResources，Tauri 无 signingIdentity 时跳过签名），
       # 浏览器下载带隔离标记后被 Gatekeeper 判「已损坏」。signingIdentity "-"
-      # 已让 Tauri 在产出 dmg/updater 产物前 ad-hoc 封印 bundle；本步验证
-      # 封印与嵌套可执行签名（arm64 内核要求全部可执行代码至少 ad-hoc 签名，
-      # daemon sidecar 缺签名会被 SIGKILL），防回归。
-      - name: Verify macOS ad-hoc code signing
+      # 已让 Tauri 在产出 dmg/updater 产物前 ad-hoc 封印 bundle；本步先对
+      # daemon sidecar 无选项重封（不带 hardened runtime/library validation
+      # ——PyInstaller 运行时解包出的内嵌 dylib 为构建期 ad-hoc 签名（无团队
+      # ID），library validation 下 dlopen 即 SIGKILL，v2.9.2 macOS「daemon
+      # 起不来」的第二失败面），再验证封印与嵌套可执行签名（arm64 内核要求
+      # 全部可执行代码至少 ad-hoc 签名）并显式打印签名标志作 CI 证据。
+      - name: Re-seal daemon sidecar without hardened runtime + verify signing
         if: runner.os == 'macOS'
         shell: bash
         run: |
@@ -251,6 +254,20 @@ jobs:
             echo "No .app bundle found to verify"
             exit 1
           fi
+          daemon_bin="$app_path/Contents/MacOS/lambchat-daemon"
+          if [ -f "$daemon_bin" ]; then
+            echo "== daemon sidecar signature BEFORE re-seal =="
+            codesign -dv --verbose=4 "$daemon_bin" 2>&1 | grep -E "Signature|flags|TeamIdentifier|Identifier=" || true
+            # 无 --options 重封：新签名不带 runtime/LV 标志（flags 归零）
+            codesign --force --sign - --timestamp=none "$daemon_bin"
+            echo "== daemon sidecar signature AFTER re-seal =="
+            codesign -dv --verbose=4 "$daemon_bin" 2>&1 | grep -E "Signature|flags|TeamIdentifier|Identifier=" || true
+            # 门禁：CodeDirectory flags 不得含 runtime (0x10000)
+            if codesign -dv --verbose=4 "$daemon_bin" 2>&1 | grep -E "flags=0x[0-9a-f]*1[0-9a-f]{4}"; then
+              echo "!! daemon sidecar 带 runtime 标志——内嵌解包库会被 library validation 击杀"
+              exit 1
+            fi
+          fi
           echo "Verifying bundle seal: $app_path"
           test -f "$app_path/Contents/_CodeSignature/CodeResources"
           codesign --verify --deep --strict --verbose=2 "$app_path"
@@ -259,7 +276,7 @@ jobs:
             echo "Verifying nested executable: $bin"
             codesign --verify --verbose=2 "$bin"
           done < <(find "$app_path/Contents/MacOS" -type f -perm -111 -print0)
-          echo "OK: .app sealed (ad-hoc) and all nested executables signed"
+          echo "OK: .app sealed (ad-hoc), sidecar re-sealed without runtime, all nested executables signed"
 
       - name: Collect Linux desktop artifacts
         if: runner.os == 'Linux'

--- a/.github/workflows/desktop-updater-publish.yml
+++ b/.github/workflows/desktop-updater-publish.yml
@@ -1,0 +1,49 @@
+name: Desktop Updater Publish
+
+# 手动发布桌面端自更新清单：出包默认「烘焙态」（资产在 Release 上、
+# latest.json 不上传，桌面端自更新不感知），真机抽检后跑本工作流把
+# latest.json 推上 Release——此刻起桌面端开始收到该版本。
+# 详见 AGENTS.md 发版流程。
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "要发布的 tag（如 v2.9.3）"
+        required: true
+        type: string
+
+jobs:
+  publish:
+    name: Publish latest.json for ${{ inputs.tag }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository (manifest generator)
+        uses: actions/checkout@v4
+
+      - name: Download release sig assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null
+          mkdir -p release-assets
+          gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
+            --pattern '*.sig' --dir release-assets
+          ls release-assets/
+
+      - name: Generate and upload latest.json
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
+          ASSET_DIR: release-assets
+        run: |
+          set -euo pipefail
+          # 五桌面不齐直接红（判据同 app-release）；齐全才上传——推给桌面端
+          python3 scripts/generate_updater_manifest.py
+          gh release upload "$RELEASE_TAG" release-assets/latest.json --clobber \
+            --repo "$GITHUB_REPOSITORY"
+          echo "✅ 桌面端自更新已推送 $RELEASE_TAG（latest.json 五平台齐全）"

--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,7 @@ YubbChat/
 !/scripts/sync_error_locales.py
 !/scripts/backfill_memory_scope.py
 !/scripts/e2e_local_sandbox.py
+!/scripts/generate_updater_manifest.py
 !/scripts/benchmark_memory_scope.py
 docs/docs/.vitepress/
 k8s/lambchat-secret.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,13 +153,17 @@ Conventional Commits + 中文描述：`类型(范围): 摘要`。
 | `main-YYYYMMDD-HHmmss` | push `main` | 生产部署 |
 | `v*` | 发版 tag（只打在 `main`） | 归档 + App Release 触发 |
 
+### 发版节奏（防热修风暴）
+
+**规矩：同一自然日最多发一个正式版。**当天发现的问题攒到 develop（P0 例外：生产不可用/数据丢失可即时热修）；出包后处于「烘焙态」，真机抽检通过再推给桌面端。桌面端打包问题（安装包内路径/签名/启动类）历史上只有装包才能发现，v2.9.0~v2.9.2 一天四版即此教训——现在 CI 已有打包产物冒烟门禁 + latest.json 延后发布双保险，但真机抽检（至少 mac + windows 各一台）仍是发布前最后一道人工关。
+
 ### 发版流程（App Release / `v*` tag）
 
 **规矩：发版 tag 一律打在 `main` 的合并提交上——hotfix 或 develop 晋升合入 `main`、CI 全绿后再打 tag；禁止在 feature 分支或未晋升到 `main` 的提交上发版。**
 
 1. 打 tag 前先 bump 六处版本文件并保持一致：`frontend/package.json`、`frontend/src-tauri/tauri.conf.json`、android `versionName`/`versionCode`（数字串 = 版本去点）、iOS `MARKETING_VERSION`、`pyproject.toml`（服务端 `/api/version` 运行时读它，漏 bump 网页端版本号就不同步）、`client/lambchat_sandbox/__init__.py` 的 `__version__`（daemon 自更新比版本，漏 bump daemon 永不更新）——app-release.yml 的 preflight 会校验 tag 与版本一致，漂移直接红。
 2. 在 `main` 合并提交上打 tag 并推送，触发 `app-release.yml`：六端矩阵构建（Linux x86_64/arm64、Windows、macOS Apple Silicon/Intel）+ Android/iOS，即发即传上传 GitHub Release。
-3. 收尾由 release job 权威重生成 `latest.json`（桌面端自更新清单，版本号取自 tag）；发版完成的判据是 latest.json 五个桌面平台条目齐全（含 `darwin-x86_64`）。
+3. 出包默认**烘焙态**：资产全部上 Release、CI 打包产物冒烟（mac 直接跑 .app 内 daemon、Linux 解包 deb 跑、Windows 跑 sidecar）须绿，但 `latest.json` **不上传**——桌面端自更新不感知。真机抽检（mac/windows）通过后，到 Actions 手动跑 **Desktop Updater Publish**（输入 tag）才把 latest.json 推给桌面端；此时发版完成的判据是 latest.json 五个桌面平台条目齐全（含 `darwin-x86_64`）。仓库变量 `DESKTOP_UPDATER_AUTO_PUBLISH=true` 可恢复随包直发（不建议）。
 4. 重打同一 tag：先删远端 tag 与旧 run，再在新提交上重推；资产同名 `--clobber` 原地替换。
 
 ### 晋升 checklist（develop → main）

--- a/client/pyinstaller.spec
+++ b/client/pyinstaller.spec
@@ -65,6 +65,12 @@ exe = EXE(
     disable_windowed_traceback=False,
     argv_emulation=False,
     target_arch=None,
-    codesign_identity=None,
+    # macOS：强制 ad-hoc 签名**全部内嵌二进制**（dylib/so/可执行逐个，构建期
+    # 落印、随归档分发）。默认 None 时 PyInstaller 按宿主/目标架构启发式决定
+    # 是否签名（x86_64 目标在 arm64 宿主上跳过），未签名的 libpython3.12.dylib
+    # 解包后 dlopen 即被 arm64 内核/AMFI SIGKILL——v2.9.2 macOS「daemon 起不
+    # 来」的第一失败点（临时副本实验证实：解包目录里的内嵌库缺有效签名）。
+    # ad-hoc（'-'）与发布链路的 tauri signingIdentity "-" 同语义，无需证书。
+    codesign_identity="-" if __import__("sys").platform == "darwin" else None,
     entitlements_file=None,
 )

--- a/scripts/generate_updater_manifest.py
+++ b/scripts/generate_updater_manifest.py
@@ -1,0 +1,80 @@
+"""生成桌面端自更新清单 latest.json（app-release 与手动 publish 工作流共用）。
+
+用法：
+  RELEASE_TAG=v2.9.3 ASSET_DIR=release-assets uv run python scripts/generate_updater_manifest.py
+
+从 ASSET_DIR 下的各平台 .sig 文件组装清单（端点见 tauri.conf.json
+updater.endpoints）；版本取自 tag（app-release 的 preflight 已校验与六处
+版本文件一致）；macOS updater 走 .app.tar.gz，dmg 仅用于首装。
+缺某平台 sig 时告警并省略该条目（发布完成的判据是五桌面齐全——由调用方
+校验，本脚本只如实反映现状）。
+"""
+
+from __future__ import annotations
+
+import datetime
+import glob
+import json
+import os
+import pathlib
+import sys
+
+MAPPING = [
+    ("windows-x86_64", "*_x64_en-US.msi.sig", "Windows.msi"),
+    ("linux-x86_64", "*_amd64.AppImage.sig", "Linux-x86_64.AppImage"),
+    ("linux-aarch64", "*_aarch64.AppImage.sig", "Linux-arm64.AppImage"),
+    # 双 darwin：sig 按 Tauri updater 产物名的 arch 段区分
+    ("darwin-aarch64", "*-macOS-Apple-Silicon.app.tar.gz.sig", "macOS-Apple-Silicon.app.tar.gz"),
+    ("darwin-x86_64", "*-macOS-Intel.app.tar.gz.sig", "macOS-Intel.app.tar.gz"),
+]
+
+REQUIRED_PLATFORMS = ("darwin-aarch64", "darwin-x86_64", "linux-x86_64", "windows-x86_64")
+
+
+def main() -> int:
+    tag = os.environ.get("RELEASE_TAG", "").strip()
+    asset_dir = pathlib.Path(os.environ.get("ASSET_DIR", "release-assets"))
+    if not tag.startswith("v"):
+        print(f"RELEASE_TAG 必须形如 v2.9.3，收到: {tag!r}", file=sys.stderr)
+        return 1
+
+    base = f"https://github.com/Yanyutin753/LambChat/releases/download/{tag}"
+    version = tag.lstrip("v")
+
+    def sig(pattern: str) -> str | None:
+        files = sorted(glob.glob(str(asset_dir / pattern)))
+        return pathlib.Path(files[0]).read_text().strip() if files else None
+
+    platforms: dict[str, dict[str, str]] = {}
+    for key, pattern, asset_suffix in MAPPING:
+        signature = sig(pattern)
+        if signature:
+            platforms[key] = {
+                "signature": signature,
+                "url": f"{base}/LambChat-{tag}-{asset_suffix}",
+            }
+        else:
+            print(f"WARN: no sig file matches {pattern}, platform {key} omitted")
+
+    manifest = {
+        "version": version,
+        "notes": f"LambChat {tag}",
+        "pub_date": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "platforms": platforms,
+    }
+    out = asset_dir / "latest.json"
+    out.write_text(json.dumps(manifest, indent=2))
+    print(f"latest.json platforms: {sorted(platforms)}")
+
+    if not all(p in platforms for p in REQUIRED_PLATFORMS):
+        print(
+            "发布判据未满足（五桌面须齐全，含 darwin-x86_64）——清单已生成但缺:",
+            [p for p in REQUIRED_PLATFORMS if p not in platforms],
+            file=sys.stderr,
+        )
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

一天四版（v2.9.0~v2.9.2 三连热修）的流程性根治：桌面打包 bug 历史上只有装包才能发现，每次事故都逼出一个紧急版本。

## 三重优化

1. **打包产物冒烟门禁**：真实打包产物上跑 daemon version 断言——macOS 执行 .app 内 sidecar（v2.9.2 签名击杀当场红）、Linux 解包 deb 执行 + 布局锁（v2.9.0 路径事故锚点）、Windows 执行 sidecar。
2. **latest.json 烘焙态**：出包默认不上传自更新清单（资产在 Release 可手工验证、桌面端不感知）；真机抽检后手动跑 **Desktop Updater Publish** 工作流才推送。变量 `DESKTOP_UPDATER_AUTO_PUBLISH=true` 可恢复直发。
3. **公共生成器** `scripts/generate_updater_manifest.py`（五桌面不齐 exit 2 拒发）；AGENTS.md 节奏规矩：**同日最多一个正式版**、热修攒批、P0 例外。

## Testing

- [x] YAML 解析通过；生成器单测（齐全 exit 0 / 缺平台 exit 2）
- [x] 与 #488（mac 签名修复）正交，可同批出 v2.9.3