### PR TITLE
fix(config): ARQ_EMBEDDED_WORKER 改为 env 权威——DB 种子值不得拉起 API 内嵌 worker

### DIFF
--- a/src/kernel/config/constants.py
+++ b/src/kernel/config/constants.py
@@ -50,6 +50,9 @@ RESTART_REQUIRED_SETTINGS = {
     "S3_CUSTOM_DOMAIN",
     "S3_PATH_STYLE",
     "S3_PUBLIC_BUCKET",
+    # 任务执行拓扑：k8s/compose 拆分部署（API + 独立 worker）由 env 决定，
+    # DB 历史种子值不得反向拉起 API 内嵌 worker（会与独立 worker 双消费）
+    "ARQ_EMBEDDED_WORKER",
 }
 
 

--- a/tests/kernel/config/test_db_override_policy.py
+++ b/tests/kernel/config/test_db_override_policy.py
@@ -149,6 +149,21 @@ async def test_env_authoritative_warning_masks_sensitive_values(
 
 
 @pytest.mark.asyncio
+async def test_arq_embedded_worker_is_env_authoritative(
+    monkeypatch: pytest.MonkeyPatch, _isolated_config_globals
+) -> None:
+    """worker 拆分部署后 ARQ_EMBEDDED_WORKER 是部署拓扑决策（k8s/compose 设
+    env=false + 独立 worker Deployment），必须 env-authoritative：DB 里的历史
+    种子值（system:init 曾写 true）不得把 API 进程的内嵌 worker 重新拉起，
+    否则 API 与独立 worker 双消费同一队列（2026-09-09 staging 实测踩坑）。"""
+    monkeypatch.setattr(config_service.settings, "ARQ_EMBEDDED_WORKER", False)
+
+    await _run_initialize(monkeypatch, [("ARQ_EMBEDDED_WORKER", True)])
+
+    assert config_service.settings.ARQ_EMBEDDED_WORKER is False
+
+
+@pytest.mark.asyncio
 async def test_refresh_keeps_panel_override_semantics(
     monkeypatch: pytest.MonkeyPatch, _isolated_config_globals
 ) -> None:


### PR DESCRIPTION
## Summary

`ARQ_EMBEDDED_WORKER` 加入 `RESTART_REQUIRED_SETTINGS`（env-authoritative 白名单）。worker 拆分部署（#507）实测失效：settings 加载顺序是 DB > env，`system_settings` 的历史种子值（`system:init` 写入 `true`）覆盖了 k8s/compose 里的 `env=false`，API 内嵌 worker 照常启动，与独立 worker Deployment **双消费同一 arq 队列**。

## 问题复现（2026-09-09 staging）

- staging 已部署 worker 拆分（API `ARQ_EMBEDDED_WORKER=false` + `lambchat-staging-worker` Deployment）
- API pod 启动日志仍有 `Embedded arq worker started`，提交对话任务后被 **API pod** 消费执行（worker pod 空转）
- pod env 确认 `false`、`system_settings` 里存在种子行 `value: true` → DB 覆盖 env

## Fix

- 该开关是**部署拓扑决策**（哪个进程跑 worker），归入连接类白名单，env/compose 唯一权威；DB 值仅告警不生效
- 运行时面板修改（`refresh_settings`）语义不变
- 全新安装：`init_from_env` 会把 env 值种进 DB，UI 展示与实际一致

## Testing

- [x] RED：`test_arq_embedded_worker_is_env_authoritative`（DB=true + env=false → 保持 false），修复前失败、修复后通过
- [x] `tests/kernel/config/` 65 passed；`tests/infra/task/` + `tests/infra/settings/` 311 passed
- [x] ruff check / format 通过
