### PR TITLE
fix(hitl): 沙箱确认门整批复批携带 tool_call_ids——点忽略后执行卡不再无 result

### DIFF
--- a/frontend/src/hooks/useAgent/__tests__/eventProcessor.test.ts
+++ b/frontend/src/hooks/useAgent/__tests__/eventProcessor.test.ts
@@ -86,8 +86,7 @@ test("keeps cancelled ask-human tool results pending while HITL resumes", () => 
   });
 });
 
-test("resolves the exact ask-human tool from a durable approval event", () => {
-  const first = processMessageEvent(
+test("resolves the exact ask-human tool from a durable approval event", () => {  const first = processMessageEvent(
     "tool:start",
     { tool: "ask_human", tool_call_id: "ask-1", args: { message: "first" } },
     [],
@@ -183,6 +182,47 @@ test("replayed approval resolution is idempotent", () => {
 
   expect(replayed.parts).toEqual(first.parts);
   expect(replayed.parts).toHaveLength(1);
+});
+
+test("sandbox confirm resolution finalizes the whole batch of execute cards", () => {
+  // 沙箱确认门不合成 ask_human 卡，聊天里挂起的是执行工具卡（等待确认）；
+  // 点忽略后 approval_resolved 携带整批 tool_call_ids，全部执行卡必须转为
+  // 终态，否则工具卡永远没有 result（2026-09-09 生产反馈）。
+  let parts: MessagePart[] = [];
+  for (const id of ["exec-1", "exec-2"]) {
+    const started = processMessageEvent(
+      "tool:start",
+      { tool: "execute", tool_call_id: id, args: { command: `du ${id}` } },
+      parts,
+      "",
+      [],
+      0,
+      [],
+      true,
+      "message-1",
+    );
+    parts = started.parts;
+  }
+
+  const resolved = processMessageEvent(
+    "approval_resolved",
+    {
+      id: "approval-batch",
+      tool_call_ids: ["exec-1", "exec-2"],
+      result: { status: "rejected", message: "用户拒绝了此请求", values: {} },
+      success: false,
+    },
+    parts,
+    "",
+    [],
+    0,
+    [],
+    true,
+    "message-1",
+  );
+
+  expect(resolved.parts[0]).toMatchObject({ id: "exec-1", isPending: false });
+  expect(resolved.parts[1]).toMatchObject({ id: "exec-2", isPending: false });
 });
 
 test("does not duplicate a replayed tool start with the same tool call id", () => {

--- a/frontend/src/hooks/useAgent/eventProcessor.ts
+++ b/frontend/src/hooks/useAgent/eventProcessor.ts
@@ -313,11 +313,34 @@ export function processMessageEvent(
 
     case "approval_resolved": {
       const toolCallId = data.tool_call_id as string | undefined;
+      // 沙箱确认门整批：回执携带全部受控工具卡的 tool_call_ids，逐一转终态
+      const batchToolCallIds = Array.isArray(data.tool_call_ids)
+        ? (data.tool_call_ids as unknown[]).filter(
+            (id): id is string => typeof id === "string" && id.length > 0,
+          )
+        : [];
       const resolvedResult =
         typeof data.result === "object" && data.result !== null
           ? data.result
           : { status: data.success === false ? "rejected" : "success" };
-      if (toolCallId) {
+      if (batchToolCallIds.length > 0) {
+        // 沙箱确认门整批：执行卡（等待确认→结果）按 tool_call_ids 批量转终态；
+        // 确认门不合成 ask_human 卡（保持 Codex 式执行卡体验）
+        let updatedParts = parts;
+        for (const batchId of batchToolCallIds) {
+          updatedParts = updateToolResultInDepth(
+            updatedParts,
+            batchId,
+            resolvedResult,
+            data.success !== false,
+            data.error,
+            depth,
+            agentId,
+            data.timestamp,
+          );
+        }
+        result.parts = updatedParts;
+      } else if (toolCallId) {
         result.parts = updateToolResultInDepth(
           parts,
           toolCallId,

--- a/frontend/src/hooks/useAgent/types.ts
+++ b/frontend/src/hooks/useAgent/types.ts
@@ -56,6 +56,8 @@ export interface EventData {
   agent_avatar?: string;
   tool?: string;
   tool_call_id?: string;
+  /** 沙箱确认门整批复批：全部受控执行卡的 tool_call_id 集合 */
+  tool_call_ids?: string[];
   args?: Record<string, unknown>;
   result?: string | Record<string, unknown>;
   artifact?: Record<string, unknown>;

--- a/src/infra/agent/middleware/sandbox_confirm.py
+++ b/src/infra/agent/middleware/sandbox_confirm.py
@@ -255,6 +255,9 @@ class SandboxConfirmMiddleware(AgentMiddleware):
                 "origin": "sandbox_confirm",
                 "message": message,
                 "fields": [],
+                # 各自 tool_call_id：物化层聚合进审批 metadata，approval_resolved
+                # 回执据此终结聊天里的执行工具卡（缺失则点忽略后卡永远无 result）
+                "tool_call_id": str(tool_call.get("id", "") or ""),
             }
         )
         approved = bool(isinstance(resume_value, dict) and resume_value.get("approved"))

--- a/src/infra/task/hitl.py
+++ b/src/infra/task/hitl.py
@@ -161,7 +161,16 @@ async def materialize_ask_human_approvals(
     created = 0
     # 沙箱确认门整批：并行工具各自中断但携带同一批消息——同 origin+message
     # 只物化一张审批卡（恢复侧 expand_sandbox_confirm_resume 负责把批复值
-    # 映射回全部同批中断）
+    # 映射回全部同批中断）；各中断的 tool_call_id 预聚合进该卡 metadata，
+    # approval_resolved 回执据此批量终结执行工具卡
+    sandbox_batch_tool_call_ids: dict[str, list[str]] = {}
+    for payload in payloads:
+        if payload.get("origin") != "sandbox_confirm":
+            continue
+        batch_ids = sandbox_batch_tool_call_ids.setdefault(str(payload.get("message", "")), [])
+        payload_tool_call_id = str(payload.get("tool_call_id") or "")
+        if payload_tool_call_id and payload_tool_call_id not in batch_ids:
+            batch_ids.append(payload_tool_call_id)
     sandbox_seen_messages: set[str] = set()
     for payload in payloads:
         message = str(payload.get("message", ""))
@@ -189,6 +198,9 @@ async def materialize_ask_human_approvals(
         tool_call_id = payload.get("tool_call_id")
         if tool_call_id:
             metadata["tool_call_id"] = str(tool_call_id)
+        batch_ids = sandbox_batch_tool_call_ids.get(message) or []
+        if payload.get("origin") == "sandbox_confirm" and batch_ids:
+            metadata["tool_call_ids"] = list(batch_ids)
         origin = payload.get("origin")
         if origin:
             metadata["origin"] = str(origin)
@@ -389,6 +401,8 @@ def build_hitl_resume_payload(
         "approval_resolved": {
             "id": approval.id,
             "tool_call_id": approval_metadata.get("tool_call_id"),
+            # 沙箱确认门整批：全部受控工具卡的终结锚点（前端批量转终态）
+            "tool_call_ids": list(approval_metadata.get("tool_call_ids") or []),
             "interrupt_id": interrupt_id,
             "status": "approved" if resume_value.get("approved") else "rejected",
             "success": bool(resume_value.get("approved")),

--- a/tests/infra/agent/middleware/test_sandbox_confirm.py
+++ b/tests/infra/agent/middleware/test_sandbox_confirm.py
@@ -124,6 +124,39 @@ async def test_parallel_batch_each_call_interrupts_with_identical_payload(
     assert "du /home" in msg and "du /var" in msg and "snap list" in msg
 
 
+async def test_interrupt_payload_carries_tool_call_id(policy, interrupt, supported):
+    """中断 payload 必须携带各自 tool_call_id：审批解析回执（approval_resolved）
+    靠它终结聊天里的执行工具卡——缺失时用户点忽略后执行卡永远无 result
+    （2026-09-09 生产反馈）。并行批每个调用各带自己的 id。"""
+    interrupt["raise"] = False
+    interrupt["resume"] = {"approved": False, "values": {}}
+    batch = [
+        {"name": "execute", "args": {"command": "du /home"}, "id": "c1"},
+        {"name": "execute", "args": {"command": "du /var"}, "id": "c2"},
+    ]
+    mw = SandboxConfirmMiddleware(user_id="u1")
+    rec = _Recorder()
+
+    for item in batch:
+        state = {"messages": [AIMessage(content="", tool_calls=batch)]}
+        req = type(
+            "R",
+            (),
+            {
+                "tool_call": {
+                    "name": "execute",
+                    "args": item["args"],
+                    "id": item["id"],
+                },
+                "state": state,
+            },
+        )()
+        await mw.awrap_tool_call(req, rec.handler)
+
+    ids = [p.get("tool_call_id") for p in interrupt["payloads"]]
+    assert ids == ["c1", "c2"]
+
+
 async def test_replay_each_task_interrupt_returns_batch_decision(policy, interrupt, supported):
     """恢复重放：各任务 interrupt() 返回（扩展映射后的）批复值，各自执行。"""
     interrupt["raise"] = False

--- a/tests/infra/task/test_hitl_resume.py
+++ b/tests/infra/task/test_hitl_resume.py
@@ -466,6 +466,7 @@ async def test_submit_resume_submits_run_with_hitl_payload(fake_redis, monkeypat
     assert submitted["kwargs"]["hitl_resume"]["approval_resolved"] == {
         "id": "approval-1",
         "tool_call_id": None,
+        "tool_call_ids": [],
         "interrupt_id": "interrupt-a",
         "status": "approved",
         "success": True,

--- a/tests/infra/tool/test_ask_human_graph_interrupt.py
+++ b/tests/infra/tool/test_ask_human_graph_interrupt.py
@@ -457,6 +457,58 @@ async def test_materialize_dedups_sandbox_confirm_batch_to_one_approval(
     assert len(recorder.created) == 1
 
 
+async def test_materialize_aggregates_batch_tool_call_ids(
+    interrupt_mode: None, recorder: ApprovalRecorder
+) -> None:
+    """同批去重为一张卡时，各中断携带的 tool_call_id 聚合进 metadata——
+    approval_resolved 回执据此批量终结执行工具卡（点忽略后不再无 result）。"""
+    msg = "确认在本机执行 2 项操作：\n1. 执行命令：df -h\n2. 执行命令：lsblk"
+    snapshot = SimpleNamespace(
+        tasks=[
+            SimpleNamespace(
+                interrupts=[
+                    SimpleNamespace(
+                        id=f"intr-{i}",
+                        value={
+                            "kind": "ask_human",
+                            "origin": "sandbox_confirm",
+                            "message": msg,
+                            "fields": [],
+                            "tool_call_id": f"call-{i}",
+                        },
+                    )
+                ]
+            )
+            for i in range(3)
+        ]
+    )
+    await materialize_ask_human_approvals(snapshot, session_id="s1", run_id="r1", user_id="u1")
+    assert len(recorder.created) == 1
+    ids = recorder.created[0]["metadata"].get("tool_call_ids")
+    assert sorted(ids) == ["call-0", "call-1", "call-2"]
+
+
+async def test_resume_payload_receipt_carries_batch_tool_call_ids() -> None:
+    """approval_resolved 回执透传 tool_call_ids：前端据此把整批执行卡转终态。"""
+    from src.infra.task.hitl import build_hitl_resume_payload
+
+    approval = SimpleNamespace(
+        id="ap-1",
+        message="确认在本机执行 2 项操作",
+        metadata={
+            "mode": "interrupt",
+            "origin": "sandbox_confirm",
+            "interrupt_id": "intr-0",
+            "tool_call_ids": ["call-0", "call-1"],
+        },
+    )
+    payload = build_hitl_resume_payload(approval, {"approved": False, "values": {}})
+    receipt = payload["approval_resolved"]
+    assert receipt["tool_call_ids"] == ["call-0", "call-1"]
+    assert receipt["tool_call_id"] is None  # 单值字段不虚构
+    assert receipt["status"] == "rejected"
+
+
 async def test_expand_sandbox_confirm_resume_maps_all_batch_interrupts() -> None:
     """恢复扩展：同批（同 origin+message）全部中断共享同一批复值。"""
     from src.infra.task.hitl import expand_sandbox_confirm_resume


### PR DESCRIPTION
## Summary

修复：命令的沙箱确认卡点「忽略」后，聊天里的执行工具卡永远无 result（等待确认态挂死）。agent 对话本身不受影响（拒绝后正确续跑），纯前端卡片终态丢失。

## 根因链

1. 确认门 interrupt payload 不带 `tool_call_id`（普通 ask_human 有带）→ 物化的审批 metadata 缺该字段
2. `approval_resolved` 回执 `tool_call_id=null` → 前端只能走「终结最近 ask_human 卡」兜底
3. 确认门 by-design 不合成 ask_human 卡（Codex 式执行卡体验）→ 兜底也落空 → 执行卡无人终结

## Fix（保持「不合成确认卡」原设计）

- 确认门 interrupt payload 携带各自 `tool_call_id`；`materialize_ask_human_approvals` **预聚合**同批全部 id 进审批 `metadata.tool_call_ids`（同批仍只建一张卡，去重语义不变）
- `build_hitl_resume_payload` 的 `approval_resolved` 回执透传 `tool_call_ids`
- 前端 `approval_resolved` 支持按 `tool_call_ids` 批量把执行卡转终态（拒绝 → 「用户拒绝了此请求」）

## Testing

- [x] TDD：payload 带 id（并行批各带各的）、物化聚合、回执透传——三个后端 RED→GREEN
- [x] 前端：`approval_resolved` 批量终结执行卡（RED→GREEN）；全套 2610 passed（含钉住「不合成确认卡」的既有测试，确认原设计未动）
- [x] 后端相关 1493 passed；ruff/mypy/eslint/build 全绿
