### PR TITLE
chore(release): 晋级 develop → main（#498/#499/#500/#502）

### DIFF
--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -238,13 +238,17 @@ jobs:
       # macOS 签名门禁：v2.8.4 及更早的 .app 没有 bundle 封印（无
       # _CodeSignature/CodeResources，Tauri 无 signingIdentity 时跳过签名），
       # 浏览器下载带隔离标记后被 Gatekeeper 判「已损坏」。signingIdentity "-"
-      # 已让 Tauri 在产出 dmg/updater 产物前 ad-hoc 封印 bundle；本步先对
-      # daemon sidecar 无选项重封（不带 hardened runtime/library validation
-      # ——PyInstaller 运行时解包出的内嵌 dylib 为构建期 ad-hoc 签名（无团队
-      # ID），library validation 下 dlopen 即 SIGKILL，v2.9.2 macOS「daemon
-      # 起不来」的第二失败面），再验证封印与嵌套可执行签名（arm64 内核要求
-      # 全部可执行代码至少 ad-hoc 签名）并显式打印签名标志作 CI 证据。
-      - name: Re-seal daemon sidecar without hardened runtime + verify signing
+      # 让 Tauri 在产出 dmg/updater 产物前 ad-hoc 封印 bundle。
+      # runtime 标志必须在打包期就 absence（tauri.conf.json hardenedRuntime:
+      # false）：PyInstaller 运行时解包出的内嵌 dylib 是构建期 ad-hoc 签名
+      # （无团队 ID），hardened runtime 隐含的 library validation 下 dlopen 即
+      # SIGKILL——v2.9.2 macOS「daemon 起不来」的根因。不能打包后重封 sidecar
+      # 补救：改内嵌二进制会破坏外层 CodeResources 封印（deep verify 必红），
+      # 且 updater .app.tar.gz 在 Tauri 打包期已生成，重封晚于归档、包内仍是
+      # 坏字节。本步只验证不修改：sidecar 无 runtime 标志 + bundle 封印 +
+      # 嵌套可执行逐一签名（arm64 内核要求全部可执行代码至少 ad-hoc 签名），
+      # 签名标志显式打印作 CI 证据。
+      - name: Verify macOS code signing (sidecar must have no runtime flag)
         if: runner.os == 'macOS'
         shell: bash
         run: |
@@ -256,15 +260,12 @@ jobs:
           fi
           daemon_bin="$app_path/Contents/MacOS/lambchat-daemon"
           if [ -f "$daemon_bin" ]; then
-            echo "== daemon sidecar signature BEFORE re-seal =="
+            echo "== daemon sidecar signature =="
             codesign -dv --verbose=4 "$daemon_bin" 2>&1 | grep -E "Signature|flags|TeamIdentifier|Identifier=" || true
-            # 无 --options 重封：新签名不带 runtime/LV 标志（flags 归零）
-            codesign --force --sign - --timestamp=none "$daemon_bin"
-            echo "== daemon sidecar signature AFTER re-seal =="
-            codesign -dv --verbose=4 "$daemon_bin" 2>&1 | grep -E "Signature|flags|TeamIdentifier|Identifier=" || true
-            # 门禁：CodeDirectory flags 不得含 runtime (0x10000)
+            # 门禁：CodeDirectory flags 不得含 runtime (0x10000)——应在打包期由
+            # tauri.conf.json 的 hardenedRuntime: false 保证，出现即打包链回归
             if codesign -dv --verbose=4 "$daemon_bin" 2>&1 | grep -E "flags=0x[0-9a-f]*1[0-9a-f]{4}"; then
-              echo "!! daemon sidecar 带 runtime 标志——内嵌解包库会被 library validation 击杀"
+              echo "!! daemon sidecar 带 runtime 标志——检查 tauri.conf.json 的 bundle.macOS.hardenedRuntime 是否为 false"
               exit 1
             fi
           fi
@@ -276,7 +277,7 @@ jobs:
             echo "Verifying nested executable: $bin"
             codesign --verify --verbose=2 "$bin"
           done < <(find "$app_path/Contents/MacOS" -type f -perm -111 -print0)
-          echo "OK: .app sealed (ad-hoc), sidecar re-sealed without runtime, all nested executables signed"
+          echo "OK: .app sealed (ad-hoc, no runtime flag on sidecar), all nested executables signed"
 
       - name: Collect Linux desktop artifacts
         if: runner.os == 'Linux'

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -28,7 +28,8 @@
     "targets": "all",
     "createUpdaterArtifacts": true,
     "macOS": {
-      "signingIdentity": "-"
+      "signingIdentity": "-",
+      "hardenedRuntime": false
     },
     "externalBin": ["binaries/lambchat-daemon"],
     "resources": ["resources/python/"],

--- a/frontend/src/components/chat/ChatMessage/__tests__/runStepsCollapseUtils.test.ts
+++ b/frontend/src/components/chat/ChatMessage/__tests__/runStepsCollapseUtils.test.ts
@@ -211,6 +211,29 @@ describe("getRunElapsedMs", () => {
   test("returns null when no timing information exists", () => {
     expect(getRunElapsedMs({ parts: [text("hi")] } as Message)).toBeNull();
   });
+
+  test("heals stale HITL segment duration with the full parts span", () => {
+    // 旧数据：审批分段计时的 duration 只含最后一段（44s），parts 全跨度 5m48s
+    const message = {
+      duration: 44000,
+      parts: [
+        tool("a", "2026-09-08T13:48:29Z", "2026-09-08T13:48:58Z"),
+        tool("b", "2026-09-08T13:53:33Z", "2026-09-08T13:54:17Z"),
+      ],
+    } as unknown as Message;
+    expect(getRunElapsedMs(message)).toBe(348000);
+  });
+
+  test("keeps message.duration when it already covers the parts span", () => {
+    const message = {
+      duration: 350000,
+      parts: [
+        tool("a", "2026-09-08T13:48:29Z", "2026-09-08T13:48:58Z"),
+        tool("b", "2026-09-08T13:53:33Z", "2026-09-08T13:54:17Z"),
+      ],
+    } as unknown as Message;
+    expect(getRunElapsedMs(message)).toBe(350000);
+  });
 });
 
 describe("getRunStartedAtMs", () => {

--- a/frontend/src/components/chat/ChatMessage/runStepsCollapseUtils.ts
+++ b/frontend/src/components/chat/ChatMessage/runStepsCollapseUtils.ts
@@ -126,20 +126,25 @@ function collectPartTimes(part: MessagePart, times: number[]): void {
 /**
  * 计算 run 总时长：优先 message.duration（token:usage / 历史加载写入），
  * 否则用 parts 中最早 startedAt 与最晚 completedAt 推算。
+ * 旧数据里 HITL 分段计时的 duration 只含最后一次审批恢复后的那段，
+ * 与 parts 全跨度取较大值兜底（新数据的 duration 本就是 run 全程墙钟）。
  */
 export function getRunElapsedMs(
   message: Pick<Message, "duration" | "parts">,
 ): number | null {
+  const times: number[] = [];
+  for (const part of message.parts ?? []) collectPartTimes(part, times);
+  const partsSpanMs =
+    times.length >= 2 ? Math.max(...times) - Math.min(...times) : null;
+
   if (typeof message.duration === "number" && message.duration > 0) {
+    if (partsSpanMs !== null && partsSpanMs > message.duration) {
+      return partsSpanMs;
+    }
     return message.duration;
   }
 
-  const times: number[] = [];
-  for (const part of message.parts ?? []) collectPartTimes(part, times);
-  if (times.length === 0) return null;
-
-  const elapsed = Math.max(...times) - Math.min(...times);
-  return elapsed > 0 ? elapsed : null;
+  return partsSpanMs !== null && partsSpanMs > 0 ? partsSpanMs : null;
 }
 
 /**

--- a/frontend/src/components/layout/AppContent/ChatAppContent.tsx
+++ b/frontend/src/components/layout/AppContent/ChatAppContent.tsx
@@ -71,6 +71,7 @@ export function ChatAppContent({
     refresh: refreshApprovals,
     respondToApproval,
     addApproval,
+    removeApproval,
     clearApprovals,
     isLoading: approvalLoading,
   } = useApprovals({
@@ -216,6 +217,9 @@ export function ChatAppContent({
     },
     onClearApprovals: (approvalSessionId) => {
       clearApprovals(approvalSessionId);
+    },
+    onApprovalResolved: (approvalId) => {
+      removeApproval(approvalId);
     },
     getEnabledTools: getDisabledToolNames,
     getDisabledSkills: () => sessionConfigRef.current.disabledSkills,

--- a/frontend/src/hooks/useAgent/__tests__/eventHandlers.test.ts
+++ b/frontend/src/hooks/useAgent/__tests__/eventHandlers.test.ts
@@ -149,6 +149,87 @@ test("renders approval_required from the SSE payload when approval lookup is una
   vi.unstubAllGlobals();
 });
 
+test("removes a replayed resolved approval from the interactive queue", () => {
+  const onApprovalResolved = vi.fn();
+  const ctx = createContext(
+    [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        content: "",
+        timestamp: new Date("2026-09-08T01:02:03.456Z"),
+        parts: [
+          {
+            type: "tool",
+            id: "call-1",
+            name: "ask_human",
+            args: { message: "确认在本机执行 1 项操作" },
+            isPending: true,
+          },
+        ],
+        isStreaming: true,
+      },
+    ],
+    null,
+  );
+  ctx.options = { onApprovalResolved };
+
+  handleStreamEvent(
+    {
+      event: "approval_resolved",
+      data: JSON.stringify({
+        id: "approval-1",
+        tool_call_id: "call-1",
+        status: "approved",
+        success: true,
+        result: { status: "success", message: "用户已响应", values: {} },
+      }),
+    },
+    "assistant-1",
+    "approval-resolved-event-1",
+    "2026-09-08T01:02:04.000Z",
+    ctx,
+  );
+
+  // 队列收敛：已答复审批出队（与 approval_required 成对，重放/直播同流）
+  expect(onApprovalResolved).toHaveBeenCalledWith("approval-1");
+  // 部件收尾照常：pill 由 tool_call_id 命中转已批准
+  const part = ctx.messages()[0]?.parts?.[0];
+  expect(part).toMatchObject({ type: "tool", id: "call-1", isPending: false });
+});
+
+test("sandbox confirm approval enqueues the approval without an ask_human pill", () => {
+  const onApprovalRequired = vi.fn();
+  const ctx = createContext([], null);
+  ctx.options = { onApprovalRequired };
+
+  handleStreamEvent(
+    {
+      event: "approval_required",
+      data: JSON.stringify({
+        id: "approval-1",
+        message: "确认在本机执行 1 项操作：1. 执行 ls",
+        type: "confirm",
+        fields: [],
+        origin: "sandbox_confirm",
+        interrupt_id: "intr-1",
+      }),
+    },
+    "assistant-1",
+    "approval-event-sandbox",
+    "2026-09-08T01:02:03.456Z",
+    ctx,
+  );
+
+  // 审批面板照常入队（执行确认的应答入口）
+  expect(onApprovalRequired).toHaveBeenCalledWith(
+    expect.objectContaining({ id: "approval-1" }),
+  );
+  // 不合成 ask_human 工具卡：执行卡（等待确认→结果）已完整表达，
+  // 与历史回放对齐，避免一次执行双卡
+  expect(ctx.messages().length).toBe(0);
+});
+
 test("renders a delivered steer event and removes its optimistic duplicate", () => {
   const timestamp = "2026-04-19T01:02:03.456Z";
   const marked: string[] = [];

--- a/frontend/src/hooks/useAgent/__tests__/messagePartsAskHuman.test.ts
+++ b/frontend/src/hooks/useAgent/__tests__/messagePartsAskHuman.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { clearAllLoadingStates, hasPendingAskHuman } from "../messageParts";
+import {
+  clearAllLoadingStates,
+  hasPendingAskHuman,
+  isSandboxConfirmApprovalEvent,
+} from "../messageParts";
 
 const pendingAskHuman = {
   type: "tool" as const,
@@ -56,6 +60,45 @@ describe("hasPendingAskHuman", () => {
       hasPendingAskHuman([
         { ...pendingAskHuman, isPending: false, success: true },
       ]),
+    ).toBe(false);
+  });
+});
+
+describe("isSandboxConfirmApprovalEvent", () => {
+  it("matches the sandbox_confirm origin marker", () => {
+    expect(
+      isSandboxConfirmApprovalEvent({
+        origin: "sandbox_confirm",
+        message: "任意文案",
+      }),
+    ).toBe(true);
+  });
+
+  it("matches legacy events without origin by the fixed message prefix", () => {
+    expect(
+      isSandboxConfirmApprovalEvent({ message: "确认在本机执行 1 项操作" }),
+    ).toBe(true);
+    expect(
+      isSandboxConfirmApprovalEvent({ message: "确认上传 2 个文件" }),
+    ).toBe(true);
+  });
+
+  it("does not match regular ask_human or scheduled-task approvals", () => {
+    expect(isSandboxConfirmApprovalEvent({ message: "请选择发布渠道" })).toBe(
+      false,
+    );
+    expect(
+      isSandboxConfirmApprovalEvent({
+        origin: "scheduled_task",
+        message: "确认创建定时任务",
+      }),
+    ).toBe(false);
+  });
+
+  it("tolerates non-string payloads", () => {
+    expect(isSandboxConfirmApprovalEvent({})).toBe(false);
+    expect(
+      isSandboxConfirmApprovalEvent({ message: undefined, origin: undefined }),
     ).toBe(false);
   });
 });

--- a/frontend/src/hooks/useAgent/eventHandlers.ts
+++ b/frontend/src/hooks/useAgent/eventHandlers.ts
@@ -19,7 +19,11 @@ import type {
   SubagentStackItem,
   UseAgentOptions,
 } from "./types";
-import { clearAllLoadingStates, createToolPart } from "./messageParts";
+import {
+  clearAllLoadingStates,
+  createToolPart,
+  isSandboxConfirmApprovalEvent,
+} from "./messageParts";
 import { splitAssistantTurn } from "./steerTurnSplit";
 import { convertAttachments, processMessageEvent } from "./eventProcessor";
 import { dispatchToolMutationRefresh } from "../../components/chat/ChatMessage/items/toolMutationEvents";
@@ -385,6 +389,16 @@ export function handleStreamEvent(
       return;
     }
 
+    case "approval_resolved": {
+      // 审批出队与 approval_required 成对（直播/整段重放同一条流）：
+      // 中 run 刷新后 SSE 从头重放全部事件，已答复审批若只入队不出队，
+      // 会以可交互表单的形式整批重现。break 落回部件收尾（pill 转终态）。
+      if (typeof data.id === "string" && data.id) {
+        ctx.options?.onApprovalResolved?.(data.id);
+      }
+      break;
+    }
+
     case "skills:changed": {
       if (ctx.options?.onSkillAdded) {
         const action = (data.action as string) || "updated";
@@ -708,6 +722,11 @@ function appendAskHumanToolPart(
   eventTimestamp: string | undefined,
   ctx: EventHandlerContext,
 ): void {
+  // 沙箱确认门：执行卡（等待确认→结果）+ 审批面板已完整表达，不合成
+  // ask_human 工具卡，与历史回放共用判定（避免一次执行双卡）
+  if (isSandboxConfirmApprovalEvent(data)) {
+    return;
+  }
   const toolCallId = data.tool_call_id || data.id;
   const args = {
     message: data.message || "",

--- a/frontend/src/hooks/useAgent/historyLoader.ts
+++ b/frontend/src/hooks/useAgent/historyLoader.ts
@@ -20,7 +20,11 @@ import type {
   ActiveGoalSpec,
 } from "./types";
 import { convertAttachments, processMessageEvent } from "./eventProcessor";
-import { clearAllLoadingStates, createToolPart } from "./messageParts";
+import {
+  clearAllLoadingStates,
+  createToolPart,
+  isSandboxConfirmApprovalEvent,
+} from "./messageParts";
 import { markInterruptedBySteer } from "./steerTurnSplit";
 import { parseDate } from "../../utils/datetime";
 
@@ -196,18 +200,13 @@ function processHistoryEvent(
     }
     // 沙箱确认门（origin=sandbox_confirm）：执行卡（等待确认→结果）+
     // 审批面板已完整表达，不合成 ask_human 工具卡（避免一次执行双卡）；
-    // 常规审批（ask_human/定时任务）保持合成，历史回放与直播对齐。
+    // 常规审批（ask_human/定时任务）保持合成，历史回放与直播共用判定。
     // approval_required.id is the persisted approval id; resolution events
     // identify the tool part by tool_call_id. Keep the tool part keyed by the
     // latter so historical approvals resolve exactly like live events.
     const toolCallId = approvalData.tool_call_id || approvalData.id;
-    // 旧数据兜底：origin 标记上线前落库的沙箱确认事件，按确认门固定文案
-    // 前缀识别（后端 local.py 硬编码中文，稳定）
-    const isSandboxConfirm =
-      approvalData.origin === "sandbox_confirm" ||
-      /^确认(在本机|上传)/.test(approvalData.message || "");
     if (
-      !isSandboxConfirm &&
+      !isSandboxConfirmApprovalEvent(approvalData) &&
       toolCallId &&
       !currentAssistantMessage.parts?.some(
         (part) => part.type === "tool" && part.id === toolCallId,

--- a/frontend/src/hooks/useAgent/messageParts.ts
+++ b/frontend/src/hooks/useAgent/messageParts.ts
@@ -899,6 +899,22 @@ export function updateToolResultInPartsById(
 // ============================================
 
 /**
+ * 沙箱确认门（origin=sandbox_confirm）审批事件判定：执行卡（等待确认→结果）
+ * + 审批面板已完整表达，不合成 ask_human 工具卡（避免一次执行双卡）。
+ * 直播与历史回放共用；origin 标记缺失的旧数据按确认门固定文案前缀兜底
+ * （后端 local.py 硬编码中文，稳定）。
+ */
+export function isSandboxConfirmApprovalEvent(data: {
+  origin?: unknown;
+  message?: unknown;
+}): boolean {
+  if (data.origin === "sandbox_confirm") return true;
+  return (
+    typeof data.message === "string" && /^确认(在本机|上传)/.test(data.message)
+  );
+}
+
+/**
  * Whether a message still contains an unanswered ask-human interrupt.
  * Ask-human may be nested inside one or more subagent parts.
  */

--- a/frontend/src/hooks/useAgent/types.ts
+++ b/frontend/src/hooks/useAgent/types.ts
@@ -175,6 +175,9 @@ export interface UseAgentOptions {
     timeout?: number;
     metadata?: Record<string, unknown>;
   }) => void;
+  /** 审批终态（approval_resolved）出队：与 onApprovalRequired 成对，
+   *  使审批队列对 SSE 整段重放幂等（刷新中 run 不再重现已答复卡片）。 */
+  onApprovalResolved?: (approvalId: string) => void;
   onClearApprovals?: (sessionId?: string | null) => void;
   getEnabledTools?: () => string[];
   getDisabledSkills?: () => string[];

--- a/frontend/src/hooks/useApprovals.ts
+++ b/frontend/src/hooks/useApprovals.ts
@@ -47,6 +47,19 @@ export function useApprovals({
     });
   }, []);
 
+  // 审批终态出队（approval_resolved 事件）：与 addApproval 成对收敛，
+  // 使队列对 SSE 整段重放幂等——重放中已答复的审批先入队再出队，不残留
+  const removeApproval = useCallback((approvalId: string) => {
+    setApprovals((prev) => {
+      if (!prev.some((a) => a.id === approvalId)) {
+        return prev;
+      }
+      const next = prev.filter((a) => a.id !== approvalId);
+      hasApprovalsRef.current = next.length > 0;
+      return next;
+    });
+  }, []);
+
   // 清除 approvals（用于对话失败时）；传入 sessionId 时只清除该会话的，
   // 避免误清其他会话（如后台等待审批的会话）的待处理审批
   const clearApprovals = useCallback((sessionId?: string | null) => {
@@ -108,6 +121,7 @@ export function useApprovals({
     isLoading,
     respondToApproval,
     addApproval,
+    removeApproval,
     clearApprovals,
     refresh: fetchApprovals,
   };

--- a/src/agents/core/node_utils.py
+++ b/src/agents/core/node_utils.py
@@ -579,6 +579,41 @@ def build_human_message(
     )
 
 
+def resolve_run_usage_carry(
+    hitl_resume: dict | None, *, default_started_at: float
+) -> tuple[float, dict | None]:
+    """HITL 恢复执行沿用原 run 的起点与先前分段的累计用量。
+
+    审批恢复会从节点顶部重新执行 agent_node，本函数从
+    configurable.hitl_resume 还原跨分段锚点：run_started_at 是原 run
+    的墙钟起点（token:usage 的 duration 据此累计，而非每段清零），
+    prior_usage 是先前分段已记的 token 总量（seed 进处理器后，
+    最终事件与 usage_logs 才是全量口径）。非恢复执行或载荷残缺时
+    回退节点入口时间、不带先验用量。
+    """
+    if not isinstance(hitl_resume, dict):
+        return default_started_at, None
+
+    raw_anchor = hitl_resume.get("run_started_at")
+    started_at = raw_anchor if isinstance(raw_anchor, (int, float)) else default_started_at
+
+    prior = hitl_resume.get("prior_usage")
+    if not isinstance(prior, dict):
+        return started_at, None
+    carried = {
+        key: prior[key]
+        for key in (
+            "input_tokens",
+            "output_tokens",
+            "total_tokens",
+            "cache_creation_tokens",
+            "cache_read_tokens",
+        )
+        if isinstance(prior.get(key), int)
+    }
+    return started_at, carried or None
+
+
 async def emit_token_usage(
     event_processor: AgentEventProcessor,
     presenter,

--- a/src/agents/core/prompt_policy.py
+++ b/src/agents/core/prompt_policy.py
@@ -35,9 +35,24 @@ Use this alias only with file tools and uploads. For shell commands, use relativ
 WORKSPACE_POLICY = """### Workspace Boundaries
 Check whether a target exists before creating it. Modify an existing project only when requested or clearly relevant; otherwise use a named directory in the current session workspace."""
 
+#: 本地 daemon 会话的身份段（所有已上报平台共用）：沙箱就是用户自己的真实
+#: 电脑，不是隔离虚拟机。生产会话 26ed193a 实测：linux daemon 不加任何段时，
+#: 模型自认「隔离沙箱、跟用户电脑完全不连通」，当面否认控制能力还反指用户
+#: 可能中了远控木马——而命令实际就跑在用户机器上。
+#: 缓存纪律：本段注入点在文件工具 description 尾部、排在逐会话 {work_dir}
+#: 之后（SandboxWorkspaceMiddleware），跨会话本无共享前缀可失；注入方式
+#: 一律纯尾部追加（见 sandbox_shell_platform_section），存量会话已缓存字节
+#: 零失效，新会话仅首 turn 一次性多 prefill 本段。
+_SANDBOX_LOCAL_MACHINE_IDENTITY = """### Local Machine Sandbox
+
+The sandbox for this session is the user's own real computer (connected via the local desktop daemon), not an isolated virtual machine. Every shell command and file operation executes on the user's actual machine and touches their real files; the daemon may ask the user to confirm each command before it runs.
+- Be honest about this capability: you CAN operate the user's computer through this session. Never claim your environment is isolated from or unconnected to the user's machine.
+- Operate like a careful human operator on someone else's computer: confirm before deleting, overwriting, or modifying anything outside the session workspace, and prefer the session workspace for new files."""
+
 #: win32 本地 daemon 的 shell 方言提示（cmd.exe）。daemon 上报平台经注册表第三段
-#: 查得（win32/linux/darwin），linux 与未上报不加段——云端沙箱与 Linux 本地
-#: 的 prompt 逐字节保持现状，provider 前缀缓存零失效。
+#: 查得（win32/linux/darwin）。身份段对三个平台一律注入；方言段仅 win32/darwin
+#: 需要（POSIX 语法在 Linux daemon 本来就成立）。空串（云端沙箱、daemon 离线、
+#: 旧版未上报）不加任何段——云端 prompt 逐字节保持现状，也绝不错入 Windows 分支。
 _SANDBOX_SHELL_WIN32 = """### Local Machine Shell: Windows (cmd.exe)
 
 The local sandbox is the user's Windows machine; `execute` runs commands through cmd.exe, NOT bash.
@@ -58,13 +73,23 @@ The local sandbox is the user's Mac; `execute` runs commands via /bin/sh (POSIX)
 def sandbox_shell_platform_section(daemon_platform: str) -> str:
     """daemon 上报平台 → 沙箱运行时提示追加段；空串 = 不追加（保持现状）。
 
-    平台串是注册表第三段的归一值（win32/linux/darwin）；空串涵盖云端沙箱、
-    daemon 离线与旧版未上报——一律不加段，绝不错入 Windows 分支。
+    平台串是注册表第三段的归一值（win32/linux/darwin）。三个已上报平台都
+    注入 _SANDBOX_LOCAL_MACHINE_IDENTITY（沙箱=用户本机的身份与谨慎纪律段）；
+    win32/darwin 另需 shell 方言段。
+
+    KV 缓存纪律：方言段字节保持历史原样，身份段一律**尾部追加**——整段文本
+    经 SandboxWorkspaceMiddleware 落在文件工具 description 里、排在逐会话
+    的 {work_dir} 之后，跨会话本就无共享前缀可失；纯追加保证部署时存量
+    会话已缓存的旧字节零失效，新文本只在会话首 turn 一次性多 prefill。
+    空串涵盖云端沙箱、daemon 离线与旧版未上报——一律不加段，云端 prompt
+    逐字节保持现状，也绝不错入 Windows 分支。
     """
     if daemon_platform == "win32":
-        return _SANDBOX_SHELL_WIN32
+        return _SANDBOX_SHELL_WIN32 + "\n\n" + _SANDBOX_LOCAL_MACHINE_IDENTITY
     if daemon_platform == "darwin":
-        return _SANDBOX_SHELL_DARWIN
+        return _SANDBOX_SHELL_DARWIN + "\n\n" + _SANDBOX_LOCAL_MACHINE_IDENTITY
+    if daemon_platform == "linux":
+        return _SANDBOX_LOCAL_MACHINE_IDENTITY
     return ""
 
 

--- a/src/agents/fast_agent/nodes.py
+++ b/src/agents/fast_agent/nodes.py
@@ -23,6 +23,7 @@ from src.agents.core.node_utils import (
     resolve_fallback_model,
     resolve_model_image_url_to_base64,
     resolve_model_supports_vision,
+    resolve_run_usage_carry,
 )
 from src.agents.core.persona import build_persona_prompt_sections
 from src.agents.core.startup_preparation import prepare_agent_inputs
@@ -368,6 +369,11 @@ async def fast_agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict
     hitl_resume = configurable.get("hitl_resume")
     user_input = state.get("input", "")
     recommendation_input = configurable.get("recommendation_input") or user_input
+    # HITL 恢复沿用原 run 的墙钟起点与先前分段累计用量：token:usage 的
+    # duration 与 token 数跨恢复累计，否则只记审批恢复后的最后一段
+    run_started_at, prior_usage = resolve_run_usage_carry(
+        hitl_resume, default_started_at=start_time
+    )
     if hitl_resume is not None:
         from langgraph.types import Command
 
@@ -396,6 +402,8 @@ async def fast_agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict
     # 创建事件处理器（使用 AgentEventProcessor 处理 astream_events）
     logger.info("[FastAgent] Creating AgentEventProcessor")
     event_processor = AgentEventProcessor(presenter, base_url=configurable.get("base_url", ""))
+    if prior_usage is not None:
+        event_processor.seed_usage(prior_usage)
 
     logger.info("[FastAgent] Starting astream_events")
     # 流式处理事件（不重试，直接调用）
@@ -423,7 +431,7 @@ async def fast_agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict
         await emit_token_usage(
             event_processor,
             presenter,
-            start_time,
+            run_started_at,
             model_id=model_id,
             model=selected_model,
         )
@@ -458,6 +466,8 @@ async def fast_agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict
                         "active_goal": active_goal,
                         "recommendation_input": recommendation_input,
                         "goal_started_at": configurable.get("goal_started_at"),
+                        "run_started_at": run_started_at,
+                        "prior_usage": event_processor.usage_totals(),
                     },
                 )
         except Exception as e:

--- a/src/agents/search_agent/nodes.py
+++ b/src/agents/search_agent/nodes.py
@@ -92,13 +92,14 @@ logger = get_logger(__name__)
 async def _build_sandbox_runtime_policy(
     sandbox_backend: Any, sandbox_work_dir: str | None, *, user_id: str
 ) -> str:
-    """沙箱运行时提示段：workspace 策略 + （仅本地 daemon）shell 方言段。
+    """沙箱运行时提示段：workspace 策略 + （仅本地 daemon）本机身份/平台段。
 
-    本地 daemon 在 win32/darwin 上时追加平台段（prompt_policy.sandbox_shell_platform_section），
-    让模型生成 cmd.exe / macOS 兼容命令——否则模型默认 POSIX 语法在 Windows
-    cmd.exe 全军覆没（实测根因之二）。云端沙箱与 Linux/未上报一律不加段，
-    prompt 逐字节保持现状；段文本随会话内 daemon 平台稳定，provider 前缀
-    缓存不受逐 turn 影响。
+    本地 daemon 上报 win32/linux/darwin 任一平台时追加
+    prompt_policy.sandbox_shell_platform_section（「沙箱=用户本机」身份段 +
+    win32/darwin 的 shell 方言段），让模型既知道自己真的在操作用户的电脑，
+    又能生成 cmd.exe / macOS 兼容命令。云端沙箱与未上报一律不加段，prompt
+    逐字节保持现状；段文本随会话内 daemon 平台稳定，provider 前缀缓存不受
+    逐 turn 影响。
     """
     if not sandbox_backend or not sandbox_work_dir:
         return ""

--- a/src/agents/search_agent/nodes.py
+++ b/src/agents/search_agent/nodes.py
@@ -24,6 +24,7 @@ from src.agents.core.node_utils import (
     resolve_fallback_model,
     resolve_model_image_url_to_base64,
     resolve_model_supports_vision,
+    resolve_run_usage_carry,
 )
 from src.agents.core.persona import build_persona_prompt_sections
 from src.agents.core.prompt_policy import sandbox_shell_platform_section
@@ -433,6 +434,11 @@ async def agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict[str,
     # HITL 恢复运行（issue #218）：以 Command(resume=...) 从挂起断点继续，
     # 不注入新的用户消息。
     hitl_resume = configurable.get("hitl_resume")
+    # HITL 恢复沿用原 run 的墙钟起点与先前分段累计用量：token:usage 的
+    # duration 与 token 数跨恢复累计，否则只记审批恢复后的最后一段
+    run_started_at, prior_usage = resolve_run_usage_carry(
+        hitl_resume, default_started_at=start_time
+    )
     if hitl_resume is not None:
         from langgraph.types import Command
 
@@ -467,6 +473,8 @@ async def agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict[str,
             sandbox_backend.before_tool_start if sandbox_backend is not None else None
         ),
     )
+    if prior_usage is not None:
+        event_processor.seed_usage(prior_usage)
 
     logger.info("[SearchAgent] Starting astream_events")
     # 流式处理事件（不重试，直接调用）
@@ -494,7 +502,7 @@ async def agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict[str,
         await emit_token_usage(
             event_processor,
             presenter,
-            start_time,
+            run_started_at,
             model_id=model_id,
             model=selected_model,
         )
@@ -529,6 +537,8 @@ async def agent_node(state: Dict[str, Any], config: RunnableConfig) -> Dict[str,
                         "active_goal": active_goal,
                         "recommendation_input": recommendation_input,
                         "goal_started_at": configurable.get("goal_started_at"),
+                        "run_started_at": run_started_at,
+                        "prior_usage": event_processor.usage_totals(),
                     },
                 )
         except Exception as e:

--- a/src/agents/team_agent/nodes.py
+++ b/src/agents/team_agent/nodes.py
@@ -23,6 +23,7 @@ from src.agents.core.node_utils import (
     resolve_fallback_model,
     resolve_model_image_url_to_base64,
     resolve_model_supports_vision,
+    resolve_run_usage_carry,
 )
 from src.agents.core.persona import build_persona_prompt_sections
 from src.agents.core.startup_preparation import prepare_agent_inputs
@@ -854,6 +855,11 @@ async def team_router_node(state: Dict[str, Any], config: RunnableConfig) -> Dic
     # HITL 恢复运行（issue #218）：以 Command(resume=...) 从挂起断点继续，
     # 不注入新的用户消息。
     hitl_resume = configurable.get("hitl_resume")
+    # HITL 恢复沿用原 run 的墙钟起点与先前分段累计用量：token:usage 的
+    # duration 与 token 数跨恢复累计，否则只记审批恢复后的最后一段
+    run_started_at, prior_usage = resolve_run_usage_carry(
+        hitl_resume, default_started_at=start_time
+    )
     if hitl_resume is not None:
         from langgraph.types import Command
 
@@ -878,6 +884,8 @@ async def team_router_node(state: Dict[str, Any], config: RunnableConfig) -> Dic
         subagent_display_names=subagent_display_names,
         subagent_avatars=subagent_avatars,
     )
+    if prior_usage is not None:
+        event_processor.seed_usage(prior_usage)
 
     logger.info("[TeamAgent] Starting astream_events")
     # interrupt 模式在任意 checkpointer（包括进程内 MemorySaver）可用。
@@ -904,7 +912,7 @@ async def team_router_node(state: Dict[str, Any], config: RunnableConfig) -> Dic
         await emit_token_usage(
             event_processor,
             presenter,
-            start_time,
+            run_started_at,
             model_id=model_id,
             model=selected_model,
         )
@@ -939,6 +947,8 @@ async def team_router_node(state: Dict[str, Any], config: RunnableConfig) -> Dic
                         "active_goal": active_goal,
                         "recommendation_input": recommendation_input,
                         "goal_started_at": configurable.get("goal_started_at"),
+                        "run_started_at": run_started_at,
+                        "prior_usage": event_processor.usage_totals(),
                     },
                 )
         except Exception as e:

--- a/src/infra/agent/events/processor.py
+++ b/src/infra/agent/events/processor.py
@@ -135,6 +135,35 @@ class AgentEventProcessor(SubagentEventMixin, StreamEventMixin, ToolEventMixin):
         """Return accumulated top-level assistant output text."""
         return self._output_buffer.getvalue()
 
+    def seed_usage(self, prior_usage: dict | None) -> None:
+        """HITL 恢复：把先前分段的累计用量并入计数器。
+
+        恢复分段重新执行节点时计数器从零开始，不 seed 的话最终
+        token:usage（以及取 last 落库的 usage_logs）只含最后一段。
+        """
+        if not isinstance(prior_usage, dict):
+            return
+        if isinstance(prior_usage.get("input_tokens"), int):
+            self.total_input_tokens += prior_usage["input_tokens"]
+        if isinstance(prior_usage.get("output_tokens"), int):
+            self.total_output_tokens += prior_usage["output_tokens"]
+        if isinstance(prior_usage.get("total_tokens"), int):
+            self.total_tokens += prior_usage["total_tokens"]
+        if isinstance(prior_usage.get("cache_creation_tokens"), int):
+            self.total_cache_creation_tokens += prior_usage["cache_creation_tokens"]
+        if isinstance(prior_usage.get("cache_read_tokens"), int):
+            self.total_cache_read_tokens += prior_usage["cache_read_tokens"]
+
+    def usage_totals(self) -> dict:
+        """当前累计用量快照，用于挂起时写入 resume_context 传给下一段。"""
+        return {
+            "input_tokens": self.total_input_tokens,
+            "output_tokens": self.total_output_tokens,
+            "total_tokens": self.total_tokens,
+            "cache_creation_tokens": self.total_cache_creation_tokens,
+            "cache_read_tokens": self.total_cache_read_tokens,
+        }
+
     async def flush(self) -> None:
         """Flush pending stream chunks without clearing counters or output text."""
         await self._flush_chunk_buffer()

--- a/src/infra/agent/middleware/steer.py
+++ b/src/infra/agent/middleware/steer.py
@@ -152,6 +152,19 @@ class SteerMiddleware(AgentMiddleware):
                 self._session_id, pending, presenter=self._presenter
             )
 
+        # drain 即送达，随之释放 Redis lease 并清 inflight：否则 run 终态的
+        # emit_undelivered_steer_events（list_items 读 pending+inflight）会把
+        # 已送达的插话误报 steer:undelivered，前端补发流程会重复投递。ack
+        # 失败只记日志——注入语义已由下方 state 更新保证，不因清理失败而中断。
+        try:
+            await queue.ack_items(self._session_id)
+        except Exception:
+            logger.warning(
+                "[Steer] session=%s failed to ack drained steer items after injection",
+                self._session_id,
+                exc_info=True,
+            )
+
         # 更新经 before_model 节点提交 checkpoint（先于模型节点），插话即
         # 持久化送达；随后模型调用失败也不回队——新 run 从 state 续跑仍能
         # 看到插话，回队反而会重复注入。

--- a/src/infra/agent/middleware/steer.py
+++ b/src/infra/agent/middleware/steer.py
@@ -1,11 +1,19 @@
 """SteerMiddleware — 运行中插话注入（Codex 式 steer）。
 
 用户在任务运行期间发送的消息（POST /chat/sessions/{id}/steer）先进入
-``SteerQueue``；本中间件在每次主 agent 模型调用前取出该会话的排队消息，
-在调用开始前写出 ``steer:message`` 事件（事件先于本次调用的输出进入
-Redis/MongoDB，实时 SSE 与历史回放中插话都排在回答之前），再追加到本次
-请求的消息末尾（模型在当前步骤后即可看到），并通过 ``Command(update)``
-把它们持久化进图状态，落盘到 checkpoint，刷新/重载后历史不丢。
+``SteerQueue``；本中间件在每次模型调用前（``before_model`` 钩子，独立图
+节点）取出该会话的排队消息，在模型调用开始前写出 ``steer:message``
+事件（事件先于本次调用的输出进入 Redis/MongoDB，实时 SSE 与历史回放中
+插话都排在回答之前），再以 state 更新把消息注入图状态。
+
+注入必须发生在模型响应之前：``before_model`` 节点的更新先于模型节点提交
+checkpoint，插话因此落在本次模型响应之前（模型是对插话做出的响应）。
+OpenAI 协议要求带 ``tool_calls`` 的 assistant 消息后紧跟对应 tool 消息；
+若插话经 ``Command(update)`` 在模型节点完成后追加（旧实现），一旦该次
+响应携带 tool_calls，tools 节点写回的 ToolMessage 会落在插话之后，下一
+次模型调用即 400 "insufficient tool messages following tool_calls
+message"（2026-09-08 生产实例）。注入时顺带把历史中已被写乱的消息重排
+自愈，存量坏会话不再永久 400。
 """
 
 from __future__ import annotations
@@ -14,20 +22,56 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from langchain.agents.middleware.types import AgentMiddleware
+from langchain_core.messages import AIMessage, AnyMessage, RemoveMessage, ToolMessage
+from langgraph.graph.message import REMOVE_ALL_MESSAGES
 
 from src.agents.core.node_utils import build_human_message
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
-
-    from langchain.agents.middleware.types import (
-        ContextT,
-        ModelRequest,
-        ModelResponse,
-        ResponseT,
-    )
+    from langchain.agents.middleware.types import AgentState
+    from langgraph.runtime import Runtime
 
 logger = logging.getLogger(__name__)
+
+
+def _reorder_tool_response_adjacency(messages: list[AnyMessage]) -> list[AnyMessage] | None:
+    """把夹在 AIMessage(tool_calls) 与其 ToolMessage 之间的其他消息后移。
+
+    返回重排后的完整列表；顺序本就合法时返回 ``None``（调用方免于整表
+    重写）。悬空 tool_calls（始终没有 ToolMessage 回应）不在此处理——
+    deepagents 的 PatchToolCallsMiddleware 负责在 AI 消息后补合成响应，
+    与本函数的移动语义兼容。
+    """
+    result: list[AnyMessage] = []
+    held: list[AnyMessage] = []
+    pending_ids: set[str | None] = set()
+    for message in messages:
+        if isinstance(message, AIMessage):
+            call_ids = {
+                call["id"]
+                for call in (*message.tool_calls, *message.invalid_tool_calls)
+                if call.get("id") is not None
+            }
+            if call_ids:
+                result.extend(held)
+                held = []
+                result.append(message)
+                pending_ids = call_ids
+                continue
+        if isinstance(message, ToolMessage):
+            result.append(message)
+            pending_ids.discard(message.tool_call_id)
+            if not pending_ids and held:
+                result.extend(held)
+                held = []
+        elif pending_ids:
+            held.append(message)
+        else:
+            result.append(message)
+    result.extend(held)
+    if len(result) == len(messages) and all(a is b for a, b in zip(result, messages)):
+        return None
+    return result
 
 
 async def _persist_injected_steer_messages(
@@ -41,9 +85,6 @@ async def _persist_injected_steer_messages(
     记录用户发送时刻，供前端作为消息时间戳。优先复用当前 run 的
     presenter（事件归属该 run 的 trace）；无 presenter 时回退
     dual_writer 直写（仅实时 SSE 兜底）。失败只记日志。
-
-    若注入的模型调用失败，消息带原 ID 回队重试，送达时会再次写出
-    同 ``message_id`` 的事件，由前端按 ID 去重。
     """
     import uuid
 
@@ -80,28 +121,26 @@ async def _persist_injected_steer_messages(
 
 
 class SteerMiddleware(AgentMiddleware):
-    """把会话插话队列中的用户消息注入下一次模型调用。"""
+    """把会话插话队列中的用户消息在下一次模型调用前注入图状态。"""
 
     def __init__(self, *, session_id: str, presenter: Any = None) -> None:
         super().__init__()
         self._session_id = session_id
         self._presenter = presenter
 
-    async def awrap_model_call(
-        self,
-        request: ModelRequest[ContextT],
-        handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]],
-    ) -> ModelResponse[ResponseT] | Any:
+    async def abefore_model(
+        self, state: AgentState, runtime: Runtime[Any]
+    ) -> dict[str, Any] | None:  # noqa: ARG002
         from src.infra.task.steer import get_steer_queue
 
         queue = get_steer_queue()
         pending = await queue.drain_items(self._session_id)
         if not pending:
-            return await handler(request)
+            return None
 
         injected = [build_human_message(item.content, item.attachments) for item in pending]
         logger.info(
-            "[Steer] session=%s injecting %d user message(s) into model call",
+            "[Steer] session=%s injecting %d user message(s) before model call",
             self._session_id,
             len(injected),
         )
@@ -113,20 +152,10 @@ class SteerMiddleware(AgentMiddleware):
                 self._session_id, pending, presenter=self._presenter
             )
 
-        try:
-            response = await handler(request.override(messages=[*request.messages, *injected]))
-        except BaseException:
-            # 整体失败（含取消）：放回队首，等重试或下次运行送达，不丢失。
-            # 重试送达会再次写出同 message_id 事件，前端按 ID 去重。
-            await queue.requeue_front_items(self._session_id, pending)
-            raise
-
-        await queue.ack_items(self._session_id)
-
-        from langchain.agents.middleware.types import ExtendedModelResponse
-        from langgraph.types import Command as LangCommand
-
-        return ExtendedModelResponse(
-            model_response=response,
-            command=LangCommand(update={"messages": injected}),
-        )
+        # 更新经 before_model 节点提交 checkpoint（先于模型节点），插话即
+        # 持久化送达；随后模型调用失败也不回队——新 run 从 state 续跑仍能
+        # 看到插话，回队反而会重复注入。
+        reordered = _reorder_tool_response_adjacency(state.get("messages") or [])
+        if reordered is None:
+            return {"messages": injected}
+        return {"messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES), *reordered, *injected]}

--- a/src/infra/task/arq_runtime.py
+++ b/src/infra/task/arq_runtime.py
@@ -62,6 +62,7 @@ class EmbeddedArqRuntime:
             handle_signals=False,
             max_jobs=settings.ARQ_WORKER_MAX_JOBS,
             job_timeout=settings.ARQ_JOB_TIMEOUT_SECONDS,
+            poll_delay=settings.ARQ_POLL_DELAY_SECONDS,
             ctx={
                 "payload_store": TaskArqPayloadStore(),
                 "search_index_payload_store": UserMessageSearchIndexPayloadStore(),

--- a/src/infra/task/hitl.py
+++ b/src/infra/task/hitl.py
@@ -311,6 +311,50 @@ async def wait_for_hitl_resume_activation(
     )
 
 
+def build_hitl_resume_payload(
+    approval: Any,
+    resume_value: Dict[str, Any],
+    *,
+    resume_attempt_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """构建恢复执行的 hitl_resume 载荷。
+
+    resume_context 在挂起时物化进审批 metadata（Mongo，跨副本可靠），
+    其中 run_started_at / prior_usage 让恢复分段沿用原 run 的墙钟起点
+    与先前分段累计用量——否则 token:usage（及取 last 落库的 usage_logs）
+    只记最后一段，工作时长也只剩末段。
+    """
+    approval_metadata = getattr(approval, "metadata", None) or {}
+    resume_context = approval_metadata.get("resume_context") or {}
+    interrupt_id = approval_metadata.get("interrupt_id")
+    sandbox_confirm_message = (
+        str(approval.message) if approval_metadata.get("origin") == "sandbox_confirm" else None
+    )
+    command_resume = {str(interrupt_id): resume_value} if interrupt_id else resume_value
+    return {
+        "approval_id": approval.id,
+        "resume_attempt_id": resume_attempt_id,
+        "resume_value": command_resume,
+        **({"sandbox_confirm_message": sandbox_confirm_message} if sandbox_confirm_message else {}),
+        "goal_started_at": resume_context.get("goal_started_at"),
+        "run_started_at": resume_context.get("run_started_at"),
+        "prior_usage": resume_context.get("prior_usage"),
+        "approval_resolved": {
+            "id": approval.id,
+            "tool_call_id": approval_metadata.get("tool_call_id"),
+            "interrupt_id": interrupt_id,
+            "status": "approved" if resume_value.get("approved") else "rejected",
+            "success": bool(resume_value.get("approved")),
+            "result": {
+                "status": "success" if resume_value.get("approved") else "rejected",
+                "message": ("用户已响应" if resume_value.get("approved") else "用户拒绝了此请求"),
+                "values": resume_value.get("values") or {},
+            },
+            "timestamp": utc_now_iso(),
+        },
+    }
+
+
 async def submit_hitl_resume_run(
     approval: Any,
     resume_value: Dict[str, Any],
@@ -387,38 +431,10 @@ async def submit_hitl_resume_run(
 
         from .manager import get_task_manager
 
-        interrupt_id = approval_metadata.get("interrupt_id")
         resume_context = approval_metadata.get("resume_context") or {}
-        sandbox_confirm_message = (
-            str(approval.message) if approval_metadata.get("origin") == "sandbox_confirm" else None
+        hitl_resume = build_hitl_resume_payload(
+            approval, resume_value, resume_attempt_id=resume_attempt_id
         )
-        command_resume = {str(interrupt_id): resume_value} if interrupt_id else resume_value
-        hitl_resume = {
-            "approval_id": approval.id,
-            "resume_attempt_id": resume_attempt_id,
-            "resume_value": command_resume,
-            **(
-                {"sandbox_confirm_message": sandbox_confirm_message}
-                if sandbox_confirm_message
-                else {}
-            ),
-            "goal_started_at": resume_context.get("goal_started_at"),
-            "approval_resolved": {
-                "id": approval.id,
-                "tool_call_id": approval_metadata.get("tool_call_id"),
-                "interrupt_id": interrupt_id,
-                "status": "approved" if resume_value.get("approved") else "rejected",
-                "success": bool(resume_value.get("approved")),
-                "result": {
-                    "status": "success" if resume_value.get("approved") else "rejected",
-                    "message": (
-                        "用户已响应" if resume_value.get("approved") else "用户拒绝了此请求"
-                    ),
-                    "values": resume_value.get("values") or {},
-                },
-                "timestamp": utc_now_iso(),
-            },
-        }
         manager = get_task_manager()
         common_kwargs: dict[str, Any] = {
             "disabled_tools": metadata.get("disabled_tools") or None,

--- a/src/infra/task/hitl.py
+++ b/src/infra/task/hitl.py
@@ -29,6 +29,18 @@ HITL_RESUME_LOCK_TTL_SECONDS = 300
 HITL_SOURCE_RELEASE_PREFIX = "hitl:source-released:"
 HITL_SOURCE_RELEASE_TTL_SECONDS = 300
 HITL_RESUME_ACTIVATION_PREFIX = "hitl:resume-activated:"
+# respond 抢跑兜底：审批卡 SSE 早于 WAITING_HUMAN 状态翻转可见（审批物化在
+# 挂起检测处、状态更新在源 run 收尾），源 run 仍在飞行中时短暂等待翻转。
+HITL_WAITING_HUMAN_GRACE_SECONDS = 3.0
+HITL_WAITING_HUMAN_POLL_INTERVAL = 0.05
+_HITL_INFLIGHT_STATUSES = frozenset(
+    {
+        TaskStatus.QUEUED.value,
+        TaskStatus.PENDING.value,
+        TaskStatus.STARTING.value,
+        TaskStatus.RUNNING.value,
+    }
+)
 
 
 def hitl_interrupt_mode_enabled() -> bool:
@@ -289,14 +301,18 @@ async def wait_for_hitl_resume_activation(
     attempt_id: str,
     timeout: float = 2.0,
 ) -> bool:
-    """Wait for activation, then use one Mongo point read as crash fallback."""
+    """Wait for activation, then use one Mongo point read as crash fallback.
+
+    激活 key 命中后不删除（TTL 统一清理）：job 可能因 source fence 未释放
+    或并发槽占满走 Retry(defer=1) 重跑，重跑时再次等待必须立即命中——
+    否则每轮 retry 都空轮询满 timeout 才落 Mongo 兜底，白烧数秒。
+    """
     redis = get_redis_client()
     key = f"{HITL_RESUME_ACTIVATION_PREFIX}{attempt_id}"
     loop = asyncio.get_running_loop()
     deadline = loop.time() + timeout
     while loop.time() < deadline:
         if await redis.get(key) is not None:
-            await redis.delete(key)
             return True
         await asyncio.sleep(0.02)
 
@@ -309,6 +325,37 @@ async def wait_for_hitl_resume_activation(
         and getattr(approval, "status", "pending") != "pending"
         and metadata.get("resume_attempt_id") == attempt_id
     )
+
+
+async def _await_waiting_human(
+    session_storage: Any,
+    session_id: str,
+    *,
+    source_run_id: str,
+    initial: Dict[str, Any],
+) -> Dict[str, Any]:
+    """respond 抢跑竞态兜底：源 run 仍在飞行中（挂起后状态尚未翻转到
+    WAITING_HUMAN）时短暂等待翻转；状态漂移或超时立即返回最新 metadata，
+    交由调用方按非等待状态拒绝。仅当 current_run_id 仍指向源 run 才等待，
+    避免给无关运行的状态轮询买单。"""
+    metadata = initial
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + HITL_WAITING_HUMAN_GRACE_SECONDS
+    while True:
+        if metadata.get("task_status") == TaskStatus.WAITING_HUMAN.value:
+            return metadata
+        current_run_id = str(metadata.get("current_run_id") or "")
+        source_in_flight = (
+            bool(source_run_id)
+            and current_run_id == source_run_id
+            and metadata.get("task_status") in _HITL_INFLIGHT_STATUSES
+        )
+        if not source_in_flight or loop.time() >= deadline:
+            return metadata
+        await asyncio.sleep(HITL_WAITING_HUMAN_POLL_INTERVAL)
+        session = await session_storage.get_by_session_id(session_id)
+        if session is not None:
+            metadata = getattr(session, "metadata", None) or {}
 
 
 def build_hitl_resume_payload(
@@ -394,7 +441,15 @@ async def submit_hitl_resume_run(
             return {"submitted": False, "run_id": None, "message": "会话不存在"}
         if not getattr(session, "user_id", None):
             return {"submitted": False, "run_id": None, "message": "会话缺少用户信息"}
-        metadata = getattr(session, "metadata", None) or {}
+        approval_metadata = getattr(approval, "metadata", None) or {}
+        source_run_id = str(approval_metadata.get("run_id") or "")
+        source_trace_id = str(approval_metadata.get("trace_id") or "")
+        metadata = await _await_waiting_human(
+            session_storage,
+            session_id,
+            source_run_id=source_run_id,
+            initial=getattr(session, "metadata", None) or {},
+        )
         if metadata.get("task_status") != TaskStatus.WAITING_HUMAN.value:
             return {
                 "submitted": False,
@@ -402,9 +457,6 @@ async def submit_hitl_resume_run(
                 "message": "会话不在等待人工输入状态，跳过恢复",
             }
 
-        approval_metadata = getattr(approval, "metadata", None) or {}
-        source_run_id = str(approval_metadata.get("run_id") or "")
-        source_trace_id = str(approval_metadata.get("trace_id") or "")
         current_run_id = str(metadata.get("current_run_id") or "")
         if not source_run_id or (current_run_id and current_run_id != source_run_id):
             return {

--- a/src/kernel/config/_definitions_infra.py
+++ b/src/kernel/config/_definitions_infra.py
@@ -128,6 +128,15 @@ INFRA_SETTING_DEFINITIONS: dict[str, dict] = {
         "default": 86400,
         "depends_on": {"key": "TASK_BACKEND", "value": "arq"},
     },
+    "ARQ_POLL_DELAY_SECONDS": {
+        "type": SettingType.NUMBER,
+        "category": SettingCategory.REDIS,
+        "subcategory": "task",
+        "description": "settingDesc.ARQ_POLL_DELAY_SECONDS",
+        "default": 0.1,
+        "depends_on": {"key": "TASK_BACKEND", "value": "arq"},
+        "frontend_visible": False,
+    },
     "TASK_STARTUP_CLEANUP_CONCURRENCY": {
         "type": SettingType.NUMBER,
         "category": SettingCategory.REDIS,

--- a/src/kernel/config/base.py
+++ b/src/kernel/config/base.py
@@ -147,6 +147,9 @@ class Settings(BaseSettings):
     ARQ_QUEUE_NAME: str = "lambchat:arq"
     ARQ_WORKER_MAX_JOBS: int = 128
     ARQ_JOB_TIMEOUT_SECONDS: int = 86400
+    # arq 取任务轮询间隔（秒）：arq 默认 0.5s 轮询 sorted-set（非阻塞弹出），
+    # 平均吃掉 ~0.25s 派发延迟；缩短以压低 HITL resume 等即时任务的拾取时延。
+    ARQ_POLL_DELAY_SECONDS: float = 0.1
     TASK_STARTUP_CLEANUP_CONCURRENCY: int = 16
     # 周期孤儿接管间隔：缩短实例死亡后对话自动恢复的停顿（心跳按龄判死 + 扫描间隔）
     TASK_ORPHAN_RECOVERY_INTERVAL_SECONDS: int = 15

--- a/tests/agents/core/test_node_utils_usage_carry.py
+++ b/tests/agents/core/test_node_utils_usage_carry.py
@@ -1,0 +1,48 @@
+"""HITL 恢复的 run 用量携带（issue：审批恢复后 token:usage 只记最后一段）。
+
+agent_node 每次恢复都从节点顶部重新执行，计时锚点与 token 计数器随之清零。
+resolve_run_usage_carry 从 configurable.hitl_resume 还原原 run 的起点与
+先前分段的累计用量，让 token:usage 事件跨恢复累计。
+"""
+
+from src.agents.core.node_utils import resolve_run_usage_carry
+
+
+def test_no_hitl_resume_falls_back_to_node_entry_time():
+    started_at, prior_usage = resolve_run_usage_carry(None, default_started_at=123.5)
+    assert started_at == 123.5
+    assert prior_usage is None
+
+
+def test_hitl_resume_carries_run_anchor_and_prior_usage():
+    prior = {
+        "input_tokens": 199581,
+        "output_tokens": 6695,
+        "total_tokens": 206276,
+        "cache_creation_tokens": 10,
+        "cache_read_tokens": 20,
+    }
+    started_at, carried = resolve_run_usage_carry(
+        {"run_started_at": 111.5, "prior_usage": dict(prior)},
+        default_started_at=999.0,
+    )
+    assert started_at == 111.5
+    assert carried == prior
+
+
+def test_malformed_hitl_resume_falls_back_to_defaults():
+    started_at, carried = resolve_run_usage_carry(
+        {"run_started_at": "not-a-number", "prior_usage": "garbage"},
+        default_started_at=42.0,
+    )
+    assert started_at == 42.0
+    assert carried is None
+
+
+def test_partial_hitl_resume_still_restores_anchor():
+    started_at, carried = resolve_run_usage_carry(
+        {"run_started_at": 77.25},
+        default_started_at=42.0,
+    )
+    assert started_at == 77.25
+    assert carried is None

--- a/tests/agents/core/test_prompt_policy.py
+++ b/tests/agents/core/test_prompt_policy.py
@@ -24,12 +24,38 @@ def test_attribution_discipline_reaches_all_main_agents():
         assert any(phrase in section for section in MAIN_AGENT_PROMPT_SECTIONS)
 
 
-def test_shell_platform_section_empty_for_posix_and_unknown():
-    """linux/空串（云端沙箱、未上报、查询失败）不加平台段：prompt 逐字节保持
-    现状，provider 前缀缓存零失效。"""
+def test_shell_platform_section_empty_for_unknown_only():
+    """空串/未知平台（云端沙箱、未上报、查询失败）不加平台段：prompt 逐字节保持
+    现状，provider 前缀缓存零失效，也绝不错入 Windows 方言分支。"""
     assert sandbox_shell_platform_section("") == ""
-    assert sandbox_shell_platform_section("linux") == ""
     assert sandbox_shell_platform_section("winxp") == ""
+
+
+def test_shell_platform_section_linux_injects_local_machine_identity():
+    """linux 本地 daemon 也必须注入「沙箱=用户本机」身份段。
+
+    生产会话 26ed193a 实测：linux daemon 不加段时，模型自认「隔离沙箱、
+    跟用户电脑完全不连通」，当面否认控制能力并反指用户可能中了远控木马
+    ——而命令实际就跑在用户机器上。身份认知正确优先于前缀缓存。"""
+    section = sandbox_shell_platform_section("linux")
+    assert "user's own real computer" in section
+    assert "never claim" in section.lower()
+    # 谨慎操作纪律：真实机器上删改要先确认、新文件优先会话 workspace
+    assert "confirm" in section.lower()
+    assert "session workspace" in section
+
+
+def test_local_machine_identity_reaches_win32_and_darwin():
+    """win32/darwin 的方言段之前只在开头顺带提一句「用户机器」，缺身份与
+    谨慎纪律框架；身份段必须补上，且以纯尾部追加方式——方言段历史字节
+    保持原样（存量会话已缓存前缀零失效），身份段接在最后。"""
+    markers = {"win32": "cmd.exe", "darwin": "macOS"}
+    for platform, marker in markers.items():
+        section = sandbox_shell_platform_section(platform)
+        assert "user's own real computer" in section
+        # 方言段原字节在前的纯追加：分叉点不前移
+        assert section.startswith("### Local Machine Shell:")
+        assert section.index(marker) < section.index("user's own real computer")
 
 
 def test_shell_platform_section_win32_guides_cmdexe_syntax():

--- a/tests/client/test_packaging.py
+++ b/tests/client/test_packaging.py
@@ -319,17 +319,27 @@ def test_tauri_bundle_adhoc_signs_macos_app() -> None:
     assert conf["bundle"]["macOS"]["signingIdentity"] == "-"
 
 
+def test_tauri_bundle_disables_hardened_runtime_for_adhoc_sidecar() -> None:
+    """v2.10.0 发版事故防线：Tauri 默认对全部可执行（含 daemon sidecar）落
+    hardened runtime 标志，而 runtime 隐含 library validation——PyInstaller
+    onefile 运行时解包的内嵌 dylib 是无团队 ID 的 ad-hoc 签名，LV 下 dlopen
+    即 SIGKILL（v2.9.2 macOS「daemon 起不来」根因）。ad-hoc 分发不做公证，
+    runtime 标志只有害处，必须在打包期关闭；打包后重封 sidecar 补救不可行
+    （破坏外层封印，且 updater 归档先于重封生成、包内仍是坏字节）。"""
+    import json
+
+    conf = json.loads(_source("frontend/src-tauri/tauri.conf.json"))
+    assert conf["bundle"]["macOS"]["hardenedRuntime"] is False
+
+
 def test_release_workflow_verifies_macos_code_signing() -> None:
-    """签名门禁（v2.9.2 层2）：macOS 打包后先把 daemon sidecar 无 --options
-    重封（不带 hardened runtime / library validation——PyInstaller 解包出的
-    内嵌库无团队 ID，LV 下 dlopen 即被杀），runtime 标志残留时构建直接失败；
-    再验证 bundle 封印与嵌套可执行签名（arm64 内核要求全部可执行代码至少
-    ad-hoc 签名）。"""
+    """签名门禁（v2.9.2 层2）：macOS 打包后验证 sidecar 无 runtime 标志
+    （打包期由 tauri.conf.json hardenedRuntime: false 保证，出现即打包链
+    回归）、bundle 封印与嵌套可执行逐一签名（arm64 内核要求全部可执行代码
+    至少 ad-hoc 签名）。只验证不修改——改内嵌二进制会破坏外层封印。"""
     steps = {step["name"]: step for step in _desktop_job()["steps"]}
-    verify = steps["Re-seal daemon sidecar without hardened runtime + verify signing"]
+    verify = steps["Verify macOS code signing (sidecar must have no runtime flag)"]
     assert verify["if"] == "runner.os == 'macOS'"
-    # 无 --options 重封：新签名不带 runtime/LV 标志（flags 归零）
-    assert 'codesign --force --sign - --timestamp=none "$daemon_bin"' in verify["run"]
     # 门禁：CodeDirectory flags 含 runtime (0x10000) 即红
     assert "flags=0x[0-9a-f]*1[0-9a-f]{4}" in verify["run"]
     assert "codesign --verify --deep --strict" in verify["run"]

--- a/tests/infra/agent/test_steer_middleware.py
+++ b/tests/infra/agent/test_steer_middleware.py
@@ -1,72 +1,88 @@
 """SteerMiddleware（运行中插话注入）单元测试。"""
 
-import pytest
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import (
+    AIMessage,
+    HumanMessage,
+    RemoveMessage,
+    ToolMessage,
+)
 
 from src.infra.agent.middleware.steer import SteerMiddleware
 
-
-class _Request:
-    """模拟 ModelRequest：记录 override 调用。"""
-
-    def __init__(self, messages=None):
-        self.messages = messages if messages is not None else [HumanMessage(content="原消息")]
-        self.override_calls: list[dict] = []
-
-    def override(self, **kwargs):
-        self.override_calls.append(kwargs)
-        return _Request(messages=kwargs.get("messages", self.messages))
+try:  # deepagents 为这些 agent 提供真实的 messages 通道 reducer
+    from deepagents._messages_reducer import _messages_delta_reducer
+except ImportError:  # pragma: no cover - 环境缺 deepagents 时跳过 reducer 级断言
+    _messages_delta_reducer = None
 
 
-class _Response:
-    """模拟 ModelResponse。"""
+def _tool_call(call_id: str = "call_1", name: str = "ls") -> dict:
+    return {"name": name, "args": {}, "id": call_id, "type": "tool_call"}
 
 
-async def test_pending_message_is_injected_and_persisted() -> None:
+def _tool_response_adjacent(messages: list) -> bool:
+    """OpenAI 协议不变量：每个带 tool_calls 的 AI 消息后紧跟其全部 ToolMessage。"""
+    pending: set[str] = set()
+    for m in messages:
+        if isinstance(m, AIMessage) and m.tool_calls:
+            if pending:
+                return False
+            pending = {tc["id"] for tc in m.tool_calls}
+        elif isinstance(m, ToolMessage):
+            pending.discard(m.tool_call_id)
+        elif pending:
+            return False
+    return True
+
+
+async def test_injected_message_lands_before_model_response() -> None:
+    """回归（2026-09-08 生产 400）：插话必须先于模型响应进入图状态。
+
+    旧实现经 ``Command(update)`` 在模型节点完成后追加插话，一旦该次响应
+    携带 tool_calls，tools 节点写回的 ToolMessage 落在插话之后，下一次
+    模型调用因 "insufficient tool messages following tool_calls message"
+    被 DeepSeek/OpenAI 拒绝。注入改到 ``before_model`` 钩子后，插话先落
+    state、模型响应后落，顺序恒为 [插话, AI(tool_calls), ToolMessage]。
+    """
     from src.infra.task.steer import get_steer_queue
 
     await get_steer_queue().enqueue("middleware-session-1", "中途插话")
 
     middleware = SteerMiddleware(session_id="middleware-session-1")
-    request = _Request()
-    seen_requests: list[_Request] = []
+    state = {
+        "messages": [
+            HumanMessage(content="原消息"),
+            AIMessage(content="看下目录", tool_calls=[_tool_call()]),
+            ToolMessage(content="No files found", name="ls", tool_call_id="call_1"),
+        ]
+    }
 
-    async def handler(req):
-        seen_requests.append(req)
-        return _Response()
+    update = await middleware.abefore_model(state, None)
 
-    result = await middleware.awrap_model_call(request, handler)
-
-    # 模型看到了插话消息（追加在历史之后）
-    assert len(seen_requests) == 1
-    contents = [m.content for m in seen_requests[0].messages]
-    assert contents == ["原消息", "中途插话"]
-
-    # 结果携带 Command(update) 把插话消息持久化进图状态
-    command = getattr(result, "command", None)
-    update = getattr(command, "update", None)
     assert update is not None
-    injected = update.get("messages")
-    assert isinstance(injected, list) and len(injected) == 1
-    assert isinstance(injected[0], HumanMessage)
-    assert injected[0].content == "中途插话"
 
-    # 注入后队列被清空（不会重复注入下一次调用）
-    assert await get_steer_queue().drain("middleware-session-1") == []
+    injected = [m for m in update["messages"] if not isinstance(m, RemoveMessage)]
+    assert [m.content for m in injected] == ["中途插话"]
+
+    if _messages_delta_reducer is not None:
+        # 模拟框架时序：before_model 更新先提交，随后模型响应与工具结果追加
+        after_update = _messages_delta_reducer(state["messages"], [update["messages"]])
+        final = _messages_delta_reducer(
+            after_update,
+            [
+                [AIMessage(content="", tool_calls=[_tool_call("call_2", "write_file")])],
+                [ToolMessage(content="ok", name="write_file", tool_call_id="call_2")],
+            ],
+        )
+        assert _tool_response_adjacent(final)
+        # 插话在 AI(tool_calls) 之前（模型是对插话做出的响应）
+        contents = [m.content for m in final]
+        assert contents.index("中途插话") < len(final) - 2
 
 
-async def test_no_pending_message_passes_through_untouched() -> None:
+async def test_no_pending_message_returns_none() -> None:
     middleware = SteerMiddleware(session_id="session-clean")
-    request = _Request()
-    sentinel = _Response()
 
-    async def handler(_req):
-        return sentinel
-
-    result = await middleware.awrap_model_call(request, handler)
-
-    assert result is sentinel
-    assert request.override_calls == []
+    assert await middleware.abefore_model({"messages": []}, None) is None
 
 
 async def test_multiple_pending_messages_inject_in_order() -> None:
@@ -77,16 +93,11 @@ async def test_multiple_pending_messages_inject_in_order() -> None:
     await queue.enqueue("session-2", "插话二")
 
     middleware = SteerMiddleware(session_id="session-2")
-    seen: list[_Request] = []
+    update = await middleware.abefore_model({"messages": []}, None)
 
-    async def handler(req):
-        seen.append(req)
-        return _Response()
-
-    await middleware.awrap_model_call(_Request(), handler)
-
-    contents = [m.content for m in seen[0].messages]
-    assert contents == ["原消息", "插话一", "插话二"]
+    injected = [m for m in update["messages"] if not isinstance(m, RemoveMessage)]
+    assert [m.content for m in injected] == ["插话一", "插话二"]
+    assert await queue.drain("session-2") == []
 
 
 async def test_other_session_messages_are_not_injected() -> None:
@@ -95,42 +106,72 @@ async def test_other_session_messages_are_not_injected() -> None:
     await get_steer_queue().enqueue("session-other", "别的会话")
 
     middleware = SteerMiddleware(session_id="session-mine")
-    sentinel = _Response()
 
-    async def handler(_req):
-        return sentinel
-
-    result = await middleware.awrap_model_call(_Request(), handler)
-
-    assert result is sentinel
+    assert await middleware.abefore_model({"messages": []}, None) is None
     # 别的会话消息仍在队列中，未被消费
     assert await get_steer_queue().drain("session-other") == ["别的会话"]
 
 
-async def test_failed_model_call_requeues_messages() -> None:
-    """模型调用整体失败时，插话消息重新入队，等待下次运行送达（不丢失）。"""
+async def test_misordered_history_is_healed_on_injection() -> None:
+    """存量坏会话自愈：历史里 AI(tool_calls) 与 ToolMessage 之间夹了消息时重排。
+
+    旧 bug 已在生产写出 [AI(tool_calls), Human, ToolMessage] 形态的 state，
+    不自愈则该会话每次调用都 400。重排把夹中间的消息后移到 ToolMessage 之后。
+    """
     from src.infra.task.steer import get_steer_queue
 
-    await get_steer_queue().enqueue("session-fail", "重要插话")
+    await get_steer_queue().enqueue("session-heal", "新插话")
 
-    middleware = SteerMiddleware(session_id="session-fail")
+    middleware = SteerMiddleware(session_id="session-heal")
+    state = {
+        "messages": [
+            HumanMessage(content="原消息"),
+            AIMessage(content="", tool_calls=[_tool_call("call_a", "search_tools")]),
+            HumanMessage(content="旧插话"),
+            ToolMessage(content="found", name="search_tools", tool_call_id="call_a"),
+        ]
+    }
 
-    async def handler(_req):
-        raise RuntimeError("model down")
+    update = await middleware.abefore_model(state, None)
 
-    with pytest.raises(RuntimeError):
-        await middleware.awrap_model_call(_Request(), handler)
+    messages = update["messages"]
+    assert isinstance(messages[0], RemoveMessage)  # 整表重写
+    healed = messages[1:]
+    assert [type(m).__name__ for m in healed] == [
+        "HumanMessage",  # 原消息
+        "AIMessage",  # AI(tool_calls)
+        "ToolMessage",  # 其响应紧跟
+        "HumanMessage",  # 旧插话后移
+        "HumanMessage",  # 新插话在末尾
+    ]
+    if _messages_delta_reducer is not None:
+        final = _messages_delta_reducer(state["messages"], [messages])
+        assert _tool_response_adjacent(final)
 
-    # 失败后消息回到队列最前（保持 FIFO：先到的插话先送达）
-    assert await get_steer_queue().drain("session-fail") == ["重要插话"]
+
+async def test_clean_history_injects_without_full_rewrite() -> None:
+    """顺序合法时不整表重写（避免每次调用都写全量消息）。"""
+    from src.infra.task.steer import get_steer_queue
+
+    await get_steer_queue().enqueue("session-clean-hist", "插话")
+
+    middleware = SteerMiddleware(session_id="session-clean-hist")
+    state = {
+        "messages": [
+            HumanMessage(content="原消息"),
+            AIMessage(content="", tool_calls=[_tool_call()]),
+            ToolMessage(content="ok", name="ls", tool_call_id="call_1"),
+        ]
+    }
+
+    update = await middleware.abefore_model(state, None)
+
+    assert not any(isinstance(m, RemoveMessage) for m in update["messages"])
+    assert [m.content for m in update["messages"]] == ["插话"]
 
 
 async def test_steer_event_persisted_before_model_call_runs() -> None:
-    """steer:message 事件在模型调用开始前写出。
-
-    事件必须先于本次调用的输出事件进入 Redis/MongoDB，实时 SSE 与
-    历史回放中插话才会排在回答之前（而不是落在 run 尾部）。
-    """
+    """steer:message 事件在注入时写出（before_model 节点先于模型节点执行）。"""
     from src.infra.task.steer import get_steer_queue
 
     await get_steer_queue().enqueue("session-order", "插话")
@@ -142,15 +183,9 @@ async def test_steer_event_persisted_before_model_call_runs() -> None:
             saved.append(event)
 
     middleware = SteerMiddleware(session_id="session-order", presenter=_FakePresenter())
-    observed_save_counts: list[int] = []
 
-    async def handler(_req):
-        observed_save_counts.append(len(saved))
-        return _Response()
+    await middleware.abefore_model({"messages": []}, None)
 
-    await middleware.awrap_model_call(_Request(), handler)
-
-    assert observed_save_counts == [1]
     assert saved[0]["event"] == "steer:message"
     assert saved[0]["data"]["content"] == "插话"
 
@@ -175,73 +210,17 @@ async def test_steer_event_carries_created_at_send_time() -> None:
 
     middleware = SteerMiddleware(session_id="session-created-at", presenter=_FakePresenter())
 
-    async def handler(_req):
-        return _Response()
-
-    await middleware.awrap_model_call(_Request(), handler)
+    await middleware.abefore_model({"messages": []}, None)
 
     assert saved[0]["data"]["created_at"] == "2026-08-22T15:14:55+00:00"
 
 
-async def test_failed_model_call_keeps_injected_event_and_requeues() -> None:
-    """调用失败时注入事件已按注入时刻写出（消息确已发送）；消息原 ID 回队重试。"""
-    from src.infra.task.steer import SteerItem, get_steer_queue
-
-    await get_steer_queue().enqueue_item(
-        "session-fail-order",
-        SteerItem(id="steer-retry-me", content="重要插话"),
-    )
-
-    saved: list[dict] = []
-
-    class _FakePresenter:
-        async def save_event(self, event):
-            saved.append(event)
-
-    middleware = SteerMiddleware(session_id="session-fail-order", presenter=_FakePresenter())
-
-    async def handler(_req):
-        raise RuntimeError("model down")
-
-    with pytest.raises(RuntimeError):
-        await middleware.awrap_model_call(_Request(), handler)
-
-    assert [event["data"]["message_id"] for event in saved] == ["steer-retry-me"]
-    requeued = await get_steer_queue().drain("session-fail-order")
-    assert requeued == ["重要插话"]
-
-
-async def test_successful_injection_persists_via_presenter(monkeypatch) -> None:
-    """注入成功后经 presenter.save_event 写独立 steer:message 事件（归属当前 run 的 trace）。"""
+async def test_injection_persists_via_presenter_with_run_id() -> None:
+    """注入经 presenter.save_event 写独立 steer:message 事件（归属当前 run 的 trace）。"""
     from src.infra.task.steer import get_steer_queue
 
     await get_steer_queue().enqueue("session-p", "要持久化的插话")
 
-    saved: list[dict] = []
-
-    class _FakePresenter:
-        async def save_event(self, event):
-            saved.append(event)
-
-    middleware = SteerMiddleware(session_id="session-p", presenter=_FakePresenter())
-
-    async def handler(_req):
-        return _Response()
-
-    await middleware.awrap_model_call(_Request(), handler)
-
-    assert len(saved) == 1
-    assert saved[0]["event"] == "steer:message"
-    assert saved[0]["data"]["content"] == "要持久化的插话"
-    assert str(saved[0]["data"]["message_id"]).startswith("steer-")
-
-
-async def test_successful_injection_preserves_client_message_id() -> None:
-    from src.infra.task.steer import SteerItem, get_steer_queue
-
-    await get_steer_queue().enqueue_item(
-        "session-id", SteerItem(id="client-123", content="按这个方向")
-    )
     saved: list[dict] = []
 
     class _FakePresenter:
@@ -250,14 +229,78 @@ async def test_successful_injection_preserves_client_message_id() -> None:
         async def save_event(self, event):
             saved.append(event)
 
-    middleware = SteerMiddleware(session_id="session-id", presenter=_FakePresenter())
+    middleware = SteerMiddleware(session_id="session-p", presenter=_FakePresenter())
 
-    async def handler(_req):
-        return _Response()
+    await middleware.abefore_model({"messages": []}, None)
 
-    await middleware.awrap_model_call(_Request(), handler)
-    assert saved[0]["data"]["message_id"] == "client-123"
+    assert len(saved) == 1
+    assert saved[0]["event"] == "steer:message"
+    assert saved[0]["data"]["content"] == "要持久化的插话"
+    assert str(saved[0]["data"]["message_id"]).startswith("steer-")
     assert saved[0]["data"]["run_id"] == "run-123"
+
+
+async def test_injection_falls_back_to_dual_writer(monkeypatch) -> None:
+    """无 presenter 时回退 dual_writer 直写（实时 SSE 兜底）。"""
+    from src.infra.task.steer import get_steer_queue
+
+    await get_steer_queue().enqueue("session-p2", "兜底的插话")
+
+    written: list[dict] = []
+
+    class _FakeWriter:
+        async def write_event(self, **kwargs):
+            written.append(kwargs)
+
+    monkeypatch.setattr("src.infra.session.dual_writer.get_dual_writer", lambda: _FakeWriter())
+
+    middleware = SteerMiddleware(session_id="session-p2")
+
+    update = await middleware.abefore_model({"messages": []}, None)
+
+    assert len(written) == 1
+    assert written[0]["event_type"] == "steer:message"
+    assert written[0]["data"]["content"] == "兜底的插话"
+    assert update is not None  # 事件失败不影响注入本身
+
+
+async def test_persist_failure_does_not_break_injection(monkeypatch) -> None:
+    """事件写入失败不影响注入本身（尽力而为）。"""
+    from src.infra.task.steer import get_steer_queue
+
+    await get_steer_queue().enqueue("session-pp", "插话")
+
+    def broken_writer():
+        raise RuntimeError("dual writer down")
+
+    monkeypatch.setattr("src.infra.session.dual_writer.get_dual_writer", broken_writer)
+
+    middleware = SteerMiddleware(session_id="session-pp")
+
+    update = await middleware.abefore_model({"messages": []}, None)
+
+    assert update is not None  # 注入仍成功
+
+
+async def test_drained_message_is_delivered_via_state_not_requeue() -> None:
+    """drain 即送达：更新经 before_model 节点提交 checkpoint，模型调用失败也不回队。
+
+    消息已在图状态里持久化，失败后新 run 从 state 续跑仍能看到插话；
+    再回队反而会在下次注入时重复。
+    """
+    from src.infra.task.steer import SteerItem, get_steer_queue
+
+    await get_steer_queue().enqueue_item(
+        "session-fail", SteerItem(id="steer-1", content="重要插话")
+    )
+
+    middleware = SteerMiddleware(session_id="session-fail")
+
+    update = await middleware.abefore_model({"messages": []}, None)
+
+    injected = [m for m in update["messages"] if not isinstance(m, RemoveMessage)]
+    assert [m.content for m in injected] == ["重要插话"]
+    assert await get_steer_queue().drain("session-fail") == []
 
 
 async def test_queued_steer_survives_hitl_pause_and_uses_same_resumed_run() -> None:
@@ -282,18 +325,13 @@ async def test_queued_steer_survives_hitl_pause_and_uses_same_resumed_run() -> N
             saved.append(event)
 
     middleware = SteerMiddleware(session_id="session-hitl", presenter=_ResumedPresenter())
-    seen: list[_Request] = []
 
-    async def handler(req):
-        seen.append(req)
-        return _Response()
+    first = await middleware.abefore_model({"messages": []}, None)
+    # 恢复后再次进入 before_model：队列已空，不重复注入
+    second = await middleware.abefore_model({"messages": []}, None)
 
-    await middleware.awrap_model_call(_Request(), handler)
-
-    assert [message.content for message in seen[0].messages] == [
-        "原消息",
-        "继续时按这个方向",
-    ]
+    assert first is not None
+    assert second is None
     assert saved == [
         {
             "event": "steer:message",
@@ -307,54 +345,6 @@ async def test_queued_steer_survives_hitl_pause_and_uses_same_resumed_run() -> N
         }
     ]
     assert await queue.drain_items("session-hitl") == []
-
-
-async def test_successful_injection_falls_back_to_dual_writer(monkeypatch) -> None:
-    """无 presenter 时回退 dual_writer 直写（实时 SSE 兜底）。"""
-    from src.infra.task.steer import get_steer_queue
-
-    await get_steer_queue().enqueue("session-p2", "兜底的插话")
-
-    written: list[dict] = []
-
-    class _FakeWriter:
-        async def write_event(self, **kwargs):
-            written.append(kwargs)
-
-    monkeypatch.setattr("src.infra.session.dual_writer.get_dual_writer", lambda: _FakeWriter())
-
-    middleware = SteerMiddleware(session_id="session-p2")
-
-    async def handler(_req):
-        return _Response()
-
-    await middleware.awrap_model_call(_Request(), handler)
-
-    assert len(written) == 1
-    assert written[0]["event_type"] == "steer:message"
-    assert written[0]["data"]["content"] == "兜底的插话"
-
-
-async def test_persist_failure_does_not_break_injection(monkeypatch) -> None:
-    """事件写入失败不影响注入本身（尽力而为）。"""
-    from src.infra.task.steer import get_steer_queue
-
-    await get_steer_queue().enqueue("session-pp", "插话")
-
-    def broken_writer():
-        raise RuntimeError("dual writer down")
-
-    monkeypatch.setattr("src.infra.session.dual_writer.get_dual_writer", broken_writer)
-
-    middleware = SteerMiddleware(session_id="session-pp")
-    sentinel = _Response()
-
-    async def handler(_req):
-        return sentinel
-
-    result = await middleware.awrap_model_call(_Request(), handler)
-
-    assert getattr(result, "command", None) is not None  # 注入仍成功
 
 
 def test_imports_match_langchain_middleware_shape() -> None:

--- a/tests/infra/agent/test_steer_middleware.py
+++ b/tests/infra/agent/test_steer_middleware.py
@@ -170,6 +170,112 @@ async def test_clean_history_injects_without_full_rewrite() -> None:
     assert [m.content for m in update["messages"]] == ["插话"]
 
 
+def _reorder(messages: list) -> list | None:
+    from src.infra.agent.middleware.steer import _reorder_tool_response_adjacency
+
+    return _reorder_tool_response_adjacency(messages)
+
+
+def test_reorder_multi_tool_calls_keep_all_responses_adjacent() -> None:
+    """一条 AI 消息带多个 tool_calls：全部响应必须紧跟其后，夹层消息后移。"""
+    reordered = _reorder(
+        [
+            HumanMessage(content="原消息"),
+            AIMessage(
+                content="",
+                tool_calls=[_tool_call("c1"), _tool_call("c2", "grep")],
+            ),
+            HumanMessage(content="夹层插话"),
+            ToolMessage(content="r1", name="ls", tool_call_id="c1"),
+            ToolMessage(content="r2", name="grep", tool_call_id="c2"),
+        ]
+    )
+
+    assert reordered is not None
+    assert [type(m).__name__ for m in reordered] == [
+        "HumanMessage",
+        "AIMessage",
+        "ToolMessage",
+        "ToolMessage",
+        "HumanMessage",
+    ]
+    assert reordered[4].content == "夹层插话"
+
+
+def test_reorder_holds_messages_between_partial_tool_responses() -> None:
+    """多响应之间也夹了消息：响应聚合完之前不得放行夹层。"""
+    reordered = _reorder(
+        [
+            AIMessage(content="", tool_calls=[_tool_call("c1"), _tool_call("c2", "grep")]),
+            ToolMessage(content="r1", name="ls", tool_call_id="c1"),
+            HumanMessage(content="夹层"),
+            ToolMessage(content="r2", name="grep", tool_call_id="c2"),
+        ]
+    )
+
+    assert reordered is not None
+    assert [type(m).__name__ for m in reordered] == [
+        "AIMessage",
+        "ToolMessage",
+        "ToolMessage",
+        "HumanMessage",
+    ]
+
+
+def test_reorder_dangling_tool_calls_left_untouched() -> None:
+    """悬空 tool_calls（始终无响应）不重排：留给 PatchToolCallsMiddleware 补合成响应。"""
+    messages = [
+        HumanMessage(content="原消息"),
+        AIMessage(content="", tool_calls=[_tool_call("c-never")]),
+        HumanMessage(content="插话A"),
+        AIMessage(content="done"),
+    ]
+
+    assert _reorder(messages) is None
+
+
+def test_reorder_ai_without_tool_calls_does_not_hold() -> None:
+    """无 tool_calls 的 AI 消息不开启响应等待，后续消息顺序原样保留。"""
+    messages = [
+        HumanMessage(content="问题"),
+        AIMessage(content="回答"),
+        HumanMessage(content="追问"),
+        AIMessage(content="", tool_calls=[_tool_call("c9")]),
+        ToolMessage(content="ok", name="ls", tool_call_id="c9"),
+    ]
+
+    assert _reorder(messages) is None
+
+
+def test_reorder_consecutive_broken_pairs_all_healed() -> None:
+    """多处乱序一次全部修复，且原始相对顺序（除后移外）保持稳定。"""
+    reordered = _reorder(
+        [
+            HumanMessage(content="q1"),
+            AIMessage(content="", tool_calls=[_tool_call("a1")]),
+            HumanMessage(content="s1"),
+            ToolMessage(content="r1", name="ls", tool_call_id="a1"),
+            HumanMessage(content="q2"),
+            AIMessage(content="", tool_calls=[_tool_call("a2")]),
+            HumanMessage(content="s2"),
+            ToolMessage(content="r2", name="ls", tool_call_id="a2"),
+        ]
+    )
+
+    assert reordered is not None
+    assert [(type(m).__name__, m.content) for m in reordered] == [
+        ("HumanMessage", "q1"),
+        ("AIMessage", ""),
+        ("ToolMessage", "r1"),
+        ("HumanMessage", "s1"),
+        ("HumanMessage", "q2"),
+        ("AIMessage", ""),
+        ("ToolMessage", "r2"),
+        ("HumanMessage", "s2"),
+    ]
+    assert _tool_response_adjacent(reordered)
+
+
 async def test_steer_event_persisted_before_model_call_runs() -> None:
     """steer:message 事件在注入时写出（before_model 节点先于模型节点执行）。"""
     from src.infra.task.steer import get_steer_queue

--- a/tests/infra/agent/test_steer_middleware_integration.py
+++ b/tests/infra/agent/test_steer_middleware_integration.py
@@ -1,0 +1,162 @@
+"""SteerMiddleware 与真实 langchain agent 图的集成测试。
+
+用 MemorySaver + 假模型跑完整的 model→tools→before_model 循环，验证
+插话注入后发给模型的消息序列满足 OpenAI 协议不变量（带 tool_calls 的
+assistant 消息后紧跟对应 ToolMessage），以及存量乱序会话的自愈。
+"""
+
+from typing import Any
+
+from langchain.agents import create_agent
+from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
+from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, ToolMessage
+from langgraph.checkpoint.memory import MemorySaver
+from pydantic import Field
+
+from src.infra.agent.middleware.steer import SteerMiddleware
+
+
+class _RecordingModel(FakeMessagesListChatModel):
+    """按脚本顺序返回响应，并记录每次调用收到的消息序列。"""
+
+    received: list[list[AnyMessage]] = Field(default_factory=list)
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs: Any):
+        self.received.append(list(messages))
+        return super()._generate(messages, stop=stop, run_manager=run_manager, **kwargs)
+
+    async def _agenerate(self, messages, stop=None, run_manager=None, **kwargs: Any):
+        return self._generate(messages, stop=stop, run_manager=run_manager, **kwargs)
+
+    def bind_tools(self, tools, **kwargs: Any):  # noqa: ARG002
+        """脚本响应已含 tool_calls，绑定为空操作。"""
+        return self
+
+
+def _assert_tool_response_adjacent(messages: list[AnyMessage]) -> None:
+    """OpenAI 协议不变量：AI(tool_calls) 后必须紧跟其全部 ToolMessage。"""
+    pending: set[str] = set()
+    for message in messages:
+        if isinstance(message, AIMessage) and message.tool_calls:
+            assert not pending, (
+                f"AI(tool_calls) 后存在未回应的调用 {pending}：{[m.type for m in messages]}"
+            )
+            pending = {tc["id"] for tc in message.tool_calls}
+        elif isinstance(message, ToolMessage):
+            pending.discard(message.tool_call_id)
+        else:
+            assert not pending, (
+                f"AI(tool_calls) 与其 ToolMessage 之间夹了 {message.type} 消息："
+                f"{[m.type for m in messages]}"
+            )
+
+
+class _SilentPresenter:
+    run_id = "run-integration"
+
+    async def save_event(self, event: dict) -> None:
+        pass
+
+
+async def test_mid_run_steer_keeps_request_order_valid() -> None:
+    """工具执行期间插话：后续所有模型调用收到的序列必须协议合法。
+
+    回归场景（2026-09-08 生产）：插话注入后模型以 tool_calls 响应插话，
+    旧实现经 Command(update) 在模型节点完成后追加插话，导致 ToolMessage
+    落在插话之后，下一次模型调用被 DeepSeek 拒绝（400）。
+    """
+    from src.infra.task.steer import get_steer_queue
+
+    session_id = "integration-mid-run"
+    queue = get_steer_queue()
+
+    async def enqueue_steer() -> str:
+        """模拟用户在工具执行期间插话：把消息放入 steer 队列。"""
+        await queue.enqueue(session_id, "中途插话")
+        return "ok"
+
+    model = _RecordingModel(
+        responses=[
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {"name": "enqueue_steer", "args": {}, "id": "call_1", "type": "tool_call"}
+                ],
+            ),
+            AIMessage(
+                content="按插话的方向处理",
+                tool_calls=[
+                    {"name": "enqueue_steer", "args": {}, "id": "call_2", "type": "tool_call"}
+                ],
+            ),
+            AIMessage(content="完成"),
+        ]
+    )
+    graph = create_agent(
+        model,
+        tools=[enqueue_steer],
+        middleware=[SteerMiddleware(session_id=session_id, presenter=_SilentPresenter())],
+        checkpointer=MemorySaver(),
+    )
+
+    result = await graph.ainvoke(
+        {"messages": [HumanMessage(content="原消息")]},
+        config={"configurable": {"thread_id": "t-mid-run"}},
+    )
+
+    assert "完成" in str(result["messages"][-1].content)
+    assert len(model.received) == 3
+
+    for received in model.received:
+        _assert_tool_response_adjacent(received)
+
+    # 插话注入后的那次调用：插话在已完成的 ToolMessage 之后、模型响应之前
+    second = model.received[1]
+    assert [m.content for m in second if isinstance(m, HumanMessage)] == ["原消息", "中途插话"]
+    assert isinstance(second[-1], HumanMessage) and second[-1].content == "中途插话"
+
+
+async def test_previously_broken_thread_is_healed_on_next_run() -> None:
+    """旧 bug 写出的乱序 state（AI(tool_calls) 与 ToolMessage 之间夹消息）自愈。"""
+    from src.infra.task.steer import get_steer_queue
+
+    session_id = "integration-heal"
+    queue = get_steer_queue()
+    config = {"configurable": {"thread_id": "t-heal"}}
+
+    model = _RecordingModel(responses=[AIMessage(content="已恢复")])
+    graph = create_agent(
+        model,
+        tools=[],
+        middleware=[SteerMiddleware(session_id=session_id, presenter=_SilentPresenter())],
+        checkpointer=MemorySaver(),
+    )
+
+    # 复现旧 bug 写入的 state：插话夹在 AI(tool_calls) 与 ToolMessage 之间
+    await graph.aupdate_state(
+        config,
+        {
+            "messages": [
+                HumanMessage(content="原消息"),
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {"name": "search_tools", "args": {}, "id": "call_x", "type": "tool_call"}
+                    ],
+                ),
+                HumanMessage(content="旧插话"),
+                ToolMessage(content="found 1 tool", name="search_tools", tool_call_id="call_x"),
+            ]
+        },
+    )
+
+    await queue.enqueue(session_id, "新插话")
+    await graph.ainvoke({"messages": []}, config=config)
+
+    assert len(model.received) == 1
+    received = model.received[0]
+    _assert_tool_response_adjacent(received)
+    types = [m.type for m in received]
+    assert types == ["human", "ai", "tool", "human", "human"]
+    assert received[3].content == "旧插话"
+    assert received[4].content == "新插话"

--- a/tests/infra/agent/test_steer_middleware_integration.py
+++ b/tests/infra/agent/test_steer_middleware_integration.py
@@ -7,6 +7,7 @@ assistant 消息后紧跟对应 ToolMessage），以及存量乱序会话的自�
 
 from typing import Any
 
+import pytest
 from langchain.agents import create_agent
 from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
 from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, ToolMessage
@@ -160,3 +161,165 @@ async def test_previously_broken_thread_is_healed_on_next_run() -> None:
     assert types == ["human", "ai", "tool", "human", "human"]
     assert received[3].content == "旧插话"
     assert received[4].content == "新插话"
+
+
+async def test_failed_model_call_after_injection_resumes_without_duplicate() -> None:
+    """注入后模型调用失败：新 run 从 state 续跑，插话恰好送达一次。
+
+    before_model 更新已随 checkpoint 提交（drain 即送达），失败后插话仍在
+    图状态里；再次 ainvoke（模拟新 run）不得重复注入、序列仍协议合法。
+    """
+    from src.infra.task.steer import get_steer_queue
+
+    session_id = "integration-fail-resume"
+    queue = get_steer_queue()
+
+    class _FlakyModel(_RecordingModel):
+        """第一次调用抛错，之后恢复正常（模拟模型故障后新 run 恢复）。"""
+
+        fail_first: bool = True
+
+        def _generate(self, messages, stop=None, run_manager=None, **kwargs: Any):
+            if self.fail_first:
+                self.fail_first = False
+                raise RuntimeError("model down")
+            return super()._generate(messages, stop=stop, run_manager=run_manager, **kwargs)
+
+    model = _FlakyModel(
+        responses=[AIMessage(content="恢复完成")],
+    )
+    graph = create_agent(
+        model,
+        tools=[],
+        middleware=[SteerMiddleware(session_id=session_id, presenter=_SilentPresenter())],
+        checkpointer=MemorySaver(),
+    )
+    config = {"configurable": {"thread_id": "t-fail-resume"}}
+
+    # 模拟用户在模型故障前插话，注入成功但模型调用失败
+    await queue.enqueue(session_id, "故障前插话")
+    with pytest.raises(RuntimeError, match="model down"):
+        await graph.ainvoke({"messages": [HumanMessage(content="原消息")]}, config=config)
+
+    # 故障后不回队（drain 即送达），队列视角干净
+    assert await queue.list_items(session_id) == []
+
+    # 新 run 续跑：插话仍在 state，恰好一次；序列协议合法
+    result = await graph.ainvoke({"messages": []}, config=config)
+
+    assert "恢复完成" in str(result["messages"][-1].content)
+    # 故障调用不计入 received（父类只在成功路径记录）；续跑调用恰好一次
+    assert len(model.received) == 1
+    for received in model.received:
+        _assert_tool_response_adjacent(received)
+    humans = [m.content for m in model.received[0] if isinstance(m, HumanMessage)]
+    assert humans == ["原消息", "故障前插话"]
+
+
+async def test_multiple_steers_across_model_calls_each_injected_once() -> None:
+    """两次不同时点的插话，分别注入各自的下一次模型调用，顺序与协议都合法。"""
+    from src.infra.task.steer import get_steer_queue
+
+    session_id = "integration-multi-steer"
+    queue = get_steer_queue()
+
+    async def steer_one() -> str:
+        "用户第一段插话"
+        await queue.enqueue(session_id, "插话一")
+        return "ok"
+
+    async def steer_two() -> str:
+        "用户第二段插话"
+        await queue.enqueue(session_id, "插话二")
+        return "ok"
+
+    model = _RecordingModel(
+        responses=[
+            AIMessage(
+                content="",
+                tool_calls=[{"name": "steer_one", "args": {}, "id": "c1", "type": "tool_call"}],
+            ),
+            AIMessage(
+                content="",
+                tool_calls=[{"name": "steer_two", "args": {}, "id": "c2", "type": "tool_call"}],
+            ),
+            AIMessage(content="两段插话都已处理"),
+        ]
+    )
+    graph = create_agent(
+        model,
+        tools=[steer_one, steer_two],
+        middleware=[SteerMiddleware(session_id=session_id, presenter=_SilentPresenter())],
+        checkpointer=MemorySaver(),
+    )
+
+    result = await graph.ainvoke(
+        {"messages": [HumanMessage(content="原消息")]},
+        config={"configurable": {"thread_id": "t-multi"}},
+    )
+
+    assert "两段插话都已处理" in str(result["messages"][-1].content)
+    assert len(model.received) == 3
+    for received in model.received:
+        _assert_tool_response_adjacent(received)
+        humans = [m.content for m in received if isinstance(m, HumanMessage)]
+        assert humans.count("插话一") <= 1 and humans.count("插话二") <= 1
+    # 第二次调用看到插话一、第三次调用看到插话一+插话二（state 累积）
+    assert [m.content for m in model.received[1] if isinstance(m, HumanMessage)] == [
+        "原消息",
+        "插话一",
+    ]
+    assert [m.content for m in model.received[2] if isinstance(m, HumanMessage)] == [
+        "原消息",
+        "插话一",
+        "插话二",
+    ]
+
+
+async def test_deepagents_graph_mid_run_steer_keeps_protocol() -> None:
+    """生产栈形态（deepagents create_deep_agent，Fast Agent 同款）下的插话回归。
+
+    deepagents 在 langchain create_agent 外再包了 filesystem/subagents 等
+    中间件与自带的 messages reducer；插话注入与乱序自愈必须在该栈下同样
+    成立（协议不变量 + 插话先于响应）。
+    """
+    from deepagents import create_deep_agent
+
+    from src.infra.task.steer import get_steer_queue
+
+    session_id = "integration-deepagents"
+    queue = get_steer_queue()
+
+    async def enqueue_steer() -> str:
+        "用户在工具执行期间插话"
+        await queue.enqueue(session_id, "deepagents 栈下的插话")
+        return "ok"
+
+    model = _RecordingModel(
+        responses=[
+            AIMessage(
+                content="",
+                tool_calls=[{"name": "enqueue_steer", "args": {}, "id": "d1", "type": "tool_call"}],
+            ),
+            AIMessage(content="deepagents 栈处理完成"),
+        ]
+    )
+    graph = create_deep_agent(
+        model,
+        [enqueue_steer],
+        system_prompt="You are a test agent.",
+        middleware=[SteerMiddleware(session_id=session_id, presenter=_SilentPresenter())],
+        checkpointer=MemorySaver(),
+    )
+
+    result = await graph.ainvoke(
+        {"messages": [HumanMessage(content="原消息")]},
+        config={"configurable": {"thread_id": "t-deepagents"}},
+    )
+
+    assert "deepagents 栈处理完成" in str(result["messages"][-1].content)
+    assert len(model.received) == 2
+    for received in model.received:
+        _assert_tool_response_adjacent(received)
+    humans = [m.content for m in model.received[1] if isinstance(m, HumanMessage)]
+    assert humans == ["原消息", "deepagents 栈下的插话"]

--- a/tests/infra/agent/test_steer_redis_integration.py
+++ b/tests/infra/agent/test_steer_redis_integration.py
@@ -1,0 +1,127 @@
+"""SteerMiddleware + SteerQueue 真 Redis 集成测试。
+
+复现生产部署形态（Redis 队列多 worker 共享）：验证「drain 即送达」在
+Redis 路径上的完整不变量——注入后队列视角必须干净（pending/inflight
+清空），否则 run 终态的 ``emit_undelivered_steer_events`` 会把已送达的
+插话误报为 ``steer:undelivered``，前端补发流程会把同一条消息再发一次
+（用户看到重复消息）。
+
+本机/CI 无 Redis 时自动跳过（非静默：标记 skip 留痕）。
+"""
+
+from uuid import uuid4
+
+import pytest
+
+from src.infra.agent.middleware.steer import SteerMiddleware
+from src.infra.task.steer import SteerItem, SteerQueue, emit_undelivered_steer_events
+
+
+def _redis_available() -> bool:
+    import asyncio
+
+    async def _probe() -> bool:
+        try:
+            from src.infra.storage.redis import create_redis_client
+
+            client = create_redis_client()
+            try:
+                return bool(await client.ping())
+            finally:
+                await client.aclose()
+        except Exception:
+            return False
+
+    try:
+        return asyncio.run(_probe())
+    except RuntimeError:
+        return False
+
+
+redis_required = pytest.mark.skipif(not _redis_available(), reason="local Redis unreachable")
+
+
+class _RecordingPresenter:
+    run_id = "run-redis-integration"
+
+    def __init__(self) -> None:
+        self.saved: list[dict] = []
+
+    async def save_event(self, event: dict) -> None:
+        self.saved.append(event)
+
+
+@pytest.fixture
+async def redis_queue(monkeypatch):
+    """真 Redis 队列 + 会话级隔离 + 用后清理。
+
+    conftest 的 autouse fixture 会把队列单例换成进程内实现；这里重新把
+    ``get_steer_queue`` 单例绑回真 Redis 队列，中间件 drain/ack 才走
+    Redis 路径（生产部署形态），结束后还原。
+    """
+    import src.infra.task.steer as steer_module
+
+    queue = SteerQueue()
+    session_id = f"steer-redis-test-{uuid4().hex[:8]}"
+    previous = steer_module._steer_queue
+    steer_module._steer_queue = queue
+    try:
+        yield queue, session_id
+    finally:
+        steer_module._steer_queue = previous
+        await queue.clear_session(session_id)
+
+
+@redis_required
+async def test_injected_steer_is_not_reported_undelivered_at_run_end(redis_queue) -> None:
+    """注入成功的插话在 run 终态不得被误报 steer:undelivered（前端会补发导致重复）。"""
+    queue, session_id = redis_queue
+    await queue.enqueue_item(session_id, SteerItem(id="steer-delivered", content="已送达的插话"))
+
+    middleware = SteerMiddleware(session_id=session_id, presenter=_RecordingPresenter())
+    update = await middleware.abefore_model({"messages": []}, None)
+    assert update is not None  # 注入成功
+
+    # executor 终态路径：列出残留插话并写 steer:undelivered
+    presenter = _RecordingPresenter()
+    written = await emit_undelivered_steer_events(
+        session_id, run_id="run-end", presenter=presenter, queue=queue
+    )
+
+    assert written == 0, f"已送达插话被误报 undelivered：{presenter.saved}"
+    assert presenter.saved == []
+    # 队列视角必须干净（list_items 读 pending+inflight，被 enqueue 幂等与补发流程依赖）
+    assert await queue.list_items(session_id) == []
+
+
+@redis_required
+async def test_injected_steer_survives_across_queue_instances(redis_queue) -> None:
+    """多 worker 形态：drain 后另起队列实例，inflight/lease 不得残留。"""
+    queue, session_id = redis_queue
+    await queue.enqueue_item(session_id, SteerItem(id="steer-cross", content="跨实例插话"))
+
+    middleware = SteerMiddleware(session_id=session_id)
+    assert await middleware.abefore_model({"messages": []}, None) is not None
+
+    # 模拟另一个 worker / 进程重启后的队列实例
+    other = SteerQueue()
+    try:
+        assert await other.list_items(session_id) == []
+    finally:
+        await other.clear_session(session_id)
+
+
+@redis_required
+async def test_never_injected_steer_is_still_reported_undelivered(redis_queue) -> None:
+    """对照：未被注入的插话仍照常落 steer:undelivered（不丢消息语义不变）。"""
+    queue, session_id = redis_queue
+    await queue.enqueue_item(session_id, SteerItem(id="steer-pending", content="未注入的插话"))
+
+    presenter = _RecordingPresenter()
+    written = await emit_undelivered_steer_events(
+        session_id, run_id="run-pending", presenter=presenter, queue=queue
+    )
+
+    assert written == 1
+    assert presenter.saved[0]["event"] == "steer:undelivered"
+    assert presenter.saved[0]["data"]["message_id"] == "steer-pending"

--- a/tests/infra/agent/test_token_usage_carry.py
+++ b/tests/infra/agent/test_token_usage_carry.py
@@ -1,0 +1,89 @@
+"""token:usage 跨 HITL 恢复累计（issue：审批恢复后只记最后一段）。
+
+恢复分段重新执行 agent_node 时，AgentEventProcessor 计数器从零开始，
+先前分段的用量经 seed_usage 并入，emit_token_usage 输出 run 累计值；
+usage_logs 取 trace 最后一个 token:usage，自然拿到全量 token 与费用。
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from src.infra.agent.events.processor import AgentEventProcessor
+from src.infra.writer.present import Presenter
+
+
+def _make_processor(emitted: list[dict]) -> AgentEventProcessor:
+    presenter = MagicMock(spec=Presenter)
+    presenter.emit = AsyncMock(side_effect=lambda e: emitted.append(e))
+    presenter.present_token_usage = MagicMock(
+        side_effect=lambda **kw: {"event": "token:usage", "data": kw}
+    )
+    return AgentEventProcessor(presenter)
+
+
+def test_seed_usage_merges_prior_segment_counters():
+    processor = _make_processor([])
+    processor.seed_usage(
+        {
+            "input_tokens": 1000,
+            "output_tokens": 100,
+            "total_tokens": 1100,
+            "cache_creation_tokens": 3,
+            "cache_read_tokens": 7,
+        }
+    )
+    # 本分段统计到的增量（模拟 process_event 累加）
+    processor.total_input_tokens += 50
+    processor.total_output_tokens += 10
+
+    assert processor.usage_totals() == {
+        "input_tokens": 1050,
+        "output_tokens": 110,
+        "total_tokens": 1100,
+        "cache_creation_tokens": 3,
+        "cache_read_tokens": 7,
+    }
+
+
+def test_seed_usage_ignores_empty_or_malformed_payload():
+    processor = _make_processor([])
+    processor.seed_usage(None)
+    processor.seed_usage({})
+    processor.seed_usage({"input_tokens": "x"})  # type: ignore[dict-item]
+
+    assert processor.usage_totals() == {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "total_tokens": 0,
+        "cache_creation_tokens": 0,
+        "cache_read_tokens": 0,
+    }
+
+
+async def test_emit_token_usage_outputs_cumulative_totals_with_seeded_usage():
+    emitted: list[dict] = []
+    processor = _make_processor(emitted)
+    processor.seed_usage({"input_tokens": 199581, "output_tokens": 6695})
+    processor.total_input_tokens += 60358
+    processor.total_output_tokens += 1063
+
+    ok = await processor.emit_token_usage(duration=349.1)
+
+    assert ok is True
+    assert len(emitted) == 1
+    data = emitted[0]["data"]
+    assert data["input_tokens"] == 259939
+    assert data["output_tokens"] == 7758
+    assert data["total_tokens"] == 267697
+    assert data["duration"] == 349.1
+
+
+async def test_emit_token_usage_emits_with_seeded_usage_even_without_segment_llm_calls():
+    """零 LLM 分段（挂起即恢复）也要刷新累计值，避免终态回退到分段口径。"""
+    emitted: list[dict] = []
+    processor = _make_processor(emitted)
+    processor.seed_usage({"input_tokens": 500, "output_tokens": 5, "total_tokens": 505})
+
+    ok = await processor.emit_token_usage(duration=2.0)
+
+    assert ok is True
+    assert emitted[0]["data"]["total_tokens"] == 505

--- a/tests/infra/task/test_arq_runtime.py
+++ b/tests/infra/task/test_arq_runtime.py
@@ -48,6 +48,7 @@ async def test_start_embedded_arq_worker_runs_with_signals_disabled(
         ARQ_EMBEDDED_WORKER=True,
         ARQ_WORKER_MAX_JOBS=128,
         ARQ_JOB_TIMEOUT_SECONDS=30,
+        ARQ_POLL_DELAY_SECONDS=0.1,
         ARQ_QUEUE_NAME="lambchat:arq",
         REDIS_URL="redis://localhost:6379/0",
         REDIS_PASSWORD=None,
@@ -74,6 +75,23 @@ async def test_start_embedded_arq_worker_runs_with_signals_disabled(
 
 
 @pytest.mark.asyncio
+async def test_worker_polls_queue_at_configured_fast_delay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """取任务轮询间隔来自设置（默认 0.1s）：arq 默认 0.5s 轮询直接吃掉恢复时延。"""
+    _FakeWorker.instances.clear()
+    monkeypatch.setattr(arq_runtime, "settings", _arq_settings())
+
+    runtime = arq_runtime.EmbeddedArqRuntime(worker_factory=_FakeWorker)
+    await runtime.start()
+
+    worker = _FakeWorker.instances[0]
+    assert worker.kwargs["poll_delay"] == 0.1
+
+    await runtime.stop()
+
+
+@pytest.mark.asyncio
 async def test_start_embedded_arq_worker_accepts_future_returned_by_async_run(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -95,6 +113,7 @@ async def test_start_embedded_arq_worker_accepts_future_returned_by_async_run(
         ARQ_EMBEDDED_WORKER=True,
         ARQ_WORKER_MAX_JOBS=128,
         ARQ_JOB_TIMEOUT_SECONDS=30,
+        ARQ_POLL_DELAY_SECONDS=0.1,
         ARQ_QUEUE_NAME="lambchat:arq",
         REDIS_URL="redis://localhost:6379/0",
         REDIS_PASSWORD=None,
@@ -135,6 +154,7 @@ async def test_stop_embedded_arq_worker_awaits_future_returned_by_close(
         ARQ_EMBEDDED_WORKER=True,
         ARQ_WORKER_MAX_JOBS=128,
         ARQ_JOB_TIMEOUT_SECONDS=30,
+        ARQ_POLL_DELAY_SECONDS=0.1,
         ARQ_QUEUE_NAME="lambchat:arq",
         REDIS_URL="redis://localhost:6379/0",
         REDIS_PASSWORD=None,
@@ -173,6 +193,7 @@ def _arq_settings() -> SimpleNamespace:
         ARQ_EMBEDDED_WORKER=True,
         ARQ_WORKER_MAX_JOBS=128,
         ARQ_JOB_TIMEOUT_SECONDS=30,
+        ARQ_POLL_DELAY_SECONDS=0.1,
         ARQ_QUEUE_NAME="lambchat:arq",
         REDIS_URL="redis://localhost:6379/0",
         REDIS_PASSWORD=None,

--- a/tests/infra/task/test_hitl_resume.py
+++ b/tests/infra/task/test_hitl_resume.py
@@ -42,6 +42,13 @@ class _FakeRedis:
         released = self.store.pop(key, None) == token
         return _maybe_await(int(released))
 
+    def get(self, key):
+        return _maybe_await(self.store.get(key))
+
+    def delete(self, key):
+        self.store.pop(key, None)
+        return _maybe_await(1)
+
 
 def _maybe_await(value):
     import asyncio
@@ -205,6 +212,28 @@ async def test_resume_activation_mongo_fallback_requires_exact_terminal_attempt(
 
 
 @pytest.mark.asyncio
+async def test_resume_activation_key_survives_read_for_fast_retry(monkeypatch) -> None:
+    """激活 key 读取后必须保留（TTL 清理）：job 因 source fence / 并发槽
+    Retry 重跑时再次等待要立即命中，不得空轮询满 timeout 才落 Mongo 兜底。"""
+    redis = _FakeRedis()
+    key = f"{hitl_mod.HITL_RESUME_ACTIVATION_PREFIX}attempt-1"
+    redis.store[key] = "approval-1"
+    monkeypatch.setattr(hitl_mod, "get_redis_client", lambda: redis)
+    storage = SimpleNamespace(
+        get=AsyncMock(return_value=SimpleNamespace(status="approved", metadata={}))
+    )
+    monkeypatch.setattr("src.infra.storage.mongodb.get_approval_storage", lambda: storage)
+
+    first = await hitl_mod.wait_for_hitl_resume_activation("approval-1", "attempt-1", timeout=0.1)
+    second = await hitl_mod.wait_for_hitl_resume_activation("approval-1", "attempt-1", timeout=0.1)
+
+    assert first is True
+    assert second is True
+    assert key in redis.store
+    storage.get.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_submit_resume_skips_when_not_waiting_human(fake_redis, monkeypatch):
     monkeypatch.setattr(hitl_mod.settings, "HITL_MODE", "interrupt", raising=False)
 
@@ -220,6 +249,53 @@ async def test_submit_resume_skips_when_not_waiting_human(fake_redis, monkeypatc
     result = await submit_hitl_resume_run(_approval(), {"approved": True, "values": {}})
     assert result["submitted"] is False
     assert "等待" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_submit_resume_waits_briefly_when_source_run_still_inflight(fake_redis, monkeypatch):
+    """审批卡 SSE 早于 WAITING_HUMAN 状态翻转可见：respond 抢跑（源 run 还在
+    running/starting 收尾）时短暂等待状态翻转，而不是直接拒绝导致要点两次。"""
+    monkeypatch.setattr(hitl_mod.settings, "TASK_BACKEND", "arq", raising=False)
+
+    statuses = ["running", "running", "waiting_human"]
+
+    class _Storage:
+        calls = 0
+
+        async def get_by_session_id(self, _session_id):
+            _Storage.calls += 1
+            status = statuses[min(_Storage.calls - 1, len(statuses) - 1)]
+            return SimpleNamespace(
+                user_id="user-1",
+                name="s",
+                metadata={
+                    "task_status": status,
+                    "current_run_id": "run-1",
+                    "executor_key": "agent_stream",
+                    "agent_id": "search",
+                },
+            )
+
+    monkeypatch.setattr("src.infra.session.storage.SessionStorage", lambda: _Storage())
+
+    async def fake_executor():
+        yield
+
+    monkeypatch.setattr(
+        "src.infra.task.concurrency.get_registered_executor", lambda key: fake_executor
+    )
+
+    class _FakeManager:
+        async def submit_arq(self, *args, **kwargs):
+            return "run-1", "trace-1"
+
+    monkeypatch.setattr("src.infra.task.manager.get_task_manager", lambda: _FakeManager())
+
+    result = await submit_hitl_resume_run(_approval(), {"approved": True, "values": {}})
+
+    assert result["submitted"] is True
+    assert result["run_id"] == "run-1"
+    assert _Storage.calls >= 3
 
 
 @pytest.mark.asyncio

--- a/tests/infra/task/test_hitl_resume_usage_carry.py
+++ b/tests/infra/task/test_hitl_resume_usage_carry.py
@@ -1,0 +1,47 @@
+"""hitl_resume 载荷携带 run 用量锚点（issue：审批恢复后只记最后一段）。
+
+build_hitl_resume_payload 从审批 metadata.resume_context 还原
+run_started_at / prior_usage，恢复执行据此累计 token 与工作时长。
+"""
+
+from types import SimpleNamespace
+
+from src.infra.task.hitl import build_hitl_resume_payload
+
+
+def _approval(resume_context: dict | None) -> SimpleNamespace:
+    return SimpleNamespace(
+        id="ap1",
+        message="确认执行",
+        metadata={
+            "run_id": "run_20260908134828_3cf0b70a",
+            "trace_id": "trace_1",
+            "interrupt_id": "i1",
+            "tool_call_id": "tc1",
+            "resume_context": resume_context or {},
+        },
+    )
+
+
+def test_payload_carries_run_anchor_and_prior_usage():
+    prior = {"input_tokens": 23478, "output_tokens": 1019, "total_tokens": 24497}
+    payload = build_hitl_resume_payload(
+        _approval({"run_started_at": 1757336908.8, "prior_usage": prior}),
+        {"approved": True},
+    )
+
+    assert payload["run_started_at"] == 1757336908.8
+    assert payload["prior_usage"] == prior
+    # 既有字段保持不变
+    assert payload["approval_id"] == "ap1"
+    assert payload["resume_value"] == {"i1": {"approved": True}}
+    assert payload["approval_resolved"]["status"] == "approved"
+
+
+def test_payload_without_resume_context_keeps_none_carry():
+    payload = build_hitl_resume_payload(_approval(None), {"approved": False})
+
+    assert payload["run_started_at"] is None
+    assert payload["prior_usage"] is None
+    assert payload["goal_started_at"] is None
+    assert payload["approval_resolved"]["status"] == "rejected"

--- a/tests/kernel/config/test_arq_poll_delay_setting.py
+++ b/tests/kernel/config/test_arq_poll_delay_setting.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+"""arq 取任务轮询间隔设置：缩短派发拾取延迟（HITL resume 提速）。"""
+
+from src.kernel.config.base import Settings
+from src.kernel.config.definitions import SETTING_DEFINITIONS
+
+
+def test_arq_poll_delay_definition_exists() -> None:
+    definition = SETTING_DEFINITIONS["ARQ_POLL_DELAY_SECONDS"]
+    assert definition["category"].value == "redis"
+    assert definition["subcategory"] == "task"
+    assert definition["frontend_visible"] is False
+
+
+def test_arq_poll_delay_defaults_match_settings_field() -> None:
+    assert Settings().ARQ_POLL_DELAY_SECONDS == 0.1
+    assert SETTING_DEFINITIONS["ARQ_POLL_DELAY_SECONDS"]["default"] == 0.1


### PR DESCRIPTION
## Summary

develop → main 例行晋升，含 4 个已验证变更：

- #498 fix(agent): HITL 审批恢复后 token 用量与工作时长跨分段累计
- #499 fix(prompt): 本地 daemon 会话注入「沙箱=用户本机」身份段
- #500 fix(frontend): 审批队列对 SSE 整段重放收敛，刷新中 run 不再重现已答复的 ask human 卡
- #502 perf(task): HITL resume 提速——arq 拾取 0.1s 轮询、retry 免 2s 空等、respond 抢跑宽限

## 验证

- develop CI 全绿（develop-20260908-153658），后端全量 4373 passed
- staging 真实链路 12/12 通过：真实对话、HITL 审批挂起/恢复、SSE 整段重放收敛、跨段 usage/duration 累计（duration 545.88s 横跨挂起期）、HITL 全循环墙钟 10.3s