### PR TITLE
fix(transfer): 技能迁移三连修——并发传输、空文件误跳过、同步包装跨循环

### DIFF
--- a/src/infra/backend/_skills_path_utils.py
+++ b/src/infra/backend/_skills_path_utils.py
@@ -11,6 +11,7 @@ Contains:
 import asyncio
 import re
 
+from src.infra.async_utils import loop_bridge
 from src.infra.logging import get_logger
 from src.infra.skill.storage import SkillStorage
 
@@ -41,22 +42,28 @@ def _run_async(coro):
     """
     在同步上下文中安全地运行异步协程。
 
-    如果没有运行中的事件循环 → 使用 asyncio.run()
-    如果已有运行中的事件循环 → 报错，要求调用方使用异步 API
+    如果没有运行中的事件循环 → 经 loop_bridge 投递到已登记的进程主循环
+    （API lifespan / arq worker 启动时登记），未登记时退回 asyncio.run()；
+    如果已有运行中的事件循环 → 报错，要求调用方使用异步 API。
+
+    背景（生产事故 2026-09-09，会话 7ffcfc36）：同步包装经 asyncio.run 在
+    blocking-io 线程里临时建循环执行协程，而全局缓存的 SkillStorage（Motor）
+    绑定 worker 主循环——跨循环复用报 ``got Future attached to a different
+    loop``，transfer_path 下载 fallback 直接失败、文件被静默跳过。统一投递到
+    主循环后共享存储全部收敛到同一循环。
     """
     try:
-        loop = asyncio.get_running_loop()
+        asyncio.get_running_loop()
     except RuntimeError:
-        loop = None
-
-    if loop is not None and loop.is_running():
+        pass
+    else:
         coro.close()
         raise RuntimeError(
             "SkillsStoreBackend synchronous API cannot run inside an active event loop; "
             "use the async backend methods instead."
         )
 
-    return asyncio.run(coro)
+    return loop_bridge.run_coro_sync(coro)
 
 
 def normalize_path(path: str) -> str:

--- a/src/infra/tool/transfer_file_tool.py
+++ b/src/infra/tool/transfer_file_tool.py
@@ -20,6 +20,7 @@ Transfer File / Transfer Path 工具
 - 目录深度/文件数限制（深度 5 层，500 文件）
 """
 
+import asyncio
 import inspect
 import json
 import os
@@ -132,6 +133,10 @@ MAX_RECURSION_DEPTH = 5
 MAX_BATCH_FILES = 500
 # 工具响应中最多返回的逐文件明细数，避免大批量传输把 LLM 消息体撑爆。
 TRANSFER_PATH_RESULT_FILE_LIMIT = 100
+# 目录传输的并发度：串行逐文件往返在多文件技能上单次工具调用可达数分钟
+# 零事件（生产事故 2026-09-09：100 文件技能 2.5 分钟界面完全静默），
+# 有界并发把静默窗口压到与一次模型回合同量级。
+TRANSFER_PATH_CONCURRENCY = 8
 
 
 # ==========================================
@@ -272,7 +277,8 @@ async def _download_from_backend(backend: Any, file_path: str) -> Optional[bytes
             responses = await backend.adownload_files([file_path])
             if responses:
                 resp = responses[0]
-                if resp.content:
+                # 空文件（b""）是合法内容，不得误判为缺失落入同步 fallback
+                if resp.content is not None:
                     return resp.content
                 if resp.error:
                     logger.warning(f"[transfer_file] Download error for {file_path}: {resp.error}")
@@ -284,7 +290,7 @@ async def _download_from_backend(backend: Any, file_path: str) -> Optional[bytes
             responses = await run_blocking_io(backend.download_files, [file_path])
             if responses:
                 resp = responses[0]
-                if resp.content:
+                if resp.content is not None:
                     return resp.content
                 if resp.error:
                     logger.warning(f"[transfer_file] Download error for {file_path}: {resp.error}")
@@ -592,117 +598,93 @@ async def transfer_path(
             }
         )
 
-    # 4. 逐个传输
-    results: list[dict[str, Any]] = []
+    # 4. 有界并发传输（结果按 file_paths 顺序汇总，配额经锁原子累加）
     total_size = 0
-    transferred = 0
-    skipped = 0
-    failed = 0
-    files_omitted = 0
+    budget_lock = asyncio.Lock()
+    semaphore = asyncio.Semaphore(TRANSFER_PATH_CONCURRENCY)
+    source_dir_stripped = source_dir.rstrip("/")
 
-    for file_path, known_size in file_paths:
+    async def _transfer_one(file_path: str, known_size: int | None) -> dict[str, Any]:
+        nonlocal total_size
         filename = file_path.rsplit("/", 1)[-1]
 
         # 计算相对路径，映射到目标
         rel_path = file_path
-        source_dir_stripped = source_dir.rstrip("/")
         if file_path.startswith(source_dir_stripped):
             rel_path = file_path[len(source_dir_stripped) :].lstrip("/")
         target_path = f"{target_base}/{rel_path}" if rel_path else f"{target_base}/{filename}"
 
         size_err = _check_known_file_size(known_size, filename)
         if size_err:
-            files_omitted = _append_transfer_result(
-                results,
-                {"file": file_path, "status": "skipped", "error": size_err},
-                files_omitted,
-            )
-            skipped += 1
-            continue
-        if known_size is not None and total_size + known_size > MAX_BATCH_SIZE:
-            files_omitted = _append_transfer_result(
-                results,
-                {
+            return {"file": file_path, "status": "skipped", "error": size_err}
+
+        async with semaphore:
+            # 已知大小时先做批量配额预检（无 IO）
+            if known_size is not None and total_size + known_size > MAX_BATCH_SIZE:
+                return {
                     "file": file_path,
                     "status": "skipped",
                     "error": (
                         f"batch size limit exceeded ({total_size + known_size} > {MAX_BATCH_SIZE})"
                     ),
-                },
-                files_omitted,
-            )
-            skipped += 1
-            continue
+                }
 
-        # 下载
-        try:
-            content = await _download_from_backend(backend, file_path)
-        except Exception as e:
-            logger.warning(f"[transfer_path] Download failed for {file_path}: {e}")
-            files_omitted = _append_transfer_result(
-                results,
-                {"file": file_path, "status": "failed", "error": str(e)},
-                files_omitted,
-            )
-            failed += 1
-            continue
+            # 下载
+            try:
+                content = await _download_from_backend(backend, file_path)
+            except Exception as e:
+                logger.warning(f"[transfer_path] Download failed for {file_path}: {e}")
+                return {"file": file_path, "status": "failed", "error": str(e)}
 
-        if content is None:
-            files_omitted = _append_transfer_result(
-                results,
-                {"file": file_path, "status": "skipped", "error": "file not found or empty"},
-                files_omitted,
-            )
-            skipped += 1
-            continue
+            if content is None:
+                return {"file": file_path, "status": "skipped", "error": "file not found or empty"}
 
-        # 文件校验
-        validation_err = _validate_text_file(filename, content)
-        if validation_err:
-            files_omitted = _append_transfer_result(
-                results,
-                {"file": file_path, "status": "skipped", "error": validation_err},
-                files_omitted,
-            )
-            skipped += 1
-            continue
+            # 文件校验
+            validation_err = _validate_text_file(filename, content)
+            if validation_err:
+                return {"file": file_path, "status": "skipped", "error": validation_err}
 
-        # 总大小检查
-        total_size += len(content)
-        if total_size > MAX_BATCH_SIZE:
-            files_omitted = _append_transfer_result(
-                results,
-                {
+            # 下载后按实际大小做批量配额（锁内原子累加，防止并发超发）
+            async with budget_lock:
+                over_budget = total_size + len(content) > MAX_BATCH_SIZE
+                if not over_budget:
+                    total_size += len(content)
+            if over_budget:
+                return {
                     "file": file_path,
                     "status": "skipped",
-                    "error": f"batch size limit exceeded ({total_size} > {MAX_BATCH_SIZE})",
-                },
-                files_omitted,
-            )
-            skipped += 1
-            continue
+                    "error": f"batch size limit exceeded ({total_size + len(content)} > {MAX_BATCH_SIZE})",
+                }
 
-        # 上传
-        upload_err = await _upload_to_backend_with_retry(backend, target_path, content)
-        if upload_err:
-            files_omitted = _append_transfer_result(
-                results,
-                {"file": file_path, "status": "failed", "error": upload_err},
-                files_omitted,
-            )
-            failed += 1
-        else:
-            files_omitted = _append_transfer_result(
-                results,
-                {
-                    "file": file_path,
-                    "status": "transferred",
-                    "target": target_path,
-                    "size": len(content),
-                },
-                files_omitted,
-            )
+            # 上传
+            upload_err = await _upload_to_backend_with_retry(backend, target_path, content)
+            if upload_err:
+                return {"file": file_path, "status": "failed", "error": upload_err}
+            return {
+                "file": file_path,
+                "status": "transferred",
+                "target": target_path,
+                "size": len(content),
+            }
+
+    file_records = await asyncio.gather(
+        *(_transfer_one(file_path, known_size) for file_path, known_size in file_paths)
+    )
+
+    results: list[dict[str, Any]] = []
+    transferred = 0
+    skipped = 0
+    failed = 0
+    files_omitted = 0
+    for record in file_records:
+        status = record["status"]
+        if status == "transferred":
             transferred += 1
+        elif status == "skipped":
+            skipped += 1
+        else:
+            failed += 1
+        files_omitted = _append_transfer_result(results, record, files_omitted)
 
     logger.info(
         f"[transfer_path] {source_dir} -> {target_base}/ "

--- a/tests/infra/backend/test_skills_store_backend.py
+++ b/tests/infra/backend/test_skills_store_backend.py
@@ -608,3 +608,66 @@ async def test_skills_store_backend_rechecks_actual_binary_download_size(monkeyp
     assert len(responses) == 1
     assert _field(responses[0], "content") is None
     assert _field(responses[0], "error") == "file_too_large"
+
+
+def test_skills_store_backend_sync_api_runs_on_registered_main_loop() -> None:
+    """同步包装经 loop_bridge 投递到已登记主循环执行。
+
+    生产事故（2026-09-09，会话 7ffcfc36）：transfer_path 的下载 fallback 在
+    blocking-io 线程里经 ``asyncio.run`` 临时建循环执行 ``adownload_files``，
+    而缓存的 SkillStorage（Motor）绑定 worker 主循环——跨循环复用直接
+    ``got Future attached to a different loop``，文件被静默跳过。
+    """
+    import asyncio
+    import threading
+
+    from src.infra.async_utils.loop_bridge import clear_main_loop, set_main_loop
+
+    class _LoopCaptureStorage:
+        def __init__(self) -> None:
+            self.seen_loop: object | None = None
+
+        async def get_effective_skills(self, user_id: str) -> dict:
+            return {"skills": {}}
+
+        async def get_skill_file(self, skill_name: str, file_name: str, user_id: str) -> str | None:
+            return "captured"
+
+        async def list_skill_file_paths(self, skill_name: str, user_id: str) -> list[str]:
+            return ["SKILL.md"]
+
+        async def batch_get_skill_files(self, skill_keys: list[tuple[str, str]]) -> dict:
+            return {}
+
+    captured: dict[str, object] = {}
+
+    async def _probe_aread(file_path: str, offset: int = 0, limit: int = 2000):
+        from deepagents.backends.utils import create_file_data, slice_read_response
+
+        captured["loop"] = asyncio.get_running_loop()
+        return slice_read_response(create_file_data("captured"), offset, limit)
+
+    main_loop = asyncio.new_event_loop()
+    set_main_loop(main_loop)
+    try:
+        runner = threading.Thread(target=main_loop.run_forever, daemon=True)
+        runner.start()
+
+        backend = SkillsStoreBackend(user_id="user-1", disabled_skills=[])
+        backend._storage = _LoopCaptureStorage()
+        # 把 aread 替换为探测协程，记录实际执行循环
+        backend.aread = _probe_aread  # type: ignore[method-assign]
+
+        def sync_read() -> None:
+            backend.read("/skills/visible/SKILL.md")
+
+        worker = threading.Thread(target=sync_read)
+        worker.start()
+        worker.join(timeout=10)
+        assert not worker.is_alive(), "sync read did not return from bridged loop"
+        assert captured["loop"] is main_loop
+    finally:
+        main_loop.call_soon_threadsafe(main_loop.stop)
+        runner.join(timeout=10)
+        clear_main_loop()
+        main_loop.close()

--- a/tests/infra/tool/test_transfer_file_tool.py
+++ b/tests/infra/tool/test_transfer_file_tool.py
@@ -469,9 +469,7 @@ async def test_transfer_path_transfers_empty_file_instead_of_skipping() -> None:
     class _EmptyFileBackend:
         async def als(self, path: str) -> LsResult:
             if path == "/skills/demo":
-                return LsResult(
-                    entries=[{"path": "/skills/demo/__init__.py", "is_dir": False}]
-                )
+                return LsResult(entries=[{"path": "/skills/demo/__init__.py", "is_dir": False}])
             return LsResult(entries=[])
 
         async def adownload_files(self, paths):

--- a/tests/infra/tool/test_transfer_file_tool.py
+++ b/tests/infra/tool/test_transfer_file_tool.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from types import SimpleNamespace
 
@@ -439,3 +440,188 @@ async def test_transfer_path_retries_transient_upload_failure_per_file() -> None
     assert result["success"] is True
     assert result["transferred"] == 1
     assert result["failed"] == 0
+
+
+@pytest.mark.asyncio
+async def test_download_from_backend_returns_empty_file_content() -> None:
+    """空文件（content=b""）是合法内容，不得误判为缺失后落入同步 fallback。"""
+
+    class _EmptyFileBackend:
+        def __init__(self) -> None:
+            self.sync_download_called = False
+
+        async def adownload_files(self, paths: list[str]):
+            return [SimpleNamespace(content=b"", error=None)]
+
+        def download_files(self, paths: list[str]):
+            self.sync_download_called = True
+            raise RuntimeError("sync fallback must not run when async path succeeded")
+
+    backend = _EmptyFileBackend()
+    content = await transfer_file_tool._download_from_backend(backend, "/skills/demo/__init__.py")
+
+    assert content == b""
+    assert backend.sync_download_called is False
+
+
+@pytest.mark.asyncio
+async def test_transfer_path_transfers_empty_file_instead_of_skipping() -> None:
+    class _EmptyFileBackend:
+        async def als(self, path: str) -> LsResult:
+            if path == "/skills/demo":
+                return LsResult(
+                    entries=[{"path": "/skills/demo/__init__.py", "is_dir": False}]
+                )
+            return LsResult(entries=[])
+
+        async def adownload_files(self, paths):
+            return [SimpleNamespace(content=b"", error=None)]
+
+        async def aupload_files(self, files):
+            return [SimpleNamespace(error=None) for _f in files]
+
+    result = json.loads(
+        await transfer_file_tool.transfer_path.coroutine(
+            source_dir="/skills/demo",
+            target_prefix="/workspace/w1/",
+            runtime=_Runtime(_EmptyFileBackend()),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["transferred"] == 1
+    assert result["skipped"] == 0
+    assert result["files"][0]["size"] == 0
+
+
+@pytest.mark.asyncio
+async def test_transfer_path_transfers_files_concurrently() -> None:
+    """多文件目录并发下载：串行实现会在栅栏处超时失败。"""
+    root = "/skills/big"
+    need = 4
+
+    class _ConcurrentBackend:
+        def __init__(self) -> None:
+            self.in_flight = 0
+            self.max_in_flight = 0
+            self.gate = asyncio.Event()
+
+        async def als(self, path: str) -> LsResult:
+            if path == root:
+                return LsResult(
+                    entries=[
+                        {"path": f"{root}/file-{index}.txt", "is_dir": False}
+                        for index in range(need)
+                    ]
+                )
+            return LsResult(entries=[])
+
+        async def adownload_files(self, paths):
+            self.in_flight += 1
+            self.max_in_flight = max(self.max_in_flight, self.in_flight)
+            if self.in_flight >= need:
+                self.gate.set()
+            try:
+                await asyncio.wait_for(self.gate.wait(), timeout=5)
+            finally:
+                self.in_flight -= 1
+            return [SimpleNamespace(content=b"data", error=None)]
+
+        async def aupload_files(self, files):
+            return [SimpleNamespace(error=None) for _f in files]
+
+    backend = _ConcurrentBackend()
+    result = json.loads(
+        await transfer_file_tool.transfer_path.coroutine(
+            source_dir=root,
+            target_prefix="/workspace/w1/",
+            runtime=_Runtime(backend),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["transferred"] == need
+    assert result["failed"] == 0
+    assert result["skipped"] == 0
+    assert backend.max_in_flight >= need
+
+
+@pytest.mark.asyncio
+async def test_transfer_path_preserves_result_order_under_concurrency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = "/skills/ordered"
+    count = 6
+
+    class _StaggeredBackend:
+        def __init__(self) -> None:
+            self.download_delay = {f"{root}/file-{i}.txt": 0.02 * (count - i) for i in range(count)}
+
+        async def als(self, path: str) -> LsResult:
+            if path == root:
+                return LsResult(
+                    entries=[
+                        {"path": f"{root}/file-{index}.txt", "is_dir": False}
+                        for index in range(count)
+                    ]
+                )
+            return LsResult(entries=[])
+
+        async def adownload_files(self, paths):
+            await asyncio.sleep(self.download_delay[paths[0]])
+            return [SimpleNamespace(content=b"x", error=None)]
+
+        async def aupload_files(self, files):
+            return [SimpleNamespace(error=None) for _f in files]
+
+    result = json.loads(
+        await transfer_file_tool.transfer_path.coroutine(
+            source_dir=root,
+            target_prefix="/workspace/w1/",
+            runtime=_Runtime(_StaggeredBackend()),
+        )
+    )
+
+    assert [entry["file"] for entry in result["files"]] == [
+        f"{root}/file-{index}.txt" for index in range(count)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_transfer_path_enforces_batch_budget_under_concurrency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """下载完成后才知道大小的文件也要受 MAX_BATCH_SIZE 约束（锁内原子配额）。"""
+    monkeypatch.setattr(transfer_file_tool, "MAX_BATCH_SIZE", 10)
+    root = "/skills/budget"
+    count = 3
+
+    class _UnknownSizeBackend:
+        async def als(self, path: str) -> LsResult:
+            if path == root:
+                return LsResult(
+                    entries=[
+                        {"path": f"{root}/file-{index}.txt", "is_dir": False}
+                        for index in range(count)
+                    ]
+                )
+            return LsResult(entries=[])
+
+        async def adownload_files(self, paths):
+            await asyncio.sleep(0.01)
+            return [SimpleNamespace(content=b"1234", error=None)]
+
+        async def aupload_files(self, files):
+            return [SimpleNamespace(error=None) for _f in files]
+
+    result = json.loads(
+        await transfer_file_tool.transfer_path.coroutine(
+            source_dir=root,
+            target_prefix="/workspace/w1/",
+            runtime=_Runtime(_UnknownSizeBackend()),
+        )
+    )
+
+    assert result["transferred"] == 2
+    assert result["skipped"] == 1
+    assert result["total_size"] == 8


### PR DESCRIPTION
## 背景

生产事故（2026-09-09 会话 7ffcfc36「💻 技能迁移」）：子代理用 `transfer_path` 把 94 个技能从 `/skills/` 搬到工作区，用户看到"子代理卡死了一样"，反复刷新页面（SSE 重连 4 次）。实查三处问题叠加：

1. **串行慢 + 长静默**：逐文件「MongoDB 下载 → 本机沙箱上传」串行往返 ~1.6s/文件，`deep-analysis`（100 文件）单次工具调用 **2 分 32 秒零事件**，工具卡秒表虽在走但完全无进度反馈；
2. **空文件误跳过（数据丢失）**：`_download_from_backend` 用真值判断 `if resp.content:`，空文件（`b""`，如 `__init__.py`）被误判为"没下载到"，落入同步 fallback；
3. **同步 fallback 跨循环必挂**：`SkillsStoreBackend.download_files` 经 `_run_async` 在 blocking-io 线程里 `asyncio.run` 临时建循环，而缓存的 SkillStorage（Motor）绑定 worker 主循环 → `got Future attached to a different loop`，该文件被静默 skipped（生产日志实锤：`/skills/docx/scripts/office/helpers/__init__.py`，docx 最终 skipped=1）。

## 修复

- `transfer_path` 改**有界并发**（`asyncio.Semaphore(8)`）：结果按 `file_paths` 顺序汇总；`MAX_BATCH_SIZE` 配额改锁内原子累加防并发超发。100 文件技能的静默窗口从 ~152s 压到 ~20s（与一次模型回合同量级）。
- `resp.content` 真值判断改 `is not None`：空文件正常传输（size=0），不再误入 fallback。
- `_run_async` 经 `loop_bridge.run_coro_sync` 投递到已登记主循环（arq worker / API lifespan 启动时登记），与 2026-09-06 本地沙箱 Redis 池跨循环事故（`_local_compat._run_coro_sync`）同款修法；未登记时退回 `asyncio.run` 保持旧行为。

## 测试

TDD：5 个新测试先 RED 后 GREEN——

- `test_download_from_backend_returns_empty_file_content`（毒丸 fallback 探测）
- `test_transfer_path_transfers_empty_file_instead_of_skipping`
- `test_transfer_path_transfers_files_concurrently`（栅栏并发探测，串行实现超时失败）
- `test_transfer_path_preserves_result_order_under_concurrency`
- `test_transfer_path_enforces_batch_budget_under_concurrency`
- `test_skills_store_backend_sync_api_runs_on_registered_main_loop`（主循环探测）

验证：`uv run pytest` 全量 **4400 passed**；`make lint` / `make typecheck` 绿。

## 备注

- 进度事件（工具中途上报已传 N/M 文件）需要新前后端 SSE 契约 + 五语言文案，未纳入本次；并发修复后静默窗口已低于一次模型回合，且工具卡本身有秒表计时。
- 工作区遗留的 `ToolResultPanel` 前端改动是另一分支未提交内容，未包含在本 PR。