### PR TITLE
fix(release): macOS 签名门禁改为打包期关 runtime——修复 v2.10.0 双 mac 发版失败

### DIFF
--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -238,13 +238,17 @@ jobs:
       # macOS 签名门禁：v2.8.4 及更早的 .app 没有 bundle 封印（无
       # _CodeSignature/CodeResources，Tauri 无 signingIdentity 时跳过签名），
       # 浏览器下载带隔离标记后被 Gatekeeper 判「已损坏」。signingIdentity "-"
-      # 已让 Tauri 在产出 dmg/updater 产物前 ad-hoc 封印 bundle；本步先对
-      # daemon sidecar 无选项重封（不带 hardened runtime/library validation
-      # ——PyInstaller 运行时解包出的内嵌 dylib 为构建期 ad-hoc 签名（无团队
-      # ID），library validation 下 dlopen 即 SIGKILL，v2.9.2 macOS「daemon
-      # 起不来」的第二失败面），再验证封印与嵌套可执行签名（arm64 内核要求
-      # 全部可执行代码至少 ad-hoc 签名）并显式打印签名标志作 CI 证据。
-      - name: Re-seal daemon sidecar without hardened runtime + verify signing
+      # 让 Tauri 在产出 dmg/updater 产物前 ad-hoc 封印 bundle。
+      # runtime 标志必须在打包期就 absence（tauri.conf.json hardenedRuntime:
+      # false）：PyInstaller 运行时解包出的内嵌 dylib 是构建期 ad-hoc 签名
+      # （无团队 ID），hardened runtime 隐含的 library validation 下 dlopen 即
+      # SIGKILL——v2.9.2 macOS「daemon 起不来」的根因。不能打包后重封 sidecar
+      # 补救：改内嵌二进制会破坏外层 CodeResources 封印（deep verify 必红），
+      # 且 updater .app.tar.gz 在 Tauri 打包期已生成，重封晚于归档、包内仍是
+      # 坏字节。本步只验证不修改：sidecar 无 runtime 标志 + bundle 封印 +
+      # 嵌套可执行逐一签名（arm64 内核要求全部可执行代码至少 ad-hoc 签名），
+      # 签名标志显式打印作 CI 证据。
+      - name: Verify macOS code signing (sidecar must have no runtime flag)
         if: runner.os == 'macOS'
         shell: bash
         run: |
@@ -256,15 +260,12 @@ jobs:
           fi
           daemon_bin="$app_path/Contents/MacOS/lambchat-daemon"
           if [ -f "$daemon_bin" ]; then
-            echo "== daemon sidecar signature BEFORE re-seal =="
+            echo "== daemon sidecar signature =="
             codesign -dv --verbose=4 "$daemon_bin" 2>&1 | grep -E "Signature|flags|TeamIdentifier|Identifier=" || true
-            # 无 --options 重封：新签名不带 runtime/LV 标志（flags 归零）
-            codesign --force --sign - --timestamp=none "$daemon_bin"
-            echo "== daemon sidecar signature AFTER re-seal =="
-            codesign -dv --verbose=4 "$daemon_bin" 2>&1 | grep -E "Signature|flags|TeamIdentifier|Identifier=" || true
-            # 门禁：CodeDirectory flags 不得含 runtime (0x10000)
+            # 门禁：CodeDirectory flags 不得含 runtime (0x10000)——应在打包期由
+            # tauri.conf.json 的 hardenedRuntime: false 保证，出现即打包链回归
             if codesign -dv --verbose=4 "$daemon_bin" 2>&1 | grep -E "flags=0x[0-9a-f]*1[0-9a-f]{4}"; then
-              echo "!! daemon sidecar 带 runtime 标志——内嵌解包库会被 library validation 击杀"
+              echo "!! daemon sidecar 带 runtime 标志——检查 tauri.conf.json 的 bundle.macOS.hardenedRuntime 是否为 false"
               exit 1
             fi
           fi
@@ -276,7 +277,7 @@ jobs:
             echo "Verifying nested executable: $bin"
             codesign --verify --verbose=2 "$bin"
           done < <(find "$app_path/Contents/MacOS" -type f -perm -111 -print0)
-          echo "OK: .app sealed (ad-hoc), sidecar re-sealed without runtime, all nested executables signed"
+          echo "OK: .app sealed (ad-hoc, no runtime flag on sidecar), all nested executables signed"
 
       - name: Collect Linux desktop artifacts
         if: runner.os == 'Linux'

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -28,7 +28,8 @@
     "targets": "all",
     "createUpdaterArtifacts": true,
     "macOS": {
-      "signingIdentity": "-"
+      "signingIdentity": "-",
+      "hardenedRuntime": false
     },
     "externalBin": ["binaries/lambchat-daemon"],
     "resources": ["resources/python/"],

--- a/tests/client/test_packaging.py
+++ b/tests/client/test_packaging.py
@@ -319,17 +319,27 @@ def test_tauri_bundle_adhoc_signs_macos_app() -> None:
     assert conf["bundle"]["macOS"]["signingIdentity"] == "-"
 
 
+def test_tauri_bundle_disables_hardened_runtime_for_adhoc_sidecar() -> None:
+    """v2.10.0 发版事故防线：Tauri 默认对全部可执行（含 daemon sidecar）落
+    hardened runtime 标志，而 runtime 隐含 library validation——PyInstaller
+    onefile 运行时解包的内嵌 dylib 是无团队 ID 的 ad-hoc 签名，LV 下 dlopen
+    即 SIGKILL（v2.9.2 macOS「daemon 起不来」根因）。ad-hoc 分发不做公证，
+    runtime 标志只有害处，必须在打包期关闭；打包后重封 sidecar 补救不可行
+    （破坏外层封印，且 updater 归档先于重封生成、包内仍是坏字节）。"""
+    import json
+
+    conf = json.loads(_source("frontend/src-tauri/tauri.conf.json"))
+    assert conf["bundle"]["macOS"]["hardenedRuntime"] is False
+
+
 def test_release_workflow_verifies_macos_code_signing() -> None:
-    """签名门禁（v2.9.2 层2）：macOS 打包后先把 daemon sidecar 无 --options
-    重封（不带 hardened runtime / library validation——PyInstaller 解包出的
-    内嵌库无团队 ID，LV 下 dlopen 即被杀），runtime 标志残留时构建直接失败；
-    再验证 bundle 封印与嵌套可执行签名（arm64 内核要求全部可执行代码至少
-    ad-hoc 签名）。"""
+    """签名门禁（v2.9.2 层2）：macOS 打包后验证 sidecar 无 runtime 标志
+    （打包期由 tauri.conf.json hardenedRuntime: false 保证，出现即打包链
+    回归）、bundle 封印与嵌套可执行逐一签名（arm64 内核要求全部可执行代码
+    至少 ad-hoc 签名）。只验证不修改——改内嵌二进制会破坏外层封印。"""
     steps = {step["name"]: step for step in _desktop_job()["steps"]}
-    verify = steps["Re-seal daemon sidecar without hardened runtime + verify signing"]
+    verify = steps["Verify macOS code signing (sidecar must have no runtime flag)"]
     assert verify["if"] == "runner.os == 'macOS'"
-    # 无 --options 重封：新签名不带 runtime/LV 标志（flags 归零）
-    assert 'codesign --force --sign - --timestamp=none "$daemon_bin"' in verify["run"]
     # 门禁：CodeDirectory flags 含 runtime (0x10000) 即红
     assert "flags=0x[0-9a-f]*1[0-9a-f]{4}" in verify["run"]
     assert "codesign --verify --deep --strict" in verify["run"]


### PR DESCRIPTION
## Summary

v2.10.0 首跑两个 macOS job 挂在「Re-seal daemon sidecar」步骤。根因是 da49b470 的重封方案有两处结构性缺陷：

1. **重封破坏封印**：打包后改 .app 内嵌二进制 → 外层 `_CodeSignature/CodeResources` 失效 → `codesign --verify --deep --strict` 必红（实测 exit 1，重封本身成功 flags 0x10002→0x2，但随后 deep verify 挂）
2. **updater 包仍是坏字节**：Tauri 的 `.app.tar.gz` 在打包期生成、先于重封——就算封印不炸，推给桌面端自更新的包里装的仍是带 runtime 标志的坏 daemon

修复：**打包期就不落 runtime 标志**——`tauri.conf.json` `bundle.macOS.hardenedRuntime: false`（Tauri 默认对全部可执行含 sidecar 落 `--options runtime`；ad-hoc 签名无团队 ID 不做公证，runtime 隐含的 library validation 正是 v2.9.2 macOS「daemon 起不来」根因）。门禁步骤退化为纯验证：sidecar 无 runtime 标志（有即红）+ bundle 封印 + 嵌套可执行逐一签名。

## Changes

- `frontend/src-tauri/tauri.conf.json`：`bundle.macOS.hardenedRuntime: false`
- `.github/workflows/app-release.yml`：重封步骤替换为 `Verify macOS code signing (sidecar must have no runtime flag)`（只验证不修改）
- `tests/client/test_packaging.py`：门禁测试同步 + 新增 `hardenedRuntime is False` 回归锁

## Testing

- [x] `pytest tests/client/test_packaging.py` — 27 passed
- [x] `vitest releasePackagingSource` — 6 passed；ruff check/format 全绿
- [ ] 发版重跑验证：macOS 双架构 job 绿 + packaged daemon smoke 绿（真机验证待装包）