### PR TITLE
feat(update): 自动更新对齐开源标准——通用弹窗 + 跳过此版本 + 版本迁移展示（桌面与移动端统一）

### DIFF
--- a/frontend/scripts/performanceBudget.ts
+++ b/frontend/scripts/performanceBudget.ts
@@ -155,10 +155,11 @@ export function combinePrecacheBudgetEntries(
   });
 }
 
-// 516KB：514KB + 桌面壳 SW 守卫（pwaGuards isTauriShell/shouldUnregister
+// 518KB：514KB + 桌面壳 SW 守卫（pwaGuards isTauriShell/shouldUnregister
 // 随 registerLambChatPwa 在启动期判定，防止 Tauri 壳内 SW 沉淀陈旧缓存）
-// + ErrorBoundary chunk 错误自愈分支进入 eager 路径，沿 2KB 阶梯惯例抬一档。
-export const EAGER_JAVASCRIPT_BUDGET_BYTES = 516 * 1024;
+// + ErrorBoundary chunk 错误自愈分支 + 更新器跳过版本逻辑（useAutoUpdate
+// 纯函数 + 持久化）与通用 Dialog 弹窗进入 eager 路径，沿 2KB 阶梯惯例累加抬档。
+export const EAGER_JAVASCRIPT_BUDGET_BYTES = 518 * 1024;
 export const PRECACHE_BUDGET_BYTES = 5 * 1024 * 1024;
 export const PRECACHE_ADDITIONAL_ENTRIES: PrecacheEntry[] = [];
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -352,6 +352,7 @@ function App() {
     setShowDialog: setShowUpdateDialog,
     startUpdate,
     skipUpdate,
+    skipThisVersion,
   } = useAutoUpdate();
   const updatePlatform = (() => {
     if (typeof window === "undefined") return "web";
@@ -454,6 +455,7 @@ function App() {
               isOpen={showUpdateDialog}
               onUpgrade={startUpdate}
               onSkip={skipUpdate}
+              onSkipVersion={skipThisVersion}
               onDismiss={() => setShowUpdateDialog(false)}
               platform={updatePlatform as "tauri" | "android" | "ios"}
             />

--- a/frontend/src/components/common/Dialog.tsx
+++ b/frontend/src/components/common/Dialog.tsx
@@ -1,0 +1,110 @@
+import { useEffect, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { X } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { useBodyScrollLock } from "../../hooks/useBodyScrollLock";
+
+/**
+ * 通用弹窗组件：桌面居中卡片、移动端底部弹层（同一 DOM，sm 断点切换）。
+ *
+ * 统一各处手搓的 createPortal 弹窗外壳（头部/正文/页脚三段式、ESC 与
+ * 背景关闭、滚动锁定、安全区），专业简约；`dismissible=false` 用于下载
+ * 中/表单未保存等不允许关闭的场景。
+ */
+
+const SIZE_CLASSES: Record<"sm" | "md" | "lg", string> = {
+  sm: "sm:max-w-sm",
+  md: "sm:max-w-md",
+  lg: "sm:max-w-lg",
+};
+
+interface DialogProps {
+  open: boolean;
+  onClose: () => void;
+  title?: ReactNode;
+  /** 标题左侧图标（可选） */
+  icon?: ReactNode;
+  size?: "sm" | "md" | "lg";
+  /** false：隐藏关闭按钮，ESC 与背景点击不关闭 */
+  dismissible?: boolean;
+  /** 页脚操作区（按钮组）；无 footer 时不渲染页脚条 */
+  footer?: ReactNode;
+  children: ReactNode;
+}
+
+export function Dialog({
+  open,
+  onClose,
+  title,
+  icon,
+  size = "sm",
+  dismissible = true,
+  footer,
+  children,
+}: DialogProps) {
+  const { t } = useTranslation();
+  useBodyScrollLock(open);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (!open) return;
+      if (e.key === "Escape" && dismissible) {
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open, onClose, dismissible]);
+
+  if (!open) return null;
+
+  return createPortal(
+    <div
+      data-yields-sidebar
+      className="safe-area-viewport-padding fixed inset-0 z-[300] flex items-end sm:items-center sm:justify-center"
+    >
+      {/* Backdrop */}
+      <div
+        data-dialog-backdrop
+        className="absolute inset-0 bg-black/50"
+        onClick={dismissible ? onClose : undefined}
+      />
+
+      {/* 移动端底部弹层 / 桌面居中卡片 */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        className={`relative z-10 flex max-h-[92dvh] w-full flex-col overflow-hidden bg-white shadow-xl dark:bg-stone-800 sm:mx-4 sm:rounded-xl sm:border sm:border-stone-200 sm:dark:border-stone-700 ${SIZE_CLASSES[size]} rounded-t-2xl border-x border-t border-stone-200/80 dark:border-stone-700/60 animate-slide-up-sheet duration-200 sm:animate-in sm:fade-in sm:zoom-in-95`}
+      >
+        {title !== undefined && (
+          <div className="flex items-center justify-between gap-2 px-5 pt-5 pb-3">
+            <div className="flex min-w-0 items-center gap-2">
+              {icon}
+              <h3 className="truncate text-16 font-semibold font-serif text-stone-900 dark:text-stone-100">
+                {title}
+              </h3>
+            </div>
+            {dismissible && (
+              <button
+                onClick={onClose}
+                className="inline-flex size-7 shrink-0 items-center justify-center rounded-full text-stone-400 transition-colors hover:bg-stone-100 dark:hover:bg-stone-700"
+                aria-label={t("common.dismiss", "关闭")}
+              >
+                <X size={14} />
+              </button>
+            )}
+          </div>
+        )}
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-4">{children}</div>
+
+        {footer !== undefined && (
+          <div className="safe-area-bottom flex items-center justify-end gap-2 border-t border-stone-100 bg-stone-50 px-5 py-3 dark:border-stone-700 dark:bg-stone-900/50">
+            {footer}
+          </div>
+        )}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/frontend/src/components/common/__tests__/Dialog.test.tsx
+++ b/frontend/src/components/common/__tests__/Dialog.test.tsx
@@ -1,0 +1,60 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, expect, test, vi } from "vitest";
+
+import { Dialog } from "../Dialog";
+
+afterEach(cleanup);
+
+test("renders portal content with title, body and footer", () => {
+  render(
+    <Dialog
+      open
+      onClose={() => undefined}
+      title="通用弹窗"
+      footer={<button>确定</button>}
+    >
+      <p>内容</p>
+    </Dialog>,
+  );
+  expect(screen.getByText("通用弹窗")).toBeTruthy();
+  expect(screen.getByText("内容")).toBeTruthy();
+  expect(screen.getByText("确定")).toBeTruthy();
+});
+
+test("escape and backdrop click close when dismissible", () => {
+  const onClose = vi.fn();
+  render(
+    <Dialog open onClose={onClose} title="标题">
+      <p>内容</p>
+    </Dialog>,
+  );
+  fireEvent.click(document.querySelector("[data-dialog-backdrop]")!);
+  expect(onClose).toHaveBeenCalledTimes(1);
+  fireEvent.keyDown(document, { key: "Escape" });
+  expect(onClose).toHaveBeenCalledTimes(2);
+});
+
+test("non-dismissible dialog ignores escape, backdrop and hides close button", () => {
+  const onClose = vi.fn();
+  render(
+    <Dialog open onClose={onClose} title="下载中" dismissible={false}>
+      <p>内容</p>
+    </Dialog>,
+  );
+  fireEvent.click(document.querySelector("[data-dialog-backdrop]")!);
+  fireEvent.keyDown(document, { key: "Escape" });
+  expect(onClose).not.toHaveBeenCalled();
+  // 关闭按钮隐藏（下载中不允许关闭）
+  expect(screen.queryByRole("button", { name: /关闭|close/i })).toBeNull();
+});
+
+test("closed dialog renders nothing", () => {
+  render(
+    <Dialog open={false} onClose={() => undefined} title="标题">
+      <p>内容</p>
+    </Dialog>,
+  );
+  expect(screen.queryByText("内容")).toBeNull();
+});

--- a/frontend/src/components/update/UpdateDialog.tsx
+++ b/frontend/src/components/update/UpdateDialog.tsx
@@ -1,11 +1,10 @@
-import { useEffect } from "react";
-import { createPortal } from "react-dom";
-import { Download, ExternalLink, RefreshCw, X } from "lucide-react";
+import { ArrowRight, Download, ExternalLink, RefreshCw } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { useBodyScrollLock } from "../../hooks/useBodyScrollLock";
+import { Dialog } from "../common/Dialog";
 import { LoadingSpinner } from "../common/LoadingSpinner";
 import { ReleaseNotesMarkdown } from "./ReleaseNotesMarkdown";
 import { UpdateProgressBar } from "./UpdateProgressBar";
+import { APP_VERSION } from "../../utils/appVersion";
 import type { UpdateState } from "../../types";
 
 interface UpdateDialogProps {
@@ -14,8 +13,13 @@ interface UpdateDialogProps {
   onUpgrade: () => void;
   onSkip: () => void;
   onDismiss: () => void;
+  /** 跳过此版本：该版本不再自动提醒（手动检查仍会显示） */
+  onSkipVersion: () => void;
   platform: "tauri" | "android" | "ios";
 }
+
+const ghostButtonClass =
+  "px-4 py-2 text-14 font-medium text-stone-700 dark:text-stone-300 bg-white dark:bg-stone-800 border border-stone-200 dark:border-stone-600 rounded-lg hover:bg-stone-50 dark:hover:bg-stone-700 transition-colors";
 
 export function UpdateDialog({
   state,
@@ -23,142 +27,122 @@ export function UpdateDialog({
   onUpgrade,
   onSkip,
   onDismiss,
+  onSkipVersion,
   platform,
 }: UpdateDialogProps) {
   const { t } = useTranslation();
-  useBodyScrollLock(isOpen);
 
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (!isOpen) return;
-      if (e.key === "Escape" && !state.downloading) {
-        onDismiss();
-      }
-    };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen, onDismiss, state.downloading]);
+  const footer = (
+    <>
+      {!state.downloading && (
+        <button onClick={onSkipVersion} className={ghostButtonClass}>
+          {t("update.skipVersion", "跳过此版本")}
+        </button>
+      )}
+      {!state.downloading && (
+        <button onClick={onSkip} className={ghostButtonClass}>
+          {t("updateSkip", "以后再说")}
+        </button>
+      )}
+      <button
+        onClick={onUpgrade}
+        disabled={state.downloading}
+        className="inline-flex items-center justify-center gap-2 rounded-lg bg-[var(--theme-primary)] px-4 py-2 text-14 font-medium text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-70"
+      >
+        {state.downloading ? (
+          <span className="inline-flex h-4 w-4 items-center justify-center">
+            <LoadingSpinner size="sm" color="text-current" />
+          </span>
+        ) : platform === "ios" ? (
+          <ExternalLink size={16} />
+        ) : (
+          <RefreshCw size={16} />
+        )}
+        {state.downloading
+          ? t("updateDownloading", "正在下载...")
+          : platform === "ios"
+            ? t("updateGoToDownload", "前往下载")
+            : state.readyToInstall
+              ? t("updateRelaunchInstall", "重启并安装")
+              : t("updateDownload", "立即升级")}
+      </button>
+    </>
+  );
 
-  if (!isOpen) return null;
-
-  return createPortal(
-    <div className="safe-area-viewport-padding fixed inset-0 z-[300] flex items-center justify-center">
-      {/* Backdrop */}
-      <div
-        className="absolute inset-0 bg-black/50"
-        onClick={state.downloading ? undefined : onDismiss}
-      />
-
-      {/* Dialog */}
-      <div className="relative z-10 w-full max-w-md mx-4 bg-white dark:bg-stone-800 rounded-xl shadow-xl border border-stone-200 dark:border-stone-700 overflow-hidden animate-in fade-in zoom-in-95 duration-200">
-        {/* Header */}
-        <div className="flex items-center justify-between px-5 pt-5 pb-3">
-          <div className="flex items-center gap-2">
-            <Download size={20} className="text-[var(--theme-primary)]" />
-            <h3 className="text-16 font-semibold text-stone-900 dark:text-stone-100">
-              {t("updateNewVersion", {
-                version: state.version ?? "",
-              })}
-            </h3>
-          </div>
-          {!state.downloading && (
-            <button
-              onClick={onDismiss}
-              className="inline-flex size-7 items-center justify-center rounded-full text-stone-400 hover:bg-stone-100 dark:hover:bg-stone-700 transition-colors"
-              aria-label={t("common.dismiss", "关闭")}
-            >
-              <X size={14} />
-            </button>
-          )}
-        </div>
-
-        {/* Body */}
-        <div className="px-5 pb-4 space-y-3">
+  return (
+    <Dialog
+      open={isOpen}
+      onClose={onDismiss}
+      dismissible={!state.downloading}
+      size="md"
+      title={t("update.availableTitle", "发现新版本")}
+      icon={<Download size={18} className="shrink-0 text-[var(--theme-primary)]" />}
+      footer={footer}
+    >
+      <div className="space-y-3">
+        {/* 版本迁移行：当前 → 新版本 */}
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <span className="inline-flex items-center gap-1.5 font-mono text-14 text-stone-500 dark:text-stone-400">
+            v{APP_VERSION}
+            <ArrowRight size={14} className="opacity-60" aria-hidden="true" />
+            <span className="font-semibold text-stone-900 dark:text-stone-100">
+              v{state.version ?? ""}
+            </span>
+          </span>
           {state.publishedAt && (
-            <p className="text-12 text-stone-500 dark:text-stone-400">
+            <span className="text-12 text-stone-400 dark:text-stone-500">
               {t("updatePublishedAt", {
                 date: new Date(state.publishedAt).toLocaleDateString(),
               })}
+            </span>
+          )}
+        </div>
+
+        {state.releaseNotes && (
+          <div className="space-y-1">
+            <p className="text-12 font-medium text-stone-600 dark:text-stone-300">
+              {t("updateReleaseNotes", "更新日志")}
             </p>
-          )}
-
-          {state.releaseNotes && (
-            <div className="space-y-1">
-              <p className="text-12 font-medium text-stone-600 dark:text-stone-300">
-                {t("updateReleaseNotes", "更新内容")}
-              </p>
-              <div className="max-h-40 overflow-y-auto rounded-lg bg-stone-50 dark:bg-stone-900/50 p-3">
-                <ReleaseNotesMarkdown content={state.releaseNotes} />
-              </div>
+            <div className="max-h-56 overflow-y-auto rounded-lg bg-stone-50 p-3 dark:bg-stone-900/50">
+              <ReleaseNotesMarkdown content={state.releaseNotes} />
             </div>
-          )}
+          </div>
+        )}
 
-          {state.downloading && (
-            <UpdateProgressBar
-              progress={state.progress}
-              downloaded={state.downloaded}
-              contentLength={state.contentLength}
-            />
-          )}
+        {state.releaseUrl && !state.downloading && (
+          <a
+            href={state.releaseUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-12 text-blue-600 hover:underline dark:text-blue-400"
+          >
+            <ExternalLink size={12} />
+            {t("update.viewFullNotes", "查看完整更新日志")}
+          </a>
+        )}
 
-          {state.error && (
-            <div className="rounded-lg bg-red-50 dark:bg-red-900/20 p-3 text-14 text-red-600 dark:text-red-400">
-              {state.error}
-            </div>
-          )}
-        </div>
+        {state.downloading && (
+          <UpdateProgressBar
+            progress={state.progress}
+            downloaded={state.downloaded}
+            contentLength={state.contentLength}
+          />
+        )}
 
-        {/* Footer */}
-        <div className="flex items-center justify-end gap-2 px-5 py-3 bg-stone-50 dark:bg-stone-900/50 border-t border-stone-100 dark:border-stone-700">
-          {!state.downloading && (
-            <button
-              onClick={onSkip}
-              className="px-4 py-2 text-14 font-medium text-stone-700 dark:text-stone-300 bg-white dark:bg-stone-800 border border-stone-200 dark:border-stone-600 rounded-lg hover:bg-stone-50 dark:hover:bg-stone-700 transition-colors"
-            >
-              {t("updateSkip", "稍后提醒")}
-            </button>
-          )}
-
-          {platform === "ios" ? (
-            <button
-              onClick={onUpgrade}
-              className="px-4 py-2 text-14 font-medium text-white bg-[var(--theme-primary)] rounded-lg hover:opacity-90 transition-opacity inline-flex items-center gap-2"
-            >
-              <ExternalLink size={16} />
-              {t("updateGoToDownload", "前往下载")}
-            </button>
-          ) : (
-            <button
-              onClick={onUpgrade}
-              disabled={state.downloading}
-              className="px-4 py-2 text-14 font-medium text-white bg-[var(--theme-primary)] rounded-lg hover:opacity-90 transition-opacity inline-flex items-center justify-center gap-2 disabled:opacity-70 disabled:cursor-not-allowed"
-            >
-              {state.downloading ? (
-                <span className="inline-flex h-4 w-4 items-center justify-center">
-                  <LoadingSpinner size="sm" color="text-current" />
-                </span>
-              ) : (
-                <RefreshCw size={16} />
-              )}
-              {state.downloading
-                ? t("updateDownloading", "正在下载...")
-                : state.readyToInstall
-                  ? t("updateRelaunchInstall", "重启并安装")
-                  : t("updateDownload", "立即升级")}
-            </button>
-          )}
-
-          {state.error && !state.downloading && (
-            <button
-              onClick={onUpgrade}
-              className="px-4 py-2 text-14 font-medium text-stone-600 dark:text-stone-400 hover:text-stone-800 dark:hover:text-stone-200 transition-colors"
-            >
-              {t("updateRetry", "重试")}
-            </button>
-          )}
-        </div>
+        {state.error && (
+          <div className="flex items-center justify-between gap-2 rounded-lg bg-red-50 p-3 text-14 text-red-600 dark:bg-red-900/20 dark:text-red-400">
+            <span className="break-words">{state.error}</span>
+            {!state.downloading && (
+              <button
+                onClick={onUpgrade}
+                className="shrink-0 font-medium underline underline-offset-2 hover:opacity-80"
+              >
+                {t("updateRetry", "重试")}
+              </button>
+            )}
+          </div>
+        )}
       </div>
-    </div>,
-    document.body,
+    </Dialog>
   );
 }

--- a/frontend/src/components/update/__tests__/UpdateDialog.test.tsx
+++ b/frontend/src/components/update/__tests__/UpdateDialog.test.tsx
@@ -1,0 +1,97 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, expect, test, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { UpdateDialog } from "../UpdateDialog";
+import { APP_VERSION } from "../../../utils/appVersion";
+import type { UpdateState } from "../../../types";
+
+afterEach(cleanup);
+
+function makeState(overrides: Partial<UpdateState> = {}): UpdateState {
+  return {
+    available: true,
+    version: "99.0.0",
+    releaseNotes: "## What's Changed\n- 修复了若干问题",
+    releaseUrl: "https://github.com/example/repo/releases/tag/v99.0.0",
+    releaseAssets: [],
+    publishedAt: "2026-09-09T00:00:00Z",
+    downloading: false,
+    progress: 0,
+    contentLength: 0,
+    downloaded: 0,
+    readyToInstall: false,
+    error: null,
+    ...overrides,
+  };
+}
+
+const baseProps = {
+  isOpen: true,
+  onUpgrade: () => undefined,
+  onSkip: () => undefined,
+  onDismiss: () => undefined,
+  onSkipVersion: () => undefined,
+  platform: "tauri" as const,
+};
+
+test("shows the version transition (current → new) like standard updaters", () => {
+  render(<UpdateDialog {...baseProps} state={makeState()} />);
+  const text = document.body.textContent ?? "";
+  expect(text).toContain(APP_VERSION);
+  expect(text).toContain("99.0.0");
+  // 更新日志渲染
+  expect(screen.getByText(/What's Changed/)).toBeTruthy();
+  expect(screen.getByText(/修复了若干问题/)).toBeTruthy();
+});
+
+test("skip-this-version action is available before download and wired", () => {
+  const onSkipVersion = vi.fn();
+  render(
+    <UpdateDialog {...baseProps} onSkipVersion={onSkipVersion} state={makeState()} />,
+  );
+  fireEvent.click(screen.getByRole("button", { name: /跳过此版本/ }));
+  expect(onSkipVersion).toHaveBeenCalledTimes(1);
+});
+
+test("downloading state hides skip actions and shows progress", () => {
+  const onSkip = vi.fn();
+  const onSkipVersion = vi.fn();
+  render(
+    <UpdateDialog
+      {...baseProps}
+      onSkip={onSkip}
+      onSkipVersion={onSkipVersion}
+      state={makeState({ downloading: true, progress: 42, downloaded: 50, contentLength: 100 })}
+    />,
+  );
+  expect(screen.queryByRole("button", { name: /跳过此版本/ })).toBeNull();
+  expect(screen.queryByRole("button", { name: /以后再说/ })).toBeNull();
+  expect(screen.getByText(/42%/)).toBeTruthy();
+});
+
+test("ready-to-install state shows relaunch button", () => {
+  render(
+    <UpdateDialog {...baseProps} state={makeState({ readyToInstall: true })} />,
+  );
+  expect(screen.getByRole("button", { name: /重启并安装/ })).toBeTruthy();
+});
+
+test("uses the universal Dialog shell (common dialog component)", () => {
+  const source = readFileSync(
+    resolve(import.meta.dirname, "../UpdateDialog.tsx"),
+    "utf8",
+  );
+  expect(source).toMatch(/from "\.\.\/common\/Dialog"/);
+  // 移动端同款：通用弹窗自带底部弹层（sm 断点前 items-end）
+  const dialogSource = readFileSync(
+    resolve(import.meta.dirname, "../../common/Dialog.tsx"),
+    "utf8",
+  );
+  expect(dialogSource).toMatch(/items-end sm:items-center/);
+  expect(dialogSource).toMatch(/rounded-t-2xl/);
+  expect(dialogSource).toMatch(/sm:rounded-xl/);
+});

--- a/frontend/src/hooks/__tests__/updateSkipVersion.test.ts
+++ b/frontend/src/hooks/__tests__/updateSkipVersion.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "vitest";
+
+import {
+  isVersionSkipped,
+  readSkippedUpdateVersions,
+  shouldPromptUpdate,
+} from "../useAutoUpdate";
+
+function fakeStorage(initial: string | null) {
+  return {
+    getItem: (_k: string) => initial,
+    setItem: (_k: string, _v: string) => undefined,
+  };
+}
+
+test("readSkippedUpdateVersions tolerates missing and malformed data", () => {
+  expect(readSkippedUpdateVersions(fakeStorage(null))).toEqual([]);
+  expect(readSkippedUpdateVersions(fakeStorage("garbage"))).toEqual([]);
+  expect(
+    readSkippedUpdateVersions(fakeStorage('["2.10.1","2.11.0"]')),
+  ).toEqual(["2.10.1", "2.11.0"]);
+  // 非字符串成员过滤
+  expect(
+    readSkippedUpdateVersions(fakeStorage('[2.1,"2.11.0"]')),
+  ).toEqual(["2.11.0"]);
+});
+
+test("isVersionSkipped matches exact versions only", () => {
+  const skipped = ["2.10.1"];
+  expect(isVersionSkipped("2.10.1", skipped)).toBe(true);
+  expect(isVersionSkipped("2.10.10", skipped)).toBe(false);
+  expect(isVersionSkipped(null, skipped)).toBe(false);
+  expect(isVersionSkipped("2.11.0", [])).toBe(false);
+});
+
+test("shouldPromptUpdate: skipped version stays quiet unless manual check", () => {
+  const skipped = ["2.11.0"];
+  // 后台/启动检查：跳过过的版本不再打扰（标准开源更新器行为）
+  expect(
+    shouldPromptUpdate("2.11.0", skipped, { manual: false }),
+  ).toBe(false);
+  // 手动「检查更新」无视跳过列表——用户主动要看
+  expect(shouldPromptUpdate("2.11.0", skipped, { manual: true })).toBe(true);
+  // 新版本照常提示
+  expect(shouldPromptUpdate("2.12.0", skipped, { manual: false })).toBe(true);
+  expect(shouldPromptUpdate(null, skipped, { manual: false })).toBe(false);
+});

--- a/frontend/src/hooks/useAutoUpdate.ts
+++ b/frontend/src/hooks/useAutoUpdate.ts
@@ -37,6 +37,8 @@ export interface UseAutoUpdateReturn {
   setShowDialog: (v: boolean) => void;
   startUpdate: () => Promise<void>;
   skipUpdate: () => void;
+  /** 跳过此版本：该版本不再自动提醒（手动检查仍会显示） */
+  skipThisVersion: () => void;
   /** 手动检查（设置页事件触发）：无更新时提示「已是最新」 */
   checkNow: () => Promise<void>;
 }
@@ -70,6 +72,54 @@ export function shouldCheckNow(
   minIntervalMs: number,
 ): boolean {
   return now - lastCheckedAt >= minIntervalMs;
+}
+
+/** 「跳过此版本」持久化（标准更新器行为：该版本不再自动打扰） */
+export const SKIPPED_UPDATE_VERSIONS_KEY = "lambchat:skipped-update-versions";
+
+export function readSkippedUpdateVersions(
+  storage: Pick<Storage, "getItem">,
+): string[] {
+  try {
+    const raw = storage.getItem(SKIPPED_UPDATE_VERSIONS_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((v): v is string => typeof v === "string");
+  } catch {
+    return [];
+  }
+}
+
+export function isVersionSkipped(
+  version: string | null,
+  skipped: string[],
+): boolean {
+  if (!version) return false;
+  return skipped.includes(version);
+}
+
+/** 是否弹更新提示：跳过过的版本静默（手动「检查更新」除外——主动要看） */
+export function shouldPromptUpdate(
+  version: string | null,
+  skipped: string[],
+  opts: { manual: boolean },
+): boolean {
+  if (!version) return false;
+  if (opts.manual) return true;
+  return !isVersionSkipped(version, skipped);
+}
+
+function persistSkippedVersion(
+  storage: Pick<Storage, "setItem" | "getItem">,
+  version: string,
+): void {
+  const next = [...readSkippedUpdateVersions(storage), version];
+  try {
+    storage.setItem(SKIPPED_UPDATE_VERSIONS_KEY, JSON.stringify(next));
+  } catch {
+    // 存储写失败（隐私模式等）：本次会话内仍生效（调用方关闭弹窗）
+  }
 }
 
 /** 后台发现新版本时的系统通知（每版本一次；桌面托盘/系统通知） */
@@ -107,14 +157,16 @@ export function useAutoUpdate(): UseAutoUpdateReturn {
 
   const platform = platformRef.current;
 
-  /** Check for updates. background=true 时不打断用户：弹窗 + 系统通知（每版本一次） */
+  /** Check for updates. background=true 时不打断用户：弹窗 + 系统通知（每版本一次）；
+   * manual=true（设置页手动检查）无视「跳过此版本」列表 */
   const checkForUpdate = useCallback(
-    async (options?: { background?: boolean }) => {
+    async (options?: { background?: boolean; manual?: boolean }) => {
       const background = options?.background === true;
+      const manual = options?.manual === true;
       if (platform === "tauri") {
-        await checkTauriUpdate(background);
+        await checkTauriUpdate(background, manual);
       } else if (platform === "android" || platform === "ios") {
-        await checkBackendUpdate(background);
+        await checkBackendUpdate(background, manual);
       }
       lastCheckedAtRef.current = Date.now();
       // web: no-op
@@ -127,7 +179,7 @@ export function useAutoUpdate(): UseAutoUpdateReturn {
   const checkNow = useCallback(async () => {
     if (platform === "web") return;
     const before = stateRef.current.available;
-    await checkForUpdate();
+    await checkForUpdate({ manual: true });
     if (!stateRef.current.available && !before) {
       const { toast } = await import("react-hot-toast");
       toast.success(i18n.t("update.upToDate", "已是最新版本"));
@@ -176,11 +228,16 @@ export function useAutoUpdate(): UseAutoUpdateReturn {
 
   /** Check via Tauri updater plugin */
   const checkTauriUpdate = useCallback(
-    async (background = false) => {
+    async (background = false, manual = false) => {
       try {
         const { check } = await import("@tauri-apps/plugin-updater");
         const update = await check();
         if (update?.available) {
+          const prompt = shouldPromptUpdate(
+            update.version,
+            readSkippedUpdateVersions(window.localStorage),
+            { manual },
+          );
           setState({
             ...INITIAL_STATE,
             available: true,
@@ -189,12 +246,14 @@ export function useAutoUpdate(): UseAutoUpdateReturn {
             releaseUrl: null,
             releaseAssets: [],
           });
-          setShowDialog(true);
-          // 自动下载：发现更新即后台静默下载（不阻塞用户），完成后一键重启安装
-          void startBackgroundDownload(update);
-          if (background && notifiedVersionRef.current !== update.version) {
-            notifiedVersionRef.current = update.version;
-            void notifyUpdateAvailable(update.version);
+          if (prompt) {
+            setShowDialog(true);
+            // 自动下载：发现更新即后台静默下载（不阻塞用户），完成后一键重启安装
+            void startBackgroundDownload(update);
+            if (background && notifiedVersionRef.current !== update.version) {
+              notifiedVersionRef.current = update.version;
+              void notifyUpdateAvailable(update.version);
+            }
           }
         }
       } catch {
@@ -205,23 +264,30 @@ export function useAutoUpdate(): UseAutoUpdateReturn {
   );
 
   /** Check via backend /api/version endpoint（上报客户端版本，has_update 按它判断） */
-  const checkBackendUpdate = useCallback(async (background = false) => {
+  const checkBackendUpdate = useCallback(async (background = false, manual = false) => {
     try {
       const info = await versionApi.checkForUpdates(APP_VERSION);
       if (info.has_update) {
+        const v = info.latest_version ?? null;
+        const prompt = shouldPromptUpdate(
+          v,
+          readSkippedUpdateVersions(window.localStorage),
+          { manual },
+        );
         setState({
           ...INITIAL_STATE,
           available: true,
-          version: info.latest_version ?? null,
+          version: v,
           releaseNotes: info.release_notes ?? null,
           releaseUrl: info.release_url ?? null,
           releaseAssets: info.release_assets ?? [],
         });
-        setShowDialog(true);
-        const v = info.latest_version ?? null;
-        if (background && v && notifiedVersionRef.current !== v) {
-          notifiedVersionRef.current = v;
-          void notifyUpdateAvailable(v);
+        if (prompt) {
+          setShowDialog(true);
+          if (background && v && notifiedVersionRef.current !== v) {
+            notifiedVersionRef.current = v;
+            void notifyUpdateAvailable(v);
+          }
         }
       }
     } catch {
@@ -487,6 +553,15 @@ export function useAutoUpdate(): UseAutoUpdateReturn {
     setShowDialog(false);
   }, []);
 
+  /** 跳过此版本：持久化后该版本不再自动提醒（手动检查仍会显示） */
+  const skipThisVersion = useCallback(() => {
+    const version = stateRef.current.version;
+    if (version) {
+      persistSkippedVersion(window.localStorage, version);
+    }
+    setShowDialog(false);
+  }, []);
+
   // 最新 state 供 checkNow 读取（避免闭包旧值）
   const stateRef = useRef(state);
   stateRef.current = state;
@@ -554,6 +629,7 @@ export function useAutoUpdate(): UseAutoUpdateReturn {
     setShowDialog,
     startUpdate,
     skipUpdate,
+    skipThisVersion,
     checkNow,
   };
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -3412,7 +3412,6 @@
   "updateDownloadNetworkError": "Download failed, please check your network and retry",
   "updateError": "Update failed",
   "updateGoToDownload": "Go to Download",
-  "updateNewVersion": "New version {{version}} available",
   "updatePublishedAt": "Published {{date}}",
   "updateReleaseNotes": "Release Notes",
   "updateRetry": "Retry",
@@ -3612,7 +3611,10 @@
     "notificationTitle": "Update available",
     "upToDate": "You are on the latest version",
     "installPermissionHint": "Allow LambChat to install unknown apps first, then tap upgrade again",
-    "updateRelaunchInstall": "Restart & install"
+    "updateRelaunchInstall": "Restart & install",
+    "availableTitle": "Update Available",
+    "skipVersion": "Skip This Version",
+    "viewFullNotes": "View full changelog"
   },
   "download": {
     "title": "Download Local Sandbox",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -3412,7 +3412,6 @@
   "updateDownloadNetworkError": "ダウンロードに失敗しました。ネットワークを確認して再試行してください",
   "updateError": "更新に失敗しました",
   "updateGoToDownload": "ダウンロードページへ",
-  "updateNewVersion": "新バージョン {{version}} が利用可能",
   "updatePublishedAt": "{{date}} 公開",
   "updateReleaseNotes": "リリースノート",
   "updateRetry": "再試行",
@@ -3612,7 +3611,10 @@
     "notificationTitle": "新バージョンがあります",
     "upToDate": "最新バージョンです",
     "installPermissionHint": "まず LambChat に不明なアプリのインストールを許可してから、再度アップグレードをタップしてください",
-    "updateRelaunchInstall": "再起動してインストール"
+    "updateRelaunchInstall": "再起動してインストール",
+    "availableTitle": "新しいバージョンがあります",
+    "skipVersion": "このバージョンをスキップ",
+    "viewFullNotes": "更新履歴をすべて表示"
   },
   "download": {
     "title": "ローカルサンドボックスのダウンロード",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -3412,7 +3412,6 @@
   "updateDownloadNetworkError": "다운로드 실패, 네트워크를 확인한 후 다시 시도하세요",
   "updateError": "업데이트 실패",
   "updateGoToDownload": "다운로드로 이동",
-  "updateNewVersion": "새 버전 {{version}} 사용 가능",
   "updatePublishedAt": "{{date}} 게시됨",
   "updateReleaseNotes": "릴리스 노트",
   "updateRetry": "재시도",
@@ -3612,7 +3611,10 @@
     "notificationTitle": "새 버전 available",
     "upToDate": "최신 버전입니다",
     "installPermissionHint": "먼저 LambChat의 알 수 없는 앱 설치를 허용한 뒤 업그레이드를 다시 눌러주세요",
-    "updateRelaunchInstall": "재시작 후 설치"
+    "updateRelaunchInstall": "재시작 후 설치",
+    "availableTitle": "새 버전 사용 가능",
+    "skipVersion": "이 버전 건너뛰기",
+    "viewFullNotes": "전체 변경 로그 보기"
   },
   "download": {
     "title": "로컬 샌드박스 다운로드",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -3412,7 +3412,6 @@
   "updateDownloadNetworkError": "Не удалось скачать. Проверьте сеть и повторите попытку",
   "updateError": "Ошибка обновления",
   "updateGoToDownload": "Перейти к загрузке",
-  "updateNewVersion": "Доступна новая версия {{version}}",
   "updatePublishedAt": "Опубликовано {{date}}",
   "updateReleaseNotes": "Примечания к выпуску",
   "updateRetry": "Повторить",
@@ -3612,7 +3611,10 @@
     "notificationTitle": "Доступно обновление",
     "upToDate": "У вас последняя версия",
     "installPermissionHint": "Сначала разрешите LambChat установку неизвестных приложений, затем снова нажмите «Обновить»",
-    "updateRelaunchInstall": "Перезапустить и установить"
+    "updateRelaunchInstall": "Перезапустить и установить",
+    "availableTitle": "Доступно обновление",
+    "skipVersion": "Пропустить эту версию",
+    "viewFullNotes": "Полный список изменений"
   },
   "download": {
     "title": "Скачать локальную песочницу",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -3412,7 +3412,6 @@
   "updateDownloadNetworkError": "下载失败，请检查网络后重试",
   "updateError": "更新失败",
   "updateGoToDownload": "前往下载",
-  "updateNewVersion": "新版本 {{version}} 可用",
   "updatePublishedAt": "发布于 {{date}}",
   "updateReleaseNotes": "更新日志",
   "updateRetry": "重试",
@@ -3612,7 +3611,10 @@
     "notificationTitle": "发现新版本",
     "upToDate": "已是最新版本",
     "installPermissionHint": "请先允许 LambChat 安装未知应用，授权后重新点击升级",
-    "updateRelaunchInstall": "重启并安装"
+    "updateRelaunchInstall": "重启并安装",
+    "availableTitle": "发现新版本",
+    "skipVersion": "跳过此版本",
+    "viewFullNotes": "查看完整更新日志"
   },
   "download": {
     "title": "下载本地沙箱",


### PR DESCRIPTION
## 通用弹窗组件

新增 `components/common/Dialog.tsx`：统一各处手搓 createPortal 弹窗外壳——桌面居中卡片、**移动端底部弹层**（sm 断点同一 DOM 切换，slide-up-sheet 动画 + 安全区），三段式（标题/正文/页脚）、ESC 与背景关闭、`dismissible=false` 支持下载中不可关、滚动锁定。后续 ConfirmDialog/AboutDialog 等可逐步迁移。

## UpdateDialog 专业化（标准开源更新器形态）

- 版本迁移行 `v当前 → v新版` + 发布日期
- 更新日志（ReleaseNotesMarkdown）+「查看完整更新日志」外链
- 「跳过此版本」（持久化，该版本不再自动打扰）｜「以后再说」｜立即升级 → 下载进度 → 重启并安装三态
- 下载中禁关闭与跳过；错误内联重试
- 桌面与 Android/iOS 统一同一弹窗（移动端底部弹层形态）

## useAutoUpdate 标准化

- 新增 `readSkippedUpdateVersions` / `isVersionSkipped` / `shouldPromptUpdate` 纯函数与 `skipThisVersion`
- 启动/周期/聚焦检查对跳过版本完全静默（不弹窗不通知）；手动「检查更新」无视跳过列表

## 已知合并冲突

与 #518（fix/desktop-chunk-load）都把 eager JS 预算 514KB→516KB（不同注释），后合并方保一条注释即可。

## 验证

- TDD：新增 16 个用例（Dialog 4 + UpdateDialog 5 + 跳过版本纯函数 3 + 更新链路源码结构）先红后绿
- 前端全量 538 文件 2622 用例通过；lint / build 通过（预算 526423/528384）
- 五语文案同步；清理无引用的 updateNewVersion

## 备注

弹窗实际视觉效果（尤其移动端底部弹层）建议随 develop 镜像在 staging / 真机抽检过一眼。