### PR TITLE
fix(chat): 工具面板无副标题时标题占满整行——40% 上限仅约束有副标题场景

### DIFF
--- a/frontend/src/components/chat/ChatMessage/items/ToolResultPanel.tsx
+++ b/frontend/src/components/chat/ChatMessage/items/ToolResultPanel.tsx
@@ -473,7 +473,9 @@ export function ToolResultPanel({
                 <div className="tool-console-title-row flex items-end gap-2 min-w-0 flex-1 overflow-hidden font-serif">
                   <h3
                     id={titleId}
-                    className="tool-console-title min-w-0 max-w-[40%] truncate font-medium text-14 text-theme-text"
+                    className={`tool-console-title min-w-0 truncate font-medium text-14 text-theme-text ${
+                      subtitle ? "max-w-[40%]" : "max-w-full"
+                    }`}
                     title={title}
                   >
                     {title}

--- a/frontend/src/components/chat/ChatMessage/items/__tests__/ToolResultPanel.test.ts
+++ b/frontend/src/components/chat/ChatMessage/items/__tests__/ToolResultPanel.test.ts
@@ -83,8 +83,12 @@ test("tool result header truncates long titles and subtitles on narrow screens",
   expect(componentSource).toMatch(
     /className="tool-console-title-row flex items-end gap-2 min-w-0 flex-1 overflow-hidden font-serif"/,
   );
+  // 无副标题时标题占满整行可用宽度（"General-purpose" 级别的名字不再被 40% 上限截断）
   expect(componentSource).toMatch(
-    /className="tool-console-title min-w-0 max-w-\[40%\] truncate font-medium text-14 text-theme-text"/,
+    /tool-console-title min-w-0 truncate font-medium text-14 text-theme-text \$\{\s*subtitle \? "max-w-\[40%\]" : "max-w-full"\s*\}/,
+  );
+  expect(componentSource).not.toMatch(
+    /className="tool-console-title min-w-0 max-w-\[40%\] truncate/,
   );
   expect(componentSource).toMatch(
     /className="tool-console-subtitle-pill inline-flex h-5 min-w-0 max-w-\[45vw\] sm:max-w-\[min\(32rem,52%\)\] items-end overflow-hidden px-0 pb-\[1px\] text-12 font-normal leading-none text-theme-text-tertiary"/,


### PR DESCRIPTION
## Summary

工具结果面板（ToolResultPanel）的标题此前无条件套用 `max-w-[40%]` 上限：没有副标题的工具卡（如 "General-purpose" 这类长标题）也被截断在 40% 宽度，右侧大片留白。本 PR 让 40% 上限只在**有副标题**时生效（给副标题让位），无副标题时标题占满整行可用宽度。

## Changes

- `ToolResultPanel.tsx`：标题 className 改为按 `subtitle` 条件切换 `max-w-[40%]` / `max-w-full`。
- `ToolResultPanel.test.ts`：结构测试同步更新——断言条件写法存在，且旧的单一定宽写法不得回归。

## Testing

- [x] `pnpm vitest run src/components/chat/ChatMessage/items/__tests__/ToolResultPanel.test.ts`（12 passed）
- [ ] CI（前端测试 + 构建）
