### PR TITLE
fix(upload): 上传扩展名白名单支持 Visio(vsd/vsdx/vsdm) 与 TIFF(tif/tiff)

### DIFF
--- a/frontend/src/components/chat/ChatInputToolbar.tsx
+++ b/frontend/src/components/chat/ChatInputToolbar.tsx
@@ -82,7 +82,7 @@ const FILE_CATEGORY_ACCEPT: Record<FileCategory, string> = {
   audio:
     "audio/*,.m4a,.mp3,.wav,.ogg,.aac,.flac,.wma,.opus,.aiff,.caf,.amr,.mid,.midi,.ape,.alac,.wv",
   document:
-    ".pdf,.doc,.docx,.dot,.dotx,.docm,.xls,.xlsx,.xlsm,.csv,.xlt,.ods,.ppt,.pptx,.potx,.ppsx,.pptm,.odp,.txt,.md,.csv,.rtf,.odt,.epub,.dxf,.dwg,.log,.json,.xml,.html,.htm,.yaml,.yml,.toml,.ini,.cfg,.tex,.diff,.patch,.py,.js,.ts,.jsx,.tsx,.vue,.svelte,.go,.rs,.rb,.php,.java,.c,.cpp,.h,.cs,.swift,.kt,.scala,.dart,.lua,.r,.pl,.sql,.sh,.bash,.zsh,.fish,.ps1,.bat,.cmd,.properties,.gradle,.cmake,.env,.graphql,.proto,.zip,.rar,.7z,.tar,.gz,.bz2,.xz,.tgz",
+    ".pdf,.doc,.docx,.dot,.dotx,.docm,.xls,.xlsx,.xlsm,.csv,.xlt,.ods,.ppt,.pptx,.potx,.ppsx,.pptm,.odp,.vsd,.vsdx,.vsdm,.txt,.md,.csv,.rtf,.odt,.epub,.dxf,.dwg,.log,.json,.xml,.html,.htm,.yaml,.yml,.toml,.ini,.cfg,.tex,.diff,.patch,.py,.js,.ts,.jsx,.tsx,.vue,.svelte,.go,.rs,.rb,.php,.java,.c,.cpp,.h,.cs,.swift,.kt,.scala,.dart,.lua,.r,.pl,.sql,.sh,.bash,.zsh,.fish,.ps1,.bat,.cmd,.properties,.gradle,.cmake,.env,.graphql,.proto,.zip,.rar,.7z,.tar,.gz,.bz2,.xz,.tgz",
 };
 
 const FILE_ACCEPT_ALL = Object.values(FILE_CATEGORY_ACCEPT).join(",");

--- a/frontend/src/components/chat/FileUploadButton.tsx
+++ b/frontend/src/components/chat/FileUploadButton.tsx
@@ -34,7 +34,7 @@ const CATEGORY_ACCEPT_MAP: Record<FileCategory, string> = {
   audio:
     "audio/*,.m4a,.mp3,.wav,.ogg,.aac,.flac,.wma,.opus,.aiff,.caf,.amr,.mid,.midi,.ape,.alac,.wv",
   document:
-    ".pdf,.doc,.docx,.dot,.dotx,.docm,.xls,.xlsx,.xlsm,.csv,.xlt,.ods,.ppt,.pptx,.potx,.ppsx,.pptm,.odp,.txt,.md,.csv,.rtf,.odt,.epub,.dxf,.dwg,.log,.json,.xml,.html,.htm,.yaml,.yml,.toml,.ini,.cfg,.tex,.diff,.patch,.py,.js,.ts,.jsx,.tsx,.vue,.svelte,.go,.rs,.rb,.php,.java,.c,.cpp,.h,.cs,.swift,.kt,.scala,.dart,.lua,.r,.pl,.sql,.sh,.bash,.zsh,.fish,.ps1,.bat,.cmd,.properties,.gradle,.cmake,.env,.graphql,.proto,.zip,.rar,.7z,.tar,.gz,.bz2,.xz,.tgz",
+    ".pdf,.doc,.docx,.dot,.dotx,.docm,.xls,.xlsx,.xlsm,.csv,.xlt,.ods,.ppt,.pptx,.potx,.ppsx,.pptm,.odp,.vsd,.vsdx,.vsdm,.txt,.md,.csv,.rtf,.odt,.epub,.dxf,.dwg,.log,.json,.xml,.html,.htm,.yaml,.yml,.toml,.ini,.cfg,.tex,.diff,.patch,.py,.js,.ts,.jsx,.tsx,.vue,.svelte,.go,.rs,.rb,.php,.java,.c,.cpp,.h,.cs,.swift,.kt,.scala,.dart,.lua,.r,.pl,.sql,.sh,.bash,.zsh,.fish,.ps1,.bat,.cmd,.properties,.gradle,.cmake,.env,.graphql,.proto,.zip,.rar,.7z,.tar,.gz,.bz2,.xz,.tgz",
 };
 
 // Icons

--- a/src/api/routes/file_type.py
+++ b/src/api/routes/file_type.py
@@ -16,7 +16,7 @@ class FileCategory(str, Enum):
 
 # File extension mappings
 FILE_EXTENSIONS: dict[FileCategory, set[str]] = {
-    FileCategory.IMAGE: {"jpg", "jpeg", "png", "gif", "webp", "svg", "bmp", "ico"},
+    FileCategory.IMAGE: {"jpg", "jpeg", "png", "gif", "webp", "svg", "bmp", "ico", "tiff", "tif"},
     FileCategory.VIDEO: {"mp4", "webm", "mov", "avi", "mkv", "wmv", "flv"},
     FileCategory.AUDIO: {"mp3", "wav", "ogg", "aac", "flac", "m4a", "wma"},
     FileCategory.DOCUMENT: {
@@ -27,6 +27,9 @@ FILE_EXTENSIONS: dict[FileCategory, set[str]] = {
         "xlsx",
         "ppt",
         "pptx",
+        "vsd",
+        "vsdx",
+        "vsdm",
         "txt",
         "md",
         "csv",

--- a/tests/api/routes/test_file_type.py
+++ b/tests/api/routes/test_file_type.py
@@ -4,3 +4,14 @@ from src.api.routes.file_type import FileCategory, get_file_category
 def test_cad_files_are_treated_as_documents() -> None:
     assert get_file_category("site-plan.dxf") == FileCategory.DOCUMENT
     assert get_file_category("site-plan.dwg") == FileCategory.DOCUMENT
+
+
+def test_visio_files_are_treated_as_documents() -> None:
+    assert get_file_category("flowchart.vsdx") == FileCategory.DOCUMENT
+    assert get_file_category("flowchart.vsd") == FileCategory.DOCUMENT
+    assert get_file_category("flowchart.vsdm") == FileCategory.DOCUMENT
+
+
+def test_tiff_files_are_treated_as_images() -> None:
+    assert get_file_category("scan.tiff") == FileCategory.IMAGE
+    assert get_file_category("scan.tif") == FileCategory.IMAGE


### PR DESCRIPTION
## 问题

用户上传 `.vsdx`（Visio）文件被拒：`document 文件不允许使用 .vsdx 扩展名`。根因是后端上传扩展名白名单 `FILE_EXTENSIONS`（`src/api/routes/file_type.py`）未收录该格式——MIME 前缀 `application/vnd.*` 能正确分类，但扩展名校验分支将其拦下。

TIFF 是同类问题且更隐蔽：前端 image 类 accept 列表早已包含 `.tiff,.tif`，文件选择器能选中，但后端 `IMAGE` 白名单没有，上传必被 `file_extension_not_allowed` 拒收。

## 改动

- **后端** `src/api/routes/file_type.py`：
  - `DOCUMENT` 白名单新增 `vsd` / `vsdx` / `vsdm`（Visio 旧版二进制 / OOXML / 宏启用，与既有 `docm`/`pptm` 收录口径一致）
  - `IMAGE` 白名单新增 `tif` / `tiff`（对齐前端既有 accept 列表）
- **前端** `FileUploadButton.tsx` 与 `ChatInputToolbar.tsx` 两处 document accept 列表同步加 `.vsd,.vsdx,.vsdm`，选择器可直接选中，无需拖拽绕过

## 测试

- TDD：`tests/api/routes/test_file_type.py` 新增 Visio 归类 document、TIFF 归类 image 两组用例，均先 RED 后 GREEN
- `uv run pytest` file_type + upload 相关 28 个用例通过；ruff check / format 通过
- 前端 eslint + tsc 干净，全量 vitest 2645 个用例通过