### PR TITLE
chore(release): bump 版本 2.10.0 → 2.10.1

### DIFF
--- a/client/lambchat_sandbox/__init__.py
+++ b/client/lambchat_sandbox/__init__.py
@@ -11,4 +11,4 @@ self-update 与服务端最低版本拒连打底。
 2.x/0.3.x 均放行，旧 daemon 经 self-update 平滑升到对齐版本。
 """
 
-__version__ = "2.10.0"
+__version__ = "2.10.1"

--- a/client/lambchat_sandbox/daemon.py
+++ b/client/lambchat_sandbox/daemon.py
@@ -36,6 +36,7 @@ import json
 import signal
 import sys
 import time
+from collections import deque
 from collections.abc import AsyncIterator, Awaitable, Callable
 from pathlib import Path
 
@@ -65,6 +66,34 @@ DAEMON_AUDIT_SESSION = "daemon"  # shutdown 等进程级事件的审计会话（
 # exec 的 watchdog ack 延时（秒）：短于此的命令不发 ack、done 直接到达——
 # 省一次 HTTP 往返；长命令到点补 ack，服务端 30s ACK 死线（远大于本值）无虞
 _EXEC_ACK_DELAY_S = 8.0
+
+# call_id 去重环容量：服务端 dispatch 断联重推是 at-least-once 投递，重复帧
+# 幂等跳过（重复执行用户机器上的命令是不可接受的副作用）。重复帧总在几秒
+# 内到达，容量只需覆盖一个重推窗口内的调用数。
+_RECENT_CALL_IDS_MAX = 512
+
+
+class _CallDedupe:
+    """跨连接的 call_id 去重：断联重连后收到的重复帧跳过执行。
+
+    FIFO 环形淘汰：容量之外的旧 id 被遗忘——数小时前的迟到重复帧理论上会
+    重执行，但重推窗口只有 ACK 死线（30s），现实中不存在这种迟到。
+    """
+
+    def __init__(self, capacity: int = _RECENT_CALL_IDS_MAX) -> None:
+        self._seen: set[str] = set()
+        self._order: deque[str] = deque()
+        self._capacity = capacity
+
+    def remember(self, call_id: str) -> bool:
+        """首次见到返回 True 并登记；重复返回 False。"""
+        if call_id in self._seen:
+            return False
+        self._seen.add(call_id)
+        self._order.append(call_id)
+        while len(self._order) > self._capacity:
+            self._seen.discard(self._order.popleft())
+        return True
 
 
 def _default_machine_name() -> str:
@@ -113,6 +142,7 @@ async def run_daemon(
 
     client: ChannelClient | None = None
     attempt = 0
+    dedupe = _CallDedupe()
     try:
         while True:
             if client is not None:
@@ -129,6 +159,7 @@ async def run_daemon(
                     cfg=cfg,
                     executor=executor_,
                     auditor=auditor_,
+                    dedupe=dedupe,
                 )
             except TransportAuthError:
                 await _silently_close(client)
@@ -148,7 +179,13 @@ async def run_daemon(
                 )
                 raise
             except Exception as exc:  # noqa: BLE001 - 任何单连接失败都退避重连
-                print(f"[sandbox] 通道断开: {exc}；退避后重连…", file=sys.stderr, flush=True)
+                # httpx 超时族的 str() 为空串（ReadTimeout/ConnectTimeout），
+                # 只打消息会得到『通道断开: 』的盲日志——必须带类型名。
+                print(
+                    f"[sandbox] 通道断开: {type(exc).__name__}: {exc}；退避后重连…",
+                    file=sys.stderr,
+                    flush=True,
+                )
             attempt += 1
             # 保留当前 client（流已关但 httpx 连接池可用）跨退避窗口：取消时仍能 post_offline
             await sleep_fn(backoff_delay(attempt))
@@ -165,10 +202,13 @@ async def _handle_channel(
     cfg: SandboxConfig,
     executor: Executor,
     auditor: Auditor,
+    dedupe: _CallDedupe | None = None,
 ) -> None:
     """单次连接内逐条处理 ToolCall；流结束/异常交回外层重连循环。"""
     async for call in calls:
-        await _process_call(client, call, cfg=cfg, executor=executor, auditor=auditor)
+        await _process_call(
+            client, call, cfg=cfg, executor=executor, auditor=auditor, dedupe=dedupe
+        )
 
 
 async def _process_call(
@@ -178,8 +218,13 @@ async def _process_call(
     cfg: SandboxConfig,
     executor: Executor,
     auditor: Auditor,
+    dedupe: _CallDedupe | None = None,
 ) -> None:
     """单条 ToolCall 的完整决策链：审计 received → ack → op 分发 → 迟到检查 → 执行 → done。
+
+    call_id 去重（dedupe 非 None 时）：服务端 dispatch 在 ACK 死线内对未确认
+    调用幂等重推（断联窗口丢帧的自愈），重复帧记 audit 后直接跳过——同一
+    调用绝不执行两次。
 
     确认门控不在本层（spec §3.5 服务端实现）：服务端统一确认门在 dispatch
     前以 ask_human interrupt 完成，daemon 只收到已确认的执行请求，到达即执行。
@@ -195,6 +240,18 @@ async def _process_call(
     path = str(call.payload.get("path", ""))
     session_id = _session_id_from_cwd(virtual_cwd)
     started = time.monotonic()
+    if dedupe is not None and not dedupe.remember(call.call_id):
+        auditor.log(
+            session_id,
+            {
+                "event": "duplicate_skipped",
+                "call_id": call.call_id,
+                "op": call.op,
+                "command": command,
+                "path": path,
+            },
+        )
+        return
     auditor.log(
         session_id,
         {

--- a/client/lambchat_sandbox/transport.py
+++ b/client/lambchat_sandbox/transport.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import json
 import random
@@ -31,6 +32,12 @@ BACKOFF_JITTER = 0.2  # ±20%
 # TransportError 进入退避重连，而不是永远挂在 read 上。
 _CHANNEL_READ_TIMEOUT_S = 45.0
 _CHANNEL_CONNECT_TIMEOUT_S = 10.0
+
+# hello 阶段独立超时（秒）：健康服务端建连即发 hello（毫秒级），迟迟不到
+# 说明帧被断联通道吞掉（滚动发布切换/代理僵死）。不等 45s 读超时，快速
+# 失败进退避重连，把 daemon 掉线窗口从分钟级压到秒级（2026-09-09 生产断联
+# 实测：hello 丢失的连接挂满 45s 才重连）。
+_HELLO_TIMEOUT_S = 12.0
 
 # 结果回传/offline 通知的 per-request 超时（秒）。client 全局 timeout=None 是给
 # SSE 长连接用的（心跳流不能被读超时切断），POST 沿用同一默认时服务端半死会让
@@ -189,14 +196,21 @@ class ChannelClient:
         try:
             await _raise_for_status(response, "channel")
             hello: dict[str, Any] | None = None
-            async for line in lines:
-                frame = parser.feed(line)
-                if frame is None or frame.event != "hello":
-                    continue
-                data = _parse_json_object(frame.data)
-                if data is not None:
-                    hello = data
-                    break
+            try:
+                # hello 独立短超时：僵死连接（建连后首帧永不到达）快速失败
+                async with asyncio.timeout(_HELLO_TIMEOUT_S):
+                    async for line in lines:
+                        frame = parser.feed(line)
+                        if frame is None or frame.event != "hello":
+                            continue
+                        data = _parse_json_object(frame.data)
+                        if data is not None:
+                            hello = data
+                            break
+            except TimeoutError:
+                raise TransportError(
+                    f"channel: {_HELLO_TIMEOUT_S:.0f}s 内未收到 hello 帧（连接疑似僵死）"
+                ) from None
             if hello is None:
                 raise TransportError("SSE 通道在 hello 帧前关闭")
         except BaseException:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -59,6 +59,40 @@ services:
       - LOG_LEVEL=INFO
       - ENABLE_MESSAGE_HISTORY=true
       - EVENT_MERGE_INTERVAL=60
+      # 任务执行与 API 分进程（与 k8s 部署同构）：重任务不饿死 API 事件循环
+      # （SSE/沙箱通道心跳停发），API 重启不杀运行中的任务。任务由
+      # lambchat-worker 服务消费（Redis 队列协同）。
+      - ARQ_EMBEDDED_WORKER=false
+    volumes:
+      - lamb-data:/app/data
+      - ./workspace:/app/workspace
+      - ./uploads:/app/uploads
+
+  lambchat-worker:
+    container_name: lambchat-worker
+    image: ghcr.io/yanyutin753/lambchat:latest
+    restart: always
+    command: ["/app/.venv/bin/python", "-m", "src.infra.task.worker_main"]
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+        reservations:
+          memory: 512M
+    depends_on:
+      redis:
+        condition: service_healthy
+      mongodb:
+        condition: service_healthy
+    environment:
+      - TZ=Asia/Shanghai
+      - REDIS_URL=redis://redis:6379/0
+      - MONGODB_URL=mongodb://mongodb:27017
+      - E2B_API_KEY=${E2B_API_KEY:-}
+      - E2B_TEMPLATE=${E2B_TEMPLATE:-base}
+      - LLM_MODEL_CACHE_SIZE=${LLM_MODEL_CACHE_SIZE:-50}
+      - SESSION_MAX_EVENTS_PER_TRACE=${SESSION_MAX_EVENTS_PER_TRACE:-10000}
+      - LOG_LEVEL=INFO
     volumes:
       - lamb-data:/app/data
       - ./workspace:/app/workspace

--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.lambchat.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 2100
-        versionName "2.10.0"
+        versionCode 2101
+        versionName "2.10.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/frontend/ios/App/App.xcodeproj/project.pbxproj
+++ b/frontend/ios/App/App.xcodeproj/project.pbxproj
@@ -352,7 +352,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 2.10.0;
+				MARKETING_VERSION = 2.10.1;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.lambchat.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -372,7 +372,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 2.10.0;
+				MARKETING_VERSION = 2.10.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lambchat.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lambchat-frontend",
   "private": true,
-  "version": "2.10.0",
+  "version": "2.10.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LambChat",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "identifier": "com.lambchat.app",
   "build": {
     "frontendDist": "../dist",

--- a/frontend/src/components/auth/AuthPage.tsx
+++ b/frontend/src/components/auth/AuthPage.tsx
@@ -21,6 +21,7 @@ import {
   ShieldCheck,
   Workflow,
   Database,
+  Loader2,
 } from "lucide-react";
 import { PasswordInput } from "./PasswordInput";
 import toast from "react-hot-toast";
@@ -107,6 +108,10 @@ export function AuthPage({ onSuccess, initialMode }: AuthPageProps) {
   const [oauthProviders, setOauthProviders] = useState<
     { id: string; name: string }[]
   >([]);
+  // 点击跳转 OAuth 提供商期间锁住按钮（导航发生前页面仍可交互，防止连点）
+  const [oauthPendingProvider, setOauthPendingProvider] = useState<
+    string | null
+  >(null);
   const [registrationEnabled, setRegistrationEnabled] = useState(true);
   const [turnstileConfig, setTurnstileConfig] = useState<TurnstileConfig>({
     enabled: false,
@@ -186,12 +191,14 @@ export function AuthPage({ onSuccess, initialMode }: AuthPageProps) {
     setTurnstileKey((prev) => prev + 1);
   }, [mode]);
 
-  // OAuth 登录处理
+  // OAuth 登录处理：点击即进入 loading，直到页面跳走；失败才复位
   const handleOAuthLogin = useCallback(
     async (provider: string) => {
+      setOauthPendingProvider(provider);
       try {
         await loginWithOAuth(provider);
       } catch {
+        setOauthPendingProvider(null);
         toast.error(t("auth.oauthLoginFailed"));
       }
     },
@@ -790,49 +797,56 @@ export function AuthPage({ onSuccess, initialMode }: AuthPageProps) {
                           <button
                             type="button"
                             onClick={() => handleOAuthLogin(provider.id)}
-                            className="auth-oauth-btn auth-social-provider flex h-12 items-center justify-center gap-2 rounded-full px-6 text-16 font-semibold text-slate-900 transition-all active:translate-y-0 dark:text-stone-100 font-serif"
+                            disabled={oauthPendingProvider !== null}
+                            className="auth-oauth-btn auth-social-provider flex h-12 items-center justify-center gap-2 rounded-full px-6 text-16 font-semibold text-slate-900 transition-all active:translate-y-0 disabled:cursor-not-allowed disabled:opacity-60 dark:text-stone-100 font-serif"
                           >
-                            {provider.id === "google" && (
-                              <svg
-                                className="h-4 w-4 flex-shrink-0 sm:h-5 sm:w-5"
-                                viewBox="0 0 48 48"
-                              >
-                                <path
-                                  fill="#EA4335"
-                                  d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
-                                />
-                                <path
-                                  fill="#4285F4"
-                                  d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
-                                />
-                                <path
-                                  fill="#FBBC05"
-                                  d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
-                                />
-                                <path
-                                  fill="#34A853"
-                                  d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
-                                />
-                              </svg>
+                            {oauthPendingProvider === provider.id && (
+                              <Loader2 className="h-4 w-4 flex-shrink-0 animate-spin sm:h-5 sm:w-5" />
                             )}
-                            {provider.id === "github" && (
-                              <svg
-                                className="h-4 w-4 flex-shrink-0 sm:h-5 sm:w-5"
-                                viewBox="0 0 24 24"
-                                fill="currentColor"
-                              >
-                                <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
-                              </svg>
-                            )}
-                            {provider.id === "apple" && (
-                              <svg
-                                className="h-4 w-4 flex-shrink-0 sm:h-5 sm:w-5"
-                                viewBox="0 0 24 24"
-                                fill="currentColor"
-                              >
-                                <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
-                              </svg>
-                            )}
+                            {provider.id === "google" &&
+                              oauthPendingProvider !== provider.id && (
+                                <svg
+                                  className="h-4 w-4 flex-shrink-0 sm:h-5 sm:w-5"
+                                  viewBox="0 0 48 48"
+                                >
+                                  <path
+                                    fill="#EA4335"
+                                    d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
+                                  />
+                                  <path
+                                    fill="#4285F4"
+                                    d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
+                                  />
+                                  <path
+                                    fill="#FBBC05"
+                                    d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
+                                  />
+                                  <path
+                                    fill="#34A853"
+                                    d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
+                                  />
+                                </svg>
+                              )}
+                            {provider.id === "github" &&
+                              oauthPendingProvider !== provider.id && (
+                                <svg
+                                  className="h-4 w-4 flex-shrink-0 sm:h-5 sm:w-5"
+                                  viewBox="0 0 24 24"
+                                  fill="currentColor"
+                                >
+                                  <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
+                                </svg>
+                              )}
+                            {provider.id === "apple" &&
+                              oauthPendingProvider !== provider.id && (
+                                <svg
+                                  className="h-4 w-4 flex-shrink-0 sm:h-5 sm:w-5"
+                                  viewBox="0 0 24 24"
+                                  fill="currentColor"
+                                >
+                                  <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
+                                </svg>
+                              )}
                             <span>
                               {t("auth.loginWith", {
                                 provider:

--- a/frontend/src/components/auth/__tests__/oauthButtonLoadingSource.test.ts
+++ b/frontend/src/components/auth/__tests__/oauthButtonLoadingSource.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+
+function readAuthSource(fileName: string): string {
+  return readFileSync(join(currentDir, fileName), "utf8");
+}
+
+test("oauth provider buttons enter a loading state immediately on click", () => {
+  const authPage = readAuthSource("../AuthPage.tsx");
+
+  // 点击即记录 pending 提供商；失败才复位（成功路径页面直接跳走）
+  expect(authPage).toMatch(/oauthPendingProvider/);
+  expect(authPage).toMatch(
+    /setOauthPendingProvider\(provider\);[\s\S]*?await loginWithOAuth\(provider\)/,
+  );
+  expect(authPage).toMatch(/catch[\s\S]*?setOauthPendingProvider\(null\)/);
+
+  // pending 期间所有 OAuth 按钮禁用，防止连点重复跳转
+  expect(authPage).toMatch(/disabled=\{oauthPendingProvider !== null\}/);
+
+  // 被点击的按钮图标位换成旋转 spinner
+  expect(authPage).toMatch(
+    /oauthPendingProvider === provider\.id[\s\S]*?animate-spin/,
+  );
+});

--- a/frontend/src/components/chat/ChatMessage/items/AskHumanItem.tsx
+++ b/frontend/src/components/chat/ChatMessage/items/AskHumanItem.tsx
@@ -24,6 +24,8 @@ import { ToolInlineDetails } from "./ToolInlineDetails";
 import { ToolHoverCopyButton } from "./ToolHoverCopyButton";
 import { ToolDurationFooter } from "./ToolDurationFooter";
 import { MarkdownContent } from "../MarkdownContent";
+import { parseAskHumanMessage } from "../../../panels/askHumanMessage";
+import { ApprovalOpList } from "../../../panels/ApprovalOpList";
 import type { FormField } from "../../../../types";
 
 // ── Parsers matching backend ask_human schema ──────────────────────────
@@ -282,6 +284,7 @@ function AskHumanDetail({ args, result, isPending }: ToolDetailProps) {
   const parsedResult = useMemo(() => parseResult(result), [result]);
 
   const { message, fields } = parsed;
+  const parsedMessage = useMemo(() => parseAskHumanMessage(message), [message]);
 
   // Supplement _other field when backend didn't include it
   // (e.g. cached events before the backend fix, or non-standard flows).
@@ -364,15 +367,29 @@ function AskHumanDetail({ args, result, isPending }: ToolDetailProps) {
           )}
         </div>
 
-        {/* Message (supports markdown) */}
+        {/* Message (structured ops list, or markdown prose) */}
         {message && (
           <div className="approval-message">
-            <div
-              className="prose prose-stone dark:prose-invert max-w-none text-14 leading-relaxed prose-p:my-0.5 prose-headings:my-1"
-              style={{ color: "var(--theme-text)" }}
-            >
-              <MarkdownContent content={message} />
-            </div>
+            {parsedMessage.ops ? (
+              <div className="space-y-2">
+                {parsedMessage.headline && (
+                  <div
+                    className="text-14 font-medium leading-relaxed"
+                    style={{ color: "var(--theme-text)" }}
+                  >
+                    {parsedMessage.headline}
+                  </div>
+                )}
+                <ApprovalOpList ops={parsedMessage.ops} />
+              </div>
+            ) : (
+              <div
+                className="prose prose-stone dark:prose-invert max-w-none text-14 leading-relaxed prose-p:my-0.5 prose-headings:my-1"
+                style={{ color: "var(--theme-text)" }}
+              >
+                <MarkdownContent content={message} />
+              </div>
+            )}
           </div>
         )}
 
@@ -478,6 +495,7 @@ const AskHumanItem = memo(function AskHumanItem({
   const parsedResult = useMemo(() => parseResult(result), [result]);
 
   const { message, fields } = parsed;
+  const parsedMessage = useMemo(() => parseAskHumanMessage(message), [message]);
 
   // Supplement _other field when backend didn't include it
   // (e.g. cached events before the backend fix, or non-standard flows).
@@ -531,10 +549,12 @@ const AskHumanItem = memo(function AskHumanItem({
 
   const labelText = (() => {
     const base = t("chat.message.toolAskHuman");
+    // 优先标题行（沙箱确认门是「确认在本机执行 N 项操作」），
+    // 避免把命令截断在 pill 标签里
     if (message) {
+      const headline = parsedMessage.headline ?? parsedMessage.summary;
       const preview =
-        message.length > 50 ? message.slice(0, 47) + "…" : message;
-      // Strip markdown for pill label
+        headline.length > 50 ? headline.slice(0, 47) + "…" : headline;
       const plain = preview.replace(/[#*_`~>[\]!]/g, "").trim();
       return `${base} — ${plain}`;
     }
@@ -553,14 +573,31 @@ const AskHumanItem = memo(function AskHumanItem({
     <ToolInlineDetails>
       {/* Message summary */}
       {message && (
-        <div className="flex items-start gap-2 px-2.5 py-2 rounded-lg bg-theme-bg border border-theme-border">
-          <ShieldCheck
-            size={12}
-            className="shrink-0 mt-0.5 text-[#f59e0b] dark:text-[#fbbf24]"
-          />
-          <span className="text-12 text-theme-text leading-relaxed line-clamp-2">
-            {message.length > 200 ? message.slice(0, 197) + "…" : message}
-          </span>
+        <div className="px-2.5 py-2 rounded-lg bg-theme-bg border border-theme-border space-y-1.5">
+          <div className="flex items-start gap-2">
+            <ShieldCheck
+              size={12}
+              className="shrink-0 mt-0.5 text-[#f59e0b] dark:text-[#fbbf24]"
+            />
+            <span className="text-12 text-theme-text leading-relaxed line-clamp-2">
+              {parsedMessage.headline ?? message}
+            </span>
+          </div>
+          {parsedMessage.ops && parsedMessage.ops.length > 0 && (
+            <div className="pl-5 flex items-baseline gap-1.5 min-w-0">
+              <span className="shrink-0 text-10 font-mono text-theme-text-tertiary tabular-nums">
+                1
+              </span>
+              <span className="text-11 font-mono text-theme-text-secondary leading-relaxed break-all line-clamp-1">
+                {parsedMessage.ops[0].detail}
+              </span>
+              {parsedMessage.ops.length > 1 && (
+                <span className="shrink-0 text-10 text-theme-text-tertiary">
+                  +{parsedMessage.ops.length - 1}
+                </span>
+              )}
+            </div>
+          )}
         </div>
       )}
 
@@ -642,10 +679,11 @@ const AskHumanItem = memo(function AskHumanItem({
             title: t("chat.message.toolAskHuman"),
             icon: <ShieldCheck size={16} />,
             status,
-            subtitle:
-              message && message.length > 120
-                ? message.slice(0, 117) + "…"
-                : message || undefined,
+            subtitle: message
+              ? parsedMessage.summary.length > 120
+                ? parsedMessage.summary.slice(0, 117) + "…"
+                : parsedMessage.summary || undefined
+              : undefined,
             fallback: detailContent || undefined,
             buildDetail: (data) => (
               <AskHumanDetail {...toolDetailPropsFromPanelData(data)} />

--- a/frontend/src/components/panels/ApprovalOpList.tsx
+++ b/frontend/src/components/panels/ApprovalOpList.tsx
@@ -1,0 +1,28 @@
+import { TerminalSquare } from "lucide-react";
+import type { AskHumanOp } from "./askHumanMessage";
+
+/**
+ * 沙箱确认门的操作清单——「单据式」只读列表：
+ * 编号 + 动词标签 + 等宽命令文本，发丝线分行。
+ * 同时用于审批卡（ApprovalPanel）与历史回放的 ask_human 详情面板。
+ */
+export function ApprovalOpList({ ops }: { ops: AskHumanOp[] }) {
+  return (
+    <div className="approval-op-list" role="list">
+      {ops.map((op, index) => (
+        <div className="approval-op-row" role="listitem" key={index}>
+          <span className="approval-op-index" aria-hidden="true">
+            {index + 1}
+          </span>
+          {op.verb ? (
+            <span className="approval-op-verb">
+              <TerminalSquare size={10} strokeWidth={2} aria-hidden="true" />
+              {op.verb}
+            </span>
+          ) : null}
+          <span className="approval-op-detail">{op.detail}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/panels/ApprovalPanel.tsx
+++ b/frontend/src/components/panels/ApprovalPanel.tsx
@@ -30,6 +30,8 @@ import {
   toggleMultiSelectValue,
   toggleSingleSelectValue,
 } from "./approvalFormValidation";
+import { parseAskHumanMessage } from "./askHumanMessage";
+import { ApprovalOpList } from "./ApprovalOpList";
 
 interface ApprovalPanelProps {
   approvals: PendingApproval[];
@@ -547,7 +549,9 @@ export function ApprovalPanel({
       field.type === "multi_select" ||
       field.type === "select",
   );
-  const askHumanQuestion = approvalSummary;
+  // 头部只放标题行；编号操作清单/补充说明进明细区，长消息不再挤成一行
+  const askHumanParsed = parseAskHumanMessage(currentApproval.message);
+  const askHumanQuestion = askHumanParsed.headline ?? approvalSummary;
   const isSubmitDisabled =
     isLoading || !isFormFieldsValid(currentApproval.fields, currentFormValues);
 
@@ -690,6 +694,18 @@ export function ApprovalPanel({
                         </ReactMarkdown>
                       )}
                     </div>
+                  </div>
+                )}
+
+                {isAskHuman && (askHumanParsed.ops || askHumanParsed.prose) && (
+                  <div className="approval-ask-human-context">
+                    {askHumanParsed.ops ? (
+                      <ApprovalOpList ops={askHumanParsed.ops} />
+                    ) : (
+                      <p className="approval-ask-human-context-prose">
+                        {askHumanParsed.prose}
+                      </p>
+                    )}
                   </div>
                 )}
 

--- a/frontend/src/components/panels/ScheduledTaskApprovalContent.tsx
+++ b/frontend/src/components/panels/ScheduledTaskApprovalContent.tsx
@@ -1,4 +1,6 @@
 import { useTranslation } from "react-i18next";
+import { clsx } from "clsx";
+import { CalendarClock, TerminalSquare, Check, Minus, Bot } from "lucide-react";
 
 interface ScheduledTaskApprovalContentProps {
   preview: {
@@ -11,68 +13,96 @@ interface ScheduledTaskApprovalContentProps {
   };
 }
 
+function SpecRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="approval-st-row">
+      <span className="approval-st-label">{label}</span>
+      <span className="approval-st-value">{children}</span>
+    </div>
+  );
+}
+
+function MonoChip({ children }: { children: React.ReactNode }) {
+  return <code className="approval-st-mono">{children}</code>;
+}
+
 /**
- * Renders a scheduled task creation approval with i18n support.
- * Used by ApprovalPanel when an approval has metadata.approval_type === "scheduled_task_create".
+ * Renders a scheduled task creation approval as a compact spec sheet:
+ * definition rows for the task parameters plus a code block for the run
+ * prompt. Used by ApprovalPanel when an approval has
+ * metadata.approval_type === "scheduled_task_create".
  */
 export function ScheduledTaskApprovalContent({
   preview,
 }: ScheduledTaskApprovalContentProps) {
   const { t } = useTranslation();
 
-  const immediate = preview.run_on_start
-    ? `✅ ${t("approvals.scheduledTask.yes")}`
-    : `❌ ${t("approvals.scheduledTask.no")}`;
-
   return (
-    <div>
-      <p>{t("approvals.scheduledTask.confirmCreation")}</p>
-      <p>{t("approvals.scheduledTask.noTaskYet")}</p>
+    <div className="approval-st">
+      <p className="approval-st-lead">
+        {t("approvals.scheduledTask.confirmCreation")}
+      </p>
+      <p className="approval-st-note">
+        {t("approvals.scheduledTask.noTaskYet")}
+      </p>
 
-      <table>
-        <thead>
-          <tr>
-            <th></th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <strong>{t("approvals.scheduledTask.name")}</strong>
-            </td>
-            <td>{preview.name}</td>
-          </tr>
-          <tr>
-            <td>
-              <strong>{t("approvals.scheduledTask.agent")}</strong>
-            </td>
-            <td>
-              <code>{preview.agent_id}</code>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <strong>{t("approvals.scheduledTask.schedule")}</strong>
-            </td>
-            <td>{preview.schedule}</td>
-          </tr>
-          <tr>
-            <td>
-              <strong>{t("approvals.scheduledTask.runImmediately")}</strong>
-            </td>
-            <td>{immediate}</td>
-          </tr>
-          <tr>
-            <td>
-              <strong>{t("approvals.scheduledTask.timeout")}</strong>
-            </td>
-            <td>{preview.timeout_seconds}s</td>
-          </tr>
-        </tbody>
-      </table>
+      <div className="approval-st-sheet">
+        <SpecRow label={t("approvals.scheduledTask.name")}>
+          <span className="approval-st-name">{preview.name}</span>
+        </SpecRow>
+        <SpecRow label={t("approvals.scheduledTask.agent")}>
+          <MonoChip>
+            <Bot
+              size={11}
+              strokeWidth={2}
+              aria-hidden="true"
+              className="approval-st-chip-icon"
+            />
+            {preview.agent_id}
+          </MonoChip>
+        </SpecRow>
+        <SpecRow label={t("approvals.scheduledTask.schedule")}>
+          <MonoChip>
+            <CalendarClock
+              size={11}
+              strokeWidth={2}
+              aria-hidden="true"
+              className="approval-st-chip-icon"
+            />
+            {preview.schedule}
+          </MonoChip>
+        </SpecRow>
+        <SpecRow label={t("approvals.scheduledTask.runImmediately")}>
+          <span
+            className={clsx(
+              "approval-st-flag",
+              preview.run_on_start
+                ? "approval-st-flag--on"
+                : "approval-st-flag--off",
+            )}
+          >
+            {preview.run_on_start ? (
+              <Check size={11} strokeWidth={2.5} aria-hidden="true" />
+            ) : (
+              <Minus size={11} strokeWidth={2.5} aria-hidden="true" />
+            )}
+            {preview.run_on_start
+              ? t("approvals.scheduledTask.yes")
+              : t("approvals.scheduledTask.no")}
+          </span>
+        </SpecRow>
+        <SpecRow label={t("approvals.scheduledTask.timeout")}>
+          <MonoChip>{preview.timeout_seconds}s</MonoChip>
+        </SpecRow>
+      </div>
 
-      <p>
+      <p className="approval-st-effect">
         {t("approvals.scheduledTask.effect", {
           agent: preview.agent_id,
           schedule: preview.schedule,
@@ -80,12 +110,15 @@ export function ScheduledTaskApprovalContent({
         {preview.run_on_start && t("approvals.scheduledTask.effectImmediate")}
       </p>
 
-      <p>
-        <strong>{t("approvals.scheduledTask.promptSent")}</strong>
-      </p>
-      <pre className="max-h-48 overflow-y-auto whitespace-pre-wrap break-words">
-        <code>{preview.message}</code>
-      </pre>
+      <div className="approval-st-prompt">
+        <div className="approval-st-prompt-header">
+          <TerminalSquare size={12} strokeWidth={2} aria-hidden="true" />
+          <span>{t("approvals.scheduledTask.promptSent")}</span>
+        </div>
+        <pre className="approval-st-prompt-body">
+          <code>{preview.message}</code>
+        </pre>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/panels/__tests__/askHumanLayout.test.ts
+++ b/frontend/src/components/panels/__tests__/askHumanLayout.test.ts
@@ -13,6 +13,43 @@ const approvalCss = readFileSync(
   "utf8",
 );
 
+test("adapts sandbox-confirm op rows to two-line stacking on narrow screens", () => {
+  // 窄屏：编号 + 动词胶囊一行，命令独占整行换行并缩进对齐胶囊左缘，
+  // 避免胶囊挤压命令宽度；参数单标签列同步放宽
+  expect(approvalCss).toMatch(
+    /@media \(max-width: 640px\)[\s\S]*?\.approval-op-row\s*\{[\s\S]*?flex-wrap:\s*wrap;/,
+  );
+  expect(approvalCss).toMatch(
+    /@media \(max-width: 640px\)[\s\S]*?\.approval-op-detail\s*\{[\s\S]*?flex-basis:\s*100%;/,
+  );
+  expect(approvalCss).toMatch(
+    /@media \(max-width: 640px\)[\s\S]*?\.approval-st-label\s*\{[\s\S]*?flex-basis:\s*5rem;/,
+  );
+});
+
+test("renders sandbox-confirm batches as a structured op list, not one crammed line", () => {
+  // 沙箱确认门的 message 是「标题 + 编号操作」多行文本：头部只放标题行，
+  // 明细区渲染单据式操作清单，命令走等宽字体 + 任意断行
+  expect(approvalSource).toMatch(
+    /parseAskHumanMessage\(currentApproval\.message\)/,
+  );
+  expect(approvalSource).toMatch(
+    /askHumanQuestion = askHumanParsed\.headline \?\? approvalSummary/,
+  );
+  expect(approvalSource).toMatch(/ApprovalOpList ops=\{askHumanParsed\.ops\}/);
+  expect(approvalSource).toMatch(/approval-ask-human-context/);
+  expect(approvalSource).toMatch(/askHumanParsed\.prose/);
+  expect(approvalCss).toMatch(
+    /\.approval-op-list\s*\{[\s\S]*?flex-direction:\s*column;/,
+  );
+  expect(approvalCss).toMatch(
+    /\.approval-op-detail\s*\{[\s\S]*?overflow-wrap:\s*anywhere;/,
+  );
+  expect(approvalCss).toMatch(
+    /\.approval-op-row \+ \.approval-op-row\s*\{[\s\S]*?border-top:\s*1px dashed/,
+  );
+});
+
 test("renders ask-human as a full card with numbered choices and footer actions", () => {
   expect(approvalSource).toMatch(/approval-card--ask-human/);
   expect(approvalSource).toMatch(/approval-ask-human-option/);

--- a/frontend/src/components/panels/__tests__/askHumanMessage.test.ts
+++ b/frontend/src/components/panels/__tests__/askHumanMessage.test.ts
@@ -1,0 +1,77 @@
+import { parseAskHumanMessage } from "../askHumanMessage";
+
+test("parses sandbox confirm batch into headline and op rows", () => {
+  const parsed = parseAskHumanMessage(
+    "确认在本机执行 2 项操作：\n" +
+      "1. 执行命令：rm ~/下载/数据文件/a.json && echo 已删除; ls -A ~/下载\n" +
+      "2. 写入文件：/tmp/out.txt",
+  );
+  expect(parsed.headline).toBe("确认在本机执行 2 项操作");
+  expect(parsed.ops).toEqual([
+    {
+      verb: "执行命令",
+      detail: "rm ~/下载/数据文件/a.json && echo 已删除; ls -A ~/下载",
+    },
+    { verb: "写入文件", detail: "/tmp/out.txt" },
+  ]);
+  expect(parsed.prose).toBeNull();
+});
+
+test("keeps an op without a CJK verb prefix detail-only", () => {
+  const parsed = parseAskHumanMessage(
+    "确认在本机执行 1 项操作：\n1. 上传 3 个文件",
+  );
+  expect(parsed.ops).toEqual([{ verb: null, detail: "上传 3 个文件" }]);
+});
+
+test("does not treat colons inside the command as the verb separator", () => {
+  const parsed = parseAskHumanMessage(
+    '确认在本机执行 1 项操作：\n1. 执行命令：echo "time: 10" && echo a：b',
+  );
+  expect(parsed.ops?.[0].verb).toBe("执行命令");
+  expect(parsed.ops?.[0].detail).toBe('echo "time: 10" && echo a：b');
+});
+
+test("does not treat an ascii-colon command prefix as a CJK verb", () => {
+  const parsed = parseAskHumanMessage(
+    "确认在本机执行 1 项操作：\n1. rm：-rf /tmp/x",
+  );
+  expect(parsed.ops?.[0].verb).toBeNull();
+  expect(parsed.ops?.[0].detail).toBe("rm：-rf /tmp/x");
+});
+
+test("plain multi-line question falls back to headline plus prose", () => {
+  const parsed = parseAskHumanMessage("接下来怎么做？\n请选择一个方案继续。");
+  expect(parsed.headline).toBe("接下来怎么做？");
+  expect(parsed.ops).toBeNull();
+  expect(parsed.prose).toBe("请选择一个方案继续。");
+});
+
+test("single-line question returns headline only", () => {
+  const parsed = parseAskHumanMessage("要继续吗？");
+  expect(parsed.headline).toBe("要继续吗？");
+  expect(parsed.ops).toBeNull();
+  expect(parsed.prose).toBeNull();
+});
+
+test("mixed numbered and unnumbered lines are not forced into op rows", () => {
+  const parsed = parseAskHumanMessage(
+    "确认执行：\n1. 执行命令：ls\n注意：以上操作不可撤销",
+  );
+  expect(parsed.ops).toBeNull();
+  expect(parsed.prose).toBe("1. 执行命令：ls\n注意：以上操作不可撤销");
+});
+
+test("empty message yields no headline", () => {
+  const parsed = parseAskHumanMessage("");
+  expect(parsed.headline).toBeNull();
+  expect(parsed.ops).toBeNull();
+  expect(parsed.prose).toBeNull();
+});
+
+test("collapses to a single-line summary for pill labels", () => {
+  const summary = parseAskHumanMessage(
+    "确认在本机执行 1 项操作：\n1. 执行命令：rm -rf /tmp",
+  ).summary;
+  expect(summary).toBe("确认在本机执行 1 项操作： 1. 执行命令：rm -rf /tmp");
+});

--- a/frontend/src/components/panels/askHumanMessage.ts
+++ b/frontend/src/components/panels/askHumanMessage.ts
@@ -1,0 +1,70 @@
+/**
+ * ask_human 消息结构化解析。
+ *
+ * 后端沙箱确认门（sandbox_confirm.py）的 message 是「标题行 + 编号操作行」
+ * 的多行文本；普通提问则是任意散文。这里把它拆成 headline / ops / prose，
+ * 供审批卡与工具 pill 按各自密度渲染——标题进头部、操作清单进明细区，
+ * 避免 replace(/\s+/g, " ") 把整段压成一行的排版事故。
+ */
+
+export interface AskHumanOp {
+  /** 操作动词（执行命令 / 写入文件 / …），无法可靠识别时为 null */
+  verb: string | null;
+  /** 动词之后的具体内容（命令、路径等），原样保留 */
+  detail: string;
+}
+
+export interface AskHumanMessageShape {
+  /** 标题行（去掉收尾冒号），空消息为 null */
+  headline: string | null;
+  /** 全部剩余行均为编号行时的结构化操作清单，否则 null */
+  ops: AskHumanOp[] | null;
+  /** 非编号的补充说明（保留换行），没有则为 null */
+  prose: string | null;
+  /** 全文压成单行的摘要（pill 标签 / 折叠摘要用） */
+  summary: string;
+}
+
+const NUMBERED_LINE = /^\d{1,3}\s*[.、)．]\s*(.+)$/;
+// 动词只认「短 + 纯中文」前缀，命令内部的冒号（含全角）不会被误切
+const VERB_PREFIX = /^([\u4e00-\u9fff]{1,8})：(.+)$/;
+
+function splitVerb(detail: string): AskHumanOp {
+  const match = VERB_PREFIX.exec(detail);
+  if (match) {
+    return { verb: match[1], detail: match[2] };
+  }
+  return { verb: null, detail };
+}
+
+export function parseAskHumanMessage(message: string): AskHumanMessageShape {
+  const summary = message.replace(/\s+/g, " ").trim();
+
+  const lines = message
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  if (lines.length === 0) {
+    return { headline: null, ops: null, prose: null, summary };
+  }
+
+  const headline = lines[0].replace(/[：:]\s*$/, "");
+  const rest = lines.slice(1);
+
+  if (rest.length > 0 && rest.every((line) => NUMBERED_LINE.test(line))) {
+    return {
+      headline,
+      ops: rest.map((line) => splitVerb(NUMBERED_LINE.exec(line)![1].trim())),
+      prose: null,
+      summary,
+    };
+  }
+
+  return {
+    headline,
+    ops: null,
+    prose: rest.length > 0 ? rest.join("\n") : null,
+    summary,
+  };
+}

--- a/frontend/src/styles/approval.css
+++ b/frontend/src/styles/approval.css
@@ -308,6 +308,293 @@
   padding: 0.65rem 1.1rem 1rem;
 }
 
+/* ── 沙箱确认门操作清单（单据式只读列表） ──
+ * 也会渲染在工具实时面板（无 .approval-card 祖先），token 全部带兜底。 */
+.approval-op-list {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid
+    var(
+      --theme-border,
+      color-mix(in srgb, var(--approval-border) 60%, transparent)
+    );
+  border-radius: 0.75rem;
+  background: color-mix(
+    in srgb,
+    var(--theme-bg-card, var(--approval-bg)) 88%,
+    var(--theme-bg, transparent)
+  );
+  overflow: hidden;
+}
+
+.approval-op-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  padding: 0.55rem 0.8rem;
+}
+
+.approval-op-row + .approval-op-row {
+  border-top: 1px dashed
+    var(
+      --theme-border,
+      color-mix(in srgb, var(--approval-border) 45%, transparent)
+    );
+}
+
+.approval-op-index {
+  min-width: 0.9rem;
+  padding-top: 0.15rem;
+  color: var(--theme-text-secondary, var(--approval-text-dim));
+  font-size: 0.6875rem;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  line-height: 1.4;
+  text-align: right;
+  user-select: none;
+}
+
+.approval-op-verb {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 0.25rem;
+  margin-top: 0.05rem;
+  padding: 0.12rem 0.5rem;
+  border: 1px solid
+    color-mix(in srgb, var(--approval-accent, #f59e0b) 26%, transparent);
+  border-radius: 999px;
+  background: color-mix(
+    in srgb,
+    var(--approval-accent-light, #fef3c7) 16%,
+    transparent
+  );
+  color: color-mix(
+    in srgb,
+    var(--approval-accent-hover, #d97706) 82%,
+    var(--approval-text, var(--theme-text, inherit))
+  );
+  font-size: 0.6875rem;
+  font-weight: 500;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+.approval-op-detail {
+  min-width: 0;
+  flex: 1 1 auto;
+  color: var(--approval-text, var(--theme-text, inherit));
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+    "Liberation Mono", monospace;
+  font-size: 0.75rem;
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+/* ask_human 明细区的上下文块：标题以下、表单以上 */
+.approval-ask-human-context {
+  padding: var(--approval-section-y) var(--approval-section-x) 0;
+}
+
+.approval-ask-human-context-prose {
+  color: var(--approval-text-dim, var(--theme-text-secondary));
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+/* ── 定时任务创建审批（spec-sheet 式参数单） ── */
+.approval-st {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.approval-st-lead {
+  margin: 0;
+  color: var(--approval-text, var(--theme-text));
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+}
+
+.approval-st-note {
+  margin: 0;
+  color: var(--approval-text-dim, var(--theme-text-secondary));
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
+.approval-st-sheet {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid
+    var(
+      --theme-border,
+      color-mix(in srgb, var(--approval-border) 55%, transparent)
+    );
+  border-radius: 0.75rem;
+  background: color-mix(
+    in srgb,
+    var(--theme-bg-card, var(--approval-bg)) 88%,
+    var(--theme-bg, transparent)
+  );
+  overflow: hidden;
+}
+
+.approval-st-row {
+  display: flex;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.5rem 0.9rem;
+}
+
+.approval-st-row + .approval-st-row {
+  border-top: 1px dashed
+    var(
+      --theme-border,
+      color-mix(in srgb, var(--approval-border) 40%, transparent)
+    );
+}
+
+.approval-st-label {
+  flex: 0 0 4.5rem;
+  color: var(--approval-text-dim, var(--theme-text-secondary));
+  font-size: 0.75rem;
+  line-height: 1.5;
+  user-select: none;
+}
+
+.approval-st-value {
+  min-width: 0;
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  overflow-wrap: anywhere;
+}
+
+.approval-st-name {
+  color: var(--approval-text, var(--theme-text));
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1.5;
+}
+
+.approval-st-mono {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  max-width: 100%;
+  padding: 0.14rem 0.55rem;
+  border: 1px solid
+    color-mix(in srgb, var(--approval-accent, #f59e0b) 18%, transparent);
+  border-radius: 0.45rem;
+  background: color-mix(
+    in srgb,
+    var(--approval-accent-light, #fef3c7) 10%,
+    transparent
+  );
+  color: var(--approval-text, var(--theme-text));
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+    "Liberation Mono", monospace;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+.approval-st-chip-icon {
+  flex-shrink: 0;
+  opacity: 0.55;
+}
+
+.approval-st-flag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.14rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.5;
+}
+
+.approval-st-flag--on {
+  background: color-mix(in srgb, #10b981 12%, transparent);
+  color: #059669;
+}
+
+.approval-st-flag--off {
+  background: color-mix(
+    in srgb,
+    var(--theme-text-secondary, #78716c) 10%,
+    transparent
+  );
+  color: var(--approval-text-dim, var(--theme-text-secondary));
+}
+
+.dark .approval-st-flag--on {
+  background: color-mix(in srgb, #10b981 16%, transparent);
+  color: #34d399;
+}
+
+.approval-st-effect {
+  margin: 0;
+  color: var(--approval-text-dim, var(--theme-text-secondary));
+  font-size: 0.75rem;
+  line-height: 1.6;
+}
+
+.approval-st-prompt {
+  border: 1px solid
+    var(
+      --theme-border,
+      color-mix(in srgb, var(--approval-border) 55%, transparent)
+    );
+  border-radius: 0.75rem;
+  background: color-mix(
+    in srgb,
+    var(--theme-bg-card, var(--approval-bg)) 88%,
+    var(--theme-bg, transparent)
+  );
+  overflow: hidden;
+}
+
+.approval-st-prompt-header {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.45rem 0.9rem;
+  border-bottom: 1px solid
+    color-mix(
+      in srgb,
+      var(--approval-border, var(--theme-border)) 35%,
+      transparent
+    );
+  color: var(--approval-text-dim, var(--theme-text-secondary));
+  font-family: var(--font-serif, ui-serif, Georgia, serif);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  user-select: none;
+}
+
+.approval-st-prompt-body {
+  margin: 0;
+  max-height: 14rem;
+  padding: 0.65rem 0.9rem;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  color: var(--approval-text, var(--theme-text));
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+    "Liberation Mono", monospace;
+  font-size: 0.75rem;
+  line-height: 1.65;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
 .approval-ask-human-shortcut-hint {
   align-items: center;
   gap: 0.25rem;
@@ -362,6 +649,33 @@
   .approval-card.approval-card--composer {
     --approval-section-x: 1rem;
     border-radius: 1.25rem;
+  }
+
+  /* 窄屏操作行改两段：编号 + 动词胶囊一行，命令独占整行换行，
+   * 避免胶囊挤压命令可用宽度、换行后左边距参差 */
+  .approval-op-row {
+    flex-wrap: wrap;
+    gap: 0.4rem 0.55rem;
+    padding: 0.5rem 0.7rem;
+  }
+
+  .approval-op-detail {
+    flex-basis: 100%;
+    padding-left: 1.45rem; /* 与动词胶囊左缘对齐 */
+  }
+
+  /* 参数单标签列放宽：四字标签 + 间距在窄屏不换行 */
+  .approval-st-label {
+    flex-basis: 5rem;
+  }
+
+  .approval-st-row {
+    gap: 0.75rem;
+    padding: 0.5rem 0.75rem;
+  }
+
+  .approval-st-prompt-body {
+    padding: 0.55rem 0.75rem;
   }
 
   .approval-ask-human-header {

--- a/k8s/lambchat.yaml
+++ b/k8s/lambchat.yaml
@@ -79,8 +79,11 @@ spec:
           value: "redis"
         - name: TASK_BACKEND
           value: "arq"
+        # 任务执行与 API 分进程（2026-09-09 断联复盘）：agent 任务的同步段
+        # 会饿死 API 事件循环（SSE/沙箱通道心跳停发），API 滚动发布还会杀掉
+        # 运行中的任务。任务全部由 lambchat-worker Deployment 消费。
         - name: ARQ_EMBEDDED_WORKER
-          value: "true"
+          value: "false"
         # --- Object Storage (required for multi-replica deployments) ---
         - name: S3_ENABLED
           value: "true"
@@ -129,6 +132,114 @@ spec:
           periodSeconds: 15
           timeoutSeconds: 10
           failureThreshold: 5
+        volumeMounts:
+        - name: workspace
+          mountPath: /app/workspace
+      volumes:
+      - name: workspace
+        emptyDir: {}
+
+---
+# LambChat Worker Deployment（独立 arq worker 进程）
+# 与 API 分进程：任务全部由本 Deployment 消费（Redis 队列协同），API 进程
+# 不再内嵌 worker——重任务不饿死 API 事件循环，API 滚动发布不杀运行中任务。
+# 注意：label 必须与 Service selector（app: lambchat）区分，否则 worker 会
+# 收到 NodePort 流量。首次上线顺序见 PR 说明（先并存验证、后关内嵌）。
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lambchat-worker
+  namespace: lambchat
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: lambchat-worker
+  template:
+    metadata:
+      labels:
+        app: lambchat-worker
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+      - name: lambchat-worker
+        image: ghcr.io/yanyutin753/lambchat:latest
+        imagePullPolicy: Always
+        command: ["/app/.venv/bin/python", "-m", "src.infra.task.worker_main"]
+        env:
+        - name: JWT_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: lambchat-secrets
+              key: jwt-secret-key
+        - name: MCP_ENCRYPTION_SALT
+          valueFrom:
+            secretKeyRef:
+              name: lambchat-secrets
+              key: mcp-encryption-salt
+        - name: MONGODB_URL
+          value: "mongodb://MONGO_HOST:27017"
+        - name: MONGODB_DB
+          value: "agent_state"
+        - name: MONGODB_ENABLED
+          value: "true"
+        - name: MONGODB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: lambchat-secrets
+              key: mongodb-username
+        - name: MONGODB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: lambchat-secrets
+              key: mongodb-password
+        - name: MONGODB_AUTH_SOURCE
+          value: "admin"
+        - name: REDIS_URL
+          value: "redis://REDIS_HOST:6379/3"
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: lambchat-secrets
+              key: redis-password
+        - name: LAMBCHAT_DISTRIBUTED_MODE
+          value: "true"
+        - name: SESSION_BACKEND
+          value: "redis"
+        - name: TASK_BACKEND
+          value: "arq"
+        # --- Object Storage（与 API 一致：任务内文件读写走 S3）---
+        - name: S3_ENABLED
+          value: "true"
+        - name: S3_PROVIDER
+          value: "custom"
+        - name: S3_ENDPOINT_URL
+          value: "https://s3.example.com"
+        - name: S3_BUCKET_NAME
+          value: "lambchat-files"
+        - name: S3_REGION
+          value: "us-east-1"
+        - name: S3_PATH_STYLE
+          value: "false"
+        - name: ENABLE_LOCAL_FILESYSTEM_FALLBACK
+          value: "false"
+        - name: S3_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: lambchat-secrets
+              key: s3-access-key
+        - name: S3_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: lambchat-secrets
+              key: s3-secret-key
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "250m"
+          limits:
+            memory: "4Gi"
+            cpu: "2000m"
         volumeMounts:
         - name: workspace
           mountPath: /app/workspace

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lambchat"
-version = "2.10.0"
+version = "2.10.1"
 description = "Full-featured AI Agent system with FastAPI, LangGraph, and LangSmith"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/api/routes/sandbox.py
+++ b/src/api/routes/sandbox.py
@@ -94,11 +94,12 @@ async def channel_frames(
 ) -> AsyncIterator[str]:
     """SSE 帧生成器：hello -> (tool_call | 心跳) 循环；连接期心跳注册表。
 
-    心跳前校验属主：新连接 register 清空注册表后，旧流在此退场（后连踢前连），
-    踢旧窗口收敛到一个心跳周期（15s）。旧流结束时 finally 的 unregister 只
-    hdel 自己的字段，不会破坏新连接的注册。心跳带同一 ``version``/``platform``
-    /``confirm_policy`` 重写——不带会把注册值降级回纯 node_id，daemon
-    版本/平台/策略 15s 后丢失。
+    心跳先发射、后校验属主：keepalive 只依赖事件循环本身，注册表三连写走
+    共享池，池被重任务占满时心跳会跟着停发（2026-09-09 生产断联）。属主
+    校验（后连踢前连）因此后移一拍，踢旧窗口收敛到一两个心跳周期。旧流结
+    束时 finally 的 unregister 只 hdel 自己的字段，不会破坏新连接的注册。心
+    跳带同一 ``version``/``platform``/``confirm_policy`` 重写——不带会把注册
+    值降级回纯 node_id，daemon 版本/平台/策略 15s 后丢失。
 
     多机（``machine_id`` 非空）：属主校验按机器属主键（同机重连换属主踢旧流），
     下发队列按 ``registry.queue_key`` 分机器；legacy 路径语义零变化。
@@ -121,6 +122,12 @@ async def channel_frames(
     while not stop.is_set():
         now = loop.time()
         if now - last_beat >= _HEARTBEAT_SECONDS:
+            # 心跳先发射、后写注册表：keepalive 依赖的只是事件循环本身——
+            # 注册表三连写走共享池，池被重任务占满时 await 会长时间挂起，
+            # 心跳跟着停发、daemon 侧 45s 读超时误判断联（2026-09-09 生产）。
+            # 属主校验后移一个节拍，旧流多活一个心跳周期（repush 兜底误吃帧）。
+            last_beat = now
+            yield ": heartbeat\n\n"
             if machine_id:
                 # 多机属主校验：同机新连接已改写属主键时，旧流退场
                 owner = await redis.get(_owner_key(user_id, machine_id))
@@ -142,8 +149,6 @@ async def channel_frames(
             )
             if machine_id:
                 await redis.set(_owner_key(user_id, machine_id), client_id, ex=35)
-            last_beat = now
-            yield ": heartbeat\n\n"
         # 阻塞读下发队列：超时切片返回 None → 回到心跳检查；Redis 异常上抛
         # 终结本流，daemon 走既有退避重连（与旧轮询模型同语义）
         item = await blocking.blpop(req_key, timeout=timeout_slice)

--- a/src/infra/sandbox/relay/dispatch.py
+++ b/src/infra/sandbox/relay/dispatch.py
@@ -49,6 +49,45 @@ def _registry() -> SandboxClientRegistry:
 #: 50ms 轮询更糟）；对测试 fake 而言这也是让出事件循环的点。
 _LEGACY_POLL_INTERVAL = 0.05
 
+#: ACK 未确认时的幂等重推间隔（秒）。tool_call 帧被 channel 的 BLPOP 消费后
+#: 即脱离队列——连接在投递瞬间断掉（滚动发布/代理抖动）帧就丢了，daemon
+#: 重连后无人再投递，调用方干等满 ACK 死线（2026-09-09 生产断联窗口内 exec
+#: 全灭 SANDBOX_TIMEOUT）。重推同一 call_id（daemon 侧按 call_id 去重），
+#: ACK 到达即停。
+_ACK_REPUSH_INTERVAL = 5.0
+
+
+class _AckRepusher:
+    """下发帧的幂等重推器：ack 之前周期性重推同一请求，结束时清掉队列残留。
+
+    ts 每次重推刷新——channel 侧按 ts 判龄丢弃陈旧帧，沿用原始时间戳会让
+    重推帧在 ACK 死线附近被自己的陈旧门吃掉。cleanup 用 LREM 精确移除本
+    调用推过的每一帧：调用失败（或完成）后队列里不留副本，daemon 重连后
+    不会执行「已无人等待的幽灵调用」。
+    """
+
+    def __init__(self, redis, queue: str, req: dict) -> None:
+        self._redis = redis
+        self._queue = queue
+        self._req = req
+        self._pushed: list[str] = []
+
+    async def push(self) -> None:
+        self._req["ts"] = time.time()
+        payload = json.dumps(self._req)
+        self._pushed.append(payload)
+        await self._redis.rpush(self._queue, payload)
+
+    def next_due(self) -> float:
+        return time.monotonic() + _ACK_REPUSH_INTERVAL
+
+    async def cleanup(self) -> None:
+        for payload in self._pushed:
+            try:
+                await self._redis.lrem(self._queue, 0, payload)
+            except Exception:  # noqa: BLE001 - 清理尽力而为
+                pass
+
 
 async def _pop_resp(redis, key: str, *, timeout: float | None = None):
     """读一条回传结果：新格式 RPUSH 队列优先（timeout 给出则 BLPOP 阻塞）。
@@ -108,14 +147,19 @@ async def dispatch_local_call(
     # 调用-机器绑定：results 端点据此拒绝同用户其他机器冒答（call_id 难猜，
     # 但绑定后模型上无冒答空间）；无绑定键的旧调用（兼容窗口）跳过校验
     await redis.set(_assign_key(call_id), target, ex=120)
-    await redis.rpush(registry.queue_key(user_id, target), json.dumps(req))
+    repusher = _AckRepusher(redis, registry.queue_key(user_id, target), req)
+    await repusher.push()
 
     start = time.monotonic()
     acked = False
     ack_deadline = start + settings.SANDBOX_LOCAL_ACK_TIMEOUT
     exec_deadline = start + exec_timeout
+    next_repush = repusher.next_due()
     try:
         while time.monotonic() < exec_deadline:
+            if not acked and time.monotonic() >= next_repush:
+                await repusher.push()
+                next_repush = repusher.next_due()
             remaining = exec_deadline - time.monotonic()
             raw = await _pop_resp(
                 redis, resp_key, timeout=min(_BLPOP_TIMEOUT, max(remaining, 0.01))
@@ -157,6 +201,7 @@ async def dispatch_local_call(
             await redis.delete(_assign_key(call_id))
         except Exception:  # noqa: BLE001 - 清理尽力而为
             pass
+        await repusher.cleanup()
 
 
 def _stream_key(user_id: str, call_id: str) -> str:
@@ -207,14 +252,19 @@ async def dispatch_local_stream(
     redis = _binary_redis()  # stream list 是裸二进制帧（req/resp 均为 JSON，bytes 兼容）
     stream_key = _stream_key(user_id, call_id)
     resp_key = f"sandbox:resp:{call_id}"
-    await redis.rpush(registry.queue_key(user_id, target), json.dumps(req))
+    repusher = _AckRepusher(redis, registry.queue_key(user_id, target), req)
+    await repusher.push()
 
     start = time.monotonic()
     acked = False
     ack_deadline = start + settings.SANDBOX_LOCAL_ACK_TIMEOUT
     exec_deadline = start + exec_timeout
+    next_repush = repusher.next_due()
     try:
         while time.monotonic() < exec_deadline:
+            if not acked and time.monotonic() >= next_repush:
+                await repusher.push()
+                next_repush = repusher.next_due()
             resp = None
             # results 端点为 RPUSH 队列（ack/done 按序）；滚动窗口内旧实例仍
             # SET（string）：_pop_resp 捕获 WRONGTYPE 后回落 GET
@@ -268,6 +318,7 @@ async def dispatch_local_stream(
                 await redis.delete(key)
             except Exception:  # noqa: BLE001 - 清理尽力而为
                 pass
+        await repusher.cleanup()
 
 
 _UPBLOB_WINDOW = 8  # 生产者在途帧数上限：×4MiB 帧 = Redis 峰值 ~32MiB

--- a/src/infra/task/arq_runtime.py
+++ b/src/infra/task/arq_runtime.py
@@ -41,12 +41,14 @@ class EmbeddedArqRuntime:
     def is_running(self) -> bool:
         return self._supervisor is not None and not self._supervisor.done()
 
-    async def start(self) -> None:
+    async def start(self, *, force: bool = False) -> None:
         if self.is_running:
             return
         if getattr(settings, "TASK_BACKEND", "local") != "arq":
             return
-        if not getattr(settings, "ARQ_EMBEDDED_WORKER", True):
+        # ARQ_EMBEDDED_WORKER 只约束 API 进程的内嵌行为；独立 worker 进程
+        # （worker_main，拆分部署）以 force=True 绕过。
+        if not force and not getattr(settings, "ARQ_EMBEDDED_WORKER", True):
             return
 
         self._stopping = False

--- a/src/infra/task/worker_main.py
+++ b/src/infra/task/worker_main.py
@@ -1,0 +1,149 @@
+"""独立 arq worker 进程入口：与 API 分进程部署（k8s worker Deployment）。
+
+为什么拆分（2026-09-09 生产断联复盘）：``ARQ_EMBEDDED_WORKER=true`` 时 agent
+任务与 API 共享事件循环——重任务的同步段会饿死 API（SSE/沙箱通道心跳停发），
+且 API 滚动发布会杀掉运行中的任务。拆分后 API 进程只服务 HTTP/SSE，任务全部
+由本进程消费；队列在 Redis，两拨进程天然协同，任一侧独立伸缩/发布互不牵连。
+
+启动面（任务执行在独立进程里依赖的进程内服务，对齐 API lifespan 的最小集）：
+
+- 事件循环滞后监控：观测「重任务饿死循环」的眼睛；
+- task_manager pubsub 监听：分布式取消信号必须到达**执行方**，不启动则用户
+  取消不了跑在本进程上的任务；
+- 缓存一致性 pubsub（settings/模型配置/工具/MCP/定价/记忆）：热更新传播到
+  本进程，否则 worker 里的模型配置等要等重启才刷新；
+- arq runtime（``force=True`` 越过 ``ARQ_EMBEDDED_WORKER``——该开关只管 API
+  进程）+ worker_startup（分布式配置校验、loop_bridge 登记——本地沙箱同步
+  文件操作的协程桥接依赖它）。
+
+**不**启动：内存周期 agent、定时任务 reconcile、websocket/channel 推送——
+这些是 API 进程的职责，双跑会重复执行周期任务。
+
+入口：``python -m src.infra.task.worker_main``（容器 command）；SIGTERM/SIGINT
+置停止事件 → 先停 arq worker（收尾在途任务）→ 停监听 → worker_shutdown。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import signal
+from typing import Any, Callable
+
+from src.infra.logging import get_logger
+from src.infra.monitoring.event_loop import start_event_loop_lag_monitor
+from src.kernel.config import settings
+
+from .arq_runtime import get_arq_runtime
+from .arq_worker import worker_shutdown, worker_startup
+from .manager import get_task_manager
+
+logger = get_logger(__name__)
+
+# 协作者在模块级具名：测试按 monkeypatch worker_main.<name> 注入替身。
+from src.infra.llm.pubsub import get_model_config_pubsub  # noqa: E402
+from src.infra.pricing.pubsub import get_pricing_pubsub  # noqa: E402
+from src.infra.settings.pubsub import get_settings_pubsub  # noqa: E402
+from src.infra.tool.cache_pubsub import get_tool_cache_pubsub  # noqa: E402
+from src.infra.tool.mcp_global import get_mcp_cache_pubsub  # noqa: E402
+
+
+def get_memory_pubsub() -> Any:
+    """记忆 pubsub 惰性解析（ENABLE_MEMORY 才需要，模块级导入会拖重依赖）。"""
+    from src.infra.memory.distributed import get_memory_pubsub as _get
+
+    return _get()
+
+
+# 已启动监听器引用：失败路径 shutdown 时逐一尽停
+_started_listeners: list[tuple[str, Any]] = []
+
+
+def _make_signal_handler(stop: asyncio.Event) -> Callable[[], None]:
+    """SIGTERM/SIGINT → 置停止事件；退出收尾统一在 _amain 的 finally 完成。"""
+
+    def _handle() -> None:
+        logger.info("worker_main received stop signal")
+        stop.set()
+
+    return _handle
+
+
+async def _start_cache_listeners() -> None:
+    """缓存一致性 pubsub：settings/模型/工具/MCP/定价（+记忆开关）。"""
+    listeners: list[tuple[str, Any]] = [
+        ("settings", get_settings_pubsub()),
+        ("model_config", get_model_config_pubsub()),
+        ("tool_cache", get_tool_cache_pubsub()),
+        ("mcp_cache", get_mcp_cache_pubsub()),
+        ("pricing", get_pricing_pubsub()),
+    ]
+    if settings.ENABLE_MEMORY:
+        listeners.append(("memory", get_memory_pubsub()))
+    _started_listeners.extend(listeners)
+    await asyncio.gather(*(pubsub.start_listener() for _, pubsub in listeners))
+
+
+async def _stop_started_listeners() -> None:
+    for name, pubsub in _started_listeners:
+        stop = getattr(pubsub, "stop_listener", None)
+        if stop is None:
+            continue
+        try:
+            result = stop()
+            if asyncio.iscoroutine(result):
+                await result
+        except Exception:  # noqa: BLE001 - 单个监听器停止失败不阻断其余
+            logger.warning("Failed to stop %s listener", name, exc_info=True)
+    _started_listeners.clear()
+
+
+async def _amain(stop: asyncio.Event) -> None:
+    """worker 进程主协程：startup → 等 stop → shutdown（失败也要走完退出面）。"""
+    task_manager = get_task_manager()
+    runtime = get_arq_runtime()
+    loop = asyncio.get_running_loop()
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        # 无信号实现的循环（如 Windows Proactor）抛 NotImplementedError，降级忽略
+        with contextlib.suppress(NotImplementedError):
+            loop.add_signal_handler(sig, _make_signal_handler(stop))
+
+    logger.info("standalone arq worker starting (queue=%s)", settings.ARQ_QUEUE_NAME)
+    try:
+        await start_event_loop_lag_monitor()
+        await task_manager.start_pubsub_listener()
+        await _start_cache_listeners()
+        await worker_startup({})  # 分布式配置校验 + loop_bridge 登记
+        await runtime.start(force=True)
+        logger.info("standalone arq worker started")
+        await stop.wait()
+    finally:
+        # 先停 worker（收尾在途任务），再停监听，最后生命周期标记
+        try:
+            await runtime.stop()
+        except Exception:  # noqa: BLE101 - 退出路径尽力而为
+            logger.warning("arq runtime stop failed", exc_info=True)
+        try:
+            await task_manager.stop_pubsub_listener()
+        except Exception:  # noqa: BLE101
+            logger.warning("task pubsub stop failed", exc_info=True)
+        await _stop_started_listeners()
+        try:
+            await worker_shutdown({})  # loop_bridge 清理 + 恢复入口静默
+        except Exception:  # noqa: BLE101
+            logger.warning("worker_shutdown failed", exc_info=True)
+        logger.info("standalone arq worker stopped")
+
+
+def main() -> None:
+    # API 进程由 lifespan 调 setup_logging；独立进程必须自己配，否则 INFO
+    # 及以下日志无 handler 直接吞掉（首验实测：进程正常跑但日志全空）。
+    from src.infra.logging import setup_logging
+
+    setup_logging()
+    asyncio.run(_amain(asyncio.Event()))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/api/routes/test_sandbox_routes.py
+++ b/tests/api/routes/test_sandbox_routes.py
@@ -244,7 +244,10 @@ async def test_channel_frames_returns_when_superseded(monkeypatch, superseded_by
 
     assert frames[0].startswith("event: hello\n")
     assert frames[1].startswith("event: tool_call\n")
-    assert not any(f.startswith(": heartbeat") for f in frames)
+    # 先发射后校验（keepalive 不依赖共享池）：失主观测点在发射之后——
+    # 被踢旧流至多多带一个心跳帧，但不再续写注册表
+    heartbeat_frames = [f for f in frames if f.startswith(": heartbeat")]
+    assert len(heartbeat_frames) <= 1
     assert registry.beats == 0  # 失主后不再心跳续期，不把自己写回注册表
 
 

--- a/tests/client/test_daemon.py
+++ b/tests/client/test_daemon.py
@@ -1215,3 +1215,72 @@ async def test_no_signal_support_returns_empty(monkeypatch):
 
     installed = daemon_module._install_sigterm_cancel()
     assert installed == []
+
+
+# ----------
+# call_id 去重 × 断联日志（2026-09-09 生产断联加固）
+# ----------
+
+
+async def test_duplicate_call_id_executes_once():
+    """dispatch 断联重推是 at-least-once 投递：daemon 按 call_id 去重，重复
+    帧记 audit 后跳过——重复执行用户机器上的命令是不可接受的副作用。"""
+    client = FakeClient(calls=[_call("c1"), _call("c1"), _call("c2")])
+    executor = FakeExecutor(
+        result={"status": "ok", "stdout": "hi\n", "stderr": "", "exit_code": 0, "error": None}
+    )
+    auditor = MemoryAuditor()
+
+    await _run(
+        _cfg("none"),
+        FakeFactory([client, _terminator()]),
+        executor=executor,
+        auditor=auditor,
+    )
+
+    # c1 只执行一次、c2 一次；done 也只各回一次
+    assert len(executor.calls) == 2
+    dones = [cid for cid, body in client.posted if body.get("stage") == "done"]
+    assert dones == ["c1", "c2"]
+
+    # 重复帧有专属审计记录，可事后核对
+    duplicates = [
+        event
+        for records in auditor.records.values()
+        for event in records
+        if event.get("event") == "duplicate_skipped"
+    ]
+    assert len(duplicates) == 1
+    assert duplicates[0]["call_id"] == "c1"
+
+
+async def test_channel_break_logs_exception_type(capsys):
+    """空消息异常（httpx.ReadTimeout/ConnectTimeout 的 str 为空串）断联时，
+    日志必须带异常类型：『通道断开: ReadTimeout: 』而非『通道断开: 』——
+    盲日志是 2026-09-09 断联排查的硬伤。"""
+    class _EmptyTimeoutError(Exception):
+        """str() 为空的异常替身（httpx 超时族的形态）。"""
+
+    async def calls_then_break():
+        yield _call("c1")
+        raise _EmptyTimeoutError()
+
+    class BreakAfterCall(FakeClient):
+        async def connect(self):
+            return {"sandbox_id": "sbx-fake"}, calls_then_break()
+
+    breaker = BreakAfterCall(calls=[])
+    terminator = _terminator()
+
+    with pytest.raises(TransportAuthError):
+        await run_daemon(
+            _cfg("none"),
+            pat=PAT,
+            client_factory=FakeFactory([breaker, terminator]),
+            executor=FakeExecutor(),
+            auditor=MemoryAuditor(),
+            sleep_fn=SleepRecorder(),
+        )
+
+    err = capsys.readouterr().err
+    assert "通道断开: _EmptyTimeoutError" in err

--- a/tests/client/test_daemon.py
+++ b/tests/client/test_daemon.py
@@ -1258,6 +1258,7 @@ async def test_channel_break_logs_exception_type(capsys):
     """空消息异常（httpx.ReadTimeout/ConnectTimeout 的 str 为空串）断联时，
     日志必须带异常类型：『通道断开: ReadTimeout: 』而非『通道断开: 』——
     盲日志是 2026-09-09 断联排查的硬伤。"""
+
     class _EmptyTimeoutError(Exception):
         """str() 为空的异常替身（httpx 超时族的形态）。"""
 

--- a/tests/client/test_transport.py
+++ b/tests/client/test_transport.py
@@ -6,6 +6,7 @@
 退出 POST /api/sandbox/offline。
 """
 
+import asyncio
 import json
 import random
 
@@ -630,4 +631,48 @@ async def test_post_offline_without_machine_id_omits_query():
     await client.post_offline()
 
     assert log[0].url.params.get("machine_id") is None
+    await client.close()
+
+
+# ----------
+# hello 阶段独立短超时（2026-09-09 生产断联：连接已被发布切换/代理掐死但
+# 首帧永不到达，daemon 挂满 45s 读超时才进退避，掉线窗口被拉到分钟级）
+# ----------
+
+
+class _HangingStream(httpx.AsyncByteStream):
+    """建立连接后一个字节都不发的僵死流。"""
+
+    def __init__(self) -> None:
+        self._release = asyncio.Event()
+
+    async def __aiter__(self):
+        await self._release.wait()
+        yield b""  # pragma: no cover - 测试期内不抵达
+
+
+class _HangingTransport(httpx.AsyncBaseTransport):
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=_HangingStream(),
+        )
+
+
+async def test_connect_hello_timeout_raises_transport_error(monkeypatch):
+    """hello 迟迟不到（僵死连接）时按 hello 独立超时快速失败，不挂满 45s
+    读超时——TransportError 进既有退避重连，掉线窗口压到秒级。"""
+    import lambchat_sandbox.transport as transport_module
+
+    monkeypatch.setattr(transport_module, "_HELLO_TIMEOUT_S", 0.1)
+
+    client = _channel_client(_HangingTransport())
+    import time as time_mod
+
+    t0 = time_mod.monotonic()
+    with pytest.raises(TransportError, match="hello"):
+        await client.connect()
+    dt = time_mod.monotonic() - t0
+    assert dt < 2, f"hello 超时应快速失败，耗时 {dt:.1f}s"
     await client.close()

--- a/tests/infra/sandbox/relay/test_dispatch.py
+++ b/tests/infra/sandbox/relay/test_dispatch.py
@@ -58,6 +58,11 @@ class _FakeRedis:
             await asyncio.sleep(timeout)
         return None
 
+    async def lrem(self, key: str, count: int, value: str) -> None:
+        items = self.lists.get(key)
+        if items:
+            self.lists[key] = [x for x in items if x != value]
+
 
 class _FakeRegistry:
     def __init__(self, online: bool):
@@ -571,3 +576,98 @@ async def test_upload_stream_window_wait_aborts_on_interrupt_sentinel(fake, monk
     assert exc.value.error_code == ErrorCode.SANDBOX_EXEC_FAILED
     assert "stream_interrupted" in str(exc.value.args_data.get("detail"))
     assert dt < 5, f"窗口等待未消费中断哨兵，耗时 {dt:.1f}s"
+
+
+# ----------
+# ACK 死线内幂等重推：断联窗口内 tool_call 帧不丢
+# （2026-09-09 生产断联：帧被死连接的 BLPOP 消费即丢失，daemon 重连后无人
+#  再投递，agent 侧干等 30s ACK 超时全灭 SANDBOX_TIMEOUT）
+# ----------
+
+
+async def test_unacked_call_is_repushed_until_ack(fake, monkeypatch):
+    """帧被断联通道吞掉（首次入队无人 ack）时，dispatch 周期性重推同一
+    call_id 的幂等帧：daemon 重连后收到重推帧照常执行，调用整体不失败。"""
+    monkeypatch.setattr(dispatch_module, "_BLPOP_TIMEOUT", 0.01)
+    monkeypatch.setattr(dispatch_module, "_ACK_REPUSH_INTERVAL", 0.05)
+    monkeypatch.setattr(dispatch_module.settings, "SANDBOX_LOCAL_ACK_TIMEOUT", 2)
+    monkeypatch.setattr(dispatch_module.settings, "SANDBOX_LOCAL_EXEC_TIMEOUT", 5)
+
+    received: list[dict] = []
+
+    async def daemon():
+        # 首帧被「死连接」消费（lpop 后静默）——模拟 channel 断联丢帧
+        await asyncio.sleep(0.02)
+        first = json.loads(await fake.lpop("sandbox:req:u1"))
+        received.append(first)
+        # 0.3s 后 daemon 重连，收到重推帧：ack + done
+        await asyncio.sleep(0.3)
+        retry = json.loads(await fake.lpop("sandbox:req:u1"))
+        received.append(retry)
+        assert retry["call_id"] == first["call_id"]  # 幂等重推：同一调用
+        assert retry["ts"] >= first["ts"]  # ts 刷新：不被 channel 陈旧丢弃门吃掉
+        await fake.set(
+            f"sandbox:resp:{retry['call_id']}", json.dumps({"user_id": "u1", "stage": "ack"})
+        )
+        await asyncio.sleep(0.02)
+        await fake.set(
+            f"sandbox:resp:{retry['call_id']}",
+            json.dumps({"user_id": "u1", "stage": "done", "status": "ok", "stdout": "hi"}),
+        )
+
+    task = asyncio.create_task(daemon())
+    result = await dispatch_local_call("u1", "exec", {"command": "echo hi"})
+    await task
+    assert result["stdout"] == "hi"
+    assert len(received) == 2
+
+
+async def test_acked_call_is_not_repushed(fake, monkeypatch):
+    """ack 到达后停止重推：正常往返只有一次入队（重推只针对未确认的丢失帧）。"""
+    monkeypatch.setattr(dispatch_module, "_BLPOP_TIMEOUT", 0.01)
+    monkeypatch.setattr(dispatch_module, "_ACK_REPUSH_INTERVAL", 0.05)
+    monkeypatch.setattr(dispatch_module.settings, "SANDBOX_LOCAL_ACK_TIMEOUT", 2)
+    monkeypatch.setattr(dispatch_module.settings, "SANDBOX_LOCAL_EXEC_TIMEOUT", 5)
+
+    queue_pushes: list[str] = []
+    original_rpush = fake.rpush
+
+    async def counting_rpush(key: str, value: str) -> None:
+        if key == "sandbox:req:u1":
+            queue_pushes.append(value)
+        await original_rpush(key, value)
+
+    fake.rpush = counting_rpush  # type: ignore[method-assign]
+
+    async def daemon():
+        await asyncio.sleep(0.02)  # 在首个重推点（0.05s）之前就 ack
+        req = json.loads(await fake.lpop("sandbox:req:u1"))
+        await fake.set(
+            f"sandbox:resp:{req['call_id']}", json.dumps({"user_id": "u1", "stage": "ack"})
+        )
+        await asyncio.sleep(0.15)  # done 晚于多个重推点到点：验证 ack 后不再推
+        await fake.set(
+            f"sandbox:resp:{req['call_id']}",
+            json.dumps({"user_id": "u1", "stage": "done", "status": "ok", "stdout": "hi"}),
+        )
+
+    task = asyncio.create_task(daemon())
+    result = await dispatch_local_call("u1", "exec", {"command": "echo hi"})
+    await task
+    assert result["stdout"] == "hi"
+    assert len(queue_pushes) == 1  # ack 一到重推即停，全程只入队一次
+
+
+async def test_ack_timeout_cleans_repush_residue(fake, monkeypatch):
+    """daemon 始终无响应时：重推按既有 ACK 死线失败，且 finally 清掉队列里
+    的全部重推残留——不给重连后的 daemon 留「无人等待的幽灵执行」。"""
+    monkeypatch.setattr(dispatch_module, "_BLPOP_TIMEOUT", 0.01)
+    monkeypatch.setattr(dispatch_module, "_ACK_REPUSH_INTERVAL", 0.05)
+    monkeypatch.setattr(dispatch_module.settings, "SANDBOX_LOCAL_ACK_TIMEOUT", 0.2)
+    monkeypatch.setattr(dispatch_module.settings, "SANDBOX_LOCAL_EXEC_TIMEOUT", 5)
+
+    with pytest.raises(AppError) as exc:
+        await dispatch_local_call("u1", "exec", {"command": "echo hi"})
+    assert exc.value.error_code == ErrorCode.SANDBOX_TIMEOUT
+    # 队列残留被 lrem 清空：断联期间积累的重推帧不外泄
+    assert fake.lists.get("sandbox:req:u1") in (None, [])

--- a/tests/infra/sandbox/relay/test_relay_chain.py
+++ b/tests/infra/sandbox/relay/test_relay_chain.py
@@ -260,3 +260,40 @@ async def test_results_endpoint_writes_queue_with_expiry(wired):
     assert json.loads(queue[0])["stage"] == "ack"
     assert json.loads(queue[1])["stage"] == "done"
     assert wired.expires.count("sandbox:resp:call-x") == 2
+
+
+async def test_heartbeat_emitted_before_registry_writes(monkeypatch):
+    """心跳帧必须先于注册表三连写发射：keepalive 只该依赖事件循环本身。
+
+    注册表写入走共享 Redis 池——重任务把池占满时 await 会长时间挂起，若心
+    跳跟在写后停发，daemon 侧 45s 读超时就误判断联（2026-09-09 生产断联）。
+    属主校验/注册表写后移到心跳发射之后。"""
+    monkeypatch.setattr(sandbox_route, "_HEARTBEAT_SECONDS", 0.05)
+    monkeypatch.setattr(sandbox_route, "_BLPOP_TIMEOUT", 0.01)
+
+    calls: list[str] = []
+
+    class _OrderRecordingRegistry(_FakeRegistry):
+        async def get_active(self, user_id):
+            calls.append("get_active")
+            return ("c1", "node1")
+
+        async def heartbeat(self, *args, **kwargs):
+            calls.append("heartbeat")
+
+    redis = _FakeRedis()
+    registry = _OrderRecordingRegistry("legacy")  # legacy 路径（无 machine_id）
+    stop = asyncio.Event()
+
+    agen = sandbox_route.channel_frames(redis, registry, "u1", "c1", stop=stop)
+    try:
+        hello = await agen.__anext__()
+        assert hello.startswith("event: hello")
+        beat = await agen.__anext__()
+        assert beat.startswith(": heartbeat")
+        assert calls == []  # 心跳已在客户端手上，注册表还没写
+        await agen.__anext__()  # 从 yield 恢复：此刻才做属主校验 + 注册表写
+        assert calls == ["get_active", "heartbeat"]
+    finally:
+        stop.set()
+        await agen.aclose()

--- a/tests/infra/task/test_arq_runtime.py
+++ b/tests/infra/task/test_arq_runtime.py
@@ -331,3 +331,51 @@ async def test_recovery_callback_not_invoked_without_worker_crash(
 
     assert recovery_calls == []
     await runtime.stop()
+
+
+@pytest.mark.asyncio
+async def test_start_skips_when_embedded_flag_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ARQ_EMBEDDED_WORKER=false 只约束 API 进程：默认 start() 尊重它（不启动）。"""
+    _FakeWorker.instances.clear()
+    settings = SimpleNamespace(
+        TASK_BACKEND="arq",
+        ARQ_EMBEDDED_WORKER=False,
+        ARQ_WORKER_MAX_JOBS=128,
+        ARQ_JOB_TIMEOUT_SECONDS=30,
+        ARQ_POLL_DELAY_SECONDS=0.1,
+        ARQ_QUEUE_NAME="lambchat:arq",
+        REDIS_URL="redis://localhost:6379/0",
+        REDIS_PASSWORD=None,
+    )
+    monkeypatch.setattr(arq_runtime, "settings", settings)
+
+    runtime = arq_runtime.EmbeddedArqRuntime(worker_factory=_FakeWorker)
+    await runtime.start()
+    assert runtime.is_running is False
+    assert _FakeWorker.instances == []
+
+
+@pytest.mark.asyncio
+async def test_start_with_force_bypasses_embedded_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """独立 worker 进程（worker_main）在 ARQ_EMBEDDED_WORKER=false 时也要能启动
+    worker——force=True 绕过该开关（拆分部署：API 关内嵌、worker 独立消费）。"""
+    _FakeWorker.instances.clear()
+    settings = SimpleNamespace(
+        TASK_BACKEND="arq",
+        ARQ_EMBEDDED_WORKER=False,
+        ARQ_WORKER_MAX_JOBS=128,
+        ARQ_JOB_TIMEOUT_SECONDS=30,
+        ARQ_POLL_DELAY_SECONDS=0.1,
+        ARQ_QUEUE_NAME="lambchat:arq",
+        REDIS_URL="redis://localhost:6379/0",
+        REDIS_PASSWORD=None,
+    )
+    monkeypatch.setattr(arq_runtime, "settings", settings)
+
+    runtime = arq_runtime.EmbeddedArqRuntime(worker_factory=_FakeWorker)
+    await runtime.start(force=True)
+    assert runtime.is_running is True
+    assert len(_FakeWorker.instances) == 1
+    await runtime.stop()

--- a/tests/infra/task/test_worker_main.py
+++ b/tests/infra/task/test_worker_main.py
@@ -1,0 +1,195 @@
+"""独立 arq worker 进程入口：启动面 / 信号退出 / embedded 开关绕过。
+
+拆分动机（2026-09-09 生产断联复盘）：ARQ_EMBEDDED_WORKER=true 时 agent 任务
+与 API 共享事件循环——重任务饿死 API（SSE/沙箱通道心跳停发），API 滚动发布
+杀运行中任务。worker_main 是分进程部署的进程入口，本文件锁定它的启动面契约：
+必须带上任务执行依赖的进程内服务（分布式取消监听、缓存一致性 pubsub），
+且不带上 API 职责的服务（周期任务双跑会重复执行）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from src.infra.task import worker_main
+
+
+class _FakePubSub:
+    def __init__(self) -> None:
+        self.started = 0
+        self.stopped = 0
+
+    async def start_listener(self) -> None:
+        self.started += 1
+
+    async def stop_listener(self) -> None:
+        self.stopped += 1
+
+
+class _FakeTaskManager:
+    def __init__(self) -> None:
+        self.pubsub = _FakePubSub()
+
+    async def start_pubsub_listener(self) -> None:
+        self.pubsub.started += 1
+
+    async def stop_pubsub_listener(self) -> None:
+        self.pubsub.stopped += 1
+
+
+class _FakeArqRuntime:
+    def __init__(self) -> None:
+        self.started_with: dict | None = None
+        self.stopped = 0
+
+    async def start(self, **kwargs) -> None:
+        self.started_with = kwargs
+
+    async def stop(self) -> None:
+        self.stopped += 1
+
+
+@pytest.fixture
+def wired(monkeypatch: pytest.MonkeyPatch):
+    """worker_main 全部协作者替换为可观测 fake；返回各 fake 供断言。"""
+    task_manager = _FakeTaskManager()
+    runtime = _FakeArqRuntime()
+    pubsubs = {
+        "settings": _FakePubSub(),
+        "model_config": _FakePubSub(),
+        "tool_cache": _FakePubSub(),
+        "mcp_cache": _FakePubSub(),
+        "pricing": _FakePubSub(),
+        "memory": _FakePubSub(),
+    }
+    lag_monitor = SimpleNamespace(calls=0)
+
+    async def fake_lag_monitor() -> None:
+        lag_monitor.calls += 1
+
+    monkeypatch.setattr(worker_main, "get_task_manager", lambda: task_manager)
+    monkeypatch.setattr(worker_main, "get_arq_runtime", lambda: runtime)
+    monkeypatch.setattr(worker_main, "start_event_loop_lag_monitor", fake_lag_monitor)
+    monkeypatch.setattr(worker_main, "get_settings_pubsub", lambda: pubsubs["settings"])
+    monkeypatch.setattr(worker_main, "get_model_config_pubsub", lambda: pubsubs["model_config"])
+    monkeypatch.setattr(worker_main, "get_tool_cache_pubsub", lambda: pubsubs["tool_cache"])
+    monkeypatch.setattr(worker_main, "get_mcp_cache_pubsub", lambda: pubsubs["mcp_cache"])
+    monkeypatch.setattr(worker_main, "get_pricing_pubsub", lambda: pubsubs["pricing"])
+    monkeypatch.setattr(worker_main, "get_memory_pubsub", lambda: pubsubs["memory"])
+
+    startup_calls: list[str] = []
+    shutdown_calls: list[str] = []
+
+    async def fake_worker_startup(ctx: dict) -> None:
+        startup_calls.append("worker_startup")
+
+    async def fake_worker_shutdown(ctx: dict) -> None:
+        shutdown_calls.append("worker_shutdown")
+
+    monkeypatch.setattr(worker_main, "worker_startup", fake_worker_startup)
+    monkeypatch.setattr(worker_main, "worker_shutdown", fake_worker_shutdown)
+
+    return SimpleNamespace(
+        task_manager=task_manager,
+        runtime=runtime,
+        pubsubs=pubsubs,
+        lag_monitor=lag_monitor,
+        startup_calls=startup_calls,
+        shutdown_calls=shutdown_calls,
+    )
+
+
+async def test_amain_starts_required_services_with_forced_arq_runtime(wired, monkeypatch):
+    """启动面契约：循环监控、取消监听、缓存一致性 pubsub、force 启动的 arq。"""
+    monkeypatch.setattr(worker_main.settings, "ENABLE_MEMORY", True)
+
+    async def release_stop(stop: asyncio.Event) -> None:
+        await asyncio.sleep(0.01)
+        stop.set()
+
+    stop = asyncio.Event()
+    done = asyncio.create_task(release_stop(stop))
+    await worker_main._amain(stop)
+    await done
+
+    assert wired.lag_monitor.calls == 1
+    assert wired.task_manager.pubsub.started == 1  # 分布式取消信号必须到达执行方
+    for name in ("settings", "model_config", "tool_cache", "mcp_cache", "pricing", "memory"):
+        assert wired.pubsubs[name].started == 1, name
+    # force=True：绕过 ARQ_EMBEDDED_WORKER（该开关只约束 API 进程）
+    assert wired.runtime.started_with == {"force": True}
+    assert wired.startup_calls == ["worker_startup"]  # 分布式校验 + loop_bridge 登记
+
+
+async def test_amain_shutdown_stops_listeners_and_runtime_in_order(wired, monkeypatch):
+    """退出面契约：先停 worker（等任务收尾），再停监听，最后 worker_shutdown。"""
+    monkeypatch.setattr(worker_main.settings, "ENABLE_MEMORY", False)
+    order: list[str] = []
+
+    real_stop = wired.runtime.stop
+
+    async def recording_runtime_stop() -> None:
+        order.append("runtime_stop")
+        await real_stop()
+
+    wired.runtime.stop = recording_runtime_stop
+
+    async def release_stop(stop: asyncio.Event) -> None:
+        await asyncio.sleep(0.01)
+        stop.set()
+
+    stop = asyncio.Event()
+    done = asyncio.create_task(release_stop(stop))
+    await worker_main._amain(stop)
+    await done
+
+    assert order == ["runtime_stop"]
+    assert wired.runtime.stopped == 1
+    assert wired.task_manager.pubsub.stopped == 1
+    assert wired.shutdown_calls == ["worker_shutdown"]  # 生命周期收尾（loop/恢复静默）
+
+
+async def test_amain_skips_memory_pubsub_when_disabled(wired, monkeypatch):
+    monkeypatch.setattr(worker_main.settings, "ENABLE_MEMORY", False)
+
+    async def release_stop(stop: asyncio.Event) -> None:
+        await asyncio.sleep(0.01)
+        stop.set()
+
+    stop = asyncio.Event()
+    done = asyncio.create_task(release_stop(stop))
+    await worker_main._amain(stop)
+    await done
+
+    assert wired.pubsubs["memory"].started == 0
+    for name in ("settings", "model_config", "tool_cache", "mcp_cache", "pricing"):
+        assert wired.pubsubs[name].started == 1, name
+
+
+async def test_amain_stops_even_when_services_fail_to_start(wired, monkeypatch):
+    """某个监听器启动失败也要走完退出面（不留半启动进程），异常原样上抛。"""
+    monkeypatch.setattr(worker_main.settings, "ENABLE_MEMORY", False)
+
+    async def broken_start() -> None:
+        raise RuntimeError("redis down")
+
+    wired.pubsubs["pricing"].start_listener = broken_start  # type: ignore[method-assign]
+
+    stop = asyncio.Event()
+    with pytest.raises(RuntimeError, match="redis down"):
+        await worker_main._amain(stop)
+
+    assert wired.runtime.stopped == 1  # 未启动过也要安全调用停止
+    assert wired.task_manager.pubsub.stopped == 1
+
+
+def test_signal_handler_sets_stop_event():
+    """SIGTERM/SIGINT 的处理器只做一件事：置停止事件（退出面统一收尾）。"""
+    stop = asyncio.Event()
+    handler = worker_main._make_signal_handler(stop)
+    assert not stop.is_set()
+    handler()
+    assert stop.is_set()

--- a/tests/infra/test_k8s_manifest.py
+++ b/tests/infra/test_k8s_manifest.py
@@ -1,3 +1,11 @@
+"""k8s 清单契约：API 与独立 arq worker 分进程部署。
+
+2026-09-09 断联复盘后拆分（此前契约相反：API 内嵌 worker 且无独立
+Deployment——内嵌时 agent 任务与 API 共享事件循环，重任务饿死 SSE/沙箱通道
+心跳，API 滚动发布还会杀运行中的任务）。本文件锁定新契约：API 关内嵌、
+lambchat-worker Deployment 跑 worker_main 入口、Service 不把流量导给 worker。
+"""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -15,6 +23,14 @@ def _load_k8s_docs() -> list[dict]:
     ]
 
 
+def _deployment(name: str) -> dict:
+    return next(
+        doc
+        for doc in _load_k8s_docs()
+        if doc.get("kind") == "Deployment" and doc["metadata"]["name"] == name
+    )
+
+
 def _env_map(container: dict) -> dict[str, str]:
     result: dict[str, str] = {}
     for item in container.get("env", []):
@@ -23,24 +39,43 @@ def _env_map(container: dict) -> dict[str, str]:
     return result
 
 
-def test_k8s_api_deployment_enables_distributed_embedded_arq_worker() -> None:
-    deployment = next(
-        doc
-        for doc in _load_k8s_docs()
-        if doc.get("kind") == "Deployment" and doc["metadata"]["name"] == "lambchat"
-    )
-    container = deployment["spec"]["template"]["spec"]["containers"][0]
+def test_k8s_api_deployment_disables_embedded_arq_worker() -> None:
+    """API 进程只服务 HTTP/SSE：TASK_BACKEND=arq 但不内嵌 worker。"""
+    container = _deployment("lambchat")["spec"]["template"]["spec"]["containers"][0]
     env = _env_map(container)
 
     assert env["LAMBCHAT_DISTRIBUTED_MODE"] == "true"
     assert env["TASK_BACKEND"] == "arq"
-    assert env["ARQ_EMBEDDED_WORKER"] == "true"
+    assert env["ARQ_EMBEDDED_WORKER"] == "false"
 
 
-def test_k8s_manifest_uses_symmetric_app_nodes_without_required_worker_deployment() -> None:
-    deployment_names = {
-        doc["metadata"]["name"] for doc in _load_k8s_docs() if doc.get("kind") == "Deployment"
-    }
+def test_k8s_worker_deployment_runs_standalone_worker_entry() -> None:
+    """独立 worker Deployment：跑 worker_main 入口、同样走 arq 队列。"""
+    deployment = _deployment("lambchat-worker")
+    container = deployment["spec"]["template"]["spec"]["containers"][0]
+    env = _env_map(container)
 
-    assert "lambchat" in deployment_names
-    assert "lambchat-worker" not in deployment_names
+    assert container["command"] == [
+        "/app/.venv/bin/python",
+        "-m",
+        "src.infra.task.worker_main",
+    ]
+    assert env["TASK_BACKEND"] == "arq"
+    assert env["LAMBCHAT_DISTRIBUTED_MODE"] == "true"
+    # worker 不监听 HTTP：不得声明端口
+    assert "ports" not in container
+
+
+def test_k8s_service_selector_excludes_worker_pods() -> None:
+    """NodePort Service 只选 API pods——worker 复用同镜像但 label 必须区分，
+    否则 worker 会收到 HTTP 流量（无 HTTP 服务，连接直接黑洞）。"""
+    service = next(
+        doc
+        for doc in _load_k8s_docs()
+        if doc.get("kind") == "Service" and doc["metadata"]["name"] == "lambchat"
+    )
+    selector = service["spec"]["selector"]
+    worker_labels = _deployment("lambchat-worker")["spec"]["template"]["metadata"]["labels"]
+
+    assert selector == {"app": "lambchat"}
+    assert worker_labels == {"app": "lambchat-worker"}

--- a/uv.lock
+++ b/uv.lock
@@ -2024,7 +2024,7 @@ wheels = [
 
 [[package]]
 name = "lambchat"
-version = "2.9.2"
+version = "2.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

v2.10.1 发版批次：六处版本文件同步 bump（frontend/package.json、tauri.conf.json、android versionName/versionCode(2101)、iOS MARKETING_VERSION、pyproject.toml、daemon `__version__`），并将三个修复 PR 并入本批次同批上线。

## 本版内容（自 v2.10.0 以来）

- #498 fix(agent): HITL 审批恢复后 token 用量与工作时长跨分段累计
- #499 fix(prompt): 本地 daemon 会话注入「沙箱=用户本机」身份段
- #500 fix(frontend): 审批队列对 SSE 整段重放收敛
- #502 perf(task): HITL resume 提速
- #504 test(download): 下载页测试竞态修复
- #506 fix(frontend): ask human 审批卡换行修复与移动端适配，重设计沙箱确认清单与定时任务卡
- #507 fix(sandbox): 本地沙箱断联自愈——未 ACK 幂等重推 + daemon 去重与 hello 快速失败 + 通道心跳先发射；含 arq worker 与 API 分进程拆分
- #508 fix(frontend): OAuth 登录按钮点击即进入 loading，防止连点重复跳转

## 合入本分支的额外修正

- uv.lock 版本随 pyproject 对齐 2.10.1（2.10.0 bump 时遗漏）
- ruff format 修复 test_daemon.py 空行（补 #507 CI 遗留）

## Testing

- 版本号 preflight 校验值人工核对（tag 去点 = 2101 ✓）
- 合并后本地全量验证：ruff check/format、mypy、后端 pytest 4388 passed、前端 vitest 2609 passed、前端 build、本地沙箱 E2E 35/35 PASS
