### PR TITLE
fix(agent): 插话 drain 后补 Redis ack，杜绝已送达插话被误报 undelivered

### DIFF
--- a/src/infra/agent/middleware/steer.py
+++ b/src/infra/agent/middleware/steer.py
@@ -152,6 +152,19 @@ class SteerMiddleware(AgentMiddleware):
                 self._session_id, pending, presenter=self._presenter
             )
 
+        # drain 即送达，随之释放 Redis lease 并清 inflight：否则 run 终态的
+        # emit_undelivered_steer_events（list_items 读 pending+inflight）会把
+        # 已送达的插话误报 steer:undelivered，前端补发流程会重复投递。ack
+        # 失败只记日志——注入语义已由下方 state 更新保证，不因清理失败而中断。
+        try:
+            await queue.ack_items(self._session_id)
+        except Exception:
+            logger.warning(
+                "[Steer] session=%s failed to ack drained steer items after injection",
+                self._session_id,
+                exc_info=True,
+            )
+
         # 更新经 before_model 节点提交 checkpoint（先于模型节点），插话即
         # 持久化送达；随后模型调用失败也不回队——新 run 从 state 续跑仍能
         # 看到插话，回队反而会重复注入。

--- a/tests/infra/agent/test_steer_middleware.py
+++ b/tests/infra/agent/test_steer_middleware.py
@@ -170,6 +170,112 @@ async def test_clean_history_injects_without_full_rewrite() -> None:
     assert [m.content for m in update["messages"]] == ["插话"]
 
 
+def _reorder(messages: list) -> list | None:
+    from src.infra.agent.middleware.steer import _reorder_tool_response_adjacency
+
+    return _reorder_tool_response_adjacency(messages)
+
+
+def test_reorder_multi_tool_calls_keep_all_responses_adjacent() -> None:
+    """一条 AI 消息带多个 tool_calls：全部响应必须紧跟其后，夹层消息后移。"""
+    reordered = _reorder(
+        [
+            HumanMessage(content="原消息"),
+            AIMessage(
+                content="",
+                tool_calls=[_tool_call("c1"), _tool_call("c2", "grep")],
+            ),
+            HumanMessage(content="夹层插话"),
+            ToolMessage(content="r1", name="ls", tool_call_id="c1"),
+            ToolMessage(content="r2", name="grep", tool_call_id="c2"),
+        ]
+    )
+
+    assert reordered is not None
+    assert [type(m).__name__ for m in reordered] == [
+        "HumanMessage",
+        "AIMessage",
+        "ToolMessage",
+        "ToolMessage",
+        "HumanMessage",
+    ]
+    assert reordered[4].content == "夹层插话"
+
+
+def test_reorder_holds_messages_between_partial_tool_responses() -> None:
+    """多响应之间也夹了消息：响应聚合完之前不得放行夹层。"""
+    reordered = _reorder(
+        [
+            AIMessage(content="", tool_calls=[_tool_call("c1"), _tool_call("c2", "grep")]),
+            ToolMessage(content="r1", name="ls", tool_call_id="c1"),
+            HumanMessage(content="夹层"),
+            ToolMessage(content="r2", name="grep", tool_call_id="c2"),
+        ]
+    )
+
+    assert reordered is not None
+    assert [type(m).__name__ for m in reordered] == [
+        "AIMessage",
+        "ToolMessage",
+        "ToolMessage",
+        "HumanMessage",
+    ]
+
+
+def test_reorder_dangling_tool_calls_left_untouched() -> None:
+    """悬空 tool_calls（始终无响应）不重排：留给 PatchToolCallsMiddleware 补合成响应。"""
+    messages = [
+        HumanMessage(content="原消息"),
+        AIMessage(content="", tool_calls=[_tool_call("c-never")]),
+        HumanMessage(content="插话A"),
+        AIMessage(content="done"),
+    ]
+
+    assert _reorder(messages) is None
+
+
+def test_reorder_ai_without_tool_calls_does_not_hold() -> None:
+    """无 tool_calls 的 AI 消息不开启响应等待，后续消息顺序原样保留。"""
+    messages = [
+        HumanMessage(content="问题"),
+        AIMessage(content="回答"),
+        HumanMessage(content="追问"),
+        AIMessage(content="", tool_calls=[_tool_call("c9")]),
+        ToolMessage(content="ok", name="ls", tool_call_id="c9"),
+    ]
+
+    assert _reorder(messages) is None
+
+
+def test_reorder_consecutive_broken_pairs_all_healed() -> None:
+    """多处乱序一次全部修复，且原始相对顺序（除后移外）保持稳定。"""
+    reordered = _reorder(
+        [
+            HumanMessage(content="q1"),
+            AIMessage(content="", tool_calls=[_tool_call("a1")]),
+            HumanMessage(content="s1"),
+            ToolMessage(content="r1", name="ls", tool_call_id="a1"),
+            HumanMessage(content="q2"),
+            AIMessage(content="", tool_calls=[_tool_call("a2")]),
+            HumanMessage(content="s2"),
+            ToolMessage(content="r2", name="ls", tool_call_id="a2"),
+        ]
+    )
+
+    assert reordered is not None
+    assert [(type(m).__name__, m.content) for m in reordered] == [
+        ("HumanMessage", "q1"),
+        ("AIMessage", ""),
+        ("ToolMessage", "r1"),
+        ("HumanMessage", "s1"),
+        ("HumanMessage", "q2"),
+        ("AIMessage", ""),
+        ("ToolMessage", "r2"),
+        ("HumanMessage", "s2"),
+    ]
+    assert _tool_response_adjacent(reordered)
+
+
 async def test_steer_event_persisted_before_model_call_runs() -> None:
     """steer:message 事件在注入时写出（before_model 节点先于模型节点执行）。"""
     from src.infra.task.steer import get_steer_queue

--- a/tests/infra/agent/test_steer_middleware_integration.py
+++ b/tests/infra/agent/test_steer_middleware_integration.py
@@ -7,6 +7,7 @@ assistant 消息后紧跟对应 ToolMessage），以及存量乱序会话的自�
 
 from typing import Any
 
+import pytest
 from langchain.agents import create_agent
 from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
 from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, ToolMessage
@@ -160,3 +161,165 @@ async def test_previously_broken_thread_is_healed_on_next_run() -> None:
     assert types == ["human", "ai", "tool", "human", "human"]
     assert received[3].content == "旧插话"
     assert received[4].content == "新插话"
+
+
+async def test_failed_model_call_after_injection_resumes_without_duplicate() -> None:
+    """注入后模型调用失败：新 run 从 state 续跑，插话恰好送达一次。
+
+    before_model 更新已随 checkpoint 提交（drain 即送达），失败后插话仍在
+    图状态里；再次 ainvoke（模拟新 run）不得重复注入、序列仍协议合法。
+    """
+    from src.infra.task.steer import get_steer_queue
+
+    session_id = "integration-fail-resume"
+    queue = get_steer_queue()
+
+    class _FlakyModel(_RecordingModel):
+        """第一次调用抛错，之后恢复正常（模拟模型故障后新 run 恢复）。"""
+
+        fail_first: bool = True
+
+        def _generate(self, messages, stop=None, run_manager=None, **kwargs: Any):
+            if self.fail_first:
+                self.fail_first = False
+                raise RuntimeError("model down")
+            return super()._generate(messages, stop=stop, run_manager=run_manager, **kwargs)
+
+    model = _FlakyModel(
+        responses=[AIMessage(content="恢复完成")],
+    )
+    graph = create_agent(
+        model,
+        tools=[],
+        middleware=[SteerMiddleware(session_id=session_id, presenter=_SilentPresenter())],
+        checkpointer=MemorySaver(),
+    )
+    config = {"configurable": {"thread_id": "t-fail-resume"}}
+
+    # 模拟用户在模型故障前插话，注入成功但模型调用失败
+    await queue.enqueue(session_id, "故障前插话")
+    with pytest.raises(RuntimeError, match="model down"):
+        await graph.ainvoke({"messages": [HumanMessage(content="原消息")]}, config=config)
+
+    # 故障后不回队（drain 即送达），队列视角干净
+    assert await queue.list_items(session_id) == []
+
+    # 新 run 续跑：插话仍在 state，恰好一次；序列协议合法
+    result = await graph.ainvoke({"messages": []}, config=config)
+
+    assert "恢复完成" in str(result["messages"][-1].content)
+    # 故障调用不计入 received（父类只在成功路径记录）；续跑调用恰好一次
+    assert len(model.received) == 1
+    for received in model.received:
+        _assert_tool_response_adjacent(received)
+    humans = [m.content for m in model.received[0] if isinstance(m, HumanMessage)]
+    assert humans == ["原消息", "故障前插话"]
+
+
+async def test_multiple_steers_across_model_calls_each_injected_once() -> None:
+    """两次不同时点的插话，分别注入各自的下一次模型调用，顺序与协议都合法。"""
+    from src.infra.task.steer import get_steer_queue
+
+    session_id = "integration-multi-steer"
+    queue = get_steer_queue()
+
+    async def steer_one() -> str:
+        "用户第一段插话"
+        await queue.enqueue(session_id, "插话一")
+        return "ok"
+
+    async def steer_two() -> str:
+        "用户第二段插话"
+        await queue.enqueue(session_id, "插话二")
+        return "ok"
+
+    model = _RecordingModel(
+        responses=[
+            AIMessage(
+                content="",
+                tool_calls=[{"name": "steer_one", "args": {}, "id": "c1", "type": "tool_call"}],
+            ),
+            AIMessage(
+                content="",
+                tool_calls=[{"name": "steer_two", "args": {}, "id": "c2", "type": "tool_call"}],
+            ),
+            AIMessage(content="两段插话都已处理"),
+        ]
+    )
+    graph = create_agent(
+        model,
+        tools=[steer_one, steer_two],
+        middleware=[SteerMiddleware(session_id=session_id, presenter=_SilentPresenter())],
+        checkpointer=MemorySaver(),
+    )
+
+    result = await graph.ainvoke(
+        {"messages": [HumanMessage(content="原消息")]},
+        config={"configurable": {"thread_id": "t-multi"}},
+    )
+
+    assert "两段插话都已处理" in str(result["messages"][-1].content)
+    assert len(model.received) == 3
+    for received in model.received:
+        _assert_tool_response_adjacent(received)
+        humans = [m.content for m in received if isinstance(m, HumanMessage)]
+        assert humans.count("插话一") <= 1 and humans.count("插话二") <= 1
+    # 第二次调用看到插话一、第三次调用看到插话一+插话二（state 累积）
+    assert [m.content for m in model.received[1] if isinstance(m, HumanMessage)] == [
+        "原消息",
+        "插话一",
+    ]
+    assert [m.content for m in model.received[2] if isinstance(m, HumanMessage)] == [
+        "原消息",
+        "插话一",
+        "插话二",
+    ]
+
+
+async def test_deepagents_graph_mid_run_steer_keeps_protocol() -> None:
+    """生产栈形态（deepagents create_deep_agent，Fast Agent 同款）下的插话回归。
+
+    deepagents 在 langchain create_agent 外再包了 filesystem/subagents 等
+    中间件与自带的 messages reducer；插话注入与乱序自愈必须在该栈下同样
+    成立（协议不变量 + 插话先于响应）。
+    """
+    from deepagents import create_deep_agent
+
+    from src.infra.task.steer import get_steer_queue
+
+    session_id = "integration-deepagents"
+    queue = get_steer_queue()
+
+    async def enqueue_steer() -> str:
+        "用户在工具执行期间插话"
+        await queue.enqueue(session_id, "deepagents 栈下的插话")
+        return "ok"
+
+    model = _RecordingModel(
+        responses=[
+            AIMessage(
+                content="",
+                tool_calls=[{"name": "enqueue_steer", "args": {}, "id": "d1", "type": "tool_call"}],
+            ),
+            AIMessage(content="deepagents 栈处理完成"),
+        ]
+    )
+    graph = create_deep_agent(
+        model,
+        [enqueue_steer],
+        system_prompt="You are a test agent.",
+        middleware=[SteerMiddleware(session_id=session_id, presenter=_SilentPresenter())],
+        checkpointer=MemorySaver(),
+    )
+
+    result = await graph.ainvoke(
+        {"messages": [HumanMessage(content="原消息")]},
+        config={"configurable": {"thread_id": "t-deepagents"}},
+    )
+
+    assert "deepagents 栈处理完成" in str(result["messages"][-1].content)
+    assert len(model.received) == 2
+    for received in model.received:
+        _assert_tool_response_adjacent(received)
+    humans = [m.content for m in model.received[1] if isinstance(m, HumanMessage)]
+    assert humans == ["原消息", "deepagents 栈下的插话"]

--- a/tests/infra/agent/test_steer_redis_integration.py
+++ b/tests/infra/agent/test_steer_redis_integration.py
@@ -1,0 +1,127 @@
+"""SteerMiddleware + SteerQueue 真 Redis 集成测试。
+
+复现生产部署形态（Redis 队列多 worker 共享）：验证「drain 即送达」在
+Redis 路径上的完整不变量——注入后队列视角必须干净（pending/inflight
+清空），否则 run 终态的 ``emit_undelivered_steer_events`` 会把已送达的
+插话误报为 ``steer:undelivered``，前端补发流程会把同一条消息再发一次
+（用户看到重复消息）。
+
+本机/CI 无 Redis 时自动跳过（非静默：标记 skip 留痕）。
+"""
+
+from uuid import uuid4
+
+import pytest
+
+from src.infra.agent.middleware.steer import SteerMiddleware
+from src.infra.task.steer import SteerItem, SteerQueue, emit_undelivered_steer_events
+
+
+def _redis_available() -> bool:
+    import asyncio
+
+    async def _probe() -> bool:
+        try:
+            from src.infra.storage.redis import create_redis_client
+
+            client = create_redis_client()
+            try:
+                return bool(await client.ping())
+            finally:
+                await client.aclose()
+        except Exception:
+            return False
+
+    try:
+        return asyncio.run(_probe())
+    except RuntimeError:
+        return False
+
+
+redis_required = pytest.mark.skipif(not _redis_available(), reason="local Redis unreachable")
+
+
+class _RecordingPresenter:
+    run_id = "run-redis-integration"
+
+    def __init__(self) -> None:
+        self.saved: list[dict] = []
+
+    async def save_event(self, event: dict) -> None:
+        self.saved.append(event)
+
+
+@pytest.fixture
+async def redis_queue(monkeypatch):
+    """真 Redis 队列 + 会话级隔离 + 用后清理。
+
+    conftest 的 autouse fixture 会把队列单例换成进程内实现；这里重新把
+    ``get_steer_queue`` 单例绑回真 Redis 队列，中间件 drain/ack 才走
+    Redis 路径（生产部署形态），结束后还原。
+    """
+    import src.infra.task.steer as steer_module
+
+    queue = SteerQueue()
+    session_id = f"steer-redis-test-{uuid4().hex[:8]}"
+    previous = steer_module._steer_queue
+    steer_module._steer_queue = queue
+    try:
+        yield queue, session_id
+    finally:
+        steer_module._steer_queue = previous
+        await queue.clear_session(session_id)
+
+
+@redis_required
+async def test_injected_steer_is_not_reported_undelivered_at_run_end(redis_queue) -> None:
+    """注入成功的插话在 run 终态不得被误报 steer:undelivered（前端会补发导致重复）。"""
+    queue, session_id = redis_queue
+    await queue.enqueue_item(session_id, SteerItem(id="steer-delivered", content="已送达的插话"))
+
+    middleware = SteerMiddleware(session_id=session_id, presenter=_RecordingPresenter())
+    update = await middleware.abefore_model({"messages": []}, None)
+    assert update is not None  # 注入成功
+
+    # executor 终态路径：列出残留插话并写 steer:undelivered
+    presenter = _RecordingPresenter()
+    written = await emit_undelivered_steer_events(
+        session_id, run_id="run-end", presenter=presenter, queue=queue
+    )
+
+    assert written == 0, f"已送达插话被误报 undelivered：{presenter.saved}"
+    assert presenter.saved == []
+    # 队列视角必须干净（list_items 读 pending+inflight，被 enqueue 幂等与补发流程依赖）
+    assert await queue.list_items(session_id) == []
+
+
+@redis_required
+async def test_injected_steer_survives_across_queue_instances(redis_queue) -> None:
+    """多 worker 形态：drain 后另起队列实例，inflight/lease 不得残留。"""
+    queue, session_id = redis_queue
+    await queue.enqueue_item(session_id, SteerItem(id="steer-cross", content="跨实例插话"))
+
+    middleware = SteerMiddleware(session_id=session_id)
+    assert await middleware.abefore_model({"messages": []}, None) is not None
+
+    # 模拟另一个 worker / 进程重启后的队列实例
+    other = SteerQueue()
+    try:
+        assert await other.list_items(session_id) == []
+    finally:
+        await other.clear_session(session_id)
+
+
+@redis_required
+async def test_never_injected_steer_is_still_reported_undelivered(redis_queue) -> None:
+    """对照：未被注入的插话仍照常落 steer:undelivered（不丢消息语义不变）。"""
+    queue, session_id = redis_queue
+    await queue.enqueue_item(session_id, SteerItem(id="steer-pending", content="未注入的插话"))
+
+    presenter = _RecordingPresenter()
+    written = await emit_undelivered_steer_events(
+        session_id, run_id="run-pending", presenter=presenter, queue=queue
+    )
+
+    assert written == 1
+    assert presenter.saved[0]["event"] == "steer:undelivered"
+    assert presenter.saved[0]["data"]["message_id"] == "steer-pending"


### PR DESCRIPTION
## Summary

PR #497 的后续本地深测发现并修复一个 Redis 部署形态下的回归：已送达的插话会在 run 终态被误报 `steer:undelivered`，前端补发流程把同一条消息再发一次，用户看到重复消息。同时大幅扩充了插话链路的本地测试覆盖。

## 问题

#497 把插话注入改为 `abefore_model` + drain 即送达后，移除了旧的 ack 调用。但 Redis 路径上 `drain_items` 会把队列 RENAME 到 inflight 键并持有 lease，而 run 终态 executor 调 `emit_undelivered_steer_events` → `list_items`（读 **pending+inflight**）扫描残留插话：

```
已送达插话残留 inflight（lease 1h / 下次 run 才清）
  → run 终态误写 steer:undelivered
  → 前端补发流程按 message_id 取消并重发为普通消息
  → 插话内容在会话里出现两次
```

进程内队列（本地开发/单测）没有 inflight 键，不受影响——只有真 Redis 链路能复现，已用本机 Redis 实测复现（回退本 PR 补丁时测试红、打上后绿）。

## Changes

- `abefore_model` 注入后立即 `ack_items`（best-effort：失败只记日志，注入语义由 state 更新保证），恢复「队列视角干净 ⟺ 无待投递」不变量
- 新增真 Redis 集成测试 `test_steer_redis_integration.py`（本机/CI 无 Redis 自动 skip，CI 的 Backend Tests 自带 redis:7-alpine 服务）：
  - 注入后 `list_items` 为空、run 终态 0 个 undelivered 事件
  - 跨队列实例（模拟多 worker）无 inflight 残留
  - 对照：未注入插话照常报 undelivered（不丢消息语义不变）

## 新增测试覆盖（本地深测）

- 图级（langchain `create_agent` + MemorySaver + 假模型）：
  - 注入后模型调用失败 → 新 run 从 state 续跑，插话恰好送达一次、协议合法
  - 两次不同时点的插话，各自注入下一次模型调用，无重复
- 图级（deepagents `create_deep_agent`，Fast Agent 同款生产栈）：插话回归协议不变量
- 重排自愈边界用例：一条 AI 多个 tool_calls、部分响应之间夹层、悬空 tool_calls 不动（留给 PatchToolCallsMiddleware）、无 tool_calls 的 AI 不开启等待、多处乱序一次全修

## Testing

- [x] RED→GREEN：回退 ack 补丁时真 Redis 测试复现误报（写出 `steer:undelivered`、inflight 跨实例残留），打上后全绿
- [x] 插话相关 27 个测试全过；全量后端 pytest 4356 passed / 0 failed
- [x] ruff / ruff format / mypy 通过
