### PR TITLE
fix(skill): /skills 挂载 glob 支持 ** 递归 + transfer_path 文件上限 500→2000

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -435,12 +435,12 @@ LLM 模型通过 **Model Config UI** 配置，无需在环境变量中设置 API
 **规矩：凡涉及本地沙箱链路的开发——`src/infra/sandbox/`、`client/lambchat_sandbox/`、`src/api/routes/sandbox.py`、请求体门限/传输相关中间件、桌面端 daemon 托管（`frontend/src-tauri/src/daemon.rs`）——合并前必须在本机跑通全量 E2E：**
 
 ```bash
-uv run python scripts/e2e_local_sandbox.py             # 功能链路（15 项，须全 PASS）
+uv run python scripts/e2e_local_sandbox.py             # 功能链路（全项须 PASS）
 uv run python scripts/e2e_local_sandbox.py --stress    # 发版前/大改动追加压测段
 ```
 
-- 脚本自举环境：后端未起会自动拉起、注册一次性测试用户并铸 PAT、拉起 daemon，结束自动回收（测试用户/PAT/工作目录），只要求本机 MongoDB/Redis 可达（凭据读 `.env`）。
-- 覆盖面：SSE 握手与多机注册表、exec 往返、机器绑定防冒答（409）、双向流式大文件传输（10/50/100MB sha256 校验）、结构化 fs op、分块 base64 兜底、优雅下线秒级翻转；`--stress` 追加并发扫描与持续负载。
+- 脚本自举环境：后端未起会自动拉起（8000 被占时可用 `E2E_SANDBOX_SERVER` 指向自备实例）、注册一次性测试用户并铸 PAT、拉起 daemon，结束自动回收（测试用户/PAT/工作目录），只要求本机 MongoDB/Redis 可达（凭据读 `.env`）。
+- 覆盖面：SSE 握手与多机注册表、exec 往返、机器绑定防冒答（409）、双向流式大文件传输（10/50/100MB sha256 校验）、结构化 fs op、分块 base64 兜底、优雅下线秒级翻转、skills 虚拟挂载 glob 递归契约（真实 MongoDB）、transfer_path 大批量整树搬运（真实 daemon）；`--stress` 追加并发扫描与持续负载。
 - 这条门禁的由来：`fs_upload_stream` 分发漏注册（上传快路径整条失效）与请求体门限误伤流式回传（>8MiB 下载全灭）两个生产级 bug，都是单测/seam 全绿下只有该 E2E 抓到的。
 
 ## 本地开发地址

--- a/scripts/e2e_local_sandbox.py
+++ b/scripts/e2e_local_sandbox.py
@@ -899,7 +899,9 @@ async def file_tools_battery(user_id: str, machine_id: str) -> None:
     from src.infra.tool.transfer_file_tool import transfer_path
 
     session = "file-tools-e2e"
-    alias_backend = WorkspaceAliasBackend(user_id=user_id, session_id=session, machine_id=machine_id)
+    alias_backend = WorkspaceAliasBackend(
+        user_id=user_id, session_id=session, machine_id=machine_id
+    )
     await alias_backend.aexecute(
         "mkdir -p many && for i in $(seq 1 501); do printf 'x' > many/file-$i.txt; done"
     )

--- a/scripts/e2e_local_sandbox.py
+++ b/scripts/e2e_local_sandbox.py
@@ -829,6 +829,100 @@ async def agent_tools_battery(user_id: str, pat: str, machine_id: str) -> None:
     assert live_settings.SANDBOX_LOCAL_EXEC_TIMEOUT == 120
 
 
+async def file_tools_battery(user_id: str, machine_id: str) -> None:
+    """文件工具层 E2E：skills 虚拟挂载 glob 递归契约（真实 MongoDB）与
+    transfer_path 大批量整树搬运（真实 daemon 链路）。
+
+    对应 2026-09-09 生产会话两处缺陷：/skills 挂载 glob 不支持 `**` 递归
+    （含 `/` 的模式一律空结果）+ 501 文件整树搬运被 500 上限卡死。
+    """
+    from types import SimpleNamespace
+
+    # ---- 1. skills 挂载 glob（SkillsStoreBackend → 真实 SkillStorage/MongoDB） ----
+    from src.infra.backend.skills_store import create_skills_backend
+    from src.infra.skill.storage import SkillStorage
+
+    probe = "e2e-glob-probe"
+    skills_backend = create_skills_backend(user_id=user_id)
+    try:
+        await skills_backend.awrite(f"/skills/{probe}/SKILL.md", "probe skill")
+        await skills_backend.awrite(f"/skills/{probe}/scripts/browse.py", "# browse")
+        await skills_backend.awrite(f"/skills/{probe}/scripts/sub/deep.py", "# deep")
+
+        # aglob 是协程，逐个 await（当前已在事件循环内）
+        root_md = await skills_backend.aglob("**/SKILL.md", "/skills")
+        nested_py = await skills_backend.aglob("**/*.py", f"/skills/{probe}")
+        direct_py = await skills_backend.aglob("scripts/*.py", f"/skills/{probe}")
+        root_dirs = await skills_backend.aglob("*", "/skills")
+
+        def paths(result) -> list[str]:
+            ms = getattr(result, "matches", None) or []
+            return [
+                m.get("path", str(m)) if isinstance(m, dict) else getattr(m, "path", str(m))
+                for m in ms
+            ]
+
+        p_root_md = paths(root_md)
+        p_nested = paths(nested_py)
+        p_direct = paths(direct_py)
+        p_dirs = paths(root_dirs)
+
+        check(
+            "skills glob 根目录 **/SKILL.md 递归命中",
+            f"/{probe}/SKILL.md" in p_root_md,
+            f"matches={len(p_root_md)} sample={p_root_md[:3]}",
+        )
+        check(
+            "skills glob **/*.py 命中多层嵌套",
+            p_nested == [f"/{probe}/scripts/browse.py", f"/{probe}/scripts/sub/deep.py"],
+            ",".join(p_nested)[:80],
+        )
+        check(
+            "skills glob scripts/*.py 不跨目录（路径相对匹配）",
+            p_direct == [f"/{probe}/scripts/browse.py"],
+            ",".join(p_direct)[:80],
+        )
+        check(
+            "skills glob 根目录无尾斜杠 + 裸模式仍列目录",
+            f"/{probe}/" in p_dirs,
+            f"dirs={len(p_dirs)} sample={p_dirs[:3]}",
+        )
+    finally:
+        from src.infra.backend.skills_store import SkillsStoreBackend
+
+        storage = SkillStorage()
+        await storage.delete_skill_and_meta(probe, user_id=user_id)
+        await SkillsStoreBackend.cleanup_storage_cache()
+
+    # ---- 2. transfer_path 501 文件整树单次搬运（WorkspaceAliasBackend → 真实 daemon） ----
+    from src.infra.backend.local import WorkspaceAliasBackend
+    from src.infra.tool.transfer_file_tool import transfer_path
+
+    session = "file-tools-e2e"
+    alias_backend = WorkspaceAliasBackend(user_id=user_id, session_id=session, machine_id=machine_id)
+    await alias_backend.aexecute(
+        "mkdir -p many && for i in $(seq 1 501); do printf 'x' > many/file-$i.txt; done"
+    )
+    runtime = SimpleNamespace(config={"configurable": {"backend": alias_backend}})
+    raw = await transfer_path.coroutine(
+        source_dir=f"/workspace/{session}/many",
+        target_prefix=f"/workspace/{session}/backup/",
+        runtime=runtime,
+    )
+    result = json.loads(raw)
+    spot = await alias_backend.aread(f"/workspace/{session}/backup/many/file-500.txt")
+    fd = getattr(spot, "file_data", None)
+    spot_content = fd.get("content") if isinstance(fd, dict) else getattr(fd, "content", None)
+    check(
+        "transfer_path 501 文件整树单次搬运（真实 daemon）",
+        result.get("success") is True
+        and result.get("transferred") == 501
+        and result.get("failed") == 0,
+        f"transferred={result.get('transferred')} failed={result.get('failed')} "
+        f"err={result.get('error')} spot={str(spot_content)[:20]!r}",
+    )
+
+
 async def stress(user_id: str, machine_id: str) -> None:
     import random
 
@@ -946,6 +1040,7 @@ def main() -> int:
             await crash_recovery(user_id, pat, machine_id, holder)
             await comprehensive(user_id, pat, machine_id, holder)
             await agent_tools_battery(user_id, pat, machine_id)
+            await file_tools_battery(user_id, machine_id)
             if args.stress:
                 await stress(user_id, machine_id)
 

--- a/src/infra/backend/_skills_path_utils.py
+++ b/src/infra/backend/_skills_path_utils.py
@@ -64,6 +64,9 @@ def normalize_path(path: str) -> str:
     if not path:
         return "/skills/"
 
+    if path == "/skills":
+        return "/skills/"
+
     if path.startswith("/skills/"):
         return path
 

--- a/src/infra/backend/_skills_search.py
+++ b/src/infra/backend/_skills_search.py
@@ -6,6 +6,8 @@ Contains grep and glob utility methods used by the backend.
 
 import fnmatch
 
+from deepagents.backends.utils import compile_grep_include_glob
+
 from src.infra.async_utils import run_blocking_io
 from src.infra.backend.protocol_compat import FileInfo, GrepMatch
 from src.infra.logging import get_logger
@@ -161,18 +163,21 @@ def build_file_list_from_paths(skill_name: str, prefix: str, paths: list[str]) -
 def glob_files_from_paths(
     skill_name: str, prefix: str, pattern: str, paths: list[str]
 ) -> list[FileInfo]:
-    """在 skill 文件路径中按 glob 模式匹配（无内容大小）"""
+    """在 skill 文件路径中按共享 glob 契约匹配（无内容大小）。
+
+    契约与 deepagents BackendProtocol.glob 对齐：不含 ``/`` 的模式匹配任意深度的
+    basename；含 ``/`` 的模式按相对搜索根的路径匹配并支持 ``**`` 递归。
+    """
     prefix_slash = f"{prefix}/" if prefix else ""
+    matcher = compile_grep_include_glob(pattern)
     entries: list[FileInfo] = []
 
-    for file_path in paths:
+    for file_path in sorted(paths):
         if not file_path.startswith(prefix_slash):
             continue
 
         relative = file_path[len(prefix_slash) :]
-        basename = relative.rsplit("/", 1)[-1] if "/" in relative else relative
-
-        if fnmatch.fnmatch(basename, pattern):
+        if matcher(relative):
             entries.append(
                 FileInfo(
                     path=f"/{skill_name}/{file_path}",

--- a/src/infra/backend/skills_store.py
+++ b/src/infra/backend/skills_store.py
@@ -732,9 +732,7 @@ class SkillsStoreBackend(BackendProtocol):
                 matcher = compile_grep_include_glob(pattern)
                 file_entries: list[FileInfo] = []
                 for skill_name in skill_names:
-                    for file_path in sorted(
-                        await self._get_skill_file_paths(storage, skill_name)
-                    ):
+                    for file_path in sorted(await self._get_skill_file_paths(storage, skill_name)):
                         if matcher(f"{skill_name}/{file_path}"):
                             file_entries.append(
                                 FileInfo(path=f"/{skill_name}/{file_path}", is_dir=False)

--- a/src/infra/backend/skills_store.py
+++ b/src/infra/backend/skills_store.py
@@ -16,7 +16,11 @@ import fnmatch
 from tempfile import SpooledTemporaryFile
 from typing import TYPE_CHECKING, Any, Optional
 
-from deepagents.backends.utils import create_file_data, slice_read_response
+from deepagents.backends.utils import (
+    compile_grep_include_glob,
+    create_file_data,
+    slice_read_response,
+)
 from langgraph.config import get_config
 
 from src.infra.async_utils import run_blocking_io
@@ -715,11 +719,33 @@ class SkillsStoreBackend(BackendProtocol):
                 skill_names = [
                     name for name in sorted(all_skill_names) if self._is_skill_visible(name)
                 ]
-                entries: list[FileInfo] = []
+                if "/" not in pattern:
+                    # 裸模式：沿用既有行为，按 skill 目录名列举（ls 语义）
+                    entries: list[FileInfo] = []
+                    for skill_name in skill_names:
+                        if fnmatch.fnmatch(skill_name, pattern):
+                            entries.append(FileInfo(path=f"/{skill_name}/", is_dir=True))
+                    return GlobResult(matches=entries)
+
+                # 含 `/` 的模式：跨 skill 递归匹配文件，契约与其余 backend 对齐
+                # （`**` 递归、路径相对匹配；只出文件不出目录）
+                matcher = compile_grep_include_glob(pattern)
+                file_entries: list[FileInfo] = []
                 for skill_name in skill_names:
-                    if fnmatch.fnmatch(skill_name, pattern):
-                        entries.append(FileInfo(path=f"/{skill_name}/", is_dir=True))
-                return GlobResult(matches=entries)
+                    for file_path in sorted(
+                        await self._get_skill_file_paths(storage, skill_name)
+                    ):
+                        if matcher(f"{skill_name}/{file_path}"):
+                            file_entries.append(
+                                FileInfo(path=f"/{skill_name}/{file_path}", is_dir=False)
+                            )
+                            if len(file_entries) >= SKILLS_GREP_MAX_MATCHES:
+                                return GlobResult(
+                                    matches=file_entries,
+                                    truncated=True,
+                                    truncation_reason="budget",
+                                )
+                return GlobResult(matches=file_entries)
 
             parsed = parse_skill_path(normalized_path.rstrip("/"))
             if not parsed:

--- a/src/infra/tool/transfer_file_tool.py
+++ b/src/infra/tool/transfer_file_tool.py
@@ -17,7 +17,7 @@ Transfer File / Transfer Path 工具
 - 路径穿越防护（.. 规范化检查）
 - 文件类型限制（扩展名黑名单 + null 字节检测）
 - 文件大小限制（单文件 10MB，批量 100MB）
-- 目录深度/文件数限制（深度 5 层，500 文件）
+- 目录深度/文件数限制（深度 5 层，2000 文件）
 """
 
 import inspect
@@ -129,7 +129,9 @@ MAX_BATCH_SIZE = 100 * 1024 * 1024
 # 目录递归最大深度
 MAX_RECURSION_DEPTH = 5
 # 批量传输最大文件数
-MAX_BATCH_FILES = 500
+# 2026-09-09 生产会话：/skills 全量 501 文件刚好卡死 500 上限，agent 被迫逐目录
+# 分批。总数据量已有 MAX_BATCH_SIZE（100MB）护栏，文件数抬高到 2000。
+MAX_BATCH_FILES = 2000
 # 工具响应中最多返回的逐文件明细数，避免大批量传输把 LLM 消息体撑爆。
 TRANSFER_PATH_RESULT_FILE_LIMIT = 100
 
@@ -518,7 +520,7 @@ async def transfer_path(
 ) -> str:
     """Transfer a directory of text files between workspace and /skills/. Reusable
     directories go under /workspace/.shared/ (persists across sessions — `ls` first,
-    skip when present). Limits: 10MB/file, 100MB total, depth 5, 500 files; binary
+    skip when present). Limits: 10MB/file, 100MB total, depth 5, 2000 files; binary
     files and .. traversal are rejected."""
     backend = get_backend_from_runtime(runtime)
 

--- a/tests/infra/backend/test_skills_store_glob_recursive.py
+++ b/tests/infra/backend/test_skills_store_glob_recursive.py
@@ -1,0 +1,131 @@
+"""SkillsStoreBackend glob 共享契约（`**` 递归 / 路径相对匹配）测试。
+
+对应后端契约（deepagents BackendProtocol.glob）：
+- 不含 `/` 的模式匹配任意深度的 basename；
+- 含 `/` 的模式按相对路径匹配，支持 `**` 递归；
+- 只返回常规文件，不返回目录（根目录裸模式列举 skill 目录是既有行为，单独保护）。
+"""
+
+from __future__ import annotations
+
+from src.infra.backend.skills_store import SkillsStoreBackend
+
+
+def _field(value, name: str):
+    if isinstance(value, dict):
+        return value[name]
+    return getattr(value, name)
+
+
+def _paths(result) -> list[str]:
+    return [_field(entry, "path") for entry in _field(result, "matches")]
+
+
+class _NestedSkillStorage:
+    """带子目录层级的 skill 存储（file path 为相对 skill 根的带斜杠路径）。"""
+
+    def __init__(self) -> None:
+        self.files = {
+            "demo": {
+                "SKILL.md": "demo skill",
+                "README.md": "readme",
+                "docs/x.md": "docs x",
+                "scripts/browse.py": "browse",
+                "scripts/sub/deep.py": "deep",
+            },
+            "browser": {
+                "SKILL.md": "browser skill",
+                "scripts/interact.py": "interact",
+            },
+            "hidden": {
+                "SKILL.md": "hidden skill",
+            },
+        }
+
+    async def get_effective_skills(self, user_id: str) -> dict:
+        return {
+            "skills": {
+                name: {"name": name, "description": name, "files": files, "enabled": True}
+                for name, files in self.files.items()
+            }
+        }
+
+    async def get_skill_file(self, skill_name: str, file_name: str, user_id: str) -> str | None:
+        return self.files.get(skill_name, {}).get(file_name)
+
+    async def list_skill_file_paths(self, skill_name: str, user_id: str) -> list[str]:
+        return list(self.files.get(skill_name, {}).keys())
+
+    async def batch_get_skill_files(self, skill_keys: list[tuple[str, str]]) -> dict:
+        return {
+            (skill_name, user_id): self.files.get(skill_name, {})
+            for skill_name, user_id in skill_keys
+        }
+
+    async def get_all_user_skill_names(
+        self,
+        user_id: str,
+        limit: int | None = None,
+    ) -> list[str]:
+        names = sorted(self.files.keys())
+        if limit is not None:
+            names = names[:limit]
+        return names
+
+
+def _backend() -> SkillsStoreBackend:
+    backend = SkillsStoreBackend(user_id="user-1", disabled_skills=["hidden"])
+    backend._storage = _NestedSkillStorage()
+    return backend
+
+
+async def test_root_glob_double_star_pattern_matches_files_across_skills() -> None:
+    result = await _backend().aglob("**/SKILL.md", "/skills")
+
+    assert _paths(result) == ["/browser/SKILL.md", "/demo/SKILL.md"]
+
+
+async def test_root_glob_double_star_all_returns_nested_files_only() -> None:
+    result = await _backend().aglob("**/*", "/skills")
+
+    assert _paths(result) == [
+        "/browser/SKILL.md",
+        "/browser/scripts/interact.py",
+        "/demo/README.md",
+        "/demo/SKILL.md",
+        "/demo/docs/x.md",
+        "/demo/scripts/browse.py",
+        "/demo/scripts/sub/deep.py",
+    ]
+    assert not _field(result, "truncated")
+
+
+async def test_root_glob_bare_pattern_still_lists_skill_dirs() -> None:
+    result = await _backend().aglob("*", "/skills")
+
+    assert _paths(result) == ["/browser/", "/demo/"]
+
+
+async def test_skill_glob_recursive_double_star_matches_nested_files() -> None:
+    result = await _backend().aglob("**/*.py", "/skills/demo")
+
+    assert _paths(result) == ["/demo/scripts/browse.py", "/demo/scripts/sub/deep.py"]
+
+
+async def test_skill_glob_slash_pattern_matches_path_relative_not_basename() -> None:
+    result = await _backend().aglob("scripts/*.py", "/skills/demo")
+
+    # `*` 不跨目录：scripts/*.py 只匹配 scripts 直接子文件，不含 scripts/sub/deep.py
+    assert _paths(result) == ["/demo/scripts/browse.py"]
+
+
+async def test_skill_glob_bare_pattern_matches_basename_at_any_depth() -> None:
+    result = await _backend().aglob("*.md", "/skills/demo")
+
+    assert _paths(result) == ["/demo/README.md", "/demo/SKILL.md", "/demo/docs/x.md"]
+
+
+async def test_skill_glob_from_subdirectory_searches_below_it() -> None:
+    result = await _backend().aglob("**/deep.py", "/skills/demo/scripts")
+
+    assert _paths(result) == ["/demo/scripts/sub/deep.py"]

--- a/tests/infra/tool/test_internal_tool_schema_budget.py
+++ b/tests/infra/tool/test_internal_tool_schema_budget.py
@@ -168,7 +168,7 @@ def test_compact_descriptions_keep_tool_selection_boundaries() -> None:
         "scheduled_task_create": ("date", "interval", "cron", "timezone"),
         "create_agent_team": ("search_persona_presets", "member"),
         "transfer_file": ("text", "/skills/"),
-        "transfer_path": ("text", "10mb", "100mb", "500"),
+        "transfer_path": ("text", "10mb", "100mb", "2000"),
         "search_tools": ("+", "select:"),
     }
     for tool_name, markers in required_markers.items():

--- a/tests/infra/tool/test_transfer_file_tool.py
+++ b/tests/infra/tool/test_transfer_file_tool.py
@@ -319,6 +319,45 @@ async def test_transfer_path_skips_known_batch_oversize_before_download(
     assert backend.downloaded == [first_path]
 
 
+@pytest.mark.asyncio
+async def test_transfer_path_moves_501_file_tree_in_one_call() -> None:
+    """/skills 全量搬运场景（2026-09-09 生产会话）：501 个文件刚好卡死 500 上限。
+
+    上限抬高后，此类整树搬运应单次调用完成，而不是要求 agent 手工分批。
+    """
+
+    root = "/skills/all"
+    file_count = 501
+
+    class _FakeBackend:
+        async def als(self, path: str) -> LsResult:
+            assert path == root
+            return LsResult(
+                entries=[
+                    {"path": f"{root}/file-{index}.txt", "is_dir": False, "size": 3}
+                    for index in range(file_count)
+                ]
+            )
+
+        async def adownload_files(self, paths: list[str]):
+            return [SimpleNamespace(content=b"abc", error=None) for _path in paths]
+
+        async def aupload_files(self, files: list[tuple[str, bytes]]):
+            return [SimpleNamespace(error=None) for _path, _content in files]
+
+    result = json.loads(
+        await transfer_file_tool.transfer_path.coroutine(
+            source_dir=root,
+            target_prefix="/workspace/backup/",
+            runtime=_Runtime(_FakeBackend()),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["transferred"] == file_count
+    assert result["failed"] == 0
+
+
 def test_transfer_tools_document_persistent_shared_dir_convention() -> None:
     """工具描述写明持久共享目录约定：可复用文件进 /workspace/.shared，先 ls 复用避免重复转移。"""
     file_doc = transfer_file_tool.get_transfer_file_tool().description or ""


### PR DESCRIPTION
## Summary

背景：生产会话「帮我把 skills 移到本地电脑」（lambchat.com/chat/499fe849）被两处缺陷卡死，agent 最终被迫放弃：

1. `/skills` 虚拟挂载的 glob 用 fnmatch 对**单段名字**（根目录对 skill 名、skill 内对 basename）匹配，凡含 `/` 的模式（`**/*`、`*/SKILL.md`）结构性不可能命中，递归语义完全缺失。
2. `transfer_path` 单批文件数上限 500，501 个文件的 skills 全树搬运刚好超限整批失败，agent 只能逐目录分批。

backend 盘点结论：daytona / e2b / cubesandbox / local / lazy_sandbox / memories（StoreBackend）均已符合 deepagents 0.7.13 的共享 glob 契约（`fs_glob` daemon 侧同样契约实现），**仅 SkillsStoreBackend 离群**——本 PR 只修它，不做全量升级。

## Changes

- `skills_store.aglob` 根目录分支：含 `/` 的模式跨 skill 递归匹配文件（`compile_grep_include_glob` 共享契约，1000 条上限 + `truncated`）；裸模式（`*`）维持既有「列 skill 目录」行为不变
- `glob_files_from_paths`：basename-only fnmatch → 按相对路径的共享契约匹配（`**` 递归、`*` 不跨目录、裸模式任意深度 basename，向后兼容）
- 修复 `normalize_path("/skills")`（无尾斜杠）被误拼成 `/skills/skills` 的连带 bug
- `transfer_path` 文件数上限 500→2000（100MB 总量 / 10MB 单文件 / 深度 5 / 明细 100 条等护栏不变）
- E2E 新增 5 个用例：真实 MongoDB 的 skills glob 递归契约 ×4 + 真实 daemon 链路的 501 文件整树搬运 ×1；AGENTS.md 的 E2E 覆盖描述同步更新

## Testing

- TDD 全程红-绿：新增 7 个 glob 契约单测 + 1 个 501 文件搬运单测，均先确认失败再实现
- `uv run pytest tests/infra/backend/ tests/infra/tool/test_transfer_file_tool.py tests/infra/skill/` → 365 passed, 1 skipped
- `make lint` / `make typecheck` 全绿
- `E2E_SANDBOX_SERVER=… uv run python scripts/e2e_local_sandbox.py` → **40/40 PASS**（含新用例：`**/SKILL.md` 跨 skill 命中、`**/*.py` 多层嵌套、`scripts/*.py` 不跨目录、根目录无尾斜杠回归、501 文件 transferred=501 failed=0）
