### PR TITLE
fix(prompt): 本地 daemon 会话注入机器绑定段——写明会话连的哪台机器与 OS

### DIFF
--- a/src/agents/core/prompt_policy.py
+++ b/src/agents/core/prompt_policy.py
@@ -69,28 +69,47 @@ The local sandbox is the user's Mac; `execute` runs commands via /bin/sh (POSIX)
 - Prefer `python3 -c "..."` (embedded interpreter, on PATH) for system introspection and portable work (e.g. memory/CPU info via `os.sysconf`, `platform`, `subprocess`), since Linux-style `/proc` reads do not exist.
 - A command may legitimately fail (non-zero exit); its stdout/stderr come back to you — read the error text and adapt."""
 
+#: 会话级机器绑定段（三平台一律注入，纯尾部追加）：写明本会话 daemon 连接
+#: 的是用户的哪台机器、什么系统。生产会话 d1def0b5 实测：多机用户（Windows
+#: 工作机 + Ubuntu 本机）的 linux 会话没有任何 OS/机器陈述时，模型按记忆
+#: 猜成 Windows，连试三条 Windows 命令全 404 后才靠 uname 自纠——linux 分支
+#: 原本「POSIX 语法天然成立不需方言段」的省略，把 OS 事实也一并省掉了。
+_SANDBOX_LOCAL_MACHINE_BINDING = """### Local Machine Binding
 
-def sandbox_shell_platform_section(daemon_platform: str) -> str:
+This session's daemon is connected to the user's {os_name} machine{machine_label}. Every shell command and file operation runs on that machine: use its OS and path conventions directly, and never guess the OS from memory when the user has more than one machine."""
+
+_OS_NAMES = {"win32": "Windows", "darwin": "macOS", "linux": "Linux"}
+
+
+def sandbox_shell_platform_section(daemon_platform: str, machine_name: str = "") -> str:
     """daemon 上报平台 → 沙箱运行时提示追加段；空串 = 不追加（保持现状）。
 
     平台串是注册表第三段的归一值（win32/linux/darwin）。三个已上报平台都
     注入 _SANDBOX_LOCAL_MACHINE_IDENTITY（沙箱=用户本机的身份与谨慎纪律段）；
-    win32/darwin 另需 shell 方言段。
+    win32/darwin 另需 shell 方言段；三平台一律在最后追加机器绑定段（OS +
+    机器名，机器名第五段缺失时只写 OS）——多机用户不再需要按记忆猜会话
+    连的是哪台机器。
 
-    KV 缓存纪律：方言段字节保持历史原样，身份段一律**尾部追加**——整段文本
-    经 SandboxWorkspaceMiddleware 落在文件工具 description 里、排在逐会话
-    的 {work_dir} 之后，跨会话本就无共享前缀可失；纯追加保证部署时存量
-    会话已缓存的旧字节零失效，新文本只在会话首 turn 一次性多 prefill。
-    空串涵盖云端沙箱、daemon 离线与旧版未上报——一律不加段，云端 prompt
-    逐字节保持现状，也绝不错入 Windows 分支。
+    KV 缓存纪律：方言段与身份段字节保持历史原样，机器绑定段一律**纯尾部
+    追加**——整段文本经 SandboxWorkspaceMiddleware 落在文件工具 description
+    里、排在逐会话的 {work_dir} 之后，跨会话本就无共享前缀可失；纯追加保
+    证部署时存量会话已缓存的旧字节零失效。绑定段随会话内 daemon 目标机稳
+    定（与平台段同语义）。空串涵盖云端沙箱、daemon 离线与旧版未上报——
+    一律不加段，云端 prompt 逐字节保持现状，也绝不错入 Windows 分支。
     """
     if daemon_platform == "win32":
-        return _SANDBOX_SHELL_WIN32 + "\n\n" + _SANDBOX_LOCAL_MACHINE_IDENTITY
-    if daemon_platform == "darwin":
-        return _SANDBOX_SHELL_DARWIN + "\n\n" + _SANDBOX_LOCAL_MACHINE_IDENTITY
-    if daemon_platform == "linux":
-        return _SANDBOX_LOCAL_MACHINE_IDENTITY
-    return ""
+        base = _SANDBOX_SHELL_WIN32 + "\n\n" + _SANDBOX_LOCAL_MACHINE_IDENTITY
+    elif daemon_platform == "darwin":
+        base = _SANDBOX_SHELL_DARWIN + "\n\n" + _SANDBOX_LOCAL_MACHINE_IDENTITY
+    elif daemon_platform == "linux":
+        base = _SANDBOX_LOCAL_MACHINE_IDENTITY
+    else:
+        return ""
+    label = f" ({machine_name})" if machine_name else ""
+    binding = _SANDBOX_LOCAL_MACHINE_BINDING.format(
+        os_name=_OS_NAMES[daemon_platform], machine_label=label
+    )
+    return f"{base}\n\n{binding}"
 
 
 ARTIFACT_POLICY = """### Artifact Delivery

--- a/src/agents/search_agent/nodes.py
+++ b/src/agents/search_agent/nodes.py
@@ -93,22 +93,28 @@ logger = get_logger(__name__)
 async def _build_sandbox_runtime_policy(
     sandbox_backend: Any, sandbox_work_dir: str | None, *, user_id: str
 ) -> str:
-    """沙箱运行时提示段：workspace 策略 + （仅本地 daemon）本机身份/平台段。
+    """沙箱运行时提示段：workspace 策略 + （仅本地 daemon）本机身份/机器绑定段。
 
     本地 daemon 上报 win32/linux/darwin 任一平台时追加
     prompt_policy.sandbox_shell_platform_section（「沙箱=用户本机」身份段 +
-    win32/darwin 的 shell 方言段），让模型既知道自己真的在操作用户的电脑，
+    机器绑定段（OS+机器名，多机用户不再按记忆猜系统）+ win32/darwin 的
+    shell 方言段），让模型既知道自己真的在操作用户的电脑、连的是哪台，
     又能生成 cmd.exe / macOS 兼容命令。云端沙箱与未上报一律不加段，prompt
-    逐字节保持现状；段文本随会话内 daemon 平台稳定，provider 前缀缓存不受
-    逐 turn 影响。
+    逐字节保持现状；段文本随会话内 daemon 目标机稳定，provider 前缀缓存
+    不受逐 turn 影响。
     """
     if not sandbox_backend or not sandbox_work_dir:
         return ""
-    from src.infra.backend.local import WorkspaceAliasBackend, _lookup_daemon_platform
+    from src.infra.backend.local import (
+        WorkspaceAliasBackend,
+        _lookup_daemon_identity,
+    )
 
     shell_section = ""
     if isinstance(sandbox_backend, WorkspaceAliasBackend):
-        shell_section = sandbox_shell_platform_section(await _lookup_daemon_platform(user_id))
+        machine_id = getattr(sandbox_backend, "_machine_id", None)
+        platform, machine_name = await _lookup_daemon_identity(user_id, machine_id)
+        shell_section = sandbox_shell_platform_section(platform, machine_name)
     base = SANDBOX_RUNTIME_SECTION.format(work_dir=sandbox_work_dir)
     return "\n\n".join(part for part in (base, shell_section) if part)
 

--- a/src/infra/backend/local.py
+++ b/src/infra/backend/local.py
@@ -96,9 +96,7 @@ async def _lookup_daemon_platform(user_id: str, machine_id: str | None = None) -
         return ""
 
 
-async def _lookup_daemon_identity(
-    user_id: str, machine_id: str | None = None
-) -> tuple[str, str]:
+async def _lookup_daemon_identity(user_id: str, machine_id: str | None = None) -> tuple[str, str]:
     """经注册表查目标机 daemon 的（上报平台, 机器展示名）。
 
     prompt 机器绑定段（OS+机器名）的数据源；离线/旧格式/未上报对应成员为

--- a/src/infra/backend/local.py
+++ b/src/infra/backend/local.py
@@ -96,6 +96,21 @@ async def _lookup_daemon_platform(user_id: str, machine_id: str | None = None) -
         return ""
 
 
+async def _lookup_daemon_identity(
+    user_id: str, machine_id: str | None = None
+) -> tuple[str, str]:
+    """经注册表查目标机 daemon 的（上报平台, 机器展示名）。
+
+    prompt 机器绑定段（OS+机器名）的数据源；离线/旧格式/未上报对应成员为
+    空串，任何故障回落 ("", "")——缺什么就不注入什么，不阻断会话。
+    """
+    try:
+        return await SandboxClientRegistry().get_machine_identity(user_id, machine_id)
+    except Exception:  # noqa: BLE001 - 身份查询尽力而为，失败不注入
+        logger.warning("daemon identity lookup failed for user %s", user_id)
+        return "", ""
+
+
 # 上传分块阈值（posix）：单条命令的原始内容上限 48KB（b64 后 ~64KB）。
 # b64 内容作为单个 argv 下发，内核 MAX_ARG_STRLEN 限制单参数 128KB，
 # 扣除引号/命令前缀开销后 ~96KB 即触发 E2BIG（Errno 7）——48KB 留足余量。

--- a/src/infra/sandbox/relay/registry.py
+++ b/src/infra/sandbox/relay/registry.py
@@ -383,6 +383,20 @@ class SandboxClientRegistry:
             return ""
         return parse_daemon_platform(await self.machine_value(user_id, target))
 
+    async def get_machine_identity(
+        self, user_id: str, machine_id: str | None = None
+    ) -> tuple[str, str]:
+        """目标机的（上报平台, 机器展示名），一次解析共用 machine_value。
+
+        离线或旧格式 value（对应段缺失）返回空串成员——调用方（search agent
+        机器绑定段注入）缺什么就不注入什么，与 get_platform 同语义容错。
+        """
+        target = await self.resolve_target(user_id, machine_id)
+        if target is None:
+            return "", ""
+        value = await self.machine_value(user_id, target)
+        return parse_daemon_platform(value), parse_machine_name(value)
+
     async def get_confirm_policy(self, user_id: str, machine_id: str | None = None) -> str:
         """目标机的上报确认策略（all/commands/none）。
 

--- a/tests/agents/core/test_prompt_policy.py
+++ b/tests/agents/core/test_prompt_policy.py
@@ -75,3 +75,40 @@ def test_shell_platform_section_darwin_guides_bsd_userland():
     section = sandbox_shell_platform_section("darwin")
     assert "macOS" in section
     assert "python3" in section
+
+
+def test_shell_platform_section_linux_binds_os_and_machine_name():
+    """生产会话 d1def0b5 实测：多机用户（Windows 工作机 + Ubuntu 本机）的
+    linux 会话此前没有任何 OS/机器陈述，模型按记忆猜成 Windows，连试三条
+    Windows 命令全 404 后才靠 uname 自纠。三平台一律注入机器绑定段，写明
+    本会话连的是哪台机器、什么系统。"""
+    section = sandbox_shell_platform_section("linux", machine_name="yangyang-Lenovo")
+    assert "Linux" in section
+    assert "yangyang-Lenovo" in section
+    # 反猜纪律：多机场景不得按记忆猜 OS
+    assert "never guess" in section
+
+
+def test_machine_binding_states_os_without_name():
+    """旧 daemon 不上报机器名（第五段缺失）也必须写明 OS——OS 陈述是关键缺口。"""
+    assert "Linux" in sandbox_shell_platform_section("linux")
+    assert "Windows" in sandbox_shell_platform_section("win32")
+    assert "macOS" in sandbox_shell_platform_section("darwin")
+
+
+def test_machine_binding_is_tail_append_for_all_platforms():
+    """KV 缓存纪律：绑定段纯尾部追加——方言段、身份段历史字节不动，分叉点
+    不前移，存量会话已缓存前缀零失效。"""
+    for platform in ("win32", "darwin", "linux"):
+        section = sandbox_shell_platform_section(platform, machine_name="m1")
+        assert (
+            section.index("user's own real computer")
+            < section.index("Local Machine Binding")
+        )
+        assert section.rstrip().endswith("more than one machine.")
+
+
+def test_machine_binding_absent_for_unknown_platform():
+    """未知/空平台（云端沙箱、未上报）拿不到 OS 事实，不得编造绑定段。"""
+    assert sandbox_shell_platform_section("winxp", machine_name="m1") == ""
+    assert sandbox_shell_platform_section("", machine_name="m1") == ""

--- a/tests/agents/core/test_prompt_policy.py
+++ b/tests/agents/core/test_prompt_policy.py
@@ -101,10 +101,7 @@ def test_machine_binding_is_tail_append_for_all_platforms():
     不前移，存量会话已缓存前缀零失效。"""
     for platform in ("win32", "darwin", "linux"):
         section = sandbox_shell_platform_section(platform, machine_name="m1")
-        assert (
-            section.index("user's own real computer")
-            < section.index("Local Machine Binding")
-        )
+        assert section.index("user's own real computer") < section.index("Local Machine Binding")
         assert section.rstrip().endswith("more than one machine.")
 
 

--- a/tests/agents/search_agent/test_sandbox_runtime_policy.py
+++ b/tests/agents/search_agent/test_sandbox_runtime_policy.py
@@ -16,9 +16,7 @@ async def test_runtime_policy_carries_machine_identity(monkeypatch):
         assert user_id == "u1"
         return ("linux", "yangyang-Lenovo-XiaoXinPro")
 
-    monkeypatch.setattr(
-        "src.infra.backend.local._lookup_daemon_identity", fake_identity
-    )
+    monkeypatch.setattr("src.infra.backend.local._lookup_daemon_identity", fake_identity)
     policy = await search_nodes._build_sandbox_runtime_policy(
         backend, "/workspace/s1", user_id="u1"
     )
@@ -35,12 +33,8 @@ async def test_runtime_policy_passes_session_machine_id(monkeypatch):
         seen["machine_id"] = machine_id
         return ("darwin", "MacBook")
 
-    monkeypatch.setattr(
-        "src.infra.backend.local._lookup_daemon_identity", fake_identity
-    )
-    await search_nodes._build_sandbox_runtime_policy(
-        backend, "/workspace/s1", user_id="u1"
-    )
+    monkeypatch.setattr("src.infra.backend.local._lookup_daemon_identity", fake_identity)
+    await search_nodes._build_sandbox_runtime_policy(backend, "/workspace/s1", user_id="u1")
     assert seen["machine_id"] == "mac1"
 
 

--- a/tests/agents/search_agent/test_sandbox_runtime_policy.py
+++ b/tests/agents/search_agent/test_sandbox_runtime_policy.py
@@ -1,0 +1,52 @@
+"""search agent 沙箱运行时提示：本机 daemon 会话必须注入机器绑定段。
+
+生产会话 d1def0b5 实测：多机用户（Windows 工作机 + Ubuntu 本机）的 linux
+本地会话中模型不知道「这个会话连的是哪台机器/什么系统」，按记忆猜成
+Windows 连试三条命令全 404。绑定段（OS+机器名）必须随运行时提示注入。
+"""
+
+from src.agents.search_agent import nodes as search_nodes
+from src.infra.backend.local import WorkspaceAliasBackend
+
+
+async def test_runtime_policy_carries_machine_identity(monkeypatch):
+    backend = WorkspaceAliasBackend(user_id="u1", session_id="s1")
+
+    async def fake_identity(user_id, machine_id=None):
+        assert user_id == "u1"
+        return ("linux", "yangyang-Lenovo-XiaoXinPro")
+
+    monkeypatch.setattr(
+        "src.infra.backend.local._lookup_daemon_identity", fake_identity
+    )
+    policy = await search_nodes._build_sandbox_runtime_policy(
+        backend, "/workspace/s1", user_id="u1"
+    )
+    assert "Linux" in policy
+    assert "yangyang-Lenovo-XiaoXinPro" in policy
+
+
+async def test_runtime_policy_passes_session_machine_id(monkeypatch):
+    """会话级选机（多机 daemon）时按目标机查身份，而不是注册表默认解析。"""
+    backend = WorkspaceAliasBackend(user_id="u1", session_id="s1", machine_id="mac1")
+    seen: dict = {}
+
+    async def fake_identity(user_id, machine_id=None):
+        seen["machine_id"] = machine_id
+        return ("darwin", "MacBook")
+
+    monkeypatch.setattr(
+        "src.infra.backend.local._lookup_daemon_identity", fake_identity
+    )
+    await search_nodes._build_sandbox_runtime_policy(
+        backend, "/workspace/s1", user_id="u1"
+    )
+    assert seen["machine_id"] == "mac1"
+
+
+async def test_runtime_policy_skips_machine_section_for_non_alias_backend():
+    """非本地 daemon 后端（云端沙箱）不加机器绑定段——prompt 保持现状。"""
+    policy = await search_nodes._build_sandbox_runtime_policy(
+        object(), "/workspace/s1", user_id="u1"
+    )
+    assert "Local Machine" not in policy

--- a/tests/infra/backend/test_local_backend.py
+++ b/tests/infra/backend/test_local_backend.py
@@ -991,6 +991,17 @@ async def test_lookup_daemon_platform_defaults_posix_on_error(monkeypatch):
     assert await local_module._lookup_daemon_platform("u1") == ""
 
 
+async def test_lookup_daemon_identity_defaults_empty_pair_on_error(monkeypatch):
+    """机器身份查询失败容错回落 ("", "")——不加绑定信息，不阻断会话。"""
+
+    class _BrokenRegistry:
+        def __init__(self, *args, **kwargs):
+            raise ConnectionError("redis down")
+
+    monkeypatch.setattr(local_module, "SandboxClientRegistry", _BrokenRegistry)
+    assert await local_module._lookup_daemon_identity("u1") == ("", "")
+
+
 def test_upload_files_default_platform_keeps_posix_commands(monkeypatch):
     """无平台信息（旧格式 value/查询失败）→ 命令串与现状逐字节一致。"""
     commands: list[str] = []

--- a/tests/infra/sandbox/relay/test_registry.py
+++ b/tests/infra/sandbox/relay/test_registry.py
@@ -6,6 +6,7 @@ from src.infra.sandbox.relay.registry import (
     SandboxClientRegistry,
     parse_daemon_platform,
     parse_daemon_version,
+    parse_machine_name,
 )
 
 
@@ -168,6 +169,36 @@ def test_parse_daemon_platform_all_formats():
     assert parse_daemon_platform("node-a|0.1.0|win32") == "win32"
     assert parse_daemon_platform("node-a||darwin") == "darwin"
     assert parse_daemon_platform("node-a|0.1.0") == ""  # 两段：平台段缺失
+
+
+# ---------- 机器身份（平台+机器名）：prompt 机器绑定段的数据源 ----------
+
+
+async def test_get_machine_identity_returns_platform_and_name(registry):
+    """一次解析同时给出（平台, 机器名）——search agent 机器绑定段的查询入口。"""
+    await registry.register(
+        "u1",
+        "c1",
+        "n1",
+        version="0.3.0",
+        platform="linux",
+        confirm_policy="all",
+        machine_name="yangyang-Lenovo",
+    )
+    assert await registry.get_machine_identity("u1") == ("linux", "yangyang-Lenovo")
+
+
+async def test_get_machine_identity_empty_when_offline_or_old_value(registry):
+    """离线、旧格式 value（机器名第五段缺失）→ ("", "")，调用方不加绑定信息。"""
+    assert await registry.get_machine_identity("nobody") == ("", "")
+    await registry.register("u1", "c1", "n1", version="0.1.0", platform="linux")
+    assert await registry.get_machine_identity("u1") == ("linux", "")
+
+
+def test_parse_machine_name_all_formats():
+    assert parse_machine_name("n1|0.3.0|linux|all|yangyang-Lenovo") == "yangyang-Lenovo"
+    assert parse_machine_name("n1|0.3.0|linux") == ""  # 五段缺失（旧 daemon 未上报）
+    assert parse_machine_name("n1") == ""
     assert parse_daemon_platform("node-a") == ""  # 旧格式（无版本写入方）
     assert parse_daemon_platform("node-a|0.1.0|") == ""  # 空平台与未上报等价
 


### PR DESCRIPTION
## 背景

生产会话 d1def0b5 实测：多机用户（Windows 工作机 GIH-D-27406 + Ubuntu 本机）的 linux 会话中，模型不知道「这个会话连的是哪台机器/什么系统」，按记忆猜成 Windows，连试 `start msedge` → `cmd.exe` → `powershell.exe` 三条命令全 404，最后靠 `uname -a` 才自纠。

根因：`sandbox_shell_platform_section('linux')` 只注入身份段（不含 OS）——win32/darwin 方言段会明说 OS，唯独 linux 分支因「POSIX 语法天然成立不需要方言段」把 OS 事实也一并省掉了。

## 改动

- 三平台一律在段尾追加「Local Machine Binding」：OS + 注册表第五段机器名（未上报机器名时只写 OS），并明示 *never guess the OS from memory*
- 数据源：注册表 `get_machine_identity`（一次解析共用 machine_value，含 `parse_machine_name`）
- 会话级选机（多机 daemon）时按 backend 的 `machine_id` 查目标机，而非注册表默认解析
- 查询故障容错回落 `("",)`——缺什么不注入什么，不阻断会话

## KV 缓存纪律（重点保证）

方言段、身份段历史字节一字未动；机器绑定段**纯尾部追加**——存量会话已缓存前缀零失效；绑定段随会话内 daemon 目标机稳定，逐 turn 不变。

## 验证

- 新增 9 个测试（先红后绿）：prompt_policy 绑定段、registry 身份解析、local 容错、search_agent 接线（含 machine_id 传递）
- 全量后端 4399 passed；ruff / mypy 干净