### PR TITLE
fix(upload): xlsx 封面渲染容忍 styles.xml 空 <fill/> 条目

### DIFF
--- a/src/api/routes/upload_cover.py
+++ b/src/api/routes/upload_cover.py
@@ -205,13 +205,41 @@ def render_pdf_cover(data: bytes) -> bytes:
     return buf.getvalue()
 
 
+def _repair_empty_fill_styles(data: bytes) -> bytes:
+    """Rewrite bare ``<fill/>`` style entries as explicit no-op patternFills.
+
+    Some third-party writers emit empty fill elements in styles.xml; Excel
+    opens them fine, but openpyxl 3.1 raises
+    ``TypeError: expected <class 'openpyxl.styles.fills.Fill'>`` (seen on
+    production sheet covers). The regexes only touch fully empty fill tags —
+    ``<fills>`` containers and pattern/gradient children are unaffected.
+    """
+    import io
+    import zipfile
+
+    out = io.BytesIO()
+    with zipfile.ZipFile(io.BytesIO(data)) as zin, zipfile.ZipFile(out, "w") as zout:
+        for item in zin.infolist():
+            payload = zin.read(item.filename)
+            if item.filename == "xl/styles.xml":
+                payload = re.sub(rb"<fill\s*/>", b"<fill><patternFill/></fill>", payload)
+                payload = re.sub(rb"<fill\s*>\s*</fill>", b"<fill><patternFill/></fill>", payload)
+            zout.writestr(item, payload)
+    return out.getvalue()
+
+
 def _sheet_preview_rows(data: bytes) -> list[list[str]]:
     """First rows of the first sheet, stringified."""
     import io
 
     import openpyxl
 
-    workbook = openpyxl.load_workbook(io.BytesIO(data), read_only=True, data_only=True)
+    try:
+        workbook = openpyxl.load_workbook(io.BytesIO(data), read_only=True, data_only=True)
+    except TypeError:
+        workbook = openpyxl.load_workbook(
+            io.BytesIO(_repair_empty_fill_styles(data)), read_only=True, data_only=True
+        )
     try:
         rows: list[list[str]] = []
         if workbook.worksheets:

--- a/tests/api/routes/test_upload_cover_thumb.py
+++ b/tests/api/routes/test_upload_cover_thumb.py
@@ -545,6 +545,38 @@ def test_render_sheet_cover_draws_real_chinese_table():
     assert len(out) > 12000
 
 
+def _make_xlsx_bytes_with_empty_fill() -> bytes:
+    """Repack a workbook whose styles.xml contains a bare <fill/> — some
+    third-party writers emit these, Excel opens them fine, but openpyxl
+    3.1 raises TypeError("expected <class 'openpyxl.styles.fills.Fill'>")."""
+    import io
+    import re
+    import zipfile
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(io.BytesIO(_make_xlsx_bytes())) as zin, zipfile.ZipFile(
+        buf, "w"
+    ) as zout:
+        for item in zin.infolist():
+            payload = zin.read(item.filename)
+            if item.filename == "xl/styles.xml":
+                payload = re.sub(rb"<fill>.*?</fill>", b"<fill/>", payload, count=1)
+            zout.writestr(item, payload)
+    return buf.getvalue()
+
+
+def test_render_sheet_cover_tolerates_empty_fill_styles():
+    """空 <fill/> 样式条目（Excel 可开、openpyxl 3.1 抛 TypeError）不应让
+    封面渲染失败——修补后照常渲染出表格内容。"""
+    import io
+
+    out = render_sheet_cover(_make_xlsx_bytes_with_empty_fill())
+
+    cover = Image.open(io.BytesIO(out))
+    assert cover.size == (1120, 630)
+    assert len(out) > 12000
+
+
 # ── Concurrency protection ───────────────────────────────────────────────
 
 

--- a/tests/api/routes/test_upload_cover_thumb.py
+++ b/tests/api/routes/test_upload_cover_thumb.py
@@ -554,9 +554,7 @@ def _make_xlsx_bytes_with_empty_fill() -> bytes:
     import zipfile
 
     buf = io.BytesIO()
-    with zipfile.ZipFile(io.BytesIO(_make_xlsx_bytes())) as zin, zipfile.ZipFile(
-        buf, "w"
-    ) as zout:
+    with zipfile.ZipFile(io.BytesIO(_make_xlsx_bytes())) as zin, zipfile.ZipFile(buf, "w") as zout:
         for item in zin.infolist():
             payload = zin.read(item.filename)
             if item.filename == "xl/styles.xml":


### PR DESCRIPTION
## Summary

巡检 yang 生产日志发现 `src.api.routes.upload_cover` 连续报错（72h 内 3 次）：

```
[ERROR] Failed to render sheet cover for document/.../ea7750b495364de0.xlsx: expected <class 'openpyxl.styles.fills.Fill'>
```

根因：该 xlsx 的 `styles.xml` 含空的 `<fill/>` 样式条目（第三方工具写出，Excel 可正常打开），而 openpyxl 3.1 的 `Fill.from_tree` 对空元素返回 `None`，随后 `NestedSequence` 类型校验抛 `TypeError`，封面渲染直接失败（前端回退生成式封面）。

## Changes

- `_sheet_preview_rows`：openpyxl 解析抛 `TypeError` 时，把空 `<fill/>` 重写为显式无操作 `<patternFill/>` 并重试一次；其余 zip 成员原样保留。
- 新增测试 `test_render_sheet_cover_tolerates_empty_fill_styles`（构造带空 `<fill/>` 的工作簿，先 RED 后 GREEN）。

## Testing

- [x] `uv run pytest tests/api/routes/test_upload_cover_thumb.py` — 24 passed
- [x] 生产问题文件（从 OSS 取回）本地验证：修复后渲染出 1120x630 表格封面
- [x] `make lint` / `make typecheck` 全绿
