### PR TITLE
fix(stream): 终态 run 的过期 stream 重连时合成终态——在途工具卡不再永久转圈

### DIFF
--- a/src/api/routes/chat.py
+++ b/src/api/routes/chat.py
@@ -9,7 +9,6 @@ import asyncio
 import json
 import uuid
 from datetime import datetime, timezone
-from typing import Any
 
 from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import StreamingResponse
@@ -27,6 +26,10 @@ from src.api.routes.chat_request_config import (  # noqa: F401 - 转发导入保
 from src.api.routes.chat_sse import (  # noqa: F401 - 供 SSE 路由与既有测试导入
     CHAT_SSE_DATA_MAX_BYTES,
     _format_sse_event,
+)
+from src.api.routes.chat_stream_terminal import (
+    resolve_terminal_stream_status,
+    synthesize_terminal_stream_event,
 )
 from src.api.routes.chat_validation import validate_team_agent_request
 from src.api.routes.session import verify_session_ownership
@@ -664,9 +667,9 @@ async def session_stream(
             # 断线重连的客户端在途工具卡因此永远转圈（孤儿组件）。stream 为
             # 空且 run 已终态时立即合成终态事件返回。
             if await dual_writer.get_stream_length(session_id, run_id=run_id) == 0:
-                terminal = await _resolve_terminal_stream_status(session, run_id)
+                terminal = await resolve_terminal_stream_status(session, run_id)
                 if terminal is not None:
-                    event = _synthesize_terminal_stream_event(run_id, session, terminal)
+                    event = synthesize_terminal_stream_event(run_id, session, terminal)
                     logger.info(
                         "[SSE] Stream expired and run is terminal (%s); synthesized %s",
                         terminal,
@@ -709,71 +712,6 @@ async def session_stream(
             "X-Accel-Buffering": "no",  # Disable nginx buffering
         },
     )
-
-
-async def _resolve_terminal_stream_status(session: Any, run_id: str) -> str | None:
-    """终态 stream 过期后的 run 终态判定；非终态/查不到返回 None（维持现状）。
-
-    优先按 run_id 查 trace（会话级 metadata 的 task_status 在多 run 并存时
-    会串到别的 run）；trace 无记录时回落 session metadata，但仅当
-    current_run_id 与请求的 run_id 一致才可信。
-    """
-    from src.infra.logging import get_logger
-    from src.infra.session.trace_storage import get_trace_storage
-
-    logger = get_logger(__name__)
-    try:
-        cursor = (
-            get_trace_storage()
-            .collection.find({"run_id": run_id}, {"status": 1, "_id": 0})
-            .sort("started_at", -1)
-            .limit(1)
-        )
-        traces = await cursor.to_list(length=1)
-        if traces:
-            status = traces[0].get("status")
-            if status in ("completed", "error"):
-                return status
-            return None  # running 等非终态：孤儿接管/续跑窗口期，继续等
-    except Exception as e:
-        logger.warning("[SSE] Terminal status lookup via trace failed: %s", e)
-
-    try:
-        metadata = getattr(session, "metadata", None) or {}
-        if metadata.get("current_run_id") == run_id:
-            task_status = metadata.get("task_status")
-            if task_status == "completed":
-                return "completed"
-            if task_status in ("error", "failed", "cancelled"):
-                return "error"
-    except Exception as e:
-        logger.warning("[SSE] Terminal status lookup via session metadata failed: %s", e)
-    return None
-
-
-def _synthesize_terminal_stream_event(run_id: str, session: Any, terminal: str) -> dict:
-    """合成终态 SSE 事件（stream 已过期、无法重放真实终态事件时的替身）。"""
-    timestamp = datetime.now(timezone.utc).isoformat()
-    if terminal == "completed":
-        return {
-            "event_type": "done",
-            "data": {"status": "completed", "run_id": run_id},
-            "id": f"synthetic:{run_id}:done",
-            "timestamp": timestamp,
-        }
-    metadata = getattr(session, "metadata", None) or {}
-    message = metadata.get("task_error") or "This run has already ended."
-    return {
-        "event_type": "error",
-        "data": {
-            "error": message,
-            "type": "task_failed",
-            "run_id": run_id,
-            "code": "run_already_ended",
-        },
-        "id": f"synthetic:{run_id}:error",
-        "timestamp": timestamp,
-    }
 
 
 @router.get("/sessions/{session_id}/status")

--- a/src/api/routes/chat.py
+++ b/src/api/routes/chat.py
@@ -9,6 +9,7 @@ import asyncio
 import json
 import uuid
 from datetime import datetime, timezone
+from typing import Any
 
 from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import StreamingResponse
@@ -658,6 +659,22 @@ async def session_stream(
     async def event_generator():
         logger.info(f"[SSE] Generator started for session={session_id}, run_id={run_id}")
         try:
+            # 终态 stream 已过 60s TTL 被清（run 结束超过 60 秒后的重连）：重放
+            # 0 条事件且下方 xread 永远等不到新事件，只能靠 24h 兜底超时——
+            # 断线重连的客户端在途工具卡因此永远转圈（孤儿组件）。stream 为
+            # 空且 run 已终态时立即合成终态事件返回。
+            if await dual_writer.get_stream_length(session_id, run_id=run_id) == 0:
+                terminal = await _resolve_terminal_stream_status(session, run_id)
+                if terminal is not None:
+                    event = _synthesize_terminal_stream_event(run_id, session, terminal)
+                    logger.info(
+                        "[SSE] Stream expired and run is terminal (%s); synthesized %s",
+                        terminal,
+                        event["event_type"],
+                    )
+                    yield await run_blocking_io(_format_sse_event, event)
+                    return
+
             # 使用 run_id 读取特定轮次的事件
             event_count = 0
             async for event in dual_writer.read_from_redis(
@@ -692,6 +709,71 @@ async def session_stream(
             "X-Accel-Buffering": "no",  # Disable nginx buffering
         },
     )
+
+
+async def _resolve_terminal_stream_status(session: Any, run_id: str) -> str | None:
+    """终态 stream 过期后的 run 终态判定；非终态/查不到返回 None（维持现状）。
+
+    优先按 run_id 查 trace（会话级 metadata 的 task_status 在多 run 并存时
+    会串到别的 run）；trace 无记录时回落 session metadata，但仅当
+    current_run_id 与请求的 run_id 一致才可信。
+    """
+    from src.infra.logging import get_logger
+    from src.infra.session.trace_storage import get_trace_storage
+
+    logger = get_logger(__name__)
+    try:
+        cursor = (
+            get_trace_storage()
+            .collection.find({"run_id": run_id}, {"status": 1, "_id": 0})
+            .sort("started_at", -1)
+            .limit(1)
+        )
+        traces = await cursor.to_list(length=1)
+        if traces:
+            status = traces[0].get("status")
+            if status in ("completed", "error"):
+                return status
+            return None  # running 等非终态：孤儿接管/续跑窗口期，继续等
+    except Exception as e:
+        logger.warning("[SSE] Terminal status lookup via trace failed: %s", e)
+
+    try:
+        metadata = getattr(session, "metadata", None) or {}
+        if metadata.get("current_run_id") == run_id:
+            task_status = metadata.get("task_status")
+            if task_status == "completed":
+                return "completed"
+            if task_status in ("error", "failed", "cancelled"):
+                return "error"
+    except Exception as e:
+        logger.warning("[SSE] Terminal status lookup via session metadata failed: %s", e)
+    return None
+
+
+def _synthesize_terminal_stream_event(run_id: str, session: Any, terminal: str) -> dict:
+    """合成终态 SSE 事件（stream 已过期、无法重放真实终态事件时的替身）。"""
+    timestamp = datetime.now(timezone.utc).isoformat()
+    if terminal == "completed":
+        return {
+            "event_type": "done",
+            "data": {"status": "completed", "run_id": run_id},
+            "id": f"synthetic:{run_id}:done",
+            "timestamp": timestamp,
+        }
+    metadata = getattr(session, "metadata", None) or {}
+    message = metadata.get("task_error") or "This run has already ended."
+    return {
+        "event_type": "error",
+        "data": {
+            "error": message,
+            "type": "task_failed",
+            "run_id": run_id,
+            "code": "run_already_ended",
+        },
+        "id": f"synthetic:{run_id}:error",
+        "timestamp": timestamp,
+    }
 
 
 @router.get("/sessions/{session_id}/status")

--- a/src/api/routes/chat_stream_terminal.py
+++ b/src/api/routes/chat_stream_terminal.py
@@ -1,0 +1,79 @@
+"""chat 流式路由的终态合成助手（从 chat.py 拆出，守 1000 行守门）。
+
+run 到终态后 Redis stream 会被 60s 终态 TTL 清掉；客户端再连
+``/stream?run_id=`` 时重放 0 条事件且端点不查任务状态，只能挂着发 24h
+心跳——断线重连的客户端在途工具卡因此永远转圈。stream 为空且 run 已终态
+时用这里合成 done/error 终态事件立即返回。
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from src.infra.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+async def resolve_terminal_stream_status(session: Any, run_id: str) -> str | None:
+    """终态 stream 过期后的 run 终态判定；非终态/查不到返回 None（维持现状）。
+
+    优先按 run_id 查 trace（会话级 metadata 的 task_status 在多 run 并存时
+    会串到别的 run）；trace 无记录时回落 session metadata，但仅当
+    current_run_id 与请求的 run_id 一致才可信。
+    """
+    from src.infra.session.trace_storage import get_trace_storage
+
+    try:
+        cursor = (
+            get_trace_storage()
+            .collection.find({"run_id": run_id}, {"status": 1, "_id": 0})
+            .sort("started_at", -1)
+            .limit(1)
+        )
+        traces = await cursor.to_list(length=1)
+        if traces:
+            status = traces[0].get("status")
+            if status in ("completed", "error"):
+                return status
+            return None  # running 等非终态：孤儿接管/续跑窗口期，继续等
+    except Exception as e:  # noqa: BLE001 - 状态查询尽力而为，失败维持现状
+        logger.warning("[SSE] Terminal status lookup via trace failed: %s", e)
+
+    try:
+        metadata = getattr(session, "metadata", None) or {}
+        if metadata.get("current_run_id") == run_id:
+            task_status = metadata.get("task_status")
+            if task_status == "completed":
+                return "completed"
+            if task_status in ("error", "failed", "cancelled"):
+                return "error"
+    except Exception as e:  # noqa: BLE001 - 同上
+        logger.warning("[SSE] Terminal status lookup via session metadata failed: %s", e)
+    return None
+
+
+def synthesize_terminal_stream_event(run_id: str, session: Any, terminal: str) -> dict:
+    """合成终态 SSE 事件（stream 已过期、无法重放真实终态事件时的替身）。"""
+    timestamp = datetime.now(timezone.utc).isoformat()
+    if terminal == "completed":
+        return {
+            "event_type": "done",
+            "data": {"status": "completed", "run_id": run_id},
+            "id": f"synthetic:{run_id}:done",
+            "timestamp": timestamp,
+        }
+    metadata = getattr(session, "metadata", None) or {}
+    message = metadata.get("task_error") or "This run has already ended."
+    return {
+        "event_type": "error",
+        "data": {
+            "error": message,
+            "type": "task_failed",
+            "run_id": run_id,
+            "code": "run_already_ended",
+        },
+        "id": f"synthetic:{run_id}:error",
+        "timestamp": timestamp,
+    }

--- a/tests/api/routes/test_chat_goal.py
+++ b/tests/api/routes/test_chat_goal.py
@@ -143,6 +143,9 @@ async def test_session_stream_offloads_sse_event_formatting(monkeypatch: pytest.
             return type("Session", (), {"user_id": "user-1"})()
 
     class _DualWriter:
+        async def get_stream_length(self, session_id, run_id=None):
+            return 1  # stream 仍有事件：走重放路径，不触发终态合成
+
         async def read_from_redis(self, session_id, *, run_id):
             yield {
                 "event_type": "message:chunk",

--- a/tests/api/routes/test_chat_stream_terminal_synthesis.py
+++ b/tests/api/routes/test_chat_stream_terminal_synthesis.py
@@ -1,0 +1,170 @@
+"""session_stream 对「终态 run + 已过期 stream」的合成终态测试。
+
+生产孤儿工具卡根因：run 到终态后 Redis stream 60s TTL 过期，客户端（断线
+自动重连/刷新重连）再连 /stream 时重放 0 条事件、端点又不查任务状态，
+挂着发 24h 心跳——前端在途工具卡永远转圈。修复：stream 为空且 run 已
+终态时立即合成 done/error 终态事件返回。
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from src.api.routes.chat import session_stream
+
+
+def _user(sub="u1"):
+    return SimpleNamespace(sub=sub)
+
+
+def _session(metadata, user_id="u1"):
+    return SimpleNamespace(user_id=user_id, session_id="s1", metadata=metadata)
+
+
+class _FakeTraceCursor:
+    def __init__(self, docs):
+        self._docs = docs
+
+    def sort(self, *a, **k):
+        return self
+
+    def limit(self, *a, **k):
+        return self
+
+    async def to_list(self, length=None):
+        return self._docs[: length if length else len(self._docs)]
+
+
+class _FakeTraceCollection:
+    def __init__(self, docs):
+        self._docs = docs
+        self.find_calls = 0
+
+    def find(self, query, *a, **k):
+        self.find_calls += 1
+        assert query.get("run_id")
+        return _FakeTraceCursor(list(self._docs))
+
+
+def _install(monkeypatch, *, stream_len, metadata, trace_docs=(), replay=()):
+    read_calls: list[tuple] = []
+
+    def _read(*args, **kwargs):
+        read_calls.append((args, kwargs))
+        return _aiter(list(replay))
+
+    dual = SimpleNamespace(
+        get_stream_length=AsyncMock(return_value=stream_len),
+        read_from_redis=_read,
+    )
+    monkeypatch.setattr(
+        "src.api.routes.chat.SessionManager",
+        lambda: SimpleNamespace(get_session=AsyncMock(return_value=_session(metadata))),
+    )
+    monkeypatch.setattr(
+        "src.infra.session.dual_writer.get_dual_writer",
+        lambda: dual,
+    )
+
+    collection = _FakeTraceCollection(list(trace_docs))
+    monkeypatch.setattr(
+        "src.infra.session.trace_storage.get_trace_storage",
+        lambda: SimpleNamespace(collection=collection),
+    )
+    return dual, collection, read_calls
+
+
+async def _aiter(items):
+    for item in items:
+        yield item
+
+
+async def _collect(response):
+    return "".join([chunk async for chunk in response.body_iterator])
+
+
+async def test_expired_stream_with_completed_run_synthesizes_done(monkeypatch):
+    _install(
+        monkeypatch,
+        stream_len=0,
+        metadata={"current_run_id": "r1", "task_status": "completed"},
+        trace_docs=[{"status": "completed"}],
+    )
+    response = await session_stream("s1", run_id="r1", user=_user())
+    body = await _collect(response)
+    assert "event: done" in body
+    assert '"status":"completed"' in body.replace(" ", "")
+
+
+async def test_expired_stream_with_failed_run_synthesizes_terminal_error(monkeypatch):
+    _install(
+        monkeypatch,
+        stream_len=0,
+        metadata={
+            "current_run_id": "r1",
+            "task_status": "error",
+            "task_error": "Worker crashed",
+        },
+        trace_docs=[{"status": "error"}],
+    )
+    response = await session_stream("s1", run_id="r1", user=_user())
+    body = await _collect(response)
+    assert "event: error" in body
+    # 前端 isTerminalErrorPayload 需要 type/run_id/trace_id 之一在场
+    assert '"run_id":"r1"' in body.replace(" ", "")
+    assert "Worker crashed" in body
+
+
+async def test_expired_stream_with_running_run_keeps_waiting(monkeypatch):
+    """stream 空但 run 还在跑（孤儿接管窗口期）：维持现状挂流等待，
+    不合成终态。"""
+    dual, _, read_calls = _install(
+        monkeypatch,
+        stream_len=0,
+        metadata={"current_run_id": "r1", "task_status": "running"},
+        trace_docs=[{"status": "running"}],
+        replay=[{"event_type": "heartbeat"}],
+    )
+    response = await session_stream("s1", run_id="r1", user=_user())
+    body = await _collect(response)
+    assert ": heartbeat" in body
+    assert "event: done" not in body
+    assert "event: error" not in body
+    assert len(read_calls) == 1
+
+
+async def test_alive_stream_replays_without_status_lookup(monkeypatch):
+    """stream 还有事件（终态事件在缓冲里可重放）：走原重放路径，不查状态。"""
+    dual, collection, read_calls = _install(
+        monkeypatch,
+        stream_len=2,
+        metadata={},
+        replay=[
+            {
+                "event_type": "done",
+                "data": {"status": "completed"},
+                "id": "e2",
+                "timestamp": "2026-09-09T00:00:00Z",
+            }
+        ],
+    )
+    response = await session_stream("s1", run_id="r1", user=_user())
+    body = await _collect(response)
+    assert "event: done" in body
+    assert collection.find_calls == 0
+    assert len(read_calls) == 1
+
+
+async def test_terminal_status_from_other_run_not_trusted(monkeypatch):
+    """session metadata 是会话级：task_status 属于别的 run（current_run_id
+    不匹配）且本 run 无 trace 终态 → 不合成终态（避免误杀活 run）。"""
+    _install(
+        monkeypatch,
+        stream_len=0,
+        metadata={"current_run_id": "r2", "task_status": "completed"},
+        trace_docs=[],
+        replay=[{"event_type": "heartbeat"}],
+    )
+    response = await session_stream("s1", run_id="r1", user=_user())
+    body = await _collect(response)
+    assert "event: done" not in body
+    assert "event: error" not in body


### PR DESCRIPTION
## 背景（工具流式调用中断 → 孤儿组件）

用户实报：工具流式调用突然挂了，界面上留下永远转圈的孤儿工具卡。

完整因果链（后端调查结论）：
1. run 到终态后 Redis stream 被 60s 终态 TTL 清掉（`_expire_terminal_stream`）
2. 客端断线自动重连 / 刷新后重连 `/stream?run_id=` 时重放 0 条事件
3. **端点不查任务状态**，直接进 xread 挂流——只能靠 24h 兜底超时发 error
4. 期间前端在途工具卡（含流式 args 半截卡）永远转圈；fetch-event-source 重试退避超过 60s 后必然落入此坑

## 修复

`session_stream` 连接时 stream 为空（xlen==0）则按 run_id 解析终态，已终态立即**合成终态事件**返回：

- 终态判定：优先按 run_id 查 trace（会话级 metadata 的 task_status 多 run 并存会串，仅 `current_run_id` 匹配时才可信）
- completed → 合成 `done`；error/failed/cancelled → 合成 `error`（带 task_error 原文 + type/run_id，保证前端 `isTerminalErrorPayload` 判终态）
- stream 仍有事件（终态事件可重放）或 run 非终态（孤儿接管/无缝续跑窗口期）行为完全不变

前端收到终态后走既有 `clearAllLoadingStates` 链路把孤儿卡收敛为「已取消」，无需前端改动。

## 验证

- 新增 5 个路由测试（先红后绿）：completed/failed 合成、running 保持挂流、活 stream 不查状态、他 run 终态不误判
- 后端全量 4399 passed；ruff / mypy 干净