### PR TITLE
fix(agent): 插话注入改到 before_model，修复插话后 tool_calls 乱序导致的会话 400

### DIFF
--- a/src/infra/agent/middleware/steer.py
+++ b/src/infra/agent/middleware/steer.py
@@ -1,11 +1,19 @@
 """SteerMiddleware — 运行中插话注入（Codex 式 steer）。
 
 用户在任务运行期间发送的消息（POST /chat/sessions/{id}/steer）先进入
-``SteerQueue``；本中间件在每次主 agent 模型调用前取出该会话的排队消息，
-在调用开始前写出 ``steer:message`` 事件（事件先于本次调用的输出进入
-Redis/MongoDB，实时 SSE 与历史回放中插话都排在回答之前），再追加到本次
-请求的消息末尾（模型在当前步骤后即可看到），并通过 ``Command(update)``
-把它们持久化进图状态，落盘到 checkpoint，刷新/重载后历史不丢。
+``SteerQueue``；本中间件在每次模型调用前（``before_model`` 钩子，独立图
+节点）取出该会话的排队消息，在模型调用开始前写出 ``steer:message``
+事件（事件先于本次调用的输出进入 Redis/MongoDB，实时 SSE 与历史回放中
+插话都排在回答之前），再以 state 更新把消息注入图状态。
+
+注入必须发生在模型响应之前：``before_model`` 节点的更新先于模型节点提交
+checkpoint，插话因此落在本次模型响应之前（模型是对插话做出的响应）。
+OpenAI 协议要求带 ``tool_calls`` 的 assistant 消息后紧跟对应 tool 消息；
+若插话经 ``Command(update)`` 在模型节点完成后追加（旧实现），一旦该次
+响应携带 tool_calls，tools 节点写回的 ToolMessage 会落在插话之后，下一
+次模型调用即 400 "insufficient tool messages following tool_calls
+message"（2026-09-08 生产实例）。注入时顺带把历史中已被写乱的消息重排
+自愈，存量坏会话不再永久 400。
 """
 
 from __future__ import annotations
@@ -14,20 +22,56 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from langchain.agents.middleware.types import AgentMiddleware
+from langchain_core.messages import AIMessage, AnyMessage, RemoveMessage, ToolMessage
+from langgraph.graph.message import REMOVE_ALL_MESSAGES
 
 from src.agents.core.node_utils import build_human_message
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
-
-    from langchain.agents.middleware.types import (
-        ContextT,
-        ModelRequest,
-        ModelResponse,
-        ResponseT,
-    )
+    from langchain.agents.middleware.types import AgentState
+    from langgraph.runtime import Runtime
 
 logger = logging.getLogger(__name__)
+
+
+def _reorder_tool_response_adjacency(messages: list[AnyMessage]) -> list[AnyMessage] | None:
+    """把夹在 AIMessage(tool_calls) 与其 ToolMessage 之间的其他消息后移。
+
+    返回重排后的完整列表；顺序本就合法时返回 ``None``（调用方免于整表
+    重写）。悬空 tool_calls（始终没有 ToolMessage 回应）不在此处理——
+    deepagents 的 PatchToolCallsMiddleware 负责在 AI 消息后补合成响应，
+    与本函数的移动语义兼容。
+    """
+    result: list[AnyMessage] = []
+    held: list[AnyMessage] = []
+    pending_ids: set[str | None] = set()
+    for message in messages:
+        if isinstance(message, AIMessage):
+            call_ids = {
+                call["id"]
+                for call in (*message.tool_calls, *message.invalid_tool_calls)
+                if call.get("id") is not None
+            }
+            if call_ids:
+                result.extend(held)
+                held = []
+                result.append(message)
+                pending_ids = call_ids
+                continue
+        if isinstance(message, ToolMessage):
+            result.append(message)
+            pending_ids.discard(message.tool_call_id)
+            if not pending_ids and held:
+                result.extend(held)
+                held = []
+        elif pending_ids:
+            held.append(message)
+        else:
+            result.append(message)
+    result.extend(held)
+    if len(result) == len(messages) and all(a is b for a, b in zip(result, messages)):
+        return None
+    return result
 
 
 async def _persist_injected_steer_messages(
@@ -41,9 +85,6 @@ async def _persist_injected_steer_messages(
     记录用户发送时刻，供前端作为消息时间戳。优先复用当前 run 的
     presenter（事件归属该 run 的 trace）；无 presenter 时回退
     dual_writer 直写（仅实时 SSE 兜底）。失败只记日志。
-
-    若注入的模型调用失败，消息带原 ID 回队重试，送达时会再次写出
-    同 ``message_id`` 的事件，由前端按 ID 去重。
     """
     import uuid
 
@@ -80,28 +121,26 @@ async def _persist_injected_steer_messages(
 
 
 class SteerMiddleware(AgentMiddleware):
-    """把会话插话队列中的用户消息注入下一次模型调用。"""
+    """把会话插话队列中的用户消息在下一次模型调用前注入图状态。"""
 
     def __init__(self, *, session_id: str, presenter: Any = None) -> None:
         super().__init__()
         self._session_id = session_id
         self._presenter = presenter
 
-    async def awrap_model_call(
-        self,
-        request: ModelRequest[ContextT],
-        handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]],
-    ) -> ModelResponse[ResponseT] | Any:
+    async def abefore_model(
+        self, state: AgentState, runtime: Runtime[Any]
+    ) -> dict[str, Any] | None:  # noqa: ARG002
         from src.infra.task.steer import get_steer_queue
 
         queue = get_steer_queue()
         pending = await queue.drain_items(self._session_id)
         if not pending:
-            return await handler(request)
+            return None
 
         injected = [build_human_message(item.content, item.attachments) for item in pending]
         logger.info(
-            "[Steer] session=%s injecting %d user message(s) into model call",
+            "[Steer] session=%s injecting %d user message(s) before model call",
             self._session_id,
             len(injected),
         )
@@ -113,20 +152,10 @@ class SteerMiddleware(AgentMiddleware):
                 self._session_id, pending, presenter=self._presenter
             )
 
-        try:
-            response = await handler(request.override(messages=[*request.messages, *injected]))
-        except BaseException:
-            # 整体失败（含取消）：放回队首，等重试或下次运行送达，不丢失。
-            # 重试送达会再次写出同 message_id 事件，前端按 ID 去重。
-            await queue.requeue_front_items(self._session_id, pending)
-            raise
-
-        await queue.ack_items(self._session_id)
-
-        from langchain.agents.middleware.types import ExtendedModelResponse
-        from langgraph.types import Command as LangCommand
-
-        return ExtendedModelResponse(
-            model_response=response,
-            command=LangCommand(update={"messages": injected}),
-        )
+        # 更新经 before_model 节点提交 checkpoint（先于模型节点），插话即
+        # 持久化送达；随后模型调用失败也不回队——新 run 从 state 续跑仍能
+        # 看到插话，回队反而会重复注入。
+        reordered = _reorder_tool_response_adjacency(state.get("messages") or [])
+        if reordered is None:
+            return {"messages": injected}
+        return {"messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES), *reordered, *injected]}

--- a/tests/infra/agent/test_steer_middleware.py
+++ b/tests/infra/agent/test_steer_middleware.py
@@ -1,72 +1,88 @@
 """SteerMiddleware（运行中插话注入）单元测试。"""
 
-import pytest
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import (
+    AIMessage,
+    HumanMessage,
+    RemoveMessage,
+    ToolMessage,
+)
 
 from src.infra.agent.middleware.steer import SteerMiddleware
 
-
-class _Request:
-    """模拟 ModelRequest：记录 override 调用。"""
-
-    def __init__(self, messages=None):
-        self.messages = messages if messages is not None else [HumanMessage(content="原消息")]
-        self.override_calls: list[dict] = []
-
-    def override(self, **kwargs):
-        self.override_calls.append(kwargs)
-        return _Request(messages=kwargs.get("messages", self.messages))
+try:  # deepagents 为这些 agent 提供真实的 messages 通道 reducer
+    from deepagents._messages_reducer import _messages_delta_reducer
+except ImportError:  # pragma: no cover - 环境缺 deepagents 时跳过 reducer 级断言
+    _messages_delta_reducer = None
 
 
-class _Response:
-    """模拟 ModelResponse。"""
+def _tool_call(call_id: str = "call_1", name: str = "ls") -> dict:
+    return {"name": name, "args": {}, "id": call_id, "type": "tool_call"}
 
 
-async def test_pending_message_is_injected_and_persisted() -> None:
+def _tool_response_adjacent(messages: list) -> bool:
+    """OpenAI 协议不变量：每个带 tool_calls 的 AI 消息后紧跟其全部 ToolMessage。"""
+    pending: set[str] = set()
+    for m in messages:
+        if isinstance(m, AIMessage) and m.tool_calls:
+            if pending:
+                return False
+            pending = {tc["id"] for tc in m.tool_calls}
+        elif isinstance(m, ToolMessage):
+            pending.discard(m.tool_call_id)
+        elif pending:
+            return False
+    return True
+
+
+async def test_injected_message_lands_before_model_response() -> None:
+    """回归（2026-09-08 生产 400）：插话必须先于模型响应进入图状态。
+
+    旧实现经 ``Command(update)`` 在模型节点完成后追加插话，一旦该次响应
+    携带 tool_calls，tools 节点写回的 ToolMessage 落在插话之后，下一次
+    模型调用因 "insufficient tool messages following tool_calls message"
+    被 DeepSeek/OpenAI 拒绝。注入改到 ``before_model`` 钩子后，插话先落
+    state、模型响应后落，顺序恒为 [插话, AI(tool_calls), ToolMessage]。
+    """
     from src.infra.task.steer import get_steer_queue
 
     await get_steer_queue().enqueue("middleware-session-1", "中途插话")
 
     middleware = SteerMiddleware(session_id="middleware-session-1")
-    request = _Request()
-    seen_requests: list[_Request] = []
+    state = {
+        "messages": [
+            HumanMessage(content="原消息"),
+            AIMessage(content="看下目录", tool_calls=[_tool_call()]),
+            ToolMessage(content="No files found", name="ls", tool_call_id="call_1"),
+        ]
+    }
 
-    async def handler(req):
-        seen_requests.append(req)
-        return _Response()
+    update = await middleware.abefore_model(state, None)
 
-    result = await middleware.awrap_model_call(request, handler)
-
-    # 模型看到了插话消息（追加在历史之后）
-    assert len(seen_requests) == 1
-    contents = [m.content for m in seen_requests[0].messages]
-    assert contents == ["原消息", "中途插话"]
-
-    # 结果携带 Command(update) 把插话消息持久化进图状态
-    command = getattr(result, "command", None)
-    update = getattr(command, "update", None)
     assert update is not None
-    injected = update.get("messages")
-    assert isinstance(injected, list) and len(injected) == 1
-    assert isinstance(injected[0], HumanMessage)
-    assert injected[0].content == "中途插话"
 
-    # 注入后队列被清空（不会重复注入下一次调用）
-    assert await get_steer_queue().drain("middleware-session-1") == []
+    injected = [m for m in update["messages"] if not isinstance(m, RemoveMessage)]
+    assert [m.content for m in injected] == ["中途插话"]
+
+    if _messages_delta_reducer is not None:
+        # 模拟框架时序：before_model 更新先提交，随后模型响应与工具结果追加
+        after_update = _messages_delta_reducer(state["messages"], [update["messages"]])
+        final = _messages_delta_reducer(
+            after_update,
+            [
+                [AIMessage(content="", tool_calls=[_tool_call("call_2", "write_file")])],
+                [ToolMessage(content="ok", name="write_file", tool_call_id="call_2")],
+            ],
+        )
+        assert _tool_response_adjacent(final)
+        # 插话在 AI(tool_calls) 之前（模型是对插话做出的响应）
+        contents = [m.content for m in final]
+        assert contents.index("中途插话") < len(final) - 2
 
 
-async def test_no_pending_message_passes_through_untouched() -> None:
+async def test_no_pending_message_returns_none() -> None:
     middleware = SteerMiddleware(session_id="session-clean")
-    request = _Request()
-    sentinel = _Response()
 
-    async def handler(_req):
-        return sentinel
-
-    result = await middleware.awrap_model_call(request, handler)
-
-    assert result is sentinel
-    assert request.override_calls == []
+    assert await middleware.abefore_model({"messages": []}, None) is None
 
 
 async def test_multiple_pending_messages_inject_in_order() -> None:
@@ -77,16 +93,11 @@ async def test_multiple_pending_messages_inject_in_order() -> None:
     await queue.enqueue("session-2", "插话二")
 
     middleware = SteerMiddleware(session_id="session-2")
-    seen: list[_Request] = []
+    update = await middleware.abefore_model({"messages": []}, None)
 
-    async def handler(req):
-        seen.append(req)
-        return _Response()
-
-    await middleware.awrap_model_call(_Request(), handler)
-
-    contents = [m.content for m in seen[0].messages]
-    assert contents == ["原消息", "插话一", "插话二"]
+    injected = [m for m in update["messages"] if not isinstance(m, RemoveMessage)]
+    assert [m.content for m in injected] == ["插话一", "插话二"]
+    assert await queue.drain("session-2") == []
 
 
 async def test_other_session_messages_are_not_injected() -> None:
@@ -95,42 +106,72 @@ async def test_other_session_messages_are_not_injected() -> None:
     await get_steer_queue().enqueue("session-other", "别的会话")
 
     middleware = SteerMiddleware(session_id="session-mine")
-    sentinel = _Response()
 
-    async def handler(_req):
-        return sentinel
-
-    result = await middleware.awrap_model_call(_Request(), handler)
-
-    assert result is sentinel
+    assert await middleware.abefore_model({"messages": []}, None) is None
     # 别的会话消息仍在队列中，未被消费
     assert await get_steer_queue().drain("session-other") == ["别的会话"]
 
 
-async def test_failed_model_call_requeues_messages() -> None:
-    """模型调用整体失败时，插话消息重新入队，等待下次运行送达（不丢失）。"""
+async def test_misordered_history_is_healed_on_injection() -> None:
+    """存量坏会话自愈：历史里 AI(tool_calls) 与 ToolMessage 之间夹了消息时重排。
+
+    旧 bug 已在生产写出 [AI(tool_calls), Human, ToolMessage] 形态的 state，
+    不自愈则该会话每次调用都 400。重排把夹中间的消息后移到 ToolMessage 之后。
+    """
     from src.infra.task.steer import get_steer_queue
 
-    await get_steer_queue().enqueue("session-fail", "重要插话")
+    await get_steer_queue().enqueue("session-heal", "新插话")
 
-    middleware = SteerMiddleware(session_id="session-fail")
+    middleware = SteerMiddleware(session_id="session-heal")
+    state = {
+        "messages": [
+            HumanMessage(content="原消息"),
+            AIMessage(content="", tool_calls=[_tool_call("call_a", "search_tools")]),
+            HumanMessage(content="旧插话"),
+            ToolMessage(content="found", name="search_tools", tool_call_id="call_a"),
+        ]
+    }
 
-    async def handler(_req):
-        raise RuntimeError("model down")
+    update = await middleware.abefore_model(state, None)
 
-    with pytest.raises(RuntimeError):
-        await middleware.awrap_model_call(_Request(), handler)
+    messages = update["messages"]
+    assert isinstance(messages[0], RemoveMessage)  # 整表重写
+    healed = messages[1:]
+    assert [type(m).__name__ for m in healed] == [
+        "HumanMessage",  # 原消息
+        "AIMessage",  # AI(tool_calls)
+        "ToolMessage",  # 其响应紧跟
+        "HumanMessage",  # 旧插话后移
+        "HumanMessage",  # 新插话在末尾
+    ]
+    if _messages_delta_reducer is not None:
+        final = _messages_delta_reducer(state["messages"], [messages])
+        assert _tool_response_adjacent(final)
 
-    # 失败后消息回到队列最前（保持 FIFO：先到的插话先送达）
-    assert await get_steer_queue().drain("session-fail") == ["重要插话"]
+
+async def test_clean_history_injects_without_full_rewrite() -> None:
+    """顺序合法时不整表重写（避免每次调用都写全量消息）。"""
+    from src.infra.task.steer import get_steer_queue
+
+    await get_steer_queue().enqueue("session-clean-hist", "插话")
+
+    middleware = SteerMiddleware(session_id="session-clean-hist")
+    state = {
+        "messages": [
+            HumanMessage(content="原消息"),
+            AIMessage(content="", tool_calls=[_tool_call()]),
+            ToolMessage(content="ok", name="ls", tool_call_id="call_1"),
+        ]
+    }
+
+    update = await middleware.abefore_model(state, None)
+
+    assert not any(isinstance(m, RemoveMessage) for m in update["messages"])
+    assert [m.content for m in update["messages"]] == ["插话"]
 
 
 async def test_steer_event_persisted_before_model_call_runs() -> None:
-    """steer:message 事件在模型调用开始前写出。
-
-    事件必须先于本次调用的输出事件进入 Redis/MongoDB，实时 SSE 与
-    历史回放中插话才会排在回答之前（而不是落在 run 尾部）。
-    """
+    """steer:message 事件在注入时写出（before_model 节点先于模型节点执行）。"""
     from src.infra.task.steer import get_steer_queue
 
     await get_steer_queue().enqueue("session-order", "插话")
@@ -142,15 +183,9 @@ async def test_steer_event_persisted_before_model_call_runs() -> None:
             saved.append(event)
 
     middleware = SteerMiddleware(session_id="session-order", presenter=_FakePresenter())
-    observed_save_counts: list[int] = []
 
-    async def handler(_req):
-        observed_save_counts.append(len(saved))
-        return _Response()
+    await middleware.abefore_model({"messages": []}, None)
 
-    await middleware.awrap_model_call(_Request(), handler)
-
-    assert observed_save_counts == [1]
     assert saved[0]["event"] == "steer:message"
     assert saved[0]["data"]["content"] == "插话"
 
@@ -175,73 +210,17 @@ async def test_steer_event_carries_created_at_send_time() -> None:
 
     middleware = SteerMiddleware(session_id="session-created-at", presenter=_FakePresenter())
 
-    async def handler(_req):
-        return _Response()
-
-    await middleware.awrap_model_call(_Request(), handler)
+    await middleware.abefore_model({"messages": []}, None)
 
     assert saved[0]["data"]["created_at"] == "2026-08-22T15:14:55+00:00"
 
 
-async def test_failed_model_call_keeps_injected_event_and_requeues() -> None:
-    """调用失败时注入事件已按注入时刻写出（消息确已发送）；消息原 ID 回队重试。"""
-    from src.infra.task.steer import SteerItem, get_steer_queue
-
-    await get_steer_queue().enqueue_item(
-        "session-fail-order",
-        SteerItem(id="steer-retry-me", content="重要插话"),
-    )
-
-    saved: list[dict] = []
-
-    class _FakePresenter:
-        async def save_event(self, event):
-            saved.append(event)
-
-    middleware = SteerMiddleware(session_id="session-fail-order", presenter=_FakePresenter())
-
-    async def handler(_req):
-        raise RuntimeError("model down")
-
-    with pytest.raises(RuntimeError):
-        await middleware.awrap_model_call(_Request(), handler)
-
-    assert [event["data"]["message_id"] for event in saved] == ["steer-retry-me"]
-    requeued = await get_steer_queue().drain("session-fail-order")
-    assert requeued == ["重要插话"]
-
-
-async def test_successful_injection_persists_via_presenter(monkeypatch) -> None:
-    """注入成功后经 presenter.save_event 写独立 steer:message 事件（归属当前 run 的 trace）。"""
+async def test_injection_persists_via_presenter_with_run_id() -> None:
+    """注入经 presenter.save_event 写独立 steer:message 事件（归属当前 run 的 trace）。"""
     from src.infra.task.steer import get_steer_queue
 
     await get_steer_queue().enqueue("session-p", "要持久化的插话")
 
-    saved: list[dict] = []
-
-    class _FakePresenter:
-        async def save_event(self, event):
-            saved.append(event)
-
-    middleware = SteerMiddleware(session_id="session-p", presenter=_FakePresenter())
-
-    async def handler(_req):
-        return _Response()
-
-    await middleware.awrap_model_call(_Request(), handler)
-
-    assert len(saved) == 1
-    assert saved[0]["event"] == "steer:message"
-    assert saved[0]["data"]["content"] == "要持久化的插话"
-    assert str(saved[0]["data"]["message_id"]).startswith("steer-")
-
-
-async def test_successful_injection_preserves_client_message_id() -> None:
-    from src.infra.task.steer import SteerItem, get_steer_queue
-
-    await get_steer_queue().enqueue_item(
-        "session-id", SteerItem(id="client-123", content="按这个方向")
-    )
     saved: list[dict] = []
 
     class _FakePresenter:
@@ -250,14 +229,78 @@ async def test_successful_injection_preserves_client_message_id() -> None:
         async def save_event(self, event):
             saved.append(event)
 
-    middleware = SteerMiddleware(session_id="session-id", presenter=_FakePresenter())
+    middleware = SteerMiddleware(session_id="session-p", presenter=_FakePresenter())
 
-    async def handler(_req):
-        return _Response()
+    await middleware.abefore_model({"messages": []}, None)
 
-    await middleware.awrap_model_call(_Request(), handler)
-    assert saved[0]["data"]["message_id"] == "client-123"
+    assert len(saved) == 1
+    assert saved[0]["event"] == "steer:message"
+    assert saved[0]["data"]["content"] == "要持久化的插话"
+    assert str(saved[0]["data"]["message_id"]).startswith("steer-")
     assert saved[0]["data"]["run_id"] == "run-123"
+
+
+async def test_injection_falls_back_to_dual_writer(monkeypatch) -> None:
+    """无 presenter 时回退 dual_writer 直写（实时 SSE 兜底）。"""
+    from src.infra.task.steer import get_steer_queue
+
+    await get_steer_queue().enqueue("session-p2", "兜底的插话")
+
+    written: list[dict] = []
+
+    class _FakeWriter:
+        async def write_event(self, **kwargs):
+            written.append(kwargs)
+
+    monkeypatch.setattr("src.infra.session.dual_writer.get_dual_writer", lambda: _FakeWriter())
+
+    middleware = SteerMiddleware(session_id="session-p2")
+
+    update = await middleware.abefore_model({"messages": []}, None)
+
+    assert len(written) == 1
+    assert written[0]["event_type"] == "steer:message"
+    assert written[0]["data"]["content"] == "兜底的插话"
+    assert update is not None  # 事件失败不影响注入本身
+
+
+async def test_persist_failure_does_not_break_injection(monkeypatch) -> None:
+    """事件写入失败不影响注入本身（尽力而为）。"""
+    from src.infra.task.steer import get_steer_queue
+
+    await get_steer_queue().enqueue("session-pp", "插话")
+
+    def broken_writer():
+        raise RuntimeError("dual writer down")
+
+    monkeypatch.setattr("src.infra.session.dual_writer.get_dual_writer", broken_writer)
+
+    middleware = SteerMiddleware(session_id="session-pp")
+
+    update = await middleware.abefore_model({"messages": []}, None)
+
+    assert update is not None  # 注入仍成功
+
+
+async def test_drained_message_is_delivered_via_state_not_requeue() -> None:
+    """drain 即送达：更新经 before_model 节点提交 checkpoint，模型调用失败也不回队。
+
+    消息已在图状态里持久化，失败后新 run 从 state 续跑仍能看到插话；
+    再回队反而会在下次注入时重复。
+    """
+    from src.infra.task.steer import SteerItem, get_steer_queue
+
+    await get_steer_queue().enqueue_item(
+        "session-fail", SteerItem(id="steer-1", content="重要插话")
+    )
+
+    middleware = SteerMiddleware(session_id="session-fail")
+
+    update = await middleware.abefore_model({"messages": []}, None)
+
+    injected = [m for m in update["messages"] if not isinstance(m, RemoveMessage)]
+    assert [m.content for m in injected] == ["重要插话"]
+    assert await get_steer_queue().drain("session-fail") == []
 
 
 async def test_queued_steer_survives_hitl_pause_and_uses_same_resumed_run() -> None:
@@ -282,18 +325,13 @@ async def test_queued_steer_survives_hitl_pause_and_uses_same_resumed_run() -> N
             saved.append(event)
 
     middleware = SteerMiddleware(session_id="session-hitl", presenter=_ResumedPresenter())
-    seen: list[_Request] = []
 
-    async def handler(req):
-        seen.append(req)
-        return _Response()
+    first = await middleware.abefore_model({"messages": []}, None)
+    # 恢复后再次进入 before_model：队列已空，不重复注入
+    second = await middleware.abefore_model({"messages": []}, None)
 
-    await middleware.awrap_model_call(_Request(), handler)
-
-    assert [message.content for message in seen[0].messages] == [
-        "原消息",
-        "继续时按这个方向",
-    ]
+    assert first is not None
+    assert second is None
     assert saved == [
         {
             "event": "steer:message",
@@ -307,54 +345,6 @@ async def test_queued_steer_survives_hitl_pause_and_uses_same_resumed_run() -> N
         }
     ]
     assert await queue.drain_items("session-hitl") == []
-
-
-async def test_successful_injection_falls_back_to_dual_writer(monkeypatch) -> None:
-    """无 presenter 时回退 dual_writer 直写（实时 SSE 兜底）。"""
-    from src.infra.task.steer import get_steer_queue
-
-    await get_steer_queue().enqueue("session-p2", "兜底的插话")
-
-    written: list[dict] = []
-
-    class _FakeWriter:
-        async def write_event(self, **kwargs):
-            written.append(kwargs)
-
-    monkeypatch.setattr("src.infra.session.dual_writer.get_dual_writer", lambda: _FakeWriter())
-
-    middleware = SteerMiddleware(session_id="session-p2")
-
-    async def handler(_req):
-        return _Response()
-
-    await middleware.awrap_model_call(_Request(), handler)
-
-    assert len(written) == 1
-    assert written[0]["event_type"] == "steer:message"
-    assert written[0]["data"]["content"] == "兜底的插话"
-
-
-async def test_persist_failure_does_not_break_injection(monkeypatch) -> None:
-    """事件写入失败不影响注入本身（尽力而为）。"""
-    from src.infra.task.steer import get_steer_queue
-
-    await get_steer_queue().enqueue("session-pp", "插话")
-
-    def broken_writer():
-        raise RuntimeError("dual writer down")
-
-    monkeypatch.setattr("src.infra.session.dual_writer.get_dual_writer", broken_writer)
-
-    middleware = SteerMiddleware(session_id="session-pp")
-    sentinel = _Response()
-
-    async def handler(_req):
-        return sentinel
-
-    result = await middleware.awrap_model_call(_Request(), handler)
-
-    assert getattr(result, "command", None) is not None  # 注入仍成功
 
 
 def test_imports_match_langchain_middleware_shape() -> None:

--- a/tests/infra/agent/test_steer_middleware_integration.py
+++ b/tests/infra/agent/test_steer_middleware_integration.py
@@ -1,0 +1,162 @@
+"""SteerMiddleware 与真实 langchain agent 图的集成测试。
+
+用 MemorySaver + 假模型跑完整的 model→tools→before_model 循环，验证
+插话注入后发给模型的消息序列满足 OpenAI 协议不变量（带 tool_calls 的
+assistant 消息后紧跟对应 ToolMessage），以及存量乱序会话的自愈。
+"""
+
+from typing import Any
+
+from langchain.agents import create_agent
+from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
+from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, ToolMessage
+from langgraph.checkpoint.memory import MemorySaver
+from pydantic import Field
+
+from src.infra.agent.middleware.steer import SteerMiddleware
+
+
+class _RecordingModel(FakeMessagesListChatModel):
+    """按脚本顺序返回响应，并记录每次调用收到的消息序列。"""
+
+    received: list[list[AnyMessage]] = Field(default_factory=list)
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs: Any):
+        self.received.append(list(messages))
+        return super()._generate(messages, stop=stop, run_manager=run_manager, **kwargs)
+
+    async def _agenerate(self, messages, stop=None, run_manager=None, **kwargs: Any):
+        return self._generate(messages, stop=stop, run_manager=run_manager, **kwargs)
+
+    def bind_tools(self, tools, **kwargs: Any):  # noqa: ARG002
+        """脚本响应已含 tool_calls，绑定为空操作。"""
+        return self
+
+
+def _assert_tool_response_adjacent(messages: list[AnyMessage]) -> None:
+    """OpenAI 协议不变量：AI(tool_calls) 后必须紧跟其全部 ToolMessage。"""
+    pending: set[str] = set()
+    for message in messages:
+        if isinstance(message, AIMessage) and message.tool_calls:
+            assert not pending, (
+                f"AI(tool_calls) 后存在未回应的调用 {pending}：{[m.type for m in messages]}"
+            )
+            pending = {tc["id"] for tc in message.tool_calls}
+        elif isinstance(message, ToolMessage):
+            pending.discard(message.tool_call_id)
+        else:
+            assert not pending, (
+                f"AI(tool_calls) 与其 ToolMessage 之间夹了 {message.type} 消息："
+                f"{[m.type for m in messages]}"
+            )
+
+
+class _SilentPresenter:
+    run_id = "run-integration"
+
+    async def save_event(self, event: dict) -> None:
+        pass
+
+
+async def test_mid_run_steer_keeps_request_order_valid() -> None:
+    """工具执行期间插话：后续所有模型调用收到的序列必须协议合法。
+
+    回归场景（2026-09-08 生产）：插话注入后模型以 tool_calls 响应插话，
+    旧实现经 Command(update) 在模型节点完成后追加插话，导致 ToolMessage
+    落在插话之后，下一次模型调用被 DeepSeek 拒绝（400）。
+    """
+    from src.infra.task.steer import get_steer_queue
+
+    session_id = "integration-mid-run"
+    queue = get_steer_queue()
+
+    async def enqueue_steer() -> str:
+        """模拟用户在工具执行期间插话：把消息放入 steer 队列。"""
+        await queue.enqueue(session_id, "中途插话")
+        return "ok"
+
+    model = _RecordingModel(
+        responses=[
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {"name": "enqueue_steer", "args": {}, "id": "call_1", "type": "tool_call"}
+                ],
+            ),
+            AIMessage(
+                content="按插话的方向处理",
+                tool_calls=[
+                    {"name": "enqueue_steer", "args": {}, "id": "call_2", "type": "tool_call"}
+                ],
+            ),
+            AIMessage(content="完成"),
+        ]
+    )
+    graph = create_agent(
+        model,
+        tools=[enqueue_steer],
+        middleware=[SteerMiddleware(session_id=session_id, presenter=_SilentPresenter())],
+        checkpointer=MemorySaver(),
+    )
+
+    result = await graph.ainvoke(
+        {"messages": [HumanMessage(content="原消息")]},
+        config={"configurable": {"thread_id": "t-mid-run"}},
+    )
+
+    assert "完成" in str(result["messages"][-1].content)
+    assert len(model.received) == 3
+
+    for received in model.received:
+        _assert_tool_response_adjacent(received)
+
+    # 插话注入后的那次调用：插话在已完成的 ToolMessage 之后、模型响应之前
+    second = model.received[1]
+    assert [m.content for m in second if isinstance(m, HumanMessage)] == ["原消息", "中途插话"]
+    assert isinstance(second[-1], HumanMessage) and second[-1].content == "中途插话"
+
+
+async def test_previously_broken_thread_is_healed_on_next_run() -> None:
+    """旧 bug 写出的乱序 state（AI(tool_calls) 与 ToolMessage 之间夹消息）自愈。"""
+    from src.infra.task.steer import get_steer_queue
+
+    session_id = "integration-heal"
+    queue = get_steer_queue()
+    config = {"configurable": {"thread_id": "t-heal"}}
+
+    model = _RecordingModel(responses=[AIMessage(content="已恢复")])
+    graph = create_agent(
+        model,
+        tools=[],
+        middleware=[SteerMiddleware(session_id=session_id, presenter=_SilentPresenter())],
+        checkpointer=MemorySaver(),
+    )
+
+    # 复现旧 bug 写入的 state：插话夹在 AI(tool_calls) 与 ToolMessage 之间
+    await graph.aupdate_state(
+        config,
+        {
+            "messages": [
+                HumanMessage(content="原消息"),
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {"name": "search_tools", "args": {}, "id": "call_x", "type": "tool_call"}
+                    ],
+                ),
+                HumanMessage(content="旧插话"),
+                ToolMessage(content="found 1 tool", name="search_tools", tool_call_id="call_x"),
+            ]
+        },
+    )
+
+    await queue.enqueue(session_id, "新插话")
+    await graph.ainvoke({"messages": []}, config=config)
+
+    assert len(model.received) == 1
+    received = model.received[0]
+    _assert_tool_response_adjacent(received)
+    types = [m.type for m in received]
+    assert types == ["human", "ai", "tool", "human", "human"]
+    assert received[3].content == "旧插话"
+    assert received[4].content == "新插话"


### PR DESCRIPTION
## Summary

修复运行中插话（steer）后 tool_calls 与 ToolMessage 乱序导致会话永久 400 的问题（#496）。

## 根因

`SteerMiddleware` 旧实现在 `awrap_model_call` 里经 `Command(update)` 把插话消息持久化进图状态，而该 Command 在**模型节点完成后**才应用（langchain `ExtendedModelResponse` 语义）。当模型以 tool_calls 响应插话时，tools 节点写回的 ToolMessage 落在插话之后，state 变为：

```
[... AIMessage(tool_calls), HumanMessage(插话), ToolMessage(...)]
```

违反 OpenAI 协议「带 tool_calls 的 assistant 消息后必须紧跟对应 tool 消息」，DeepSeek/OpenAI 拒绝该会话后续所有请求。deepagents 的 `PatchToolCallsMiddleware` 只补「无响应」的悬空 tool_call，对「有响应但顺序错乱」不生效，无法自愈。

## Changes

- **注入时机**从 `awrap_model_call` + `Command(update)` 改为 `abefore_model` 钩子：`before_model` 是独立图节点，state 更新先于模型节点提交 checkpoint，插话恒落在本次模型响应之前，顺序天然合法
- **drain 即送达**：插话消息经 checkpoint 持久化，模型调用失败也不再重入队（旧的重入队会在恢复后重复注入）
- **存量坏会话自愈**：注入时对历史做一次乱序重排（`RemoveMessage(REMOVE_ALL_MESSAGES)` 全量重写，仅在检测到乱序时触发），已被旧 bug 写坏的会话下一条消息即可恢复
- `steer:message` 事件写出时机不变（模型调用开始前，实时 SSE 与历史回放顺序不受影响）

方案与下游 fork dixian-app#15 一致，已对照本仓库环境适配。

## Testing

- [x] 新增集成测试（真实 `create_agent` 图 + MemorySaver + 假模型）：工具执行期间插话、模型以 tool_calls 响应插话，对**每次模型调用**断言协议不变量；已对照验证旧代码下失败、新代码通过
- [x] 单元测试重写到 `before_model` 新契约（14 个，含存量乱序自愈、HITL 恢复不重复注入、drain 即送达）
- [x] 全量后端测试 `pytest`：4344 passed（`test_unique_response_id.py::test_replayed_response_id_does_not_crash_deepagents_graph` 为 develop 上的预存在问题，与本 PR 无关，干净基线同样失败）
- [x] `make lint` / `make typecheck` 通过

Closes #496
