### PR TITLE
fix(frontend): 审批队列对 SSE 整段重放收敛，刷新中 run 不再重现已答复的 ask human 卡

### DIFF
--- a/frontend/src/components/layout/AppContent/ChatAppContent.tsx
+++ b/frontend/src/components/layout/AppContent/ChatAppContent.tsx
@@ -71,6 +71,7 @@ export function ChatAppContent({
     refresh: refreshApprovals,
     respondToApproval,
     addApproval,
+    removeApproval,
     clearApprovals,
     isLoading: approvalLoading,
   } = useApprovals({
@@ -216,6 +217,9 @@ export function ChatAppContent({
     },
     onClearApprovals: (approvalSessionId) => {
       clearApprovals(approvalSessionId);
+    },
+    onApprovalResolved: (approvalId) => {
+      removeApproval(approvalId);
     },
     getEnabledTools: getDisabledToolNames,
     getDisabledSkills: () => sessionConfigRef.current.disabledSkills,

--- a/frontend/src/hooks/useAgent/__tests__/eventHandlers.test.ts
+++ b/frontend/src/hooks/useAgent/__tests__/eventHandlers.test.ts
@@ -149,6 +149,87 @@ test("renders approval_required from the SSE payload when approval lookup is una
   vi.unstubAllGlobals();
 });
 
+test("removes a replayed resolved approval from the interactive queue", () => {
+  const onApprovalResolved = vi.fn();
+  const ctx = createContext(
+    [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        content: "",
+        timestamp: new Date("2026-09-08T01:02:03.456Z"),
+        parts: [
+          {
+            type: "tool",
+            id: "call-1",
+            name: "ask_human",
+            args: { message: "确认在本机执行 1 项操作" },
+            isPending: true,
+          },
+        ],
+        isStreaming: true,
+      },
+    ],
+    null,
+  );
+  ctx.options = { onApprovalResolved };
+
+  handleStreamEvent(
+    {
+      event: "approval_resolved",
+      data: JSON.stringify({
+        id: "approval-1",
+        tool_call_id: "call-1",
+        status: "approved",
+        success: true,
+        result: { status: "success", message: "用户已响应", values: {} },
+      }),
+    },
+    "assistant-1",
+    "approval-resolved-event-1",
+    "2026-09-08T01:02:04.000Z",
+    ctx,
+  );
+
+  // 队列收敛：已答复审批出队（与 approval_required 成对，重放/直播同流）
+  expect(onApprovalResolved).toHaveBeenCalledWith("approval-1");
+  // 部件收尾照常：pill 由 tool_call_id 命中转已批准
+  const part = ctx.messages()[0]?.parts?.[0];
+  expect(part).toMatchObject({ type: "tool", id: "call-1", isPending: false });
+});
+
+test("sandbox confirm approval enqueues the approval without an ask_human pill", () => {
+  const onApprovalRequired = vi.fn();
+  const ctx = createContext([], null);
+  ctx.options = { onApprovalRequired };
+
+  handleStreamEvent(
+    {
+      event: "approval_required",
+      data: JSON.stringify({
+        id: "approval-1",
+        message: "确认在本机执行 1 项操作：1. 执行 ls",
+        type: "confirm",
+        fields: [],
+        origin: "sandbox_confirm",
+        interrupt_id: "intr-1",
+      }),
+    },
+    "assistant-1",
+    "approval-event-sandbox",
+    "2026-09-08T01:02:03.456Z",
+    ctx,
+  );
+
+  // 审批面板照常入队（执行确认的应答入口）
+  expect(onApprovalRequired).toHaveBeenCalledWith(
+    expect.objectContaining({ id: "approval-1" }),
+  );
+  // 不合成 ask_human 工具卡：执行卡（等待确认→结果）已完整表达，
+  // 与历史回放对齐，避免一次执行双卡
+  expect(ctx.messages().length).toBe(0);
+});
+
 test("renders a delivered steer event and removes its optimistic duplicate", () => {
   const timestamp = "2026-04-19T01:02:03.456Z";
   const marked: string[] = [];

--- a/frontend/src/hooks/useAgent/__tests__/messagePartsAskHuman.test.ts
+++ b/frontend/src/hooks/useAgent/__tests__/messagePartsAskHuman.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { clearAllLoadingStates, hasPendingAskHuman } from "../messageParts";
+import {
+  clearAllLoadingStates,
+  hasPendingAskHuman,
+  isSandboxConfirmApprovalEvent,
+} from "../messageParts";
 
 const pendingAskHuman = {
   type: "tool" as const,
@@ -56,6 +60,45 @@ describe("hasPendingAskHuman", () => {
       hasPendingAskHuman([
         { ...pendingAskHuman, isPending: false, success: true },
       ]),
+    ).toBe(false);
+  });
+});
+
+describe("isSandboxConfirmApprovalEvent", () => {
+  it("matches the sandbox_confirm origin marker", () => {
+    expect(
+      isSandboxConfirmApprovalEvent({
+        origin: "sandbox_confirm",
+        message: "任意文案",
+      }),
+    ).toBe(true);
+  });
+
+  it("matches legacy events without origin by the fixed message prefix", () => {
+    expect(
+      isSandboxConfirmApprovalEvent({ message: "确认在本机执行 1 项操作" }),
+    ).toBe(true);
+    expect(
+      isSandboxConfirmApprovalEvent({ message: "确认上传 2 个文件" }),
+    ).toBe(true);
+  });
+
+  it("does not match regular ask_human or scheduled-task approvals", () => {
+    expect(isSandboxConfirmApprovalEvent({ message: "请选择发布渠道" })).toBe(
+      false,
+    );
+    expect(
+      isSandboxConfirmApprovalEvent({
+        origin: "scheduled_task",
+        message: "确认创建定时任务",
+      }),
+    ).toBe(false);
+  });
+
+  it("tolerates non-string payloads", () => {
+    expect(isSandboxConfirmApprovalEvent({})).toBe(false);
+    expect(
+      isSandboxConfirmApprovalEvent({ message: undefined, origin: undefined }),
     ).toBe(false);
   });
 });

--- a/frontend/src/hooks/useAgent/eventHandlers.ts
+++ b/frontend/src/hooks/useAgent/eventHandlers.ts
@@ -19,7 +19,11 @@ import type {
   SubagentStackItem,
   UseAgentOptions,
 } from "./types";
-import { clearAllLoadingStates, createToolPart } from "./messageParts";
+import {
+  clearAllLoadingStates,
+  createToolPart,
+  isSandboxConfirmApprovalEvent,
+} from "./messageParts";
 import { splitAssistantTurn } from "./steerTurnSplit";
 import { convertAttachments, processMessageEvent } from "./eventProcessor";
 import { dispatchToolMutationRefresh } from "../../components/chat/ChatMessage/items/toolMutationEvents";
@@ -385,6 +389,16 @@ export function handleStreamEvent(
       return;
     }
 
+    case "approval_resolved": {
+      // 审批出队与 approval_required 成对（直播/整段重放同一条流）：
+      // 中 run 刷新后 SSE 从头重放全部事件，已答复审批若只入队不出队，
+      // 会以可交互表单的形式整批重现。break 落回部件收尾（pill 转终态）。
+      if (typeof data.id === "string" && data.id) {
+        ctx.options?.onApprovalResolved?.(data.id);
+      }
+      break;
+    }
+
     case "skills:changed": {
       if (ctx.options?.onSkillAdded) {
         const action = (data.action as string) || "updated";
@@ -708,6 +722,11 @@ function appendAskHumanToolPart(
   eventTimestamp: string | undefined,
   ctx: EventHandlerContext,
 ): void {
+  // 沙箱确认门：执行卡（等待确认→结果）+ 审批面板已完整表达，不合成
+  // ask_human 工具卡，与历史回放共用判定（避免一次执行双卡）
+  if (isSandboxConfirmApprovalEvent(data)) {
+    return;
+  }
   const toolCallId = data.tool_call_id || data.id;
   const args = {
     message: data.message || "",

--- a/frontend/src/hooks/useAgent/historyLoader.ts
+++ b/frontend/src/hooks/useAgent/historyLoader.ts
@@ -20,7 +20,11 @@ import type {
   ActiveGoalSpec,
 } from "./types";
 import { convertAttachments, processMessageEvent } from "./eventProcessor";
-import { clearAllLoadingStates, createToolPart } from "./messageParts";
+import {
+  clearAllLoadingStates,
+  createToolPart,
+  isSandboxConfirmApprovalEvent,
+} from "./messageParts";
 import { markInterruptedBySteer } from "./steerTurnSplit";
 import { parseDate } from "../../utils/datetime";
 
@@ -196,18 +200,13 @@ function processHistoryEvent(
     }
     // 沙箱确认门（origin=sandbox_confirm）：执行卡（等待确认→结果）+
     // 审批面板已完整表达，不合成 ask_human 工具卡（避免一次执行双卡）；
-    // 常规审批（ask_human/定时任务）保持合成，历史回放与直播对齐。
+    // 常规审批（ask_human/定时任务）保持合成，历史回放与直播共用判定。
     // approval_required.id is the persisted approval id; resolution events
     // identify the tool part by tool_call_id. Keep the tool part keyed by the
     // latter so historical approvals resolve exactly like live events.
     const toolCallId = approvalData.tool_call_id || approvalData.id;
-    // 旧数据兜底：origin 标记上线前落库的沙箱确认事件，按确认门固定文案
-    // 前缀识别（后端 local.py 硬编码中文，稳定）
-    const isSandboxConfirm =
-      approvalData.origin === "sandbox_confirm" ||
-      /^确认(在本机|上传)/.test(approvalData.message || "");
     if (
-      !isSandboxConfirm &&
+      !isSandboxConfirmApprovalEvent(approvalData) &&
       toolCallId &&
       !currentAssistantMessage.parts?.some(
         (part) => part.type === "tool" && part.id === toolCallId,

--- a/frontend/src/hooks/useAgent/messageParts.ts
+++ b/frontend/src/hooks/useAgent/messageParts.ts
@@ -899,6 +899,22 @@ export function updateToolResultInPartsById(
 // ============================================
 
 /**
+ * 沙箱确认门（origin=sandbox_confirm）审批事件判定：执行卡（等待确认→结果）
+ * + 审批面板已完整表达，不合成 ask_human 工具卡（避免一次执行双卡）。
+ * 直播与历史回放共用；origin 标记缺失的旧数据按确认门固定文案前缀兜底
+ * （后端 local.py 硬编码中文，稳定）。
+ */
+export function isSandboxConfirmApprovalEvent(data: {
+  origin?: unknown;
+  message?: unknown;
+}): boolean {
+  if (data.origin === "sandbox_confirm") return true;
+  return (
+    typeof data.message === "string" && /^确认(在本机|上传)/.test(data.message)
+  );
+}
+
+/**
  * Whether a message still contains an unanswered ask-human interrupt.
  * Ask-human may be nested inside one or more subagent parts.
  */

--- a/frontend/src/hooks/useAgent/types.ts
+++ b/frontend/src/hooks/useAgent/types.ts
@@ -175,6 +175,9 @@ export interface UseAgentOptions {
     timeout?: number;
     metadata?: Record<string, unknown>;
   }) => void;
+  /** 审批终态（approval_resolved）出队：与 onApprovalRequired 成对，
+   *  使审批队列对 SSE 整段重放幂等（刷新中 run 不再重现已答复卡片）。 */
+  onApprovalResolved?: (approvalId: string) => void;
   onClearApprovals?: (sessionId?: string | null) => void;
   getEnabledTools?: () => string[];
   getDisabledSkills?: () => string[];

--- a/frontend/src/hooks/useApprovals.ts
+++ b/frontend/src/hooks/useApprovals.ts
@@ -47,6 +47,19 @@ export function useApprovals({
     });
   }, []);
 
+  // 审批终态出队（approval_resolved 事件）：与 addApproval 成对收敛，
+  // 使队列对 SSE 整段重放幂等——重放中已答复的审批先入队再出队，不残留
+  const removeApproval = useCallback((approvalId: string) => {
+    setApprovals((prev) => {
+      if (!prev.some((a) => a.id === approvalId)) {
+        return prev;
+      }
+      const next = prev.filter((a) => a.id !== approvalId);
+      hasApprovalsRef.current = next.length > 0;
+      return next;
+    });
+  }, []);
+
   // 清除 approvals（用于对话失败时）；传入 sessionId 时只清除该会话的，
   // 避免误清其他会话（如后台等待审批的会话）的待处理审批
   const clearApprovals = useCallback((sessionId?: string | null) => {
@@ -108,6 +121,7 @@ export function useApprovals({
     isLoading,
     respondToApproval,
     addApproval,
+    removeApproval,
     clearApprovals,
     refresh: fetchApprovals,
   };


### PR DESCRIPTION
## 现象

对话进行中（正在等一张沙箱执行确认）刷新页面：本 run 里**已经答复过的确认卡整批重现**为可交互表单（截图底部出现「2 / 5」分页，实际只有 1 张待答复）；对话结束后再刷新，这些卡又全部消失。

## 根因

刷新时 `/events` 对活动 run 走 `active_user_only` 模式（只回 `user:message`），其余事件设计上由 `GET /sessions/{id}/stream` 补齐——而该端点用 `xrange` 从头**整段重放**当前 run 的全部事件。消息内容类事件重放进同一流式气泡可以收敛，但 `approval_required` 是副作用型事件：

1. **只入队、不出队**：直播处理 `handleApprovalRequired → addApproval` 无条件入队（不查审批已持久化的状态），随后重放到达的 `approval_resolved` 只收尾消息 pill，`useApprovals` 队列没有任何路径移除它——只有本机点响应成功 / 出错 / 取消才会清。重放一轮后，已答复审批全部残留为可交互卡片。
2. **直播缺沙箱守卫**：`appendAskHumanToolPart` 没有历史路径已有的沙箱确认判定，重放会为「确认在本机执行」合成多余的「询问用户」工具卡（历史回放按设计跳过，避免一次执行双卡）。

对话结束后刷新恢复正常：run 完成 → 历史走 complete 模式、`stream_run_id` 为空不再触发重放、`/human/pending` 只回真正 pending 的审批。

## 修复（统一收敛，事件驱动幂等）

- `approval_resolved` 与 `approval_required` **成对出队**：新增 `UseAgentOptions.onApprovalResolved` → `useApprovals.removeApproval`，直播与整段重放同一条流，队列状态自然收敛，无需为入队额外查一次状态（保持新审批即时渲染的设计）。
- 沙箱确认判定提取为 `messageParts.isSandboxConfirmApprovalEvent`（origin 标记 + 旧数据文案前缀兜底），**直播与历史回放共用**：沙箱确认只由执行卡 + 审批面板表达，不再合成 ask_human 工具卡。

三处 `approval_resolved` 发射点（hitl 恢复运行 / 封存 / 定时任务）均携带审批 `id`，出队按 id 精确匹配、幂等。

## 验证

- TDD：6 个新测试先行（红灯确认后实现）——出队收敛、沙箱确认入队但不合成 pill、共享判定函数（origin / 旧文案前缀 / 非法载荷）
- `pnpm test`：2595 通过；`pnpm run lint`、`pnpm run build` 绿
- 后端不改：`/stream` 整段重放是刷新追赶的既定机制，本次把消费侧修成幂等；`Last-Event-ID` 断点续传作为后续可选优化