### PR TITLE
fix(settings): 版本展示改用客户端自身版本——个人设置/关于不再冒充服务端版本

### DIFF
--- a/frontend/src/components/common/AboutDialog.tsx
+++ b/frontend/src/components/common/AboutDialog.tsx
@@ -9,6 +9,7 @@ import {
 import { useTranslation } from "react-i18next";
 import { useVersion } from "../../hooks/useVersion";
 import { APP_NAME } from "../../constants";
+import { APP_VERSION } from "../../utils/appVersion";
 import { SkeletonBlock, SkeletonLine } from "../skeletons";
 
 interface AboutDialogProps {
@@ -99,14 +100,15 @@ export function AboutDialog({ isOpen, onClose }: AboutDialogProps) {
             </div>
           ) : versionInfo ? (
             <>
-              {/* App Version */}
+              {/* App Version（客户端自身版本，打包进 bundle——客户端是什么
+                  版本就显示什么，与服务端版本无关） */}
               <div className="flex items-center justify-between rounded-lg bg-stone-50 p-4 dark:bg-stone-700/50">
                 <div>
                   <div className="text-12 text-stone-500 dark:text-stone-400">
                     {t("about.currentVersion", "Current Version")}
                   </div>
                   <div className="font-mono text-24 font-bold text-stone-900 dark:text-stone-100">
-                    {versionInfo.app_version}
+                    {APP_VERSION}
                   </div>
                 </div>
                 <button

--- a/frontend/src/components/layout/AppContent/AppShell.tsx
+++ b/frontend/src/components/layout/AppContent/AppShell.tsx
@@ -12,7 +12,7 @@ import {
   shouldNudgeBrowserChrome,
 } from "./appBrowserChrome";
 import { isMobileDevice } from "../../../utils/mobile";
-import type { Project, VersionInfo } from "../../../types";
+import type { Project } from "../../../types";
 import type { TabType } from "./types";
 
 function isEditableElementFocused(): boolean {
@@ -51,7 +51,6 @@ export interface AppShellProps {
   activeTab: TabType;
   showProfileModal: boolean;
   onCloseProfileModal: () => void;
-  versionInfo: VersionInfo | null;
   setMobileSidebarOpen: (open: boolean) => void;
   currentProjectId: string | null;
   projectManager: { projects: Project[] };
@@ -82,7 +81,6 @@ export function AppShell({
   activeTab,
   showProfileModal,
   onCloseProfileModal,
-  versionInfo,
   setMobileSidebarOpen,
   currentProjectId,
   projectManager,
@@ -283,7 +281,6 @@ export function AppShell({
       <ProfileModal
         showProfileModal={showProfileModal}
         onCloseProfileModal={onCloseProfileModal}
-        versionInfo={versionInfo}
       />
 
       <div

--- a/frontend/src/components/layout/AppContent/ChatAppContent.tsx
+++ b/frontend/src/components/layout/AppContent/ChatAppContent.tsx
@@ -48,7 +48,6 @@ const CHAT_SKILL_LIST_PARAMS = { limit: 100 };
 export function ChatAppContent({
   showProfileModal,
   onCloseProfileModal,
-  versionInfo,
   sidebarCollapsed,
   setSidebarCollapsed,
   mobileSidebarOpen,
@@ -750,7 +749,6 @@ export function ChatAppContent({
       activeTab="chat"
       showProfileModal={showProfileModal}
       onCloseProfileModal={onCloseProfileModal}
-      versionInfo={versionInfo}
       setMobileSidebarOpen={setMobileSidebarOpen}
       currentProjectId={currentProjectId}
       projectManager={projectManager}

--- a/frontend/src/components/layout/AppContent/NonChatAppContent.tsx
+++ b/frontend/src/components/layout/AppContent/NonChatAppContent.tsx
@@ -9,7 +9,6 @@ export interface NonChatAppContentProps {
   activeTab: Exclude<TabType, "chat">;
   showProfileModal: boolean;
   onCloseProfileModal: () => void;
-  versionInfo: import("../../../types").VersionInfo | null;
   sidebarCollapsed: boolean;
   setSidebarCollapsed: (collapsed: boolean) => void;
   mobileSidebarOpen: boolean;
@@ -21,7 +20,6 @@ export function NonChatAppContent({
   activeTab,
   showProfileModal,
   onCloseProfileModal,
-  versionInfo,
   sidebarCollapsed,
   setSidebarCollapsed,
   mobileSidebarOpen,
@@ -51,7 +49,6 @@ export function NonChatAppContent({
       activeTab={activeTab}
       showProfileModal={showProfileModal}
       onCloseProfileModal={onCloseProfileModal}
-      versionInfo={versionInfo}
       setMobileSidebarOpen={setMobileSidebarOpen}
       currentProjectId={null}
       projectManager={{ projects: [] }}

--- a/frontend/src/components/layout/AppContent/index.tsx
+++ b/frontend/src/components/layout/AppContent/index.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { RightPanelLayoutSnapshot } from "../../../hooks/rightPanelLayout";
 import { getRightPanelLayoutSnapshot } from "../../../hooks/rightPanelWidthEvents";
-import { useVersion } from "../../../hooks/useVersion";
 import { SIDEBAR_COLLAPSED_STORAGE_KEY } from "../../../hooks/useAuth";
 import { authApi } from "../../../services/api";
 import { ChatAppContent } from "./ChatAppContent";
@@ -22,7 +21,6 @@ interface AppContentProps {
 }
 
 export function AppContent({ activeTab }: AppContentProps) {
-  const { versionInfo } = useVersion();
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
 
   // Persisted sidebar state — only changes on explicit user action
@@ -160,7 +158,6 @@ export function AppContent({ activeTab }: AppContentProps) {
       <ChatAppContent
         showProfileModal={showProfileModal}
         onCloseProfileModal={handleCloseProfileModal}
-        versionInfo={versionInfo}
         sidebarCollapsed={effectiveCollapsed}
         setSidebarCollapsed={handleSetSidebarCollapsed}
         mobileSidebarOpen={mobileSidebarOpen}
@@ -175,7 +172,6 @@ export function AppContent({ activeTab }: AppContentProps) {
       activeTab={activeTab}
       showProfileModal={showProfileModal}
       onCloseProfileModal={handleCloseProfileModal}
-      versionInfo={versionInfo}
       sidebarCollapsed={effectiveCollapsed}
       setSidebarCollapsed={handleSetSidebarCollapsed}
       mobileSidebarOpen={mobileSidebarOpen}

--- a/frontend/src/components/layout/AppContent/types.ts
+++ b/frontend/src/components/layout/AppContent/types.ts
@@ -21,7 +21,6 @@ export type TabType =
 export interface ChatAppContentProps {
   showProfileModal: boolean;
   onCloseProfileModal: () => void;
-  versionInfo: import("../../../types").VersionInfo | null;
   sidebarCollapsed: boolean;
   setSidebarCollapsed: (collapsed: boolean) => void;
   mobileSidebarOpen: boolean;

--- a/frontend/src/components/profile/ProfileModal.tsx
+++ b/frontend/src/components/profile/ProfileModal.tsx
@@ -12,9 +12,9 @@ import {
   Scale,
   LogOut,
 } from "lucide-react";
-import { useVersion } from "../../hooks/useVersion";
 import { useAuth } from "../../hooks/useAuth";
 import { BrandWordmark } from "../common/BrandWordmark";
+import { APP_VERSION } from "../../utils/appVersion";
 
 import { ProfileInfoTab } from "./tabs/ProfileInfoTab";
 import { ProfileNotificationTab } from "./tabs/ProfileNotificationTab";
@@ -29,7 +29,6 @@ import { useBodyScrollLock } from "../../hooks/useBodyScrollLock";
 interface ProfileModalProps {
   showProfileModal: boolean;
   onCloseProfileModal: () => void;
-  versionInfo: ReturnType<typeof useVersion>["versionInfo"];
 }
 
 const TAB_ICONS: Record<
@@ -48,7 +47,6 @@ const TAB_ICONS: Record<
 export function ProfileModal({
   showProfileModal,
   onCloseProfileModal,
-  versionInfo,
 }: ProfileModalProps) {
   const { t } = useTranslation();
   const { logout } = useAuth();
@@ -147,11 +145,10 @@ export function ProfileModal({
           decorative
           className="inline-block h-4 w-auto text-stone-500 dark:text-stone-400"
         />
-        {versionInfo?.app_version && (
-          <span className="opacity-70 font-serif leading-none">
-            v{versionInfo.app_version}
-          </span>
-        )}
+        {/* 客户端自身版本（打包进 bundle），不是所连服务端的版本 */}
+        <span className="opacity-70 font-serif leading-none">
+          v{APP_VERSION}
+        </span>
       </a>
       <a
         href="https://github.com/Yanyutin753/LambChat"

--- a/frontend/src/components/profile/__tests__/profileModalVersionSource.test.ts
+++ b/frontend/src/components/profile/__tests__/profileModalVersionSource.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from "node:fs";
+
+/** 版本展示纪律（源码结构断言）：客户端展示的「当前版本」一律是打包进
+ *  bundle 的 APP_VERSION（客户端自身版本），不得拿服务端 /api/version 的
+ *  app_version 冒充——桌面端/移动端看到的应该是自己是什么版本。服务端
+ *  versionInfo 只用于 latest_version / has_update 等更新对比信息。 */
+
+function readSource(relativePath: string): string {
+  const url = new URL(relativePath, import.meta.url);
+  return readFileSync(url, "utf8");
+}
+
+test("profile modal footer shows the bundled client version", () => {
+  const source = readSource("../ProfileModal.tsx");
+  expect(source).toMatch(/APP_VERSION/);
+  expect(source).not.toMatch(/versionInfo\.app_version/);
+  expect(source).not.toMatch(/versionInfo\?\.app_version/);
+});
+
+test("about dialog current version shows the bundled client version", () => {
+  const source = readSource("../../common/AboutDialog.tsx");
+  expect(source).toMatch(/APP_VERSION/);
+  expect(source).not.toMatch(/versionInfo\.app_version/);
+});
+
+test("initial version fetch reports the client version for has_update", () => {
+  // 首次 get() 也带 client_version：has_update 按客户端版本比较，
+  // 而不是服务端版本（网页端服务端=客户端，桌面端两者可能相差多个版本）。
+  const source = readSource("../../../hooks/useVersion.ts");
+  expect(source).toMatch(/versionApi\.get\(\s*APP_VERSION\s*\)/);
+});
+
+test("app content no longer threads server versionInfo into the profile modal", () => {
+  const source = readSource("../../layout/AppContent/index.tsx");
+  expect(source).not.toMatch(/versionInfo/);
+  expect(source).not.toMatch(/useVersion/);
+});

--- a/frontend/src/hooks/useVersion.ts
+++ b/frontend/src/hooks/useVersion.ts
@@ -20,7 +20,9 @@ export function useVersion(): UseVersionReturn {
     setIsLoading(true);
     setError(null);
     try {
-      const info = await versionApi.get();
+      // 首次拉取也上报客户端版本：has_update 按客户端 App 版本比较，而非
+      // 服务端版本（桌面端/移动端两者可能相差多个版本）
+      const info = await versionApi.get(APP_VERSION);
       setVersionInfo(info);
     } catch (err) {
       setError(

--- a/frontend/src/services/api/version.ts
+++ b/frontend/src/services/api/version.ts
@@ -26,9 +26,16 @@ export function buildReleaseAssetDownloadUrl(
 export const versionApi = {
   /**
    * Get application version info
+   *
+   * client_version 让后端按客户端 App 版本（而非服务端版本）判断 has_update。
    */
-  async get(): Promise<VersionInfo> {
-    return authFetch<VersionInfo>(`${API_BASE}/api/version`, {
+  async get(clientVersion?: string): Promise<VersionInfo> {
+    const query = new URLSearchParams();
+    if (clientVersion) {
+      query.set("client_version", clientVersion);
+    }
+    const suffix = query.size > 0 ? `?${query}` : "";
+    return authFetch<VersionInfo>(`${API_BASE}/api/version${suffix}`, {
       skipAuth: true,
     });
   },


### PR DESCRIPTION
## 背景

个人设置（ProfileModal footer）与「关于」对话框的「当前版本」原拿后端 `/api/version` 的 `app_version` 冒充：桌面端/移动端连老服务端时显示的根本不是自己跑的版本。

## 改动

- 两处「当前版本」改用打包进 bundle 的 `APP_VERSION`（与 tauri.conf.json / Android versionName 同源，CI 构建保证一致）
- ProfileModal 的 `versionInfo` prop 链（AppContent → Chat/NonChat → AppShell → ProfileModal）整个移除——footer 不再依赖网络请求，启动期少一次 `/api/version`
- `useVersion` 首次 `get()` 也上报 `client_version`（后端已支持）：`has_update` 按客户端版本比较，桌面端更新提示不再被服务端版本干扰

## 验证

- 新增 4 个源码结构测试（先红后绿）
- 前端全量 536 文件 2614 用例通过；lint / build 通过