### PR TITLE
chore(k8s): worker 滚动改先增后减 + 优雅宽限 300s——更新不再打断在途对话

### DIFF
--- a/k8s/lambchat.yaml
+++ b/k8s/lambchat.yaml
@@ -152,6 +152,13 @@ metadata:
   namespace: lambchat
 spec:
   replicas: 2
+  # 先增后减 + 长宽限：新 worker 先上线接新任务，旧 worker SIGTERM 后
+  # 排空在途任务再退（宽限 300s，超时被杀的走 interrupted_resume 无缝续跑）
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app: lambchat-worker
@@ -160,7 +167,7 @@ spec:
       labels:
         app: lambchat-worker
     spec:
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 300
       containers:
       - name: lambchat-worker
         image: ghcr.io/yanyutin753/lambchat:latest


### PR DESCRIPTION
## Summary

worker Deployment 滚动策略优化：`maxSurge=1, maxUnavailable=0` + `terminationGracePeriodSeconds` 60→300。

- 新 worker 先上线接新任务，旧 worker SIGTERM 后排空在途任务再退（arq 语义：停止接新、跑完当前）
- 300s 宽限覆盖典型任务时长；超时被杀走 interrupted_resume 同 run 无缝续跑
- 生产/staging 集群已 kubectl patch 生效，本 PR 固化进仓库 manifest 防回退

## Testing

- tests/infra/test_k8s_manifest.py 3 passed