### PR TITLE
perf(task): HITL resume 提速——arq 拾取 0.1s 轮询、retry 免 2s 空等、respond 抢跑宽限

### DIFF
--- a/src/infra/task/arq_runtime.py
+++ b/src/infra/task/arq_runtime.py
@@ -62,6 +62,7 @@ class EmbeddedArqRuntime:
             handle_signals=False,
             max_jobs=settings.ARQ_WORKER_MAX_JOBS,
             job_timeout=settings.ARQ_JOB_TIMEOUT_SECONDS,
+            poll_delay=settings.ARQ_POLL_DELAY_SECONDS,
             ctx={
                 "payload_store": TaskArqPayloadStore(),
                 "search_index_payload_store": UserMessageSearchIndexPayloadStore(),

--- a/src/infra/task/hitl.py
+++ b/src/infra/task/hitl.py
@@ -29,6 +29,18 @@ HITL_RESUME_LOCK_TTL_SECONDS = 300
 HITL_SOURCE_RELEASE_PREFIX = "hitl:source-released:"
 HITL_SOURCE_RELEASE_TTL_SECONDS = 300
 HITL_RESUME_ACTIVATION_PREFIX = "hitl:resume-activated:"
+# respond 抢跑兜底：审批卡 SSE 早于 WAITING_HUMAN 状态翻转可见（审批物化在
+# 挂起检测处、状态更新在源 run 收尾），源 run 仍在飞行中时短暂等待翻转。
+HITL_WAITING_HUMAN_GRACE_SECONDS = 3.0
+HITL_WAITING_HUMAN_POLL_INTERVAL = 0.05
+_HITL_INFLIGHT_STATUSES = frozenset(
+    {
+        TaskStatus.QUEUED.value,
+        TaskStatus.PENDING.value,
+        TaskStatus.STARTING.value,
+        TaskStatus.RUNNING.value,
+    }
+)
 
 
 def hitl_interrupt_mode_enabled() -> bool:
@@ -289,14 +301,18 @@ async def wait_for_hitl_resume_activation(
     attempt_id: str,
     timeout: float = 2.0,
 ) -> bool:
-    """Wait for activation, then use one Mongo point read as crash fallback."""
+    """Wait for activation, then use one Mongo point read as crash fallback.
+
+    激活 key 命中后不删除（TTL 统一清理）：job 可能因 source fence 未释放
+    或并发槽占满走 Retry(defer=1) 重跑，重跑时再次等待必须立即命中——
+    否则每轮 retry 都空轮询满 timeout 才落 Mongo 兜底，白烧数秒。
+    """
     redis = get_redis_client()
     key = f"{HITL_RESUME_ACTIVATION_PREFIX}{attempt_id}"
     loop = asyncio.get_running_loop()
     deadline = loop.time() + timeout
     while loop.time() < deadline:
         if await redis.get(key) is not None:
-            await redis.delete(key)
             return True
         await asyncio.sleep(0.02)
 
@@ -309,6 +325,37 @@ async def wait_for_hitl_resume_activation(
         and getattr(approval, "status", "pending") != "pending"
         and metadata.get("resume_attempt_id") == attempt_id
     )
+
+
+async def _await_waiting_human(
+    session_storage: Any,
+    session_id: str,
+    *,
+    source_run_id: str,
+    initial: Dict[str, Any],
+) -> Dict[str, Any]:
+    """respond 抢跑竞态兜底：源 run 仍在飞行中（挂起后状态尚未翻转到
+    WAITING_HUMAN）时短暂等待翻转；状态漂移或超时立即返回最新 metadata，
+    交由调用方按非等待状态拒绝。仅当 current_run_id 仍指向源 run 才等待，
+    避免给无关运行的状态轮询买单。"""
+    metadata = initial
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + HITL_WAITING_HUMAN_GRACE_SECONDS
+    while True:
+        if metadata.get("task_status") == TaskStatus.WAITING_HUMAN.value:
+            return metadata
+        current_run_id = str(metadata.get("current_run_id") or "")
+        source_in_flight = (
+            bool(source_run_id)
+            and current_run_id == source_run_id
+            and metadata.get("task_status") in _HITL_INFLIGHT_STATUSES
+        )
+        if not source_in_flight or loop.time() >= deadline:
+            return metadata
+        await asyncio.sleep(HITL_WAITING_HUMAN_POLL_INTERVAL)
+        session = await session_storage.get_by_session_id(session_id)
+        if session is not None:
+            metadata = getattr(session, "metadata", None) or {}
 
 
 async def submit_hitl_resume_run(
@@ -350,7 +397,15 @@ async def submit_hitl_resume_run(
             return {"submitted": False, "run_id": None, "message": "会话不存在"}
         if not getattr(session, "user_id", None):
             return {"submitted": False, "run_id": None, "message": "会话缺少用户信息"}
-        metadata = getattr(session, "metadata", None) or {}
+        approval_metadata = getattr(approval, "metadata", None) or {}
+        source_run_id = str(approval_metadata.get("run_id") or "")
+        source_trace_id = str(approval_metadata.get("trace_id") or "")
+        metadata = await _await_waiting_human(
+            session_storage,
+            session_id,
+            source_run_id=source_run_id,
+            initial=getattr(session, "metadata", None) or {},
+        )
         if metadata.get("task_status") != TaskStatus.WAITING_HUMAN.value:
             return {
                 "submitted": False,
@@ -358,9 +413,6 @@ async def submit_hitl_resume_run(
                 "message": "会话不在等待人工输入状态，跳过恢复",
             }
 
-        approval_metadata = getattr(approval, "metadata", None) or {}
-        source_run_id = str(approval_metadata.get("run_id") or "")
-        source_trace_id = str(approval_metadata.get("trace_id") or "")
         current_run_id = str(metadata.get("current_run_id") or "")
         if not source_run_id or (current_run_id and current_run_id != source_run_id):
             return {

--- a/src/kernel/config/_definitions_infra.py
+++ b/src/kernel/config/_definitions_infra.py
@@ -128,6 +128,15 @@ INFRA_SETTING_DEFINITIONS: dict[str, dict] = {
         "default": 86400,
         "depends_on": {"key": "TASK_BACKEND", "value": "arq"},
     },
+    "ARQ_POLL_DELAY_SECONDS": {
+        "type": SettingType.NUMBER,
+        "category": SettingCategory.REDIS,
+        "subcategory": "task",
+        "description": "settingDesc.ARQ_POLL_DELAY_SECONDS",
+        "default": 0.1,
+        "depends_on": {"key": "TASK_BACKEND", "value": "arq"},
+        "frontend_visible": False,
+    },
     "TASK_STARTUP_CLEANUP_CONCURRENCY": {
         "type": SettingType.NUMBER,
         "category": SettingCategory.REDIS,

--- a/src/kernel/config/base.py
+++ b/src/kernel/config/base.py
@@ -147,6 +147,9 @@ class Settings(BaseSettings):
     ARQ_QUEUE_NAME: str = "lambchat:arq"
     ARQ_WORKER_MAX_JOBS: int = 128
     ARQ_JOB_TIMEOUT_SECONDS: int = 86400
+    # arq 取任务轮询间隔（秒）：arq 默认 0.5s 轮询 sorted-set（非阻塞弹出），
+    # 平均吃掉 ~0.25s 派发延迟；缩短以压低 HITL resume 等即时任务的拾取时延。
+    ARQ_POLL_DELAY_SECONDS: float = 0.1
     TASK_STARTUP_CLEANUP_CONCURRENCY: int = 16
     # 周期孤儿接管间隔：缩短实例死亡后对话自动恢复的停顿（心跳按龄判死 + 扫描间隔）
     TASK_ORPHAN_RECOVERY_INTERVAL_SECONDS: int = 15

--- a/tests/infra/task/test_arq_runtime.py
+++ b/tests/infra/task/test_arq_runtime.py
@@ -48,6 +48,7 @@ async def test_start_embedded_arq_worker_runs_with_signals_disabled(
         ARQ_EMBEDDED_WORKER=True,
         ARQ_WORKER_MAX_JOBS=128,
         ARQ_JOB_TIMEOUT_SECONDS=30,
+        ARQ_POLL_DELAY_SECONDS=0.1,
         ARQ_QUEUE_NAME="lambchat:arq",
         REDIS_URL="redis://localhost:6379/0",
         REDIS_PASSWORD=None,
@@ -74,6 +75,23 @@ async def test_start_embedded_arq_worker_runs_with_signals_disabled(
 
 
 @pytest.mark.asyncio
+async def test_worker_polls_queue_at_configured_fast_delay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """取任务轮询间隔来自设置（默认 0.1s）：arq 默认 0.5s 轮询直接吃掉恢复时延。"""
+    _FakeWorker.instances.clear()
+    monkeypatch.setattr(arq_runtime, "settings", _arq_settings())
+
+    runtime = arq_runtime.EmbeddedArqRuntime(worker_factory=_FakeWorker)
+    await runtime.start()
+
+    worker = _FakeWorker.instances[0]
+    assert worker.kwargs["poll_delay"] == 0.1
+
+    await runtime.stop()
+
+
+@pytest.mark.asyncio
 async def test_start_embedded_arq_worker_accepts_future_returned_by_async_run(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -95,6 +113,7 @@ async def test_start_embedded_arq_worker_accepts_future_returned_by_async_run(
         ARQ_EMBEDDED_WORKER=True,
         ARQ_WORKER_MAX_JOBS=128,
         ARQ_JOB_TIMEOUT_SECONDS=30,
+        ARQ_POLL_DELAY_SECONDS=0.1,
         ARQ_QUEUE_NAME="lambchat:arq",
         REDIS_URL="redis://localhost:6379/0",
         REDIS_PASSWORD=None,
@@ -135,6 +154,7 @@ async def test_stop_embedded_arq_worker_awaits_future_returned_by_close(
         ARQ_EMBEDDED_WORKER=True,
         ARQ_WORKER_MAX_JOBS=128,
         ARQ_JOB_TIMEOUT_SECONDS=30,
+        ARQ_POLL_DELAY_SECONDS=0.1,
         ARQ_QUEUE_NAME="lambchat:arq",
         REDIS_URL="redis://localhost:6379/0",
         REDIS_PASSWORD=None,
@@ -173,6 +193,7 @@ def _arq_settings() -> SimpleNamespace:
         ARQ_EMBEDDED_WORKER=True,
         ARQ_WORKER_MAX_JOBS=128,
         ARQ_JOB_TIMEOUT_SECONDS=30,
+        ARQ_POLL_DELAY_SECONDS=0.1,
         ARQ_QUEUE_NAME="lambchat:arq",
         REDIS_URL="redis://localhost:6379/0",
         REDIS_PASSWORD=None,

--- a/tests/infra/task/test_hitl_resume.py
+++ b/tests/infra/task/test_hitl_resume.py
@@ -42,6 +42,13 @@ class _FakeRedis:
         released = self.store.pop(key, None) == token
         return _maybe_await(int(released))
 
+    def get(self, key):
+        return _maybe_await(self.store.get(key))
+
+    def delete(self, key):
+        self.store.pop(key, None)
+        return _maybe_await(1)
+
 
 def _maybe_await(value):
     import asyncio
@@ -205,6 +212,28 @@ async def test_resume_activation_mongo_fallback_requires_exact_terminal_attempt(
 
 
 @pytest.mark.asyncio
+async def test_resume_activation_key_survives_read_for_fast_retry(monkeypatch) -> None:
+    """激活 key 读取后必须保留（TTL 清理）：job 因 source fence / 并发槽
+    Retry 重跑时再次等待要立即命中，不得空轮询满 timeout 才落 Mongo 兜底。"""
+    redis = _FakeRedis()
+    key = f"{hitl_mod.HITL_RESUME_ACTIVATION_PREFIX}attempt-1"
+    redis.store[key] = "approval-1"
+    monkeypatch.setattr(hitl_mod, "get_redis_client", lambda: redis)
+    storage = SimpleNamespace(
+        get=AsyncMock(return_value=SimpleNamespace(status="approved", metadata={}))
+    )
+    monkeypatch.setattr("src.infra.storage.mongodb.get_approval_storage", lambda: storage)
+
+    first = await hitl_mod.wait_for_hitl_resume_activation("approval-1", "attempt-1", timeout=0.1)
+    second = await hitl_mod.wait_for_hitl_resume_activation("approval-1", "attempt-1", timeout=0.1)
+
+    assert first is True
+    assert second is True
+    assert key in redis.store
+    storage.get.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_submit_resume_skips_when_not_waiting_human(fake_redis, monkeypatch):
     monkeypatch.setattr(hitl_mod.settings, "HITL_MODE", "interrupt", raising=False)
 
@@ -220,6 +249,53 @@ async def test_submit_resume_skips_when_not_waiting_human(fake_redis, monkeypatc
     result = await submit_hitl_resume_run(_approval(), {"approved": True, "values": {}})
     assert result["submitted"] is False
     assert "等待" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_submit_resume_waits_briefly_when_source_run_still_inflight(fake_redis, monkeypatch):
+    """审批卡 SSE 早于 WAITING_HUMAN 状态翻转可见：respond 抢跑（源 run 还在
+    running/starting 收尾）时短暂等待状态翻转，而不是直接拒绝导致要点两次。"""
+    monkeypatch.setattr(hitl_mod.settings, "TASK_BACKEND", "arq", raising=False)
+
+    statuses = ["running", "running", "waiting_human"]
+
+    class _Storage:
+        calls = 0
+
+        async def get_by_session_id(self, _session_id):
+            _Storage.calls += 1
+            status = statuses[min(_Storage.calls - 1, len(statuses) - 1)]
+            return SimpleNamespace(
+                user_id="user-1",
+                name="s",
+                metadata={
+                    "task_status": status,
+                    "current_run_id": "run-1",
+                    "executor_key": "agent_stream",
+                    "agent_id": "search",
+                },
+            )
+
+    monkeypatch.setattr("src.infra.session.storage.SessionStorage", lambda: _Storage())
+
+    async def fake_executor():
+        yield
+
+    monkeypatch.setattr(
+        "src.infra.task.concurrency.get_registered_executor", lambda key: fake_executor
+    )
+
+    class _FakeManager:
+        async def submit_arq(self, *args, **kwargs):
+            return "run-1", "trace-1"
+
+    monkeypatch.setattr("src.infra.task.manager.get_task_manager", lambda: _FakeManager())
+
+    result = await submit_hitl_resume_run(_approval(), {"approved": True, "values": {}})
+
+    assert result["submitted"] is True
+    assert result["run_id"] == "run-1"
+    assert _Storage.calls >= 3
 
 
 @pytest.mark.asyncio

--- a/tests/kernel/config/test_arq_poll_delay_setting.py
+++ b/tests/kernel/config/test_arq_poll_delay_setting.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+"""arq 取任务轮询间隔设置：缩短派发拾取延迟（HITL resume 提速）。"""
+
+from src.kernel.config.base import Settings
+from src.kernel.config.definitions import SETTING_DEFINITIONS
+
+
+def test_arq_poll_delay_definition_exists() -> None:
+    definition = SETTING_DEFINITIONS["ARQ_POLL_DELAY_SECONDS"]
+    assert definition["category"].value == "redis"
+    assert definition["subcategory"] == "task"
+    assert definition["frontend_visible"] is False
+
+
+def test_arq_poll_delay_defaults_match_settings_field() -> None:
+    assert Settings().ARQ_POLL_DELAY_SECONDS == 0.1
+    assert SETTING_DEFINITIONS["ARQ_POLL_DELAY_SECONDS"]["default"] == 0.1


### PR DESCRIPTION
## 背景

ask_human（HITL interrupt 模式）审批响应后的 resume 慢，链路排查定位出三处可量化的固定延迟，本 PR 逐一消除。LLM 全量历史重推理的 TTFT 是 HITL 固有成本，不在本 PR 范围。

## 改动

### 1. activation retry 免 2s 空等（`src/infra/task/hitl.py`）

`wait_for_hitl_resume_activation` 命中激活 key 后原来即删除；job 因 source fence 未释放或并发槽占满走 `Retry(defer=1)` 重跑时 key 已不在，只能空轮询满 2s 才落 Mongo 兜底——每轮 retry 白烧约 2s。改为命中后保留 key（TTL 300s 统一清理，key 按 attempt uuid 隔离无碰撞）。

- 实测（真实 Redis）：同一 attempt 第二次等待 2000ms+Mongo 点查 → **0.3ms**

### 2. arq 拾取轮询 0.5s → 0.1s（`src/infra/task/arq_runtime.py` + 新设置）

arq worker 取任务是 0.5s 定时轮询 sorted-set（非阻塞弹出），平均吃掉 ~0.25s 派发延迟。新增 `ARQ_POLL_DELAY_SECONDS`（默认 0.1s，`frontend_visible=False`）传入内嵌 Worker；`record_health` 有节流、cron 窗口有 `max(poll_delay, 0.5)` 钳制，10Hz 轮询只增加每秒一次 `zrangebyscore`，Redis 压力可忽略。

- 实测（真实 Redis + 真实 Worker，12 次随机相位入队）：

| poll_delay | mean | p50 | max |
|---|---|---|---|
| 0.5s（原默认） | 224.5ms | 210.8ms | 503.9ms |
| 0.1s（新默认） | **54.3ms** | 55.9ms | 102.1ms |

### 3. respond 抢跑竞态宽限（`src/infra/task/hitl.py`）

审批卡 SSE 在会话状态翻转到 `WAITING_HUMAN` **之前**就可见（审批物化在挂起检测处、状态更新在源 run 收尾），秒回会被 `submit_hitl_resume_run` 直接拒掉（"会话不在等待人工输入状态"，用户要点两次）。新增 `_await_waiting_human`：源 run 仍在飞行中（queued/pending/starting/running）且 `current_run_id` 指向源 run 时，最多宽限 3s（50ms 间隔轮询 session）等状态翻转；状态漂移或超时照旧快速拒绝，无关运行零额外开销。

## 测试

- 新增 5 个测试（TDD 先红后绿）：activation key 存活、抢跑宽限等待、poll_delay 传递、设置定义 ×2
- `tests/infra/task/` + `tests/api/routes/test_human_wait.py` + `tests/kernel/config/`：**285 passed**
- `ruff check` / `ruff format --check` / `mypy src/` 全绿

## 备注

本 PR 基于 origin/develop；另有在途分支将 `build_hitl_resume_payload` 抽出（usage carry 重构），与本 PR 在 `submit_hitl_resume_run` 状态检查区域有轻微文本重叠，后合并方需 rebase 解决（语义无冲突）。