### PR TITLE
fix(frontend): ask human 审批卡换行修复与移动端适配，重设计沙箱确认清单与定时任务卡

### DIFF
--- a/frontend/src/components/chat/ChatMessage/items/AskHumanItem.tsx
+++ b/frontend/src/components/chat/ChatMessage/items/AskHumanItem.tsx
@@ -24,6 +24,8 @@ import { ToolInlineDetails } from "./ToolInlineDetails";
 import { ToolHoverCopyButton } from "./ToolHoverCopyButton";
 import { ToolDurationFooter } from "./ToolDurationFooter";
 import { MarkdownContent } from "../MarkdownContent";
+import { parseAskHumanMessage } from "../../../panels/askHumanMessage";
+import { ApprovalOpList } from "../../../panels/ApprovalOpList";
 import type { FormField } from "../../../../types";
 
 // ── Parsers matching backend ask_human schema ──────────────────────────
@@ -282,6 +284,7 @@ function AskHumanDetail({ args, result, isPending }: ToolDetailProps) {
   const parsedResult = useMemo(() => parseResult(result), [result]);
 
   const { message, fields } = parsed;
+  const parsedMessage = useMemo(() => parseAskHumanMessage(message), [message]);
 
   // Supplement _other field when backend didn't include it
   // (e.g. cached events before the backend fix, or non-standard flows).
@@ -364,15 +367,29 @@ function AskHumanDetail({ args, result, isPending }: ToolDetailProps) {
           )}
         </div>
 
-        {/* Message (supports markdown) */}
+        {/* Message (structured ops list, or markdown prose) */}
         {message && (
           <div className="approval-message">
-            <div
-              className="prose prose-stone dark:prose-invert max-w-none text-14 leading-relaxed prose-p:my-0.5 prose-headings:my-1"
-              style={{ color: "var(--theme-text)" }}
-            >
-              <MarkdownContent content={message} />
-            </div>
+            {parsedMessage.ops ? (
+              <div className="space-y-2">
+                {parsedMessage.headline && (
+                  <div
+                    className="text-14 font-medium leading-relaxed"
+                    style={{ color: "var(--theme-text)" }}
+                  >
+                    {parsedMessage.headline}
+                  </div>
+                )}
+                <ApprovalOpList ops={parsedMessage.ops} />
+              </div>
+            ) : (
+              <div
+                className="prose prose-stone dark:prose-invert max-w-none text-14 leading-relaxed prose-p:my-0.5 prose-headings:my-1"
+                style={{ color: "var(--theme-text)" }}
+              >
+                <MarkdownContent content={message} />
+              </div>
+            )}
           </div>
         )}
 
@@ -478,6 +495,7 @@ const AskHumanItem = memo(function AskHumanItem({
   const parsedResult = useMemo(() => parseResult(result), [result]);
 
   const { message, fields } = parsed;
+  const parsedMessage = useMemo(() => parseAskHumanMessage(message), [message]);
 
   // Supplement _other field when backend didn't include it
   // (e.g. cached events before the backend fix, or non-standard flows).
@@ -531,10 +549,12 @@ const AskHumanItem = memo(function AskHumanItem({
 
   const labelText = (() => {
     const base = t("chat.message.toolAskHuman");
+    // 优先标题行（沙箱确认门是「确认在本机执行 N 项操作」），
+    // 避免把命令截断在 pill 标签里
     if (message) {
+      const headline = parsedMessage.headline ?? parsedMessage.summary;
       const preview =
-        message.length > 50 ? message.slice(0, 47) + "…" : message;
-      // Strip markdown for pill label
+        headline.length > 50 ? headline.slice(0, 47) + "…" : headline;
       const plain = preview.replace(/[#*_`~>[\]!]/g, "").trim();
       return `${base} — ${plain}`;
     }
@@ -553,14 +573,31 @@ const AskHumanItem = memo(function AskHumanItem({
     <ToolInlineDetails>
       {/* Message summary */}
       {message && (
-        <div className="flex items-start gap-2 px-2.5 py-2 rounded-lg bg-theme-bg border border-theme-border">
-          <ShieldCheck
-            size={12}
-            className="shrink-0 mt-0.5 text-[#f59e0b] dark:text-[#fbbf24]"
-          />
-          <span className="text-12 text-theme-text leading-relaxed line-clamp-2">
-            {message.length > 200 ? message.slice(0, 197) + "…" : message}
-          </span>
+        <div className="px-2.5 py-2 rounded-lg bg-theme-bg border border-theme-border space-y-1.5">
+          <div className="flex items-start gap-2">
+            <ShieldCheck
+              size={12}
+              className="shrink-0 mt-0.5 text-[#f59e0b] dark:text-[#fbbf24]"
+            />
+            <span className="text-12 text-theme-text leading-relaxed line-clamp-2">
+              {parsedMessage.headline ?? message}
+            </span>
+          </div>
+          {parsedMessage.ops && parsedMessage.ops.length > 0 && (
+            <div className="pl-5 flex items-baseline gap-1.5 min-w-0">
+              <span className="shrink-0 text-10 font-mono text-theme-text-tertiary tabular-nums">
+                1
+              </span>
+              <span className="text-11 font-mono text-theme-text-secondary leading-relaxed break-all line-clamp-1">
+                {parsedMessage.ops[0].detail}
+              </span>
+              {parsedMessage.ops.length > 1 && (
+                <span className="shrink-0 text-10 text-theme-text-tertiary">
+                  +{parsedMessage.ops.length - 1}
+                </span>
+              )}
+            </div>
+          )}
         </div>
       )}
 
@@ -642,10 +679,11 @@ const AskHumanItem = memo(function AskHumanItem({
             title: t("chat.message.toolAskHuman"),
             icon: <ShieldCheck size={16} />,
             status,
-            subtitle:
-              message && message.length > 120
-                ? message.slice(0, 117) + "…"
-                : message || undefined,
+            subtitle: message
+              ? parsedMessage.summary.length > 120
+                ? parsedMessage.summary.slice(0, 117) + "…"
+                : parsedMessage.summary || undefined
+              : undefined,
             fallback: detailContent || undefined,
             buildDetail: (data) => (
               <AskHumanDetail {...toolDetailPropsFromPanelData(data)} />

--- a/frontend/src/components/panels/ApprovalOpList.tsx
+++ b/frontend/src/components/panels/ApprovalOpList.tsx
@@ -1,0 +1,28 @@
+import { TerminalSquare } from "lucide-react";
+import type { AskHumanOp } from "./askHumanMessage";
+
+/**
+ * 沙箱确认门的操作清单——「单据式」只读列表：
+ * 编号 + 动词标签 + 等宽命令文本，发丝线分行。
+ * 同时用于审批卡（ApprovalPanel）与历史回放的 ask_human 详情面板。
+ */
+export function ApprovalOpList({ ops }: { ops: AskHumanOp[] }) {
+  return (
+    <div className="approval-op-list" role="list">
+      {ops.map((op, index) => (
+        <div className="approval-op-row" role="listitem" key={index}>
+          <span className="approval-op-index" aria-hidden="true">
+            {index + 1}
+          </span>
+          {op.verb ? (
+            <span className="approval-op-verb">
+              <TerminalSquare size={10} strokeWidth={2} aria-hidden="true" />
+              {op.verb}
+            </span>
+          ) : null}
+          <span className="approval-op-detail">{op.detail}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/panels/ApprovalPanel.tsx
+++ b/frontend/src/components/panels/ApprovalPanel.tsx
@@ -30,6 +30,8 @@ import {
   toggleMultiSelectValue,
   toggleSingleSelectValue,
 } from "./approvalFormValidation";
+import { parseAskHumanMessage } from "./askHumanMessage";
+import { ApprovalOpList } from "./ApprovalOpList";
 
 interface ApprovalPanelProps {
   approvals: PendingApproval[];
@@ -547,7 +549,9 @@ export function ApprovalPanel({
       field.type === "multi_select" ||
       field.type === "select",
   );
-  const askHumanQuestion = approvalSummary;
+  // 头部只放标题行；编号操作清单/补充说明进明细区，长消息不再挤成一行
+  const askHumanParsed = parseAskHumanMessage(currentApproval.message);
+  const askHumanQuestion = askHumanParsed.headline ?? approvalSummary;
   const isSubmitDisabled =
     isLoading || !isFormFieldsValid(currentApproval.fields, currentFormValues);
 
@@ -690,6 +694,18 @@ export function ApprovalPanel({
                         </ReactMarkdown>
                       )}
                     </div>
+                  </div>
+                )}
+
+                {isAskHuman && (askHumanParsed.ops || askHumanParsed.prose) && (
+                  <div className="approval-ask-human-context">
+                    {askHumanParsed.ops ? (
+                      <ApprovalOpList ops={askHumanParsed.ops} />
+                    ) : (
+                      <p className="approval-ask-human-context-prose">
+                        {askHumanParsed.prose}
+                      </p>
+                    )}
                   </div>
                 )}
 

--- a/frontend/src/components/panels/ScheduledTaskApprovalContent.tsx
+++ b/frontend/src/components/panels/ScheduledTaskApprovalContent.tsx
@@ -1,4 +1,6 @@
 import { useTranslation } from "react-i18next";
+import { clsx } from "clsx";
+import { CalendarClock, TerminalSquare, Check, Minus, Bot } from "lucide-react";
 
 interface ScheduledTaskApprovalContentProps {
   preview: {
@@ -11,68 +13,96 @@ interface ScheduledTaskApprovalContentProps {
   };
 }
 
+function SpecRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="approval-st-row">
+      <span className="approval-st-label">{label}</span>
+      <span className="approval-st-value">{children}</span>
+    </div>
+  );
+}
+
+function MonoChip({ children }: { children: React.ReactNode }) {
+  return <code className="approval-st-mono">{children}</code>;
+}
+
 /**
- * Renders a scheduled task creation approval with i18n support.
- * Used by ApprovalPanel when an approval has metadata.approval_type === "scheduled_task_create".
+ * Renders a scheduled task creation approval as a compact spec sheet:
+ * definition rows for the task parameters plus a code block for the run
+ * prompt. Used by ApprovalPanel when an approval has
+ * metadata.approval_type === "scheduled_task_create".
  */
 export function ScheduledTaskApprovalContent({
   preview,
 }: ScheduledTaskApprovalContentProps) {
   const { t } = useTranslation();
 
-  const immediate = preview.run_on_start
-    ? `✅ ${t("approvals.scheduledTask.yes")}`
-    : `❌ ${t("approvals.scheduledTask.no")}`;
-
   return (
-    <div>
-      <p>{t("approvals.scheduledTask.confirmCreation")}</p>
-      <p>{t("approvals.scheduledTask.noTaskYet")}</p>
+    <div className="approval-st">
+      <p className="approval-st-lead">
+        {t("approvals.scheduledTask.confirmCreation")}
+      </p>
+      <p className="approval-st-note">
+        {t("approvals.scheduledTask.noTaskYet")}
+      </p>
 
-      <table>
-        <thead>
-          <tr>
-            <th></th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <strong>{t("approvals.scheduledTask.name")}</strong>
-            </td>
-            <td>{preview.name}</td>
-          </tr>
-          <tr>
-            <td>
-              <strong>{t("approvals.scheduledTask.agent")}</strong>
-            </td>
-            <td>
-              <code>{preview.agent_id}</code>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <strong>{t("approvals.scheduledTask.schedule")}</strong>
-            </td>
-            <td>{preview.schedule}</td>
-          </tr>
-          <tr>
-            <td>
-              <strong>{t("approvals.scheduledTask.runImmediately")}</strong>
-            </td>
-            <td>{immediate}</td>
-          </tr>
-          <tr>
-            <td>
-              <strong>{t("approvals.scheduledTask.timeout")}</strong>
-            </td>
-            <td>{preview.timeout_seconds}s</td>
-          </tr>
-        </tbody>
-      </table>
+      <div className="approval-st-sheet">
+        <SpecRow label={t("approvals.scheduledTask.name")}>
+          <span className="approval-st-name">{preview.name}</span>
+        </SpecRow>
+        <SpecRow label={t("approvals.scheduledTask.agent")}>
+          <MonoChip>
+            <Bot
+              size={11}
+              strokeWidth={2}
+              aria-hidden="true"
+              className="approval-st-chip-icon"
+            />
+            {preview.agent_id}
+          </MonoChip>
+        </SpecRow>
+        <SpecRow label={t("approvals.scheduledTask.schedule")}>
+          <MonoChip>
+            <CalendarClock
+              size={11}
+              strokeWidth={2}
+              aria-hidden="true"
+              className="approval-st-chip-icon"
+            />
+            {preview.schedule}
+          </MonoChip>
+        </SpecRow>
+        <SpecRow label={t("approvals.scheduledTask.runImmediately")}>
+          <span
+            className={clsx(
+              "approval-st-flag",
+              preview.run_on_start
+                ? "approval-st-flag--on"
+                : "approval-st-flag--off",
+            )}
+          >
+            {preview.run_on_start ? (
+              <Check size={11} strokeWidth={2.5} aria-hidden="true" />
+            ) : (
+              <Minus size={11} strokeWidth={2.5} aria-hidden="true" />
+            )}
+            {preview.run_on_start
+              ? t("approvals.scheduledTask.yes")
+              : t("approvals.scheduledTask.no")}
+          </span>
+        </SpecRow>
+        <SpecRow label={t("approvals.scheduledTask.timeout")}>
+          <MonoChip>{preview.timeout_seconds}s</MonoChip>
+        </SpecRow>
+      </div>
 
-      <p>
+      <p className="approval-st-effect">
         {t("approvals.scheduledTask.effect", {
           agent: preview.agent_id,
           schedule: preview.schedule,
@@ -80,12 +110,15 @@ export function ScheduledTaskApprovalContent({
         {preview.run_on_start && t("approvals.scheduledTask.effectImmediate")}
       </p>
 
-      <p>
-        <strong>{t("approvals.scheduledTask.promptSent")}</strong>
-      </p>
-      <pre className="max-h-48 overflow-y-auto whitespace-pre-wrap break-words">
-        <code>{preview.message}</code>
-      </pre>
+      <div className="approval-st-prompt">
+        <div className="approval-st-prompt-header">
+          <TerminalSquare size={12} strokeWidth={2} aria-hidden="true" />
+          <span>{t("approvals.scheduledTask.promptSent")}</span>
+        </div>
+        <pre className="approval-st-prompt-body">
+          <code>{preview.message}</code>
+        </pre>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/panels/__tests__/askHumanLayout.test.ts
+++ b/frontend/src/components/panels/__tests__/askHumanLayout.test.ts
@@ -13,6 +13,43 @@ const approvalCss = readFileSync(
   "utf8",
 );
 
+test("adapts sandbox-confirm op rows to two-line stacking on narrow screens", () => {
+  // 窄屏：编号 + 动词胶囊一行，命令独占整行换行并缩进对齐胶囊左缘，
+  // 避免胶囊挤压命令宽度；参数单标签列同步放宽
+  expect(approvalCss).toMatch(
+    /@media \(max-width: 640px\)[\s\S]*?\.approval-op-row\s*\{[\s\S]*?flex-wrap:\s*wrap;/,
+  );
+  expect(approvalCss).toMatch(
+    /@media \(max-width: 640px\)[\s\S]*?\.approval-op-detail\s*\{[\s\S]*?flex-basis:\s*100%;/,
+  );
+  expect(approvalCss).toMatch(
+    /@media \(max-width: 640px\)[\s\S]*?\.approval-st-label\s*\{[\s\S]*?flex-basis:\s*5rem;/,
+  );
+});
+
+test("renders sandbox-confirm batches as a structured op list, not one crammed line", () => {
+  // 沙箱确认门的 message 是「标题 + 编号操作」多行文本：头部只放标题行，
+  // 明细区渲染单据式操作清单，命令走等宽字体 + 任意断行
+  expect(approvalSource).toMatch(
+    /parseAskHumanMessage\(currentApproval\.message\)/,
+  );
+  expect(approvalSource).toMatch(
+    /askHumanQuestion = askHumanParsed\.headline \?\? approvalSummary/,
+  );
+  expect(approvalSource).toMatch(/ApprovalOpList ops=\{askHumanParsed\.ops\}/);
+  expect(approvalSource).toMatch(/approval-ask-human-context/);
+  expect(approvalSource).toMatch(/askHumanParsed\.prose/);
+  expect(approvalCss).toMatch(
+    /\.approval-op-list\s*\{[\s\S]*?flex-direction:\s*column;/,
+  );
+  expect(approvalCss).toMatch(
+    /\.approval-op-detail\s*\{[\s\S]*?overflow-wrap:\s*anywhere;/,
+  );
+  expect(approvalCss).toMatch(
+    /\.approval-op-row \+ \.approval-op-row\s*\{[\s\S]*?border-top:\s*1px dashed/,
+  );
+});
+
 test("renders ask-human as a full card with numbered choices and footer actions", () => {
   expect(approvalSource).toMatch(/approval-card--ask-human/);
   expect(approvalSource).toMatch(/approval-ask-human-option/);

--- a/frontend/src/components/panels/__tests__/askHumanMessage.test.ts
+++ b/frontend/src/components/panels/__tests__/askHumanMessage.test.ts
@@ -1,0 +1,77 @@
+import { parseAskHumanMessage } from "../askHumanMessage";
+
+test("parses sandbox confirm batch into headline and op rows", () => {
+  const parsed = parseAskHumanMessage(
+    "确认在本机执行 2 项操作：\n" +
+      "1. 执行命令：rm ~/下载/数据文件/a.json && echo 已删除; ls -A ~/下载\n" +
+      "2. 写入文件：/tmp/out.txt",
+  );
+  expect(parsed.headline).toBe("确认在本机执行 2 项操作");
+  expect(parsed.ops).toEqual([
+    {
+      verb: "执行命令",
+      detail: "rm ~/下载/数据文件/a.json && echo 已删除; ls -A ~/下载",
+    },
+    { verb: "写入文件", detail: "/tmp/out.txt" },
+  ]);
+  expect(parsed.prose).toBeNull();
+});
+
+test("keeps an op without a CJK verb prefix detail-only", () => {
+  const parsed = parseAskHumanMessage(
+    "确认在本机执行 1 项操作：\n1. 上传 3 个文件",
+  );
+  expect(parsed.ops).toEqual([{ verb: null, detail: "上传 3 个文件" }]);
+});
+
+test("does not treat colons inside the command as the verb separator", () => {
+  const parsed = parseAskHumanMessage(
+    '确认在本机执行 1 项操作：\n1. 执行命令：echo "time: 10" && echo a：b',
+  );
+  expect(parsed.ops?.[0].verb).toBe("执行命令");
+  expect(parsed.ops?.[0].detail).toBe('echo "time: 10" && echo a：b');
+});
+
+test("does not treat an ascii-colon command prefix as a CJK verb", () => {
+  const parsed = parseAskHumanMessage(
+    "确认在本机执行 1 项操作：\n1. rm：-rf /tmp/x",
+  );
+  expect(parsed.ops?.[0].verb).toBeNull();
+  expect(parsed.ops?.[0].detail).toBe("rm：-rf /tmp/x");
+});
+
+test("plain multi-line question falls back to headline plus prose", () => {
+  const parsed = parseAskHumanMessage("接下来怎么做？\n请选择一个方案继续。");
+  expect(parsed.headline).toBe("接下来怎么做？");
+  expect(parsed.ops).toBeNull();
+  expect(parsed.prose).toBe("请选择一个方案继续。");
+});
+
+test("single-line question returns headline only", () => {
+  const parsed = parseAskHumanMessage("要继续吗？");
+  expect(parsed.headline).toBe("要继续吗？");
+  expect(parsed.ops).toBeNull();
+  expect(parsed.prose).toBeNull();
+});
+
+test("mixed numbered and unnumbered lines are not forced into op rows", () => {
+  const parsed = parseAskHumanMessage(
+    "确认执行：\n1. 执行命令：ls\n注意：以上操作不可撤销",
+  );
+  expect(parsed.ops).toBeNull();
+  expect(parsed.prose).toBe("1. 执行命令：ls\n注意：以上操作不可撤销");
+});
+
+test("empty message yields no headline", () => {
+  const parsed = parseAskHumanMessage("");
+  expect(parsed.headline).toBeNull();
+  expect(parsed.ops).toBeNull();
+  expect(parsed.prose).toBeNull();
+});
+
+test("collapses to a single-line summary for pill labels", () => {
+  const summary = parseAskHumanMessage(
+    "确认在本机执行 1 项操作：\n1. 执行命令：rm -rf /tmp",
+  ).summary;
+  expect(summary).toBe("确认在本机执行 1 项操作： 1. 执行命令：rm -rf /tmp");
+});

--- a/frontend/src/components/panels/askHumanMessage.ts
+++ b/frontend/src/components/panels/askHumanMessage.ts
@@ -1,0 +1,70 @@
+/**
+ * ask_human 消息结构化解析。
+ *
+ * 后端沙箱确认门（sandbox_confirm.py）的 message 是「标题行 + 编号操作行」
+ * 的多行文本；普通提问则是任意散文。这里把它拆成 headline / ops / prose，
+ * 供审批卡与工具 pill 按各自密度渲染——标题进头部、操作清单进明细区，
+ * 避免 replace(/\s+/g, " ") 把整段压成一行的排版事故。
+ */
+
+export interface AskHumanOp {
+  /** 操作动词（执行命令 / 写入文件 / …），无法可靠识别时为 null */
+  verb: string | null;
+  /** 动词之后的具体内容（命令、路径等），原样保留 */
+  detail: string;
+}
+
+export interface AskHumanMessageShape {
+  /** 标题行（去掉收尾冒号），空消息为 null */
+  headline: string | null;
+  /** 全部剩余行均为编号行时的结构化操作清单，否则 null */
+  ops: AskHumanOp[] | null;
+  /** 非编号的补充说明（保留换行），没有则为 null */
+  prose: string | null;
+  /** 全文压成单行的摘要（pill 标签 / 折叠摘要用） */
+  summary: string;
+}
+
+const NUMBERED_LINE = /^\d{1,3}\s*[.、)．]\s*(.+)$/;
+// 动词只认「短 + 纯中文」前缀，命令内部的冒号（含全角）不会被误切
+const VERB_PREFIX = /^([\u4e00-\u9fff]{1,8})：(.+)$/;
+
+function splitVerb(detail: string): AskHumanOp {
+  const match = VERB_PREFIX.exec(detail);
+  if (match) {
+    return { verb: match[1], detail: match[2] };
+  }
+  return { verb: null, detail };
+}
+
+export function parseAskHumanMessage(message: string): AskHumanMessageShape {
+  const summary = message.replace(/\s+/g, " ").trim();
+
+  const lines = message
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  if (lines.length === 0) {
+    return { headline: null, ops: null, prose: null, summary };
+  }
+
+  const headline = lines[0].replace(/[：:]\s*$/, "");
+  const rest = lines.slice(1);
+
+  if (rest.length > 0 && rest.every((line) => NUMBERED_LINE.test(line))) {
+    return {
+      headline,
+      ops: rest.map((line) => splitVerb(NUMBERED_LINE.exec(line)![1].trim())),
+      prose: null,
+      summary,
+    };
+  }
+
+  return {
+    headline,
+    ops: null,
+    prose: rest.length > 0 ? rest.join("\n") : null,
+    summary,
+  };
+}

--- a/frontend/src/styles/approval.css
+++ b/frontend/src/styles/approval.css
@@ -308,6 +308,293 @@
   padding: 0.65rem 1.1rem 1rem;
 }
 
+/* ── 沙箱确认门操作清单（单据式只读列表） ──
+ * 也会渲染在工具实时面板（无 .approval-card 祖先），token 全部带兜底。 */
+.approval-op-list {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid
+    var(
+      --theme-border,
+      color-mix(in srgb, var(--approval-border) 60%, transparent)
+    );
+  border-radius: 0.75rem;
+  background: color-mix(
+    in srgb,
+    var(--theme-bg-card, var(--approval-bg)) 88%,
+    var(--theme-bg, transparent)
+  );
+  overflow: hidden;
+}
+
+.approval-op-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  padding: 0.55rem 0.8rem;
+}
+
+.approval-op-row + .approval-op-row {
+  border-top: 1px dashed
+    var(
+      --theme-border,
+      color-mix(in srgb, var(--approval-border) 45%, transparent)
+    );
+}
+
+.approval-op-index {
+  min-width: 0.9rem;
+  padding-top: 0.15rem;
+  color: var(--theme-text-secondary, var(--approval-text-dim));
+  font-size: 0.6875rem;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  line-height: 1.4;
+  text-align: right;
+  user-select: none;
+}
+
+.approval-op-verb {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 0.25rem;
+  margin-top: 0.05rem;
+  padding: 0.12rem 0.5rem;
+  border: 1px solid
+    color-mix(in srgb, var(--approval-accent, #f59e0b) 26%, transparent);
+  border-radius: 999px;
+  background: color-mix(
+    in srgb,
+    var(--approval-accent-light, #fef3c7) 16%,
+    transparent
+  );
+  color: color-mix(
+    in srgb,
+    var(--approval-accent-hover, #d97706) 82%,
+    var(--approval-text, var(--theme-text, inherit))
+  );
+  font-size: 0.6875rem;
+  font-weight: 500;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+.approval-op-detail {
+  min-width: 0;
+  flex: 1 1 auto;
+  color: var(--approval-text, var(--theme-text, inherit));
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+    "Liberation Mono", monospace;
+  font-size: 0.75rem;
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+/* ask_human 明细区的上下文块：标题以下、表单以上 */
+.approval-ask-human-context {
+  padding: var(--approval-section-y) var(--approval-section-x) 0;
+}
+
+.approval-ask-human-context-prose {
+  color: var(--approval-text-dim, var(--theme-text-secondary));
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+/* ── 定时任务创建审批（spec-sheet 式参数单） ── */
+.approval-st {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.approval-st-lead {
+  margin: 0;
+  color: var(--approval-text, var(--theme-text));
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+}
+
+.approval-st-note {
+  margin: 0;
+  color: var(--approval-text-dim, var(--theme-text-secondary));
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
+.approval-st-sheet {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid
+    var(
+      --theme-border,
+      color-mix(in srgb, var(--approval-border) 55%, transparent)
+    );
+  border-radius: 0.75rem;
+  background: color-mix(
+    in srgb,
+    var(--theme-bg-card, var(--approval-bg)) 88%,
+    var(--theme-bg, transparent)
+  );
+  overflow: hidden;
+}
+
+.approval-st-row {
+  display: flex;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.5rem 0.9rem;
+}
+
+.approval-st-row + .approval-st-row {
+  border-top: 1px dashed
+    var(
+      --theme-border,
+      color-mix(in srgb, var(--approval-border) 40%, transparent)
+    );
+}
+
+.approval-st-label {
+  flex: 0 0 4.5rem;
+  color: var(--approval-text-dim, var(--theme-text-secondary));
+  font-size: 0.75rem;
+  line-height: 1.5;
+  user-select: none;
+}
+
+.approval-st-value {
+  min-width: 0;
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  overflow-wrap: anywhere;
+}
+
+.approval-st-name {
+  color: var(--approval-text, var(--theme-text));
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1.5;
+}
+
+.approval-st-mono {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  max-width: 100%;
+  padding: 0.14rem 0.55rem;
+  border: 1px solid
+    color-mix(in srgb, var(--approval-accent, #f59e0b) 18%, transparent);
+  border-radius: 0.45rem;
+  background: color-mix(
+    in srgb,
+    var(--approval-accent-light, #fef3c7) 10%,
+    transparent
+  );
+  color: var(--approval-text, var(--theme-text));
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+    "Liberation Mono", monospace;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+.approval-st-chip-icon {
+  flex-shrink: 0;
+  opacity: 0.55;
+}
+
+.approval-st-flag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.14rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.5;
+}
+
+.approval-st-flag--on {
+  background: color-mix(in srgb, #10b981 12%, transparent);
+  color: #059669;
+}
+
+.approval-st-flag--off {
+  background: color-mix(
+    in srgb,
+    var(--theme-text-secondary, #78716c) 10%,
+    transparent
+  );
+  color: var(--approval-text-dim, var(--theme-text-secondary));
+}
+
+.dark .approval-st-flag--on {
+  background: color-mix(in srgb, #10b981 16%, transparent);
+  color: #34d399;
+}
+
+.approval-st-effect {
+  margin: 0;
+  color: var(--approval-text-dim, var(--theme-text-secondary));
+  font-size: 0.75rem;
+  line-height: 1.6;
+}
+
+.approval-st-prompt {
+  border: 1px solid
+    var(
+      --theme-border,
+      color-mix(in srgb, var(--approval-border) 55%, transparent)
+    );
+  border-radius: 0.75rem;
+  background: color-mix(
+    in srgb,
+    var(--theme-bg-card, var(--approval-bg)) 88%,
+    var(--theme-bg, transparent)
+  );
+  overflow: hidden;
+}
+
+.approval-st-prompt-header {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.45rem 0.9rem;
+  border-bottom: 1px solid
+    color-mix(
+      in srgb,
+      var(--approval-border, var(--theme-border)) 35%,
+      transparent
+    );
+  color: var(--approval-text-dim, var(--theme-text-secondary));
+  font-family: var(--font-serif, ui-serif, Georgia, serif);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  user-select: none;
+}
+
+.approval-st-prompt-body {
+  margin: 0;
+  max-height: 14rem;
+  padding: 0.65rem 0.9rem;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  color: var(--approval-text, var(--theme-text));
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+    "Liberation Mono", monospace;
+  font-size: 0.75rem;
+  line-height: 1.65;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
 .approval-ask-human-shortcut-hint {
   align-items: center;
   gap: 0.25rem;
@@ -362,6 +649,33 @@
   .approval-card.approval-card--composer {
     --approval-section-x: 1rem;
     border-radius: 1.25rem;
+  }
+
+  /* 窄屏操作行改两段：编号 + 动词胶囊一行，命令独占整行换行，
+   * 避免胶囊挤压命令可用宽度、换行后左边距参差 */
+  .approval-op-row {
+    flex-wrap: wrap;
+    gap: 0.4rem 0.55rem;
+    padding: 0.5rem 0.7rem;
+  }
+
+  .approval-op-detail {
+    flex-basis: 100%;
+    padding-left: 1.45rem; /* 与动词胶囊左缘对齐 */
+  }
+
+  /* 参数单标签列放宽：四字标签 + 间距在窄屏不换行 */
+  .approval-st-label {
+    flex-basis: 5rem;
+  }
+
+  .approval-st-row {
+    gap: 0.75rem;
+    padding: 0.5rem 0.75rem;
+  }
+
+  .approval-st-prompt-body {
+    padding: 0.55rem 0.75rem;
   }
 
   .approval-ask-human-header {


### PR DESCRIPTION
## 问题

沙箱确认门（本地执行确认）的 ask human 卡片里，正文全部挤成一行无法换行：

- 后端 `sandbox_confirm.py` 生成的 message 本身是带 `\n` 的编号清单（「确认在本机执行 N 项操作：\n1. 执行命令：rm …」）
- 前端 `ApprovalPanel.tsx` 用 `message.replace(/\s+/g, " ")` 把所有换行压平后整段塞进头部，命令全挤成一坨（手机端尤甚）
- 「规划定时任务」审批卡是朴素 table + emoji，观感不专业

## 改动

**换行修复 + 沙箱确认卡**
- 新增 `parseAskHumanMessage` 纯函数：把 message 解析为「标题行 / 编号操作行 / 补充散文」；动词只认短中文前缀（执行命令/写入文件/删除文件/上传），命令内部的冒号不会被误切
- 新增 `ApprovalOpList` 单据式只读清单：编号 + 琥珀动词胶囊 + 等宽命令，发丝虚线分行、`overflow-wrap: anywhere`
- `ApprovalPanel` 头部只放标题行，操作清单进可滚动明细区；普通多行提问显示首行标题 + 次要色补充段
- `AskHumanItem`（历史回放 pill）：标签不再截断命令中段；内联预览显示首条命令 + "+N"；详情面板复用同一渲染

**定时任务卡重设计**
- `ScheduledTaskApprovalContent` 改为 spec-sheet 参数单：定义行（名称/智能体/执行计划/立即执行/超时时间）、agent 与 cron 等宽芯片、克制的绿色「是」胶囊、带头部栏的等宽代码块提示区

**移动端（≤640px）**
- 操作行两段式堆叠：编号 + 动词胶囊一行，命令独占整行折行并缩进对齐胶囊左缘（修复胶囊挤压命令宽度）
- 参数单标签列 4.5rem → 5rem，四字标签不换行

## 验证

- 新增 9 个解析器用例 + 6 条结构断言；develop 基底上 panels 111 用例通过；全量前端 2602 用例通过
- ESLint / tsc / build 全绿
- 无头浏览器 390px 手机视口 + 桌面 960px、浅色/深色四组截图验收（见 PR 讨论前的本地验证）