### PR TITLE
test(download): 修复 DownloadPage 偶发失败——等待锚点从静态平台名换成数据驱动内容

### DIFF
--- a/frontend/src/components/download/__tests__/DownloadPage.test.tsx
+++ b/frontend/src/components/download/__tests__/DownloadPage.test.tsx
@@ -93,8 +93,12 @@ test("renders desktop and daemon downloads from the latest release assets", asyn
 
   render(<DownloadPage />);
 
-  // 平台分区：Windows / macOS / Linux
-  expect(await screen.findByText("Windows")).toBeInTheDocument();
+  // 等待锚点必须是数据驱动内容（资产文件名）：平台卡标签（Windows/macOS）
+  // 不等 versionApi 就渲染，锚在静态标签上会在数据晚到时撞进空窗
+  expect(
+    await screen.findByText("LambChat-v2.8.1-Windows.msi"),
+  ).toBeInTheDocument();
+  expect(screen.getByText("Windows")).toBeInTheDocument();
   expect(screen.getByText("macOS")).toBeInTheDocument();
   expect(screen.getByText("Linux")).toBeInTheDocument();
 
@@ -127,9 +131,10 @@ test("macOS card shows the Gatekeeper first-launch note with the xattr command",
 
   render(<DownloadPage />);
 
-  await screen.findByText("macOS");
+  // 等数据驱动的命令本身（Gatekeeper 说明块要 links 到齐才挂载），
+  // 不锚在静态平台名上（见 test 1 注释）
   expect(
-    screen.getByText(/xattr -cr \/Applications\/LambChat\.app/),
+    await screen.findByText(/xattr -cr \/Applications\/LambChat\.app/),
   ).toBeInTheDocument();
   // 「已损坏」说明同时出现在一键安装与 xattr 兜底两段文案里
   expect(screen.getAllByText(/damaged/i).length).toBeGreaterThanOrEqual(1);
@@ -144,9 +149,11 @@ test("macOS card promotes the one-line install script command", async () => {
 
   render(<DownloadPage />);
 
-  await screen.findByText("macOS");
+  // 同上：等待命令本身出现（macOS 卡的安装块随资产数据异步挂载）
   expect(
-    screen.getByText(/curl -fsSL https:\/\/lambchat\.com\/install\.sh \| sh/),
+    await screen.findByText(
+      /curl -fsSL https:\/\/lambchat\.com\/install\.sh \| sh/,
+    ),
   ).toBeInTheDocument();
 });
 


### PR DESCRIPTION
## Summary

修复 `DownloadPage.test.tsx` 在 CI 偶发失败的老毛病（2026-09-08 develop push `1a85b720` 上 Frontend Tests 失败一次，本地复跑即过）。

**根因**：平台分区卡不等 `versionApi` 就渲染（空 links 也画 Windows/macOS 标签），而 curl 一键安装 / xattr Gatekeeper 块要资产数据到齐才挂载。原测试把等待锚点放在静态平台名（`findByText("macOS")`）上、随后同步 `getByText` 数据驱动内容——数据晚到时撞进空窗，纯时序竞态。

## Changes

- 三个用例（资产渲染 / Gatekeeper / 一键安装命令）的等待锚点换成数据驱动元素（资产文件名或命令本身）
- 测试 1 顺带把 Windows/macOS/Linux 标签断言移到数据到达之后

## Testing

- RED：延迟 mock 80ms 可确定性复现原失败（1 failed）
- GREEN：修复后同条件下 7/7 通过；正常 mock 亦 7/7
- 全量前端 2597 passed + eslint 通过