### PR TITLE
fix(agent): HITL 审批恢复后 token 用量与工作时长跨分段累计

### DIFF
--- a/frontend/src/components/chat/ChatMessage/__tests__/runStepsCollapseUtils.test.ts
+++ b/frontend/src/components/chat/ChatMessage/__tests__/runStepsCollapseUtils.test.ts
@@ -211,6 +211,29 @@ describe("getRunElapsedMs", () => {
   test("returns null when no timing information exists", () => {
     expect(getRunElapsedMs({ parts: [text("hi")] } as Message)).toBeNull();
   });
+
+  test("heals stale HITL segment duration with the full parts span", () => {
+    // 旧数据：审批分段计时的 duration 只含最后一段（44s），parts 全跨度 5m48s
+    const message = {
+      duration: 44000,
+      parts: [
+        tool("a", "2026-09-08T13:48:29Z", "2026-09-08T13:48:58Z"),
+        tool("b", "2026-09-08T13:53:33Z", "2026-09-08T13:54:17Z"),
+      ],
+    } as unknown as Message;
+    expect(getRunElapsedMs(message)).toBe(348000);
+  });
+
+  test("keeps message.duration when it already covers the parts span", () => {
+    const message = {
+      duration: 350000,
+      parts: [
+        tool("a", "2026-09-08T13:48:29Z", "2026-09-08T13:48:58Z"),
+        tool("b", "2026-09-08T13:53:33Z", "2026-09-08T13:54:17Z"),
+      ],
+    } as unknown as Message;
+    expect(getRunElapsedMs(message)).toBe(350000);
+  });
 });
 
 describe("getRunStartedAtMs", () => {

--- a/frontend/src/components/chat/ChatMessage/runStepsCollapseUtils.ts
+++ b/frontend/src/components/chat/ChatMessage/runStepsCollapseUtils.ts
@@ -126,20 +126,25 @@ function collectPartTimes(part: MessagePart, times: number[]): void {
 /**
  * 计算 run 总时长：优先 message.duration（token:usage / 历史加载写入），
  * 否则用 parts 中最早 startedAt 与最晚 completedAt 推算。
+ * 旧数据里 HITL 分段计时的 duration 只含最后一次审批恢复后的那段，
+ * 与 parts 全跨度取较大值兜底（新数据的 duration 本就是 run 全程墙钟）。
  */
 export function getRunElapsedMs(
   message: Pick<Message, "duration" | "parts">,
 ): number | null {
+  const times: number[] = [];
+  for (const part of message.parts ?? []) collectPartTimes(part, times);
+  const partsSpanMs =
+    times.length >= 2 ? Math.max(...times) - Math.min(...times) : null;
+
   if (typeof message.duration === "number" && message.duration > 0) {
+    if (partsSpanMs !== null && partsSpanMs > message.duration) {
+      return partsSpanMs;
+    }
     return message.duration;
   }
 
-  const times: number[] = [];
-  for (const part of message.parts ?? []) collectPartTimes(part, times);
-  if (times.length === 0) return null;
-
-  const elapsed = Math.max(...times) - Math.min(...times);
-  return elapsed > 0 ? elapsed : null;
+  return partsSpanMs !== null && partsSpanMs > 0 ? partsSpanMs : null;
 }
 
 /**

--- a/src/agents/core/node_utils.py
+++ b/src/agents/core/node_utils.py
@@ -579,6 +579,41 @@ def build_human_message(
     )
 
 
+def resolve_run_usage_carry(
+    hitl_resume: dict | None, *, default_started_at: float
+) -> tuple[float, dict | None]:
+    """HITL 恢复执行沿用原 run 的起点与先前分段的累计用量。
+
+    审批恢复会从节点顶部重新执行 agent_node，本函数从
+    configurable.hitl_resume 还原跨分段锚点：run_started_at 是原 run
+    的墙钟起点（token:usage 的 duration 据此累计，而非每段清零），
+    prior_usage 是先前分段已记的 token 总量（seed 进处理器后，
+    最终事件与 usage_logs 才是全量口径）。非恢复执行或载荷残缺时
+    回退节点入口时间、不带先验用量。
+    """
+    if not isinstance(hitl_resume, dict):
+        return default_started_at, None
+
+    raw_anchor = hitl_resume.get("run_started_at")
+    started_at = raw_anchor if isinstance(raw_anchor, (int, float)) else default_started_at
+
+    prior = hitl_resume.get("prior_usage")
+    if not isinstance(prior, dict):
+        return started_at, None
+    carried = {
+        key: prior[key]
+        for key in (
+            "input_tokens",
+            "output_tokens",
+            "total_tokens",
+            "cache_creation_tokens",
+            "cache_read_tokens",
+        )
+        if isinstance(prior.get(key), int)
+    }
+    return started_at, carried or None
+
+
 async def emit_token_usage(
     event_processor: AgentEventProcessor,
     presenter,

--- a/src/agents/fast_agent/nodes.py
+++ b/src/agents/fast_agent/nodes.py
@@ -23,6 +23,7 @@ from src.agents.core.node_utils import (
     resolve_fallback_model,
     resolve_model_image_url_to_base64,
     resolve_model_supports_vision,
+    resolve_run_usage_carry,
 )
 from src.agents.core.persona import build_persona_prompt_sections
 from src.agents.core.startup_preparation import prepare_agent_inputs
@@ -368,6 +369,11 @@ async def fast_agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict
     hitl_resume = configurable.get("hitl_resume")
     user_input = state.get("input", "")
     recommendation_input = configurable.get("recommendation_input") or user_input
+    # HITL 恢复沿用原 run 的墙钟起点与先前分段累计用量：token:usage 的
+    # duration 与 token 数跨恢复累计，否则只记审批恢复后的最后一段
+    run_started_at, prior_usage = resolve_run_usage_carry(
+        hitl_resume, default_started_at=start_time
+    )
     if hitl_resume is not None:
         from langgraph.types import Command
 
@@ -396,6 +402,8 @@ async def fast_agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict
     # 创建事件处理器（使用 AgentEventProcessor 处理 astream_events）
     logger.info("[FastAgent] Creating AgentEventProcessor")
     event_processor = AgentEventProcessor(presenter, base_url=configurable.get("base_url", ""))
+    if prior_usage is not None:
+        event_processor.seed_usage(prior_usage)
 
     logger.info("[FastAgent] Starting astream_events")
     # 流式处理事件（不重试，直接调用）
@@ -423,7 +431,7 @@ async def fast_agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict
         await emit_token_usage(
             event_processor,
             presenter,
-            start_time,
+            run_started_at,
             model_id=model_id,
             model=selected_model,
         )
@@ -458,6 +466,8 @@ async def fast_agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict
                         "active_goal": active_goal,
                         "recommendation_input": recommendation_input,
                         "goal_started_at": configurable.get("goal_started_at"),
+                        "run_started_at": run_started_at,
+                        "prior_usage": event_processor.usage_totals(),
                     },
                 )
         except Exception as e:

--- a/src/agents/search_agent/nodes.py
+++ b/src/agents/search_agent/nodes.py
@@ -24,6 +24,7 @@ from src.agents.core.node_utils import (
     resolve_fallback_model,
     resolve_model_image_url_to_base64,
     resolve_model_supports_vision,
+    resolve_run_usage_carry,
 )
 from src.agents.core.persona import build_persona_prompt_sections
 from src.agents.core.prompt_policy import sandbox_shell_platform_section
@@ -432,6 +433,11 @@ async def agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict[str,
     # HITL 恢复运行（issue #218）：以 Command(resume=...) 从挂起断点继续，
     # 不注入新的用户消息。
     hitl_resume = configurable.get("hitl_resume")
+    # HITL 恢复沿用原 run 的墙钟起点与先前分段累计用量：token:usage 的
+    # duration 与 token 数跨恢复累计，否则只记审批恢复后的最后一段
+    run_started_at, prior_usage = resolve_run_usage_carry(
+        hitl_resume, default_started_at=start_time
+    )
     if hitl_resume is not None:
         from langgraph.types import Command
 
@@ -466,6 +472,8 @@ async def agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict[str,
             sandbox_backend.before_tool_start if sandbox_backend is not None else None
         ),
     )
+    if prior_usage is not None:
+        event_processor.seed_usage(prior_usage)
 
     logger.info("[SearchAgent] Starting astream_events")
     # 流式处理事件（不重试，直接调用）
@@ -493,7 +501,7 @@ async def agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict[str,
         await emit_token_usage(
             event_processor,
             presenter,
-            start_time,
+            run_started_at,
             model_id=model_id,
             model=selected_model,
         )
@@ -528,6 +536,8 @@ async def agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict[str,
                         "active_goal": active_goal,
                         "recommendation_input": recommendation_input,
                         "goal_started_at": configurable.get("goal_started_at"),
+                        "run_started_at": run_started_at,
+                        "prior_usage": event_processor.usage_totals(),
                     },
                 )
         except Exception as e:

--- a/src/agents/team_agent/nodes.py
+++ b/src/agents/team_agent/nodes.py
@@ -23,6 +23,7 @@ from src.agents.core.node_utils import (
     resolve_fallback_model,
     resolve_model_image_url_to_base64,
     resolve_model_supports_vision,
+    resolve_run_usage_carry,
 )
 from src.agents.core.persona import build_persona_prompt_sections
 from src.agents.core.startup_preparation import prepare_agent_inputs
@@ -854,6 +855,11 @@ async def team_router_node(state: Dict[str, Any], config: RunnableConfig) -> Dic
     # HITL 恢复运行（issue #218）：以 Command(resume=...) 从挂起断点继续，
     # 不注入新的用户消息。
     hitl_resume = configurable.get("hitl_resume")
+    # HITL 恢复沿用原 run 的墙钟起点与先前分段累计用量：token:usage 的
+    # duration 与 token 数跨恢复累计，否则只记审批恢复后的最后一段
+    run_started_at, prior_usage = resolve_run_usage_carry(
+        hitl_resume, default_started_at=start_time
+    )
     if hitl_resume is not None:
         from langgraph.types import Command
 
@@ -878,6 +884,8 @@ async def team_router_node(state: Dict[str, Any], config: RunnableConfig) -> Dic
         subagent_display_names=subagent_display_names,
         subagent_avatars=subagent_avatars,
     )
+    if prior_usage is not None:
+        event_processor.seed_usage(prior_usage)
 
     logger.info("[TeamAgent] Starting astream_events")
     # interrupt 模式在任意 checkpointer（包括进程内 MemorySaver）可用。
@@ -904,7 +912,7 @@ async def team_router_node(state: Dict[str, Any], config: RunnableConfig) -> Dic
         await emit_token_usage(
             event_processor,
             presenter,
-            start_time,
+            run_started_at,
             model_id=model_id,
             model=selected_model,
         )
@@ -939,6 +947,8 @@ async def team_router_node(state: Dict[str, Any], config: RunnableConfig) -> Dic
                         "active_goal": active_goal,
                         "recommendation_input": recommendation_input,
                         "goal_started_at": configurable.get("goal_started_at"),
+                        "run_started_at": run_started_at,
+                        "prior_usage": event_processor.usage_totals(),
                     },
                 )
         except Exception as e:

--- a/src/infra/agent/events/processor.py
+++ b/src/infra/agent/events/processor.py
@@ -135,6 +135,35 @@ class AgentEventProcessor(SubagentEventMixin, StreamEventMixin, ToolEventMixin):
         """Return accumulated top-level assistant output text."""
         return self._output_buffer.getvalue()
 
+    def seed_usage(self, prior_usage: dict | None) -> None:
+        """HITL 恢复：把先前分段的累计用量并入计数器。
+
+        恢复分段重新执行节点时计数器从零开始，不 seed 的话最终
+        token:usage（以及取 last 落库的 usage_logs）只含最后一段。
+        """
+        if not isinstance(prior_usage, dict):
+            return
+        if isinstance(prior_usage.get("input_tokens"), int):
+            self.total_input_tokens += prior_usage["input_tokens"]
+        if isinstance(prior_usage.get("output_tokens"), int):
+            self.total_output_tokens += prior_usage["output_tokens"]
+        if isinstance(prior_usage.get("total_tokens"), int):
+            self.total_tokens += prior_usage["total_tokens"]
+        if isinstance(prior_usage.get("cache_creation_tokens"), int):
+            self.total_cache_creation_tokens += prior_usage["cache_creation_tokens"]
+        if isinstance(prior_usage.get("cache_read_tokens"), int):
+            self.total_cache_read_tokens += prior_usage["cache_read_tokens"]
+
+    def usage_totals(self) -> dict:
+        """当前累计用量快照，用于挂起时写入 resume_context 传给下一段。"""
+        return {
+            "input_tokens": self.total_input_tokens,
+            "output_tokens": self.total_output_tokens,
+            "total_tokens": self.total_tokens,
+            "cache_creation_tokens": self.total_cache_creation_tokens,
+            "cache_read_tokens": self.total_cache_read_tokens,
+        }
+
     async def flush(self) -> None:
         """Flush pending stream chunks without clearing counters or output text."""
         await self._flush_chunk_buffer()

--- a/src/infra/task/hitl.py
+++ b/src/infra/task/hitl.py
@@ -311,6 +311,50 @@ async def wait_for_hitl_resume_activation(
     )
 
 
+def build_hitl_resume_payload(
+    approval: Any,
+    resume_value: Dict[str, Any],
+    *,
+    resume_attempt_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """构建恢复执行的 hitl_resume 载荷。
+
+    resume_context 在挂起时物化进审批 metadata（Mongo，跨副本可靠），
+    其中 run_started_at / prior_usage 让恢复分段沿用原 run 的墙钟起点
+    与先前分段累计用量——否则 token:usage（及取 last 落库的 usage_logs）
+    只记最后一段，工作时长也只剩末段。
+    """
+    approval_metadata = getattr(approval, "metadata", None) or {}
+    resume_context = approval_metadata.get("resume_context") or {}
+    interrupt_id = approval_metadata.get("interrupt_id")
+    sandbox_confirm_message = (
+        str(approval.message) if approval_metadata.get("origin") == "sandbox_confirm" else None
+    )
+    command_resume = {str(interrupt_id): resume_value} if interrupt_id else resume_value
+    return {
+        "approval_id": approval.id,
+        "resume_attempt_id": resume_attempt_id,
+        "resume_value": command_resume,
+        **({"sandbox_confirm_message": sandbox_confirm_message} if sandbox_confirm_message else {}),
+        "goal_started_at": resume_context.get("goal_started_at"),
+        "run_started_at": resume_context.get("run_started_at"),
+        "prior_usage": resume_context.get("prior_usage"),
+        "approval_resolved": {
+            "id": approval.id,
+            "tool_call_id": approval_metadata.get("tool_call_id"),
+            "interrupt_id": interrupt_id,
+            "status": "approved" if resume_value.get("approved") else "rejected",
+            "success": bool(resume_value.get("approved")),
+            "result": {
+                "status": "success" if resume_value.get("approved") else "rejected",
+                "message": ("用户已响应" if resume_value.get("approved") else "用户拒绝了此请求"),
+                "values": resume_value.get("values") or {},
+            },
+            "timestamp": utc_now_iso(),
+        },
+    }
+
+
 async def submit_hitl_resume_run(
     approval: Any,
     resume_value: Dict[str, Any],
@@ -387,38 +431,10 @@ async def submit_hitl_resume_run(
 
         from .manager import get_task_manager
 
-        interrupt_id = approval_metadata.get("interrupt_id")
         resume_context = approval_metadata.get("resume_context") or {}
-        sandbox_confirm_message = (
-            str(approval.message) if approval_metadata.get("origin") == "sandbox_confirm" else None
+        hitl_resume = build_hitl_resume_payload(
+            approval, resume_value, resume_attempt_id=resume_attempt_id
         )
-        command_resume = {str(interrupt_id): resume_value} if interrupt_id else resume_value
-        hitl_resume = {
-            "approval_id": approval.id,
-            "resume_attempt_id": resume_attempt_id,
-            "resume_value": command_resume,
-            **(
-                {"sandbox_confirm_message": sandbox_confirm_message}
-                if sandbox_confirm_message
-                else {}
-            ),
-            "goal_started_at": resume_context.get("goal_started_at"),
-            "approval_resolved": {
-                "id": approval.id,
-                "tool_call_id": approval_metadata.get("tool_call_id"),
-                "interrupt_id": interrupt_id,
-                "status": "approved" if resume_value.get("approved") else "rejected",
-                "success": bool(resume_value.get("approved")),
-                "result": {
-                    "status": "success" if resume_value.get("approved") else "rejected",
-                    "message": (
-                        "用户已响应" if resume_value.get("approved") else "用户拒绝了此请求"
-                    ),
-                    "values": resume_value.get("values") or {},
-                },
-                "timestamp": utc_now_iso(),
-            },
-        }
         manager = get_task_manager()
         common_kwargs: dict[str, Any] = {
             "disabled_tools": metadata.get("disabled_tools") or None,

--- a/tests/agents/core/test_node_utils_usage_carry.py
+++ b/tests/agents/core/test_node_utils_usage_carry.py
@@ -1,0 +1,48 @@
+"""HITL 恢复的 run 用量携带（issue：审批恢复后 token:usage 只记最后一段）。
+
+agent_node 每次恢复都从节点顶部重新执行，计时锚点与 token 计数器随之清零。
+resolve_run_usage_carry 从 configurable.hitl_resume 还原原 run 的起点与
+先前分段的累计用量，让 token:usage 事件跨恢复累计。
+"""
+
+from src.agents.core.node_utils import resolve_run_usage_carry
+
+
+def test_no_hitl_resume_falls_back_to_node_entry_time():
+    started_at, prior_usage = resolve_run_usage_carry(None, default_started_at=123.5)
+    assert started_at == 123.5
+    assert prior_usage is None
+
+
+def test_hitl_resume_carries_run_anchor_and_prior_usage():
+    prior = {
+        "input_tokens": 199581,
+        "output_tokens": 6695,
+        "total_tokens": 206276,
+        "cache_creation_tokens": 10,
+        "cache_read_tokens": 20,
+    }
+    started_at, carried = resolve_run_usage_carry(
+        {"run_started_at": 111.5, "prior_usage": dict(prior)},
+        default_started_at=999.0,
+    )
+    assert started_at == 111.5
+    assert carried == prior
+
+
+def test_malformed_hitl_resume_falls_back_to_defaults():
+    started_at, carried = resolve_run_usage_carry(
+        {"run_started_at": "not-a-number", "prior_usage": "garbage"},
+        default_started_at=42.0,
+    )
+    assert started_at == 42.0
+    assert carried is None
+
+
+def test_partial_hitl_resume_still_restores_anchor():
+    started_at, carried = resolve_run_usage_carry(
+        {"run_started_at": 77.25},
+        default_started_at=42.0,
+    )
+    assert started_at == 77.25
+    assert carried is None

--- a/tests/infra/agent/test_token_usage_carry.py
+++ b/tests/infra/agent/test_token_usage_carry.py
@@ -1,0 +1,89 @@
+"""token:usage 跨 HITL 恢复累计（issue：审批恢复后只记最后一段）。
+
+恢复分段重新执行 agent_node 时，AgentEventProcessor 计数器从零开始，
+先前分段的用量经 seed_usage 并入，emit_token_usage 输出 run 累计值；
+usage_logs 取 trace 最后一个 token:usage，自然拿到全量 token 与费用。
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from src.infra.agent.events.processor import AgentEventProcessor
+from src.infra.writer.present import Presenter
+
+
+def _make_processor(emitted: list[dict]) -> AgentEventProcessor:
+    presenter = MagicMock(spec=Presenter)
+    presenter.emit = AsyncMock(side_effect=lambda e: emitted.append(e))
+    presenter.present_token_usage = MagicMock(
+        side_effect=lambda **kw: {"event": "token:usage", "data": kw}
+    )
+    return AgentEventProcessor(presenter)
+
+
+def test_seed_usage_merges_prior_segment_counters():
+    processor = _make_processor([])
+    processor.seed_usage(
+        {
+            "input_tokens": 1000,
+            "output_tokens": 100,
+            "total_tokens": 1100,
+            "cache_creation_tokens": 3,
+            "cache_read_tokens": 7,
+        }
+    )
+    # 本分段统计到的增量（模拟 process_event 累加）
+    processor.total_input_tokens += 50
+    processor.total_output_tokens += 10
+
+    assert processor.usage_totals() == {
+        "input_tokens": 1050,
+        "output_tokens": 110,
+        "total_tokens": 1100,
+        "cache_creation_tokens": 3,
+        "cache_read_tokens": 7,
+    }
+
+
+def test_seed_usage_ignores_empty_or_malformed_payload():
+    processor = _make_processor([])
+    processor.seed_usage(None)
+    processor.seed_usage({})
+    processor.seed_usage({"input_tokens": "x"})  # type: ignore[dict-item]
+
+    assert processor.usage_totals() == {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "total_tokens": 0,
+        "cache_creation_tokens": 0,
+        "cache_read_tokens": 0,
+    }
+
+
+async def test_emit_token_usage_outputs_cumulative_totals_with_seeded_usage():
+    emitted: list[dict] = []
+    processor = _make_processor(emitted)
+    processor.seed_usage({"input_tokens": 199581, "output_tokens": 6695})
+    processor.total_input_tokens += 60358
+    processor.total_output_tokens += 1063
+
+    ok = await processor.emit_token_usage(duration=349.1)
+
+    assert ok is True
+    assert len(emitted) == 1
+    data = emitted[0]["data"]
+    assert data["input_tokens"] == 259939
+    assert data["output_tokens"] == 7758
+    assert data["total_tokens"] == 267697
+    assert data["duration"] == 349.1
+
+
+async def test_emit_token_usage_emits_with_seeded_usage_even_without_segment_llm_calls():
+    """零 LLM 分段（挂起即恢复）也要刷新累计值，避免终态回退到分段口径。"""
+    emitted: list[dict] = []
+    processor = _make_processor(emitted)
+    processor.seed_usage({"input_tokens": 500, "output_tokens": 5, "total_tokens": 505})
+
+    ok = await processor.emit_token_usage(duration=2.0)
+
+    assert ok is True
+    assert emitted[0]["data"]["total_tokens"] == 505

--- a/tests/infra/task/test_hitl_resume_usage_carry.py
+++ b/tests/infra/task/test_hitl_resume_usage_carry.py
@@ -1,0 +1,47 @@
+"""hitl_resume 载荷携带 run 用量锚点（issue：审批恢复后只记最后一段）。
+
+build_hitl_resume_payload 从审批 metadata.resume_context 还原
+run_started_at / prior_usage，恢复执行据此累计 token 与工作时长。
+"""
+
+from types import SimpleNamespace
+
+from src.infra.task.hitl import build_hitl_resume_payload
+
+
+def _approval(resume_context: dict | None) -> SimpleNamespace:
+    return SimpleNamespace(
+        id="ap1",
+        message="确认执行",
+        metadata={
+            "run_id": "run_20260908134828_3cf0b70a",
+            "trace_id": "trace_1",
+            "interrupt_id": "i1",
+            "tool_call_id": "tc1",
+            "resume_context": resume_context or {},
+        },
+    )
+
+
+def test_payload_carries_run_anchor_and_prior_usage():
+    prior = {"input_tokens": 23478, "output_tokens": 1019, "total_tokens": 24497}
+    payload = build_hitl_resume_payload(
+        _approval({"run_started_at": 1757336908.8, "prior_usage": prior}),
+        {"approved": True},
+    )
+
+    assert payload["run_started_at"] == 1757336908.8
+    assert payload["prior_usage"] == prior
+    # 既有字段保持不变
+    assert payload["approval_id"] == "ap1"
+    assert payload["resume_value"] == {"i1": {"approved": True}}
+    assert payload["approval_resolved"]["status"] == "approved"
+
+
+def test_payload_without_resume_context_keeps_none_carry():
+    payload = build_hitl_resume_payload(_approval(None), {"approved": False})
+
+    assert payload["run_started_at"] is None
+    assert payload["prior_usage"] is None
+    assert payload["goal_started_at"] is None
+    assert payload["approval_resolved"]["status"] == "rejected"


### PR DESCRIPTION
## 问题

带 HITL 审批的 run，前端「已工作 N」只显示**最后一次审批恢复后的那段**，token 用量记录同样只记最后一段。

生产会话实例（trace `…134828805654…`，"写一篇800字的入党申请书 docx"）：
- 整轮墙钟 **5m48s**、7 次审批暂停、实际工作 223s，前端只显示 **44 秒**（= 最后一次恢复 → done 的 44.6s）
- 8 个 `token:usage` 事件各记一段，usage_logs 取最后一条落库：**206k tokens / 8 段只记了最后一段的 61k（少 70%）**，费用同比例少记

## 根因

审批恢复以同 run_id 重新提交执行，从节点顶部重新进入 `agent_node`：
- `start_time = time.time()` 重置 → token:usage 的 duration 只含本段
- `AgentEventProcessor` 计数器新建归零 → token 数只含本段
- 前端 `token:usage` last-write-wins、usage_logs 取 trace 最后一个事件 → 双双只剩最后一段

## 修复

token:usage 事件改为 **run 累计口径**，下游无需改语义：

1. **挂起时存锚点**：agent 挂起时把 run 墙钟起点 `run_started_at` + 累计用量 `prior_usage` 写进审批 `resume_context`（Mongo 持久化，跨副本可靠，复用 `goal_started_at` 的既有传递通道），三节点（search/fast/team）同款接线
2. **恢复时还原**：`resolve_run_usage_carry` 从 `hitl_resume` 还原起点；`AgentEventProcessor.seed_usage` 把先前用量并入计数器；时长按原起点墙钟累计；hitl.py 载荷构建抽为 `build_hitl_resume_payload`
3. **前端治愈旧数据**：`getRunElapsedMs` 取 `max(message.duration, parts 全跨度)`——存量分段计时的会话刷新后即显示完整时长（无审批的普通轮次不受影响）

效果：上述会话显示 44s → **5m48s**；usage_logs 记录 61k → **206k tokens**（费用同步修正）。

## 验证

- TDD：`resolve_run_usage_carry` / processor 累计 / hitl 载荷三组 **13 个新用例**，先红后绿
- 后端：`tests/agents + tests/infra/task + tests/infra/agent` 共 837 测试通过；ruff、mypy（488 文件）全绿
- 前端：全量 2591 测试通过，`pnpm run build` 成功
- 注：`test_replayed_response_id_does_not_crash_deepagents_graph` 在未含本改动的 develop 基线上同样失败，为预存问题，与本 PR 无关

## 备注

历史 usage_logs 未回填（修复只对增量生效）；如需修存量可另做一次性回填脚本（按 trace 汇总多个 token:usage 事件重写对应 usage_log）。