### PR TITLE
fix(prompt): 本地 daemon 会话注入「沙箱=用户本机」身份段

### DIFF
--- a/src/agents/core/prompt_policy.py
+++ b/src/agents/core/prompt_policy.py
@@ -35,9 +35,24 @@ Use this alias only with file tools and uploads. For shell commands, use relativ
 WORKSPACE_POLICY = """### Workspace Boundaries
 Check whether a target exists before creating it. Modify an existing project only when requested or clearly relevant; otherwise use a named directory in the current session workspace."""
 
+#: 本地 daemon 会话的身份段（所有已上报平台共用）：沙箱就是用户自己的真实
+#: 电脑，不是隔离虚拟机。生产会话 26ed193a 实测：linux daemon 不加任何段时，
+#: 模型自认「隔离沙箱、跟用户电脑完全不连通」，当面否认控制能力还反指用户
+#: 可能中了远控木马——而命令实际就跑在用户机器上。
+#: 缓存纪律：本段注入点在文件工具 description 尾部、排在逐会话 {work_dir}
+#: 之后（SandboxWorkspaceMiddleware），跨会话本无共享前缀可失；注入方式
+#: 一律纯尾部追加（见 sandbox_shell_platform_section），存量会话已缓存字节
+#: 零失效，新会话仅首 turn 一次性多 prefill 本段。
+_SANDBOX_LOCAL_MACHINE_IDENTITY = """### Local Machine Sandbox
+
+The sandbox for this session is the user's own real computer (connected via the local desktop daemon), not an isolated virtual machine. Every shell command and file operation executes on the user's actual machine and touches their real files; the daemon may ask the user to confirm each command before it runs.
+- Be honest about this capability: you CAN operate the user's computer through this session. Never claim your environment is isolated from or unconnected to the user's machine.
+- Operate like a careful human operator on someone else's computer: confirm before deleting, overwriting, or modifying anything outside the session workspace, and prefer the session workspace for new files."""
+
 #: win32 本地 daemon 的 shell 方言提示（cmd.exe）。daemon 上报平台经注册表第三段
-#: 查得（win32/linux/darwin），linux 与未上报不加段——云端沙箱与 Linux 本地
-#: 的 prompt 逐字节保持现状，provider 前缀缓存零失效。
+#: 查得（win32/linux/darwin）。身份段对三个平台一律注入；方言段仅 win32/darwin
+#: 需要（POSIX 语法在 Linux daemon 本来就成立）。空串（云端沙箱、daemon 离线、
+#: 旧版未上报）不加任何段——云端 prompt 逐字节保持现状，也绝不错入 Windows 分支。
 _SANDBOX_SHELL_WIN32 = """### Local Machine Shell: Windows (cmd.exe)
 
 The local sandbox is the user's Windows machine; `execute` runs commands through cmd.exe, NOT bash.
@@ -58,13 +73,23 @@ The local sandbox is the user's Mac; `execute` runs commands via /bin/sh (POSIX)
 def sandbox_shell_platform_section(daemon_platform: str) -> str:
     """daemon 上报平台 → 沙箱运行时提示追加段；空串 = 不追加（保持现状）。
 
-    平台串是注册表第三段的归一值（win32/linux/darwin）；空串涵盖云端沙箱、
-    daemon 离线与旧版未上报——一律不加段，绝不错入 Windows 分支。
+    平台串是注册表第三段的归一值（win32/linux/darwin）。三个已上报平台都
+    注入 _SANDBOX_LOCAL_MACHINE_IDENTITY（沙箱=用户本机的身份与谨慎纪律段）；
+    win32/darwin 另需 shell 方言段。
+
+    KV 缓存纪律：方言段字节保持历史原样，身份段一律**尾部追加**——整段文本
+    经 SandboxWorkspaceMiddleware 落在文件工具 description 里、排在逐会话
+    的 {work_dir} 之后，跨会话本就无共享前缀可失；纯追加保证部署时存量
+    会话已缓存的旧字节零失效，新文本只在会话首 turn 一次性多 prefill。
+    空串涵盖云端沙箱、daemon 离线与旧版未上报——一律不加段，云端 prompt
+    逐字节保持现状，也绝不错入 Windows 分支。
     """
     if daemon_platform == "win32":
-        return _SANDBOX_SHELL_WIN32
+        return _SANDBOX_SHELL_WIN32 + "\n\n" + _SANDBOX_LOCAL_MACHINE_IDENTITY
     if daemon_platform == "darwin":
-        return _SANDBOX_SHELL_DARWIN
+        return _SANDBOX_SHELL_DARWIN + "\n\n" + _SANDBOX_LOCAL_MACHINE_IDENTITY
+    if daemon_platform == "linux":
+        return _SANDBOX_LOCAL_MACHINE_IDENTITY
     return ""
 
 

--- a/src/agents/search_agent/nodes.py
+++ b/src/agents/search_agent/nodes.py
@@ -92,13 +92,14 @@ logger = get_logger(__name__)
 async def _build_sandbox_runtime_policy(
     sandbox_backend: Any, sandbox_work_dir: str | None, *, user_id: str
 ) -> str:
-    """沙箱运行时提示段：workspace 策略 + （仅本地 daemon）shell 方言段。
+    """沙箱运行时提示段：workspace 策略 + （仅本地 daemon）本机身份/平台段。
 
-    本地 daemon 在 win32/darwin 上时追加平台段（prompt_policy.sandbox_shell_platform_section），
-    让模型生成 cmd.exe / macOS 兼容命令——否则模型默认 POSIX 语法在 Windows
-    cmd.exe 全军覆没（实测根因之二）。云端沙箱与 Linux/未上报一律不加段，
-    prompt 逐字节保持现状；段文本随会话内 daemon 平台稳定，provider 前缀
-    缓存不受逐 turn 影响。
+    本地 daemon 上报 win32/linux/darwin 任一平台时追加
+    prompt_policy.sandbox_shell_platform_section（「沙箱=用户本机」身份段 +
+    win32/darwin 的 shell 方言段），让模型既知道自己真的在操作用户的电脑，
+    又能生成 cmd.exe / macOS 兼容命令。云端沙箱与未上报一律不加段，prompt
+    逐字节保持现状；段文本随会话内 daemon 平台稳定，provider 前缀缓存不受
+    逐 turn 影响。
     """
     if not sandbox_backend or not sandbox_work_dir:
         return ""

--- a/tests/agents/core/test_prompt_policy.py
+++ b/tests/agents/core/test_prompt_policy.py
@@ -24,12 +24,38 @@ def test_attribution_discipline_reaches_all_main_agents():
         assert any(phrase in section for section in MAIN_AGENT_PROMPT_SECTIONS)
 
 
-def test_shell_platform_section_empty_for_posix_and_unknown():
-    """linux/空串（云端沙箱、未上报、查询失败）不加平台段：prompt 逐字节保持
-    现状，provider 前缀缓存零失效。"""
+def test_shell_platform_section_empty_for_unknown_only():
+    """空串/未知平台（云端沙箱、未上报、查询失败）不加平台段：prompt 逐字节保持
+    现状，provider 前缀缓存零失效，也绝不错入 Windows 方言分支。"""
     assert sandbox_shell_platform_section("") == ""
-    assert sandbox_shell_platform_section("linux") == ""
     assert sandbox_shell_platform_section("winxp") == ""
+
+
+def test_shell_platform_section_linux_injects_local_machine_identity():
+    """linux 本地 daemon 也必须注入「沙箱=用户本机」身份段。
+
+    生产会话 26ed193a 实测：linux daemon 不加段时，模型自认「隔离沙箱、
+    跟用户电脑完全不连通」，当面否认控制能力并反指用户可能中了远控木马
+    ——而命令实际就跑在用户机器上。身份认知正确优先于前缀缓存。"""
+    section = sandbox_shell_platform_section("linux")
+    assert "user's own real computer" in section
+    assert "never claim" in section.lower()
+    # 谨慎操作纪律：真实机器上删改要先确认、新文件优先会话 workspace
+    assert "confirm" in section.lower()
+    assert "session workspace" in section
+
+
+def test_local_machine_identity_reaches_win32_and_darwin():
+    """win32/darwin 的方言段之前只在开头顺带提一句「用户机器」，缺身份与
+    谨慎纪律框架；身份段必须补上，且以纯尾部追加方式——方言段历史字节
+    保持原样（存量会话已缓存前缀零失效），身份段接在最后。"""
+    markers = {"win32": "cmd.exe", "darwin": "macOS"}
+    for platform, marker in markers.items():
+        section = sandbox_shell_platform_section(platform)
+        assert "user's own real computer" in section
+        # 方言段原字节在前的纯追加：分叉点不前移
+        assert section.startswith("### Local Machine Shell:")
+        assert section.index(marker) < section.index("user's own real computer")
 
 
 def test_shell_platform_section_win32_guides_cmdexe_syntax():


### PR DESCRIPTION
## Summary

生产会话 26ed193a（search agent + Linux 本地 daemon）实测：用户问「你能控制我的电脑吗」，Agent 一口咬定「我有一台隔离沙箱，跟你家电脑完全不连通」「我没在控制你的电脑」，甚至建议用户排查远控木马——而它的命令实际就执行在用户的笔记本上。根因：`sandbox_shell_platform_section` 对 linux 返回空串（win32/darwin 才有方言段），Linux 本地 daemon 会话的系统请求里没有任何「沙箱=用户本机」的说明，模型只能按「隔离云沙箱」自说自话。

## Changes

- `src/agents/core/prompt_policy.py`：新增 `_SANDBOX_LOCAL_MACHINE_IDENTITY` 身份段（沙箱即用户真实电脑、如实告知能力边界、谨慎操作纪律）；`sandbox_shell_platform_section` 对 win32/linux/darwin 三个已上报平台统一注入，win32/darwin 的 shell 方言段历史字节保持原样、身份段纯尾部追加。
- `src/agents/search_agent/nodes.py`：`_build_sandbox_runtime_policy` docstring 同步新行为。
- `tests/agents/core/test_prompt_policy.py`：linux 注入身份段、win32/darwin 纯追加（`startswith("### Local Machine Shell:")`）、未知/空平台仍为空串。

## KV 前缀缓存账

身份段落点在文件工具 description、排在逐会话 `{work_dir}`（`/workspace/{session_id}`）之后：跨会话本无共享前缀可失；会话内段文本随 daemon 平台稳定，逐 turn 复用完好；云端沙箱 prompt 逐字节不变。纯尾部追加保证部署瞬间存量 win32/darwin 会话已缓存字节零失效，新本地会话仅首 turn 一次性多 prefill 约 721 字符（≈180 token）。

## Testing

- [x] `uv run pytest tests/agents/`（基于 origin/develop 的干净 worktree，242 passed）
- [x] `ruff check` / `ruff format --check` / `mypy` 通过
- [x] RED→GREEN：先写失败测试（linux 段缺失、win32/darwin 无身份前缀）再实现
