### PR TITLE
fix(updater): 修复 Linux 桌面端更新安装失败

### DIFF
--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -107,9 +107,12 @@ jobs:
           ios="$(grep -m1 'MARKETING_VERSION' frontend/ios/App/App.xcodeproj/project.pbxproj | sed -E 's/.*= ([^;]+);.*/\1/')"
           pyproject="$(grep -m1 '^version = ' pyproject.toml | sed -E 's/version = "([^"]+)"/\1/')"
           daemon="$(grep -m1 '^__version__ = ' client/lambchat_sandbox/__init__.py | sed -E 's/__version__ = "([^"]+)"/\1/')"
+          # Cargo.toml 的包版本编译期进 CARGO_PKG_VERSION（clean_on_version_upgrade
+          # 依赖它），漂移则升级清 WebView 数据逻辑失效——曾冻在 2.8.6 达十版
+          cargo_toml="$(grep -m1 '^version = ' frontend/src-tauri/Cargo.toml | sed -E 's/version = "([^"]+)"/\1/')"
           want_code="$(printf '%s' "$tag" | tr -d '.')"
           fail=0
-          for entry in "frontend/package.json=$pkg" "tauri.conf.json=$tauri" "android versionName=$gradle_name" "iOS MARKETING_VERSION=$ios" "pyproject.toml=$pyproject" "daemon __version__=$daemon"; do
+          for entry in "frontend/package.json=$pkg" "tauri.conf.json=$tauri" "src-tauri Cargo.toml=$cargo_toml" "android versionName=$gradle_name" "iOS MARKETING_VERSION=$ios" "pyproject.toml=$pyproject" "daemon __version__=$daemon"; do
             k="${entry%%=*}"; v="${entry#*=}"
             if [ "$v" != "$tag" ]; then echo "✗ $k is $v, expected $tag"; fail=1; fi
           done
@@ -532,9 +535,12 @@ jobs:
           ios="$(grep -m1 'MARKETING_VERSION' frontend/ios/App/App.xcodeproj/project.pbxproj | sed -E 's/.*= ([^;]+);.*/\1/')"
           pyproject="$(grep -m1 '^version = ' pyproject.toml | sed -E 's/version = "([^"]+)"/\1/')"
           daemon="$(grep -m1 '^__version__ = ' client/lambchat_sandbox/__init__.py | sed -E 's/__version__ = "([^"]+)"/\1/')"
+          # Cargo.toml 的包版本编译期进 CARGO_PKG_VERSION（clean_on_version_upgrade
+          # 依赖它），漂移则升级清 WebView 数据逻辑失效——曾冻在 2.8.6 达十版
+          cargo_toml="$(grep -m1 '^version = ' frontend/src-tauri/Cargo.toml | sed -E 's/version = "([^"]+)"/\1/')"
           want_code="$(printf '%s' "$tag" | tr -d '.')"
           fail=0
-          for entry in "frontend/package.json=$pkg" "tauri.conf.json=$tauri" "android versionName=$gradle_name" "iOS MARKETING_VERSION=$ios" "pyproject.toml=$pyproject" "daemon __version__=$daemon"; do
+          for entry in "frontend/package.json=$pkg" "tauri.conf.json=$tauri" "src-tauri Cargo.toml=$cargo_toml" "android versionName=$gradle_name" "iOS MARKETING_VERSION=$ios" "pyproject.toml=$pyproject" "daemon __version__=$daemon"; do
             k="${entry%%=*}"; v="${entry#*=}"
             if [ "$v" != "$tag" ]; then echo "✗ $k is $v, expected $tag"; fail=1; fi
           done
@@ -673,9 +679,12 @@ jobs:
           ios="$(grep -m1 'MARKETING_VERSION' frontend/ios/App/App.xcodeproj/project.pbxproj | sed -E 's/.*= ([^;]+);.*/\1/')"
           pyproject="$(grep -m1 '^version = ' pyproject.toml | sed -E 's/version = "([^"]+)"/\1/')"
           daemon="$(grep -m1 '^__version__ = ' client/lambchat_sandbox/__init__.py | sed -E 's/__version__ = "([^"]+)"/\1/')"
+          # Cargo.toml 的包版本编译期进 CARGO_PKG_VERSION（clean_on_version_upgrade
+          # 依赖它），漂移则升级清 WebView 数据逻辑失效——曾冻在 2.8.6 达十版
+          cargo_toml="$(grep -m1 '^version = ' frontend/src-tauri/Cargo.toml | sed -E 's/version = "([^"]+)"/\1/')"
           want_code="$(printf '%s' "$tag" | tr -d '.')"
           fail=0
-          for entry in "frontend/package.json=$pkg" "tauri.conf.json=$tauri" "android versionName=$gradle_name" "iOS MARKETING_VERSION=$ios" "pyproject.toml=$pyproject" "daemon __version__=$daemon"; do
+          for entry in "frontend/package.json=$pkg" "tauri.conf.json=$tauri" "src-tauri Cargo.toml=$cargo_toml" "android versionName=$gradle_name" "iOS MARKETING_VERSION=$ios" "pyproject.toml=$pyproject" "daemon __version__=$daemon"; do
             k="${entry%%=*}"; v="${entry#*=}"
             if [ "$v" != "$tag" ]; then echo "✗ $k is $v, expected $tag"; fail=1; fi
           done

--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -486,13 +486,18 @@ jobs:
             const key = process.env.UPDATER_KEY;
             const signature = fs.readFileSync(process.env.SIG_FILE, "utf8").trim();
             const asset = `LambChat-${process.env.RELEASE_TAG}-${process.env.UPDATER_ASSET_SUFFIX}`;
-            const base = `https://github.com/${process.env.GITHUB_REPOSITORY}/releases/download/${process.env.RELEASE_TAG}`;
+            // 国内直连 GitHub 下载必挂：走自托管反代并锁 tag（与
+            // scripts/generate_updater_manifest.py 同一契约）
+            const base = "https://lambchat.com/api/version/assets";
             let manifest = {};
             if (fs.existsSync("latest.json")) {
               try { manifest = JSON.parse(fs.readFileSync("latest.json", "utf8")); } catch {}
             }
             manifest.platforms = manifest.platforms || {};
-            manifest.platforms[key] = { signature, url: `${base}/${asset}` };
+            manifest.platforms[key] = {
+              signature,
+              url: `${base}/${asset}/download?tag=${process.env.RELEASE_TAG}`,
+            };
             // 版本必须取自 tag：v2.8.2 发布时 tauri.conf.json 仍写 2.8.1，
             // 导致 latest.json 报 2.8.1、桌面端永远检测不到更新。
             manifest.version = process.env.RELEASE_TAG.replace(/^v/, "");

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,7 +171,7 @@ Conventional Commits + 中文描述：`类型(范围): 摘要`。
 
 **规矩：发版 tag 一律打在 `main` 的合并提交上——hotfix 或 develop 晋升合入 `main`、CI 全绿后再打 tag；禁止在 feature 分支或未晋升到 `main` 的提交上发版。**
 
-1. 打 tag 前先 bump 六处版本文件并保持一致：`frontend/package.json`、`frontend/src-tauri/tauri.conf.json`、android `versionName`/`versionCode`（数字串 = 版本去点）、iOS `MARKETING_VERSION`、`pyproject.toml`（服务端 `/api/version` 运行时读它，漏 bump 网页端版本号就不同步）、`client/lambchat_sandbox/__init__.py` 的 `__version__`（daemon 自更新比版本，漏 bump daemon 永不更新）——app-release.yml 的 preflight 会校验 tag 与版本一致，漂移直接红。
+1. 打 tag 前先 bump 七处版本文件并保持一致：`frontend/package.json`、`frontend/src-tauri/tauri.conf.json`、`frontend/src-tauri/Cargo.toml`（编译期进 `CARGO_PKG_VERSION`，`clean_on_version_upgrade` 依赖它判断升级，漏 bump 该逻辑静默失效）、android `versionName`/`versionCode`（数字串 = 版本去点）、iOS `MARKETING_VERSION`、`pyproject.toml`（服务端 `/api/version` 运行时读它，漏 bump 网页端版本号就不同步）、`client/lambchat_sandbox/__init__.py` 的 `__version__`（daemon 自更新比版本，漏 bump daemon 永不更新）——app-release.yml 的 preflight 会校验 tag 与版本一致，漂移直接红。
 2. 在 `main` 合并提交上打 tag 并推送，触发 `app-release.yml`：六端矩阵构建（Linux x86_64/arm64、Windows、macOS Apple Silicon/Intel）+ Android/iOS，即发即传上传 GitHub Release。
 3. 出包默认**烘焙态**：资产全部上 Release、CI 打包产物冒烟（mac 直接跑 .app 内 daemon、Linux 解包 deb 跑、Windows 跑 sidecar）须绿，但 `latest.json` **不上传**——桌面端自更新不感知。真机抽检（mac/windows）通过后，到 Actions 手动跑 **Desktop Updater Publish**（输入 tag）才把 latest.json 推给桌面端；此时发版完成的判据是 latest.json 五个桌面平台条目齐全（含 `darwin-x86_64`）。仓库变量 `DESKTOP_UPDATER_AUTO_PUBLISH=true` 可恢复随包直发（不建议）。
 4. 重打同一 tag：先删远端 tag 与旧 run，再在新提交上重推；资产同名 `--clobber` 原地替换。
@@ -436,6 +436,7 @@ LLM 模型通过 **Model Config UI** 配置，无需在环境变量中设置 API
 | 后端格式/类型 | `make lint` + `make typecheck` |
 | 跨栈变更 | `make check-all` |
 | 本地沙箱/daemon/传输链路 | `uv run python scripts/e2e_local_sandbox.py`（详见下方规矩） |
+| 桌面端 Linux 更新链路 | `uv run python scripts/e2e_linux_update.py`（Rust 检测/下载单测 + 本机检测冒烟 + 前端契约） |
 | 文档变更 | 确认 Markdown 链接、命令和路径正确 |
 
 如果验证因缺少服务、依赖或环境变量无法完成，明确说明。

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -1940,10 +1940,12 @@ dependencies = [
 
 [[package]]
 name = "lambchat"
-version = "2.8.6"
+version = "2.10.2"
 dependencies = [
  "command-group",
  "libc",
+ "reqwest",
+ "rustls",
  "serde",
  "serde_json",
  "sys-locale",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambchat"
-version = "2.8.6"
+version = "2.10.2"
 description = "LambChat desktop app"
 authors = ["LambChat"]
 license = ""
@@ -24,6 +24,13 @@ tauri-plugin-shell = "2"
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# Linux deb/rpm 更新安装的流式下载（linux_update.rs）。与 updater 插件共用
+# 同版本 reqwest；TLS provider 不自带（rustls-no-provider）——由下方 rustls(ring)
+# 在进程级安装，避免引入 aws-lc-sys 原生构建（reqwest `rustls` feature 的默认）
+reqwest = { version = "0.13", default-features = false, features = ["stream", "rustls-no-provider"] }
+# 声明与 updater 插件完全一致（版本/feature 取并集，lock 零新增），
+# 供 linux_update 安装进程级 ring provider
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 time = "=0.3.36"
 # 托盘菜单文案按系统 locale 五语本地化（M4 T8）；无传递依赖，纯 Rust 读 env/API
 sys-locale = "0.3"

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use tauri::Manager;
 
 mod daemon;
+mod linux_update;
 mod tray;
 
 /// SIGTERM 停机旗标：信号处理器只做原子置位（async-signal-safe 的唯一动作），
@@ -224,7 +225,9 @@ pub fn run() {
             daemon::read_machine_id,
             daemon::restart_daemon,
             daemon::daemon_process_status,
-            daemon::open_local_path
+            daemon::open_local_path,
+            linux_update::get_linux_install_source,
+            linux_update::install_linux_package
         ])
         .build(tauri::generate_context!())
         .expect("error while building LambChat desktop app")

--- a/frontend/src-tauri/src/linux_update.rs
+++ b/frontend/src-tauri/src/linux_update.rs
@@ -1,0 +1,492 @@
+//! Linux 桌面端更新安装：安装来源检测 + deb/rpm 包管理器安装。
+//!
+//! 背景：tauri-plugin-updater 在 Linux 只支持 AppImage——`.deb`/`.rpm` 安装的
+//! 壳跑 `update.install()` 时会因 `/usr/bin/lambchat` 归 root 所有而权限失败
+//! （2.10.0 → 2.10.2 的实际报错）。本模块补齐系统包路径：
+//!
+//! - [`get_linux_install_source`]：检测当前程序来源（AppImage / deb / rpm /
+//!   unknown），前端据此分流——AppImage 走 updater 替换重启，deb/rpm 走本
+//!   模块「下载 + pkexec 提权安装」，unknown 回落下载页；
+//! - [`install_linux_package`]：流式下载 deb/rpm 到临时目录（进度事件推送），
+//!   `pkexec apt|dnf install` 安装（polkit GUI 授权），成功后前端 relaunch。
+//!
+//! 检测序：AppImage 扩展名 → `dpkg -S` / `rpm -qf` 包归属反查（权威）→
+//! 系统前缀 + 本机包管理器启发式（保守，双装/都没有判 unknown）。
+
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter};
+
+/// 前端消费的安装来源词汇表（invoke 返回值；unknown 回落下载页）。
+pub const SOURCE_DEB: &str = "deb";
+pub const SOURCE_RPM: &str = "rpm";
+pub const SOURCE_APPIMAGE: &str = "appimage";
+pub const SOURCE_UNKNOWN: &str = "unknown";
+
+/// 下载进度事件名（Tauri event；payload 为 [`ProgressPayload`]）。
+pub const PROGRESS_EVENT: &str = "linux-update-progress";
+
+/// 进度事件节流间隔：大包逐块 IPC 全量推送会打爆 webview。
+const PROGRESS_THROTTLE: Duration = Duration::from_millis(200);
+
+/// pkexec 授权 + 包管理器安装的整体上限：polkit 密码框无人操作时兜底退出，
+/// 不让更新任务无限挂死。
+const INSTALL_TIMEOUT: Duration = Duration::from_secs(20 * 60);
+
+/// 下载整体超时：慢网络 100MB 包的宽容上限（连接超时另计 30s）。
+const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ProgressPayload {
+    pub downloaded: u64,
+    pub content_length: u64,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LinuxInstallInfo {
+    pub source: String,
+    /// 资产命名的 arch 段（app-release.yml 词汇：x86_64 | arm64）；未知架构
+    /// 为 None，前端不再拼 deb/rpm 资产名（回落下载页）。
+    pub arch: Option<String>,
+}
+
+/// 可执行文件是否是 AppImage（按扩展名；AppImage 自包含、不归包管理器）。
+fn is_appimage_path(exe: &Path) -> bool {
+    exe.extension()
+        .and_then(|e| e.to_str())
+        .is_some_and(|e| e.eq_ignore_ascii_case("appimage"))
+}
+
+/// 命令是否存在且可执行（`--version` 探测；找不到二进制自然为 false）。
+fn command_exists(name: &str) -> bool {
+    Command::new(name)
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// `dpkg -S` / `rpm -qf` 反查路径归属的包管理器（权威信号；先查 dpkg——
+/// 混装系统里 deb 包由 dpkg 收录优先命中）。非 Linux 平台两个命令都不存在，
+/// 自然返回 None。
+fn owning_package_manager(exe: &Path) -> Option<&'static str> {
+    let run = |argv: [&str; 3]| -> bool {
+        Command::new(argv[0])
+            .arg(argv[1])
+            .arg(argv[2])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    };
+    if run(["dpkg", "-S", &exe.to_string_lossy()]) {
+        Some(SOURCE_DEB)
+    } else if run(["rpm", "-qf", &exe.to_string_lossy()]) {
+        Some(SOURCE_RPM)
+    } else {
+        None
+    }
+}
+
+/// 包归属反查不可用时的保守启发式：系统前缀（/usr、/opt）安装 + 本机包
+/// 管理器唯一时按其判定；双装（alien 混装）或都没有判 unknown，宁可让
+/// 用户走下载页也不装错包格式。
+fn fallback_install_source(exe: &Path, has_dpkg: bool, has_rpm: bool) -> &'static str {
+    let is_system_install = exe.starts_with("/usr/") || exe.starts_with("/opt/");
+    if !is_system_install {
+        return SOURCE_UNKNOWN;
+    }
+    match (has_dpkg, has_rpm) {
+        (true, false) => SOURCE_DEB,
+        (false, true) => SOURCE_RPM,
+        _ => SOURCE_UNKNOWN,
+    }
+}
+
+/// 综合判定安装来源（检测序见模块注释）。
+pub fn detect_install_source(exe: &Path) -> &'static str {
+    if is_appimage_path(exe) {
+        return SOURCE_APPIMAGE;
+    }
+    if let Some(pm) = owning_package_manager(exe) {
+        return pm;
+    }
+    fallback_install_source(exe, command_exists("dpkg"), command_exists("rpm"))
+}
+
+/// 与 app-release.yml 资产命名的 arch 段一致（前端拼 deb/rpm 资产名用）。
+fn release_asset_arch() -> Option<&'static str> {
+    match std::env::consts::ARCH {
+        "x86_64" => Some("x86_64"),
+        "aarch64" => Some("arm64"),
+        _ => None,
+    }
+}
+
+/// deb/rpm 对应的系统安装器调用参数（pkexec 之后的部分；纯函数便于单测）。
+fn installer_argv(kind: &str, package_path: &Path) -> Option<Vec<String>> {
+    let path = package_path.to_string_lossy().into_owned();
+    match kind {
+        SOURCE_DEB => Some(vec![
+            "apt".into(),
+            "install".into(),
+            "-y".into(),
+            path,
+        ]),
+        SOURCE_RPM => Some(vec![
+            "dnf".into(),
+            "install".into(),
+            "-y".into(),
+            path,
+        ]),
+        _ => None,
+    }
+}
+
+/// 进程级安装 ring crypto provider（幂等：已装则忽略 Err）。
+///
+/// reqwest 走 `rustls-no-provider`（复用 updater 插件编入的 ring，避免
+/// aws-lc-sys 原生构建），构 Client 前必须有进程级 provider，否则直接
+/// panic（reqwest 0.13 显式校验）。
+fn ensure_rustls_provider() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
+/// 流式下载安装包到临时目录（200ms 节流回调进度；返回落盘路径）。
+/// 下载核心与 Tauri 事件解耦，便于用本地 HTTP 服务做单测。
+async fn download_to_temp<F>(url: &str, ext: &str, mut on_progress: F) -> Result<PathBuf, String>
+where
+    F: FnMut(u64, u64),
+{
+    ensure_rustls_provider();
+    let client = reqwest::Client::builder()
+        .user_agent(concat!("LambChatDesktop/", env!("CARGO_PKG_VERSION")))
+        .connect_timeout(Duration::from_secs(30))
+        .timeout(DOWNLOAD_TIMEOUT)
+        .build()
+        .map_err(|e| format!("failed to build http client: {e}"))?;
+    let mut resp = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| format!("download request failed: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("download failed: HTTP {}", resp.status()));
+    }
+    let content_length = resp.content_length().unwrap_or(0);
+    let path = std::env::temp_dir().join(format!("lambchat-update.{ext}"));
+    let mut file =
+        std::fs::File::create(&path).map_err(|e| format!("create {}: {e}", path.display()))?;
+
+    let mut downloaded: u64 = 0;
+    let mut wrote_any = false;
+    let mut last_emit: Option<Instant> = None;
+    while let Some(chunk) = resp
+        .chunk()
+        .await
+        .map_err(|e| format!("download stream failed: {e}"))?
+    {
+        if chunk.is_empty() {
+            continue;
+        }
+        file.write_all(&chunk)
+            .map_err(|e| format!("write {}: {e}", path.display()))?;
+        downloaded += chunk.len() as u64;
+        wrote_any = true;
+        if last_emit.is_none_or(|t| t.elapsed() >= PROGRESS_THROTTLE) {
+            on_progress(downloaded, content_length);
+            last_emit = Some(Instant::now());
+        }
+    }
+    if !wrote_any {
+        let _ = std::fs::remove_file(&path);
+        return Err("download produced no content".into());
+    }
+    file.flush()
+        .map_err(|e| format!("flush {}: {e}", path.display()))?;
+    // 收尾事件：让 UI 的 downloaded/content_length 落到终值
+    on_progress(downloaded, content_length);
+    Ok(path)
+}
+
+/// pkexec 调用系统包管理器安装本地包文件。
+///
+/// stderr 由独立线程持续排空（dnf 进度输出可超管道缓冲，不排空会写阻塞
+/// → 安装挂死）；stdout 丢弃（GUI 壳无处展示）。超时 kill 兜底。
+fn run_pkexec_installer(argv: &[String]) -> Result<(), String> {
+    let mut child = Command::new("pkexec")
+        .args(argv)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| {
+            format!(
+                "failed to spawn pkexec ({e}); 系统缺少 polkit 授权组件，\
+                 请从下载页手动安装新版安装包"
+            )
+        })?;
+
+    // stderr 排空线程：try_wait 轮询期间子进程的输出不能积压在管道里
+    let mut stderr_pipe = child
+        .stderr
+        .take()
+        .expect("stderr piped above");
+    let stderr_buf: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    let buf_clone = Arc::clone(&stderr_buf);
+    let drain = std::thread::spawn(move || {
+        let mut chunk = [0u8; 4096];
+        loop {
+            match stderr_pipe.read(&mut chunk) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => buf_clone.lock().unwrap().extend_from_slice(&chunk[..n]),
+            }
+        }
+    });
+
+    let deadline = Instant::now() + INSTALL_TIMEOUT;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    let _ = drain.join();
+                    return Err(format!(
+                        "installer timed out after {}s（polkit 授权未完成？），请重试或手动安装",
+                        INSTALL_TIMEOUT.as_secs()
+                    ));
+                }
+                std::thread::sleep(Duration::from_millis(200));
+            }
+            Err(e) => return Err(format!("wait installer failed: {e}")),
+        }
+    };
+    let _ = drain.join();
+    if status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&stderr_buf.lock().unwrap()).trim().to_string();
+    if stderr.is_empty() {
+        Err(format!("installer exited with {status}（polkit 授权被取消？）"))
+    } else {
+        Err(format!("installer exited with {status}: {stderr}"))
+    }
+}
+
+/// 检测当前安装来源与资产 arch（前端更新分流依据）。
+#[tauri::command]
+pub fn get_linux_install_source() -> LinuxInstallInfo {
+    let source = std::env::current_exe()
+        .map(|p| detect_install_source(&p).to_string())
+        .unwrap_or_else(|_| SOURCE_UNKNOWN.to_string());
+    LinuxInstallInfo {
+        source,
+        arch: release_asset_arch().map(str::to_string),
+    }
+}
+
+/// 下载 deb/rpm 安装包并以 pkexec 提权安装（成功后前端 relaunch 进新版）。
+#[tauri::command]
+pub async fn install_linux_package(
+    app: AppHandle,
+    url: String,
+    kind: String,
+) -> Result<(), String> {
+    if kind != SOURCE_DEB && kind != SOURCE_RPM {
+        return Err(format!("unsupported package kind: {kind}"));
+    }
+    let app_for_progress = app.clone();
+    let ext = kind.clone();
+    let path = download_to_temp(&url, &ext, move |downloaded, content_length| {
+        let _ = app_for_progress.emit(
+            PROGRESS_EVENT,
+            ProgressPayload {
+                downloaded,
+                content_length,
+            },
+        );
+    })
+    .await?;
+
+    // pkexec 安装是阻塞轮询（≤20min 授权窗口），挪出 async 线程
+    let argv = installer_argv(&kind, &path)
+        .ok_or_else(|| format!("unsupported package kind: {kind}"))?;
+    let result =
+        tauri::async_runtime::spawn_blocking(move || run_pkexec_installer(&argv)).await;
+    // 装完即清；失败也清（重试走完整重新下载，不残留半包）
+    let _ = std::fs::remove_file(&path);
+    result.map_err(|e| format!("installer task failed: {e}"))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn appimage_detection_by_extension_only() {
+        assert!(is_appimage_path(Path::new(
+            "/home/user/Applications/LambChat.AppImage"
+        )));
+        // 大小写不敏感（手工改名常见）
+        assert!(is_appimage_path(Path::new("/opt/lambchat.appimage")));
+        // deb/rpm 安装路径与裸二进制都不是 AppImage
+        assert!(!is_appimage_path(Path::new("/usr/bin/lambchat")));
+        assert!(!is_appimage_path(Path::new("/usr/bin/lambchat.deb")));
+        assert!(!is_appimage_path(Path::new("/home/user/lambchat")));
+    }
+
+    #[test]
+    fn fallback_source_needs_system_prefix_and_unique_manager() {
+        let deb = Path::new("/usr/bin/lambchat");
+        // 系统前缀 + 唯一包管理器 → 判定对应来源
+        assert_eq!(fallback_install_source(deb, true, false), SOURCE_DEB);
+        assert_eq!(fallback_install_source(deb, false, true), SOURCE_RPM);
+        assert_eq!(
+            fallback_install_source(Path::new("/usr/lib/lambchat/lambchat"), true, false),
+            SOURCE_DEB
+        );
+        assert_eq!(
+            fallback_install_source(Path::new("/opt/LambChat/lambchat"), false, true),
+            SOURCE_RPM
+        );
+        // 用户目录（AppImage 检测漏网时的手动解包等）不猜
+        assert_eq!(
+            fallback_install_source(Path::new("/home/user/bin/lambchat"), true, false),
+            SOURCE_UNKNOWN
+        );
+        // 混装 / 双缺：保守判 unknown（宁可走下载页也不装错格式）
+        assert_eq!(fallback_install_source(deb, true, true), SOURCE_UNKNOWN);
+        assert_eq!(fallback_install_source(deb, false, false), SOURCE_UNKNOWN);
+    }
+
+    #[test]
+    fn installer_argv_maps_deb_to_apt_and_rpm_to_dnf() {
+        let deb = installer_argv(SOURCE_DEB, Path::new("/tmp/lambchat-update.deb")).unwrap();
+        assert_eq!(deb, vec!["apt", "install", "-y", "/tmp/lambchat-update.deb"]);
+        let rpm = installer_argv(SOURCE_RPM, Path::new("/tmp/lambchat-update.rpm")).unwrap();
+        assert_eq!(rpm, vec!["dnf", "install", "-y", "/tmp/lambchat-update.rpm"]);
+        assert!(installer_argv(SOURCE_APPIMAGE, Path::new("/tmp/x")).is_none());
+        assert!(installer_argv("exe", Path::new("/tmp/x")).is_none());
+    }
+
+    #[test]
+    fn release_asset_arch_matches_workflow_vocabulary() {
+        // 本机构建机必在受支持架构内；词汇表与 app-release.yml 一致
+        let arch = release_asset_arch().expect("host arch must be supported");
+        assert!(arch == "x86_64" || arch == "arm64", "unexpected arch {arch}");
+    }
+
+    /// 起一个单连接本地 HTTP 服务：回指定状态行/头 + 分两段写 body
+    /// （模拟流式分块），返回请求 URL。
+    fn spawn_chunked_http_server(status_and_headers: &str, body: &[u8]) -> String {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let head = status_and_headers.as_bytes().to_vec();
+        let body = body.to_vec();
+        std::thread::spawn(move || {
+            let Ok((mut stream, _)) = listener.accept() else { return };
+            // 读完请求头再响应，避免立刻回写导致对端 RST。
+            // 注意：先追加再判帧——读到请求头后对端不会再发数据，
+            // 判旧缓冲会永久阻塞在第二次 read（首次集成即踩中）
+            let mut buf = [0u8; 4096];
+            let mut req = Vec::new();
+            loop {
+                let n = stream.read(&mut buf).unwrap_or(0);
+                if n == 0 {
+                    break;
+                }
+                req.extend_from_slice(&buf[..n]);
+                if req.windows(4).any(|w| w == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            let _ = stream.write_all(&head);
+            let _ = stream.write_all(&body[..body.len() / 2]);
+            let _ = stream.flush();
+            std::thread::sleep(Duration::from_millis(50));
+            let _ = stream.write_all(&body[body.len() / 2..]);
+            let _ = stream.flush();
+        });
+        format!("http://{addr}/lambchat-update.test")
+    }
+
+    #[test]
+    fn http_server_fixture_serves_bytes_via_plain_tcp() {
+        let url = spawn_chunked_http_server(
+            "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\n",
+            b"hello",
+        );
+        let addr = url
+            .trim_start_matches("http://")
+            .split('/')
+            .next()
+            .unwrap();
+        let mut stream = std::net::TcpStream::connect(addr).unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(10)))
+            .unwrap();
+        stream
+            .write_all(b"GET /lambchat-update.test HTTP/1.1\r\nHost: x\r\n\r\n")
+            .unwrap();
+        let mut resp = Vec::new();
+        stream.read_to_end(&mut resp).unwrap();
+        let resp = String::from_utf8_lossy(&resp);
+        assert!(resp.starts_with("HTTP/1.1 200"), "{resp}");
+        assert!(resp.ends_with("hello"), "{resp}");
+    }
+
+    #[test]
+    fn async_runtime_block_on_works_in_test_harness() {
+        assert_eq!(tauri::async_runtime::block_on(async { 7 }), 7);
+    }
+
+    #[test]
+    fn download_to_temp_streams_file_and_progress() {
+        let body: Vec<u8> = (0..100_000u32).map(|i| (i % 251) as u8).collect();
+        let head = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: application/vnd.debian.binary-package\r\nConnection: close\r\n\r\n",
+            body.len()
+        );
+        let url = spawn_chunked_http_server(&head, &body);
+        let path = tauri::async_runtime::block_on(download_to_temp(&url, "test-pkg", |d, c| {
+            // 进度单调不回退，总量不超 content-length
+            assert!(c == body.len() as u64, "content_length mismatch");
+            let _ = d;
+        }))
+        .expect("download should succeed");
+        let written = std::fs::read(&path).expect("temp file readable");
+        assert_eq!(written, body, "downloaded bytes must match served body");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn download_to_temp_surfaces_http_error_status() {
+        let head = "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+        let url = spawn_chunked_http_server(head, b"");
+        let err = tauri::async_runtime::block_on(download_to_temp(&url, "test-pkg-404", |_, _| {}))
+            .expect_err("404 must fail");
+        assert!(err.contains("404"), "error should carry status: {err}");
+    }
+
+    /// e2e（scripts/e2e_linux_update.py）专用：打印本机检测结果供人工核对。
+    /// 平时跳过——CI/单测环境的「正确值」随安装方式而变，不可断言。
+    #[test]
+    #[ignore]
+    fn detect_current_machine_source() {
+        let exe = std::env::current_exe().unwrap();
+        let info = get_linux_install_source();
+        println!(
+            "[e2e] exe={} source={} arch={:?}",
+            exe.display(),
+            info.source,
+            info.arch
+        );
+    }
+}

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -46,8 +46,8 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDY3REJCNjQ1NTgzN0NGNTkKUldSWnp6ZFlSYmJiWjRHb1lJRFhVOXl5cW93OWlnK0hhS25pdE5lWC9xaVpiL0svTzV0em5ydVIK",
       "endpoints": [
-        "https://github.com/Yanyutin753/LambChat/releases/latest/download/latest.json",
-        "https://lambchat.com/api/version/assets/latest.json/download"
+        "https://lambchat.com/api/version/assets/latest.json/download",
+        "https://github.com/Yanyutin753/LambChat/releases/latest/download/latest.json"
       ]
     }
   }

--- a/frontend/src/components/download/DownloadPage.tsx
+++ b/frontend/src/components/download/DownloadPage.tsx
@@ -15,7 +15,10 @@ import {
   Check,
   Smartphone,
 } from "lucide-react";
-import { versionApi } from "../../services/api/version";
+import {
+  buildReleaseAssetDownloadUrl,
+  versionApi,
+} from "../../services/api/version";
 import { useSEO } from "../../hooks/usePageTitle";
 import { useScrollReveal } from "../landing/hooks/useScrollReveal";
 import {
@@ -245,7 +248,17 @@ export function DownloadPage() {
       .catch(() => setFailed(true));
   }, []);
 
-  const assets = useMemo(() => info?.release_assets ?? [], [info]);
+  // 下载链接一律走自托管反代：/api/version 返回的 browser_download_url 是
+  // GitHub 直链，国内用户直连下载不稳；反代按资产名在最新 release 中查找
+  // （页面资产本就来自最新 release），移动端更新下载同一契约
+  const assets = useMemo(
+    () =>
+      (info?.release_assets ?? []).map((a) => ({
+        ...a,
+        url: buildReleaseAssetDownloadUrl(a.name),
+      })),
+    [info],
+  );
   const desktop = useMemo(() => matchDesktopAssets(assets), [assets]);
   const daemons = useMemo(() => matchDaemonAssets(assets), [assets]);
   const detected =

--- a/frontend/src/components/download/__tests__/DownloadPage.test.tsx
+++ b/frontend/src/components/download/__tests__/DownloadPage.test.tsx
@@ -17,7 +17,9 @@ const mocks = vi.hoisted(() => ({
   get: vi.fn(),
 }));
 
-vi.mock("../../../services/api/version", () => ({
+vi.mock("../../../services/api/version", async (importOriginal) => ({
+  // buildReleaseAssetDownloadUrl 用真实实现（同源反代 URL 契约本身要被测）
+  ...(await importOriginal<Record<string, unknown>>()),
   versionApi: { get: mocks.get },
 }));
 
@@ -102,11 +104,17 @@ test("renders desktop and daemon downloads from the latest release assets", asyn
   expect(screen.getByText("macOS")).toBeInTheDocument();
   expect(screen.getByText("Linux")).toBeInTheDocument();
 
-  // 下载直链锚点（跟随最新 release，自动更新）
+  // 下载直链锚点：走自托管反代（国内直连 GitHub 下载不稳），跟随最新 release
   const msi = screen.getByText("LambChat-v2.8.1-Windows.msi").closest("a");
-  expect(msi).toHaveAttribute("href", "https://gh/LambChat-v2.8.1-Windows.msi");
+  expect(msi).toHaveAttribute(
+    "href",
+    "/api/version/assets/LambChat-v2.8.1-Windows.msi/download",
+  );
   const dmg = screen.getByText("LambChat-v2.8.1-macOS.dmg").closest("a");
-  expect(dmg).toHaveAttribute("href", "https://gh/LambChat-v2.8.1-macOS.dmg");
+  expect(dmg).toHaveAttribute(
+    "href",
+    "/api/version/assets/LambChat-v2.8.1-macOS.dmg/download",
+  );
 
   // daemon 二进制区
   const daemon = screen
@@ -114,7 +122,7 @@ test("renders desktop and daemon downloads from the latest release assets", asyn
     .closest("a");
   expect(daemon).toHaveAttribute(
     "href",
-    "https://gh/lambchat-daemon-x86_64-pc-windows-msvc.exe",
+    "/api/version/assets/lambchat-daemon-x86_64-pc-windows-msvc.exe/download",
   );
 
   // 教程步骤
@@ -203,7 +211,7 @@ test("hero CTA directly downloads the detected platform's installer", async () =
     const direct = await screen.findByText(/Download for Windows/i);
     expect(direct.closest("a")).toHaveAttribute(
       "href",
-      "https://gh/LambChat-v2.8.1-Windows.msi",
+      "/api/version/assets/LambChat-v2.8.1-Windows.msi/download",
     );
   } finally {
     Object.defineProperty(window.navigator, "userAgent", {
@@ -231,7 +239,7 @@ test("android visitors get a direct apk download in the hero and a mobile sectio
     const direct = await screen.findByText(/Download for Android/i);
     expect(direct.closest("a")).toHaveAttribute(
       "href",
-      "https://gh/LambChat-android-v2.8.1-signed.apk",
+      "/api/version/assets/LambChat-android-v2.8.1-signed.apk/download",
     );
 
     // 手机端分区：APK 行可下载
@@ -240,7 +248,7 @@ test("android visitors get a direct apk download in the hero and a mobile sectio
     );
     expect(apkRow.closest("a")).toHaveAttribute(
       "href",
-      "https://gh/LambChat-android-v2.8.1-signed.apk",
+      "/api/version/assets/LambChat-android-v2.8.1-signed.apk/download",
     );
   } finally {
     Object.defineProperty(window.navigator, "userAgent", {

--- a/frontend/src/components/update/UpdateDialog.tsx
+++ b/frontend/src/components/update/UpdateDialog.tsx
@@ -32,6 +32,14 @@ export function UpdateDialog({
 }: UpdateDialogProps) {
   const { t } = useTranslation();
 
+  // Linux 安装来源分流文案：deb/rpm=下载并安装（pkexec），unknown=前往下载
+  // （无法判定安装方式不盲装），appimage/非 Linux 保持 updater 语义
+  const source = state.linuxInstallSource;
+  const isLinuxPackage =
+    platform === "tauri" && (source === "deb" || source === "rpm");
+  const isUnknownSource = platform === "tauri" && source === "unknown";
+  const isGoToDownload = platform === "ios" || isUnknownSource;
+
   const footer = (
     <>
       {!state.downloading && (
@@ -53,18 +61,22 @@ export function UpdateDialog({
           <span className="inline-flex h-4 w-4 items-center justify-center">
             <LoadingSpinner size="sm" color="text-current" />
           </span>
-        ) : platform === "ios" ? (
+        ) : isGoToDownload ? (
           <ExternalLink size={16} />
+        ) : isLinuxPackage ? (
+          <Download size={16} />
         ) : (
           <RefreshCw size={16} />
         )}
         {state.downloading
           ? t("updateDownloading", "正在下载...")
-          : platform === "ios"
+          : isGoToDownload
             ? t("updateGoToDownload", "前往下载")
-            : state.readyToInstall
-              ? t("updateRelaunchInstall", "重启并安装")
-              : t("updateDownload", "立即升级")}
+            : isLinuxPackage
+              ? t("updateDownloadAndInstall", "下载并安装")
+              : state.readyToInstall
+                ? t("updateRelaunchInstall", "重启并安装")
+                : t("updateDownload", "立即升级")}
       </button>
     </>
   );

--- a/frontend/src/components/update/__tests__/UpdateDialog.test.tsx
+++ b/frontend/src/components/update/__tests__/UpdateDialog.test.tsx
@@ -25,6 +25,7 @@ function makeState(overrides: Partial<UpdateState> = {}): UpdateState {
     downloaded: 0,
     readyToInstall: false,
     error: null,
+    linuxInstallSource: null,
     ...overrides,
   };
 }
@@ -76,6 +77,46 @@ test("downloading state hides skip actions and shows progress", () => {
 test("ready-to-install state shows relaunch button", () => {
   render(
     <UpdateDialog {...baseProps} state={makeState({ readyToInstall: true })} />,
+  );
+  expect(screen.getByRole("button", { name: /重启并安装/ })).toBeTruthy();
+});
+
+test("linux package source (deb/rpm) shows download-and-install button", () => {
+  for (const source of ["deb", "rpm"] as const) {
+    cleanup();
+    render(
+      <UpdateDialog
+        {...baseProps}
+        state={makeState({ linuxInstallSource: source })}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /下载并安装/ })).toBeTruthy();
+    // 非 updater 语义：不该出现「重启并安装」或「立即升级」
+    expect(screen.queryByRole("button", { name: /重启并安装/ })).toBeNull();
+    expect(screen.queryByRole("button", { name: /立即升级/ })).toBeNull();
+  }
+});
+
+test("unknown linux source falls back to go-to-download button", () => {
+  render(
+    <UpdateDialog
+      {...baseProps}
+      state={makeState({ linuxInstallSource: "unknown" })}
+    />,
+  );
+  expect(screen.getByRole("button", { name: /前往下载/ })).toBeTruthy();
+  expect(screen.queryByRole("button", { name: /下载并安装/ })).toBeNull();
+});
+
+test("appimage source keeps the updater button semantics", () => {
+  render(
+    <UpdateDialog
+      {...baseProps}
+      state={makeState({
+        linuxInstallSource: "appimage",
+        readyToInstall: true,
+      })}
+    />,
   );
   expect(screen.getByRole("button", { name: /重启并安装/ })).toBeTruthy();
 });

--- a/frontend/src/hooks/__tests__/useAutoUpdate.test.ts
+++ b/frontend/src/hooks/__tests__/useAutoUpdate.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from "vitest";
 import {
   FOCUS_CHECK_MIN_INTERVAL_MS,
   PERIODIC_CHECK_INTERVAL_MS,
+  isLinuxDesktopEnvironment,
   shouldCheckNow,
 } from "../useAutoUpdate";
 
@@ -28,5 +29,39 @@ describe("shouldCheckNow", () => {
     expect(PERIODIC_CHECK_INTERVAL_MS).toBeGreaterThan(
       FOCUS_CHECK_MIN_INTERVAL_MS,
     );
+  });
+});
+
+describe("isLinuxDesktopEnvironment", () => {
+  test("Linux UA 或 platform 命中即 Linux 桌面", () => {
+    expect(
+      isLinuxDesktopEnvironment({
+        userAgent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36",
+        platform: "Linux x86_64",
+      }),
+    ).toBe(true);
+    expect(isLinuxDesktopEnvironment({ platform: "Linux aarch64" })).toBe(true);
+  });
+  test("mac/Windows/移动端不算 Linux 桌面", () => {
+    expect(
+      isLinuxDesktopEnvironment({
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15",
+        platform: "MacIntel",
+      }),
+    ).toBe(false);
+    expect(
+      isLinuxDesktopEnvironment({
+        userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+        platform: "Win32",
+      }),
+    ).toBe(false);
+    // Android WebView UA 含 "Linux; Android"——不是桌面 Linux
+    expect(
+      isLinuxDesktopEnvironment({
+        userAgent: "Mozilla/5.0 (Linux; Android 14; Pixel 8)",
+        platform: "",
+      }),
+    ).toBe(false);
   });
 });

--- a/frontend/src/hooks/__tests__/useAutoUpdateSource.test.ts
+++ b/frontend/src/hooks/__tests__/useAutoUpdateSource.test.ts
@@ -149,3 +149,57 @@ test("tauri updater keeps proxy fallback endpoint for manifest fetch", () => {
     /lambchat\.com\/api\/version\/assets\/latest\.json\/download/,
   );
 });
+
+test("linux package update flow routes deb/rpm through the package manager path", () => {
+  const hook = readRepoFile("frontend/src/hooks/useAutoUpdate.ts");
+  // 来源检测 → 分流：deb/rpm 走「下载 + pkexec 安装」而非 updater
+  expect(hook).toMatch(/getLinuxInstallInfo/);
+  expect(hook).toMatch(/installLinuxPackage\(/);
+  expect(hook).toMatch(/buildLinuxPackageAssetName/);
+  expect(hook).toMatch(/buildLinuxPackageDownloadUrl/);
+  // deb/rpm 不进 updater 后台静默下载——它只会拉 AppImage 且装不上系统包
+  expect(hook).toMatch(/linuxSource !== "deb" && linuxSource !== "rpm"/);
+  // unknown 来源不盲装，回落下载页
+  expect(hook).toMatch(/buildApiUrl\("\/download"\)/);
+});
+
+test("linux update service bridges the rust commands and progress event", () => {
+  const service = readRepoFile("frontend/src/services/tauri/linuxUpdate.ts");
+  expect(service).toMatch(/get_linux_install_source/);
+  expect(service).toMatch(/install_linux_package/);
+  expect(service).toMatch(/linux-update-progress/);
+});
+
+test("rust side detects install source and installs deb/rpm via pkexec", () => {
+  const rust = readRepoFile("frontend/src-tauri/src/linux_update.rs");
+  // 检测序：AppImage 扩展名 → dpkg/rpm 包归属反查 → 系统前缀启发式
+  expect(rust).toMatch(/is_appimage_path/);
+  expect(rust).toMatch(/"dpkg", "-S"/);
+  expect(rust).toMatch(/"rpm", "-qf"/);
+  expect(rust).toMatch(/fallback_install_source/);
+  // deb → apt、rpm → dnf，pkexec 提权
+  expect(rust).toMatch(/"apt"/);
+  expect(rust).toMatch(/"dnf"/);
+  expect(rust).toMatch(/"pkexec"/);
+  // 命令注册进 invoke handler（缺注册前端 invoke 直接挂）
+  const lib = readRepoFile("frontend/src-tauri/src/lib.rs");
+  expect(lib).toMatch(/linux_update::get_linux_install_source/);
+  expect(lib).toMatch(/linux_update::install_linux_package/);
+});
+
+test("download-and-install copy exists in all five locales", () => {
+  for (const locale of ["zh", "en", "ja", "ko", "ru"]) {
+    const data = JSON.parse(
+      readRepoFile(`frontend/src/i18n/locales/${locale}.json`),
+    ) as Record<string, string>;
+    expect(data.updateDownloadAndInstall, locale).toBeTruthy();
+  }
+});
+
+test("release workflow asset naming keeps the deb/rpm contract", () => {
+  // CI 收集产物名 LambChat-${RELEASE_TAG}-Linux-${arch}.deb|.rpm 必须与
+  // buildLinuxPackageAssetName 拼出的名字一致（数值用例见 linuxUpdateAssets.test.ts）
+  const wf = readRepoFile(".github/workflows/app-release.yml");
+  expect(wf).toMatch(/LambChat-\$\{RELEASE_TAG\}-Linux-\$\{arch\}\.deb/);
+  expect(wf).toMatch(/LambChat-\$\{RELEASE_TAG\}-Linux-\$\{arch\}\.rpm/);
+});

--- a/frontend/src/hooks/useAutoUpdate.ts
+++ b/frontend/src/hooks/useAutoUpdate.ts
@@ -58,6 +58,15 @@ const INITIAL_STATE: UpdateState = {
   error: null,
 };
 
+export function formatUpdateError(error: unknown, platform: string): string {
+  const raw = error instanceof Error ? error.message : String(error ?? "");
+  const detail = raw.trim() || "更新失败";
+  if (platform === "tauri" && /permission|access denied|拒绝访问|权限|replace|rename/i.test(detail)) {
+    return `${detail}。Linux 请确认 AppImage 所在目录可写，并从用户目录运行；如果安装的是 .deb/.rpm，请手动安装新版安装包。`;
+  }
+  return detail;
+}
+
 /** Debounce delay (ms) before checking for updates on startup */
 const CHECK_DELAY_MS = 5000;
 
@@ -308,10 +317,7 @@ export function useAutoUpdate(): UseAutoUpdateReturn {
         } catch (err) {
           setState((prev) => ({
             ...prev,
-            error:
-              err instanceof Error
-                ? err.message
-                : i18n.t("updateError", "更新失败"),
+            error: formatUpdateError(err, platform),
           }));
         }
         return;
@@ -371,10 +377,7 @@ export function useAutoUpdate(): UseAutoUpdateReturn {
       setState((prev) => ({
         ...prev,
         downloading: false,
-        error:
-          err instanceof Error
-            ? err.message
-            : i18n.t("updateError", "更新失败"),
+        error: formatUpdateError(err, platform),
       }));
     }
   }, []);

--- a/frontend/src/hooks/useAutoUpdate.ts
+++ b/frontend/src/hooks/useAutoUpdate.ts
@@ -1,6 +1,17 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import i18n from "i18next";
 import { versionApi, buildReleaseAssetDownloadUrl } from "../services/api";
+import { buildApiUrl } from "../services/api/config";
+import {
+  getLinuxInstallInfo,
+  installLinuxPackage,
+  subscribeLinuxUpdateProgress,
+  type LinuxInstallSource,
+} from "../services/tauri/linuxUpdate";
+import {
+  buildLinuxPackageAssetName,
+  buildLinuxPackageDownloadUrl,
+} from "../utils/linuxUpdateAssets";
 import { APP_VERSION } from "../utils/appVersion";
 import { bytesToBase64 } from "../utils/bytesToBase64";
 import type { UpdateState, ReleaseAsset } from "../types";
@@ -56,7 +67,21 @@ const INITIAL_STATE: UpdateState = {
   downloaded: 0,
   readyToInstall: false,
   error: null,
+  linuxInstallSource: null,
 };
+
+/** 当前 runtime 是否是 Linux 桌面（deb/rpm/AppImage 分流只在这类设备生效） */
+export function isLinuxDesktopEnvironment(
+  nav: { userAgent?: string; platform?: string } = typeof navigator !== "undefined"
+    ? navigator
+    : {},
+): boolean {
+  const ua = nav.userAgent ?? "";
+  const platform = nav.platform ?? "";
+  // Android WebView UA 含 "Linux; Android"——排除移动端
+  const uaIsLinux = /linux/i.test(ua) && !/android/i.test(ua);
+  return uaIsLinux || /linux/i.test(platform);
+}
 
 export function formatUpdateError(error: unknown, platform: string): string {
   const raw = error instanceof Error ? error.message : String(error ?? "");
@@ -163,8 +188,68 @@ export function useAutoUpdate(): UseAutoUpdateReturn {
   const pendingUpdateRef = useRef<{
     install: () => Promise<void>;
   } | null>(null);
+  /** Linux 安装来源（Rust 检测；null=非 Linux 桌面或检测未完成） */
+  const linuxSourceRef = useRef<LinuxInstallSource | null>(null);
+  /** 资产命名的 arch 段（Rust 上报；拼 deb/rpm 资产名用） */
+  const linuxArchRef = useRef<string | null>(null);
+  /** 检测 promise 缓存：更新检查与安装分流共用一次检测结果 */
+  const linuxDetectPromiseRef = useRef<Promise<LinuxInstallSource | null> | null>(
+    null,
+  );
 
   const platform = platformRef.current;
+
+  /**
+   * 确保 Linux 安装来源已检测（一次）：更新检查时决定是否后台静默下载、
+   * 安装时决定走 updater 还是 deb/rpm 包管理器路径。非 Linux 桌面返回 null。
+   */
+  const ensureLinuxSource = useCallback(
+    async (): Promise<LinuxInstallSource | null> => {
+      if (platform !== "tauri" || !isLinuxDesktopEnvironment()) return null;
+      if (!linuxDetectPromiseRef.current) {
+        linuxDetectPromiseRef.current = (async () => {
+          const info = await getLinuxInstallInfo();
+          const source: LinuxInstallSource = info?.source ?? "unknown";
+          linuxSourceRef.current = source;
+          linuxArchRef.current = info?.arch ?? null;
+          setState((prev) => ({ ...prev, linuxInstallSource: source }));
+          return source;
+        })();
+      }
+      return linuxDetectPromiseRef.current;
+    },
+    [platform],
+  );
+
+  // Linux 桌面：启动即检测安装来源 + 订阅 deb/rpm 下载进度事件
+  useEffect(() => {
+    if (platform !== "tauri" || !isLinuxDesktopEnvironment()) return;
+    void ensureLinuxSource();
+    let unsub: (() => void) | null = null;
+    let disposed = false;
+    void subscribeLinuxUpdateProgress((p) => {
+      setState((prev) => ({
+        ...prev,
+        downloaded: p.downloaded,
+        contentLength: p.contentLength,
+        progress:
+          p.contentLength > 0
+            ? (p.downloaded / p.contentLength) * 100
+            : prev.progress,
+      }));
+    }).then((fn) => {
+      if (disposed) {
+        fn?.();
+      } else {
+        unsub = fn;
+      }
+    });
+    return () => {
+      disposed = true;
+      unsub?.();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [platform]);
 
   /** Check for updates. background=true 时不打断用户：弹窗 + 系统通知（每版本一次）；
    * manual=true（设置页手动检查）无视「跳过此版本」列表 */
@@ -247,6 +332,7 @@ export function useAutoUpdate(): UseAutoUpdateReturn {
             readSkippedUpdateVersions(window.localStorage),
             { manual },
           );
+          const linuxSource = await ensureLinuxSource();
           setState({
             ...INITIAL_STATE,
             available: true,
@@ -254,11 +340,16 @@ export function useAutoUpdate(): UseAutoUpdateReturn {
             releaseNotes: update.body ?? null,
             releaseUrl: null,
             releaseAssets: [],
+            linuxInstallSource: linuxSourceRef.current,
           });
           if (prompt) {
             setShowDialog(true);
-            // 自动下载：发现更新即后台静默下载（不阻塞用户），完成后一键重启安装
-            void startBackgroundDownload(update);
+            // 自动下载：发现更新即后台静默下载（不阻塞用户），完成后一键重启安装。
+            // deb/rpm 除外——updater 只会拉 AppImage 且装不上系统包，改为点击时
+            // 走「下载 deb/rpm + pkexec 安装」
+            if (linuxSource !== "deb" && linuxSource !== "rpm") {
+              void startBackgroundDownload(update);
+            }
             if (background && notifiedVersionRef.current !== update.version) {
               notifiedVersionRef.current = update.version;
               void notifyUpdateAvailable(update.version);
@@ -269,7 +360,7 @@ export function useAutoUpdate(): UseAutoUpdateReturn {
         // Silently fail — updater may not be available in dev
       }
     },
-    [startBackgroundDownload],
+    [startBackgroundDownload, ensureLinuxSource],
   );
 
   /** Check via backend /api/version endpoint（上报客户端版本，has_update 按它判断） */
@@ -307,6 +398,17 @@ export function useAutoUpdate(): UseAutoUpdateReturn {
   /** Start the update process */
   const startUpdate = useCallback(async () => {
     if (platform === "tauri") {
+      // Linux 安装来源分流：deb/rpm 走包管理器安装；unknown 回落下载页；
+      // appimage / 非 Linux 走 updater 替换重启（含后台已下载的 pending）
+      const linuxSource = await ensureLinuxSource();
+      if (linuxSource === "deb" || linuxSource === "rpm") {
+        await installLinuxPackageUpdate(linuxSource);
+        return;
+      }
+      if (linuxSource === "unknown") {
+        openDownloadPage();
+        return;
+      }
       const pending = pendingUpdateRef.current;
       if (pending) {
         // 后台已下载完成：直接安装 + 重启
@@ -330,6 +432,49 @@ export function useAutoUpdate(): UseAutoUpdateReturn {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [platform, state]);
+
+  /**
+   * Linux deb/rpm 安装：同源反代下载对应安装包 → Rust 侧 pkexec
+   * `apt|dnf install` 提权安装（进度经 linux-update-progress 事件）→ 成功后
+   * relaunch 进新版。系统包归 root 所有，不能也不该由 updater 直接覆盖。
+   */
+  const installLinuxPackageUpdate = useCallback(
+    async (source: "deb" | "rpm") => {
+      setState((prev) => ({
+        ...prev,
+        downloading: true,
+        error: null,
+        progress: 0,
+        downloaded: 0,
+      }));
+      try {
+        const version = stateRef.current.version;
+        const arch = linuxArchRef.current;
+        if (!version) throw new Error("No update version known");
+        if (!arch) {
+          throw new Error("Unsupported Linux architecture for package update");
+        }
+        const assetName = buildLinuxPackageAssetName(version, arch, source);
+        const url = buildLinuxPackageDownloadUrl(assetName, version);
+        await installLinuxPackage(url, source);
+        setState((prev) => ({ ...prev, downloading: false, progress: 100 }));
+        const { relaunch } = await import("@tauri-apps/plugin-process");
+        await relaunch();
+      } catch (err) {
+        setState((prev) => ({
+          ...prev,
+          downloading: false,
+          error: formatUpdateError(err, platform),
+        }));
+      }
+    },
+    [platform],
+  );
+
+  /** 打开下载页（Linux unknown 来源兜底：无法判定安装方式时不盲装） */
+  const openDownloadPage = useCallback(() => {
+    window.open(buildApiUrl("/download"), "_blank", "noopener");
+  }, []);
 
   /** Install via Tauri updater (download + install + relaunch) */
   const installTauriUpdate = useCallback(async () => {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -3442,6 +3442,7 @@
     "toolsEnabled": "tools enabled"
   },
   "updateDownload": "Update Now",
+  "updateDownloadAndInstall": "Download and Install",
   "updateDownloading": "Downloading...",
   "updateDownloadNetworkError": "Download failed, please check your network and retry",
   "updateError": "Update failed",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -3442,6 +3442,7 @@
     "toolsEnabled": "件のツールが有効"
   },
   "updateDownload": "今すぐ更新",
+  "updateDownloadAndInstall": "ダウンロードしてインストール",
   "updateDownloading": "ダウンロード中...",
   "updateDownloadNetworkError": "ダウンロードに失敗しました。ネットワークを確認して再試行してください",
   "updateError": "更新に失敗しました",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -3442,6 +3442,7 @@
     "toolsEnabled": "개 도구 활성화됨"
   },
   "updateDownload": "지금 업데이트",
+  "updateDownloadAndInstall": "다운로드 후 설치",
   "updateDownloading": "다운로드 중...",
   "updateDownloadNetworkError": "다운로드 실패, 네트워크를 확인한 후 다시 시도하세요",
   "updateError": "업데이트 실패",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -3442,6 +3442,7 @@
     "toolsEnabled": "инструментов включено"
   },
   "updateDownload": "Обновить",
+  "updateDownloadAndInstall": "Скачать и установить",
   "updateDownloading": "Загрузка...",
   "updateDownloadNetworkError": "Не удалось скачать. Проверьте сеть и повторите попытку",
   "updateError": "Ошибка обновления",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -3442,6 +3442,7 @@
     "toolsEnabled": "个工具已启用"
   },
   "updateDownload": "立即更新",
+  "updateDownloadAndInstall": "下载并安装",
   "updateDownloading": "正在下载...",
   "updateDownloadNetworkError": "下载失败，请检查网络后重试",
   "updateError": "更新失败",

--- a/frontend/src/services/tauri/linuxUpdate.ts
+++ b/frontend/src/services/tauri/linuxUpdate.ts
@@ -1,0 +1,69 @@
+/**
+ * Linux 桌面端更新安装 —— Tauri 壳 invoke 封装。
+ *
+ * 对应 Rust 侧 linux_update.rs：安装来源检测（AppImage / deb / rpm /
+ * unknown）与「下载 deb/rpm + pkexec 提权安装」。仅桌面壳内可用，
+ * 非壳环境由调用方降级（null / 抛错）。
+ */
+
+import type { LinuxInstallSource } from "../../types";
+import { invokeInShell, isShellAvailable } from "./sandboxShell";
+
+export type { LinuxInstallSource };
+
+/** get_linux_install_source 返回：来源 + 资产命名 arch 段。 */
+export interface LinuxInstallInfo {
+  source: LinuxInstallSource;
+  arch: string | null;
+}
+
+/** 检测当前安装来源（非壳环境 null；invoke 失败也 null 走 unknown 兜底）。 */
+export async function getLinuxInstallInfo(): Promise<LinuxInstallInfo | null> {
+  if (!isShellAvailable()) return null;
+  try {
+    return await invokeInShell<LinuxInstallInfo>("get_linux_install_source");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 下载 deb/rpm 安装包并以 pkexec 提权安装（成功后调用方 relaunch）。
+ * 进度经 linux-update-progress 事件推送（subscribeLinuxUpdateProgress）。
+ */
+export function installLinuxPackage(
+  url: string,
+  kind: "deb" | "rpm",
+): Promise<void> {
+  return invokeInShell("install_linux_package", { url, kind }).then(
+    () => undefined,
+  );
+}
+
+export interface LinuxUpdateProgressEvent {
+  downloaded: number;
+  contentLength: number;
+}
+
+/**
+ * 订阅 deb/rpm 下载进度事件（Tauri event `linux-update-progress`）。
+ * 非壳环境返回 null（调用方不订阅）；返回的取消函数幂等。
+ */
+export async function subscribeLinuxUpdateProgress(
+  listener: (event: LinuxUpdateProgressEvent) => void,
+): Promise<(() => void) | null> {
+  if (!isShellAvailable()) {
+    return null;
+  }
+  const { listen } = await import("@tauri-apps/api/event");
+  const unlisten = await listen<LinuxUpdateProgressEvent>(
+    "linux-update-progress",
+    (event) => listener(event.payload),
+  );
+  let cancelled = false;
+  return () => {
+    if (cancelled) return;
+    cancelled = true;
+    void unlisten();
+  };
+}

--- a/frontend/src/services/tauri/sandboxShell.ts
+++ b/frontend/src/services/tauri/sandboxShell.ts
@@ -43,7 +43,8 @@ export function isShellAvailable(): boolean {
   return protocol === "tauri:" || hostname === "tauri.localhost";
 }
 
-async function invokeInShell<T>(
+/** 壳内 invoke（linuxUpdate 等其他 Tauri 桥共用；非壳环境抛错由调用方降级）。 */
+export async function invokeInShell<T>(
   command: string,
   args?: Record<string, unknown>,
 ): Promise<T> {

--- a/frontend/src/types/common.ts
+++ b/frontend/src/types/common.ts
@@ -24,6 +24,13 @@ export interface ReleaseAsset {
   content_type: string;
 }
 
+/**
+ * Linux 桌面端安装来源（Rust get_linux_install_source 检测）：
+ * appimage 走 updater 替换重启；deb/rpm 走「下载 + pkexec 安装」；
+ * unknown 回落下载页。非桌面端 / 未检测为 null。
+ */
+export type LinuxInstallSource = "deb" | "rpm" | "appimage" | "unknown";
+
 export interface UpdateState {
   available: boolean;
   version: string | null;
@@ -38,4 +45,6 @@ export interface UpdateState {
   /** 后台静默下载已完成，待用户确认重启安装 */
   readyToInstall: boolean;
   error: string | null;
+  /** Linux 桌面端安装来源（更新流程分流依据；null=非桌面/未检测） */
+  linuxInstallSource: LinuxInstallSource | null;
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -231,7 +231,12 @@ export type {
 // ============================================
 // Version Types
 // ============================================
-export type { VersionInfo, ReleaseAsset, UpdateState } from "./common";
+export type {
+  VersionInfo,
+  ReleaseAsset,
+  UpdateState,
+  LinuxInstallSource,
+} from "./common";
 
 // ============================================
 // Team Types

--- a/frontend/src/utils/__tests__/linuxUpdateAssets.test.ts
+++ b/frontend/src/utils/__tests__/linuxUpdateAssets.test.ts
@@ -1,0 +1,47 @@
+/** Linux deb/rpm 更新链路的纯函数：资产名拼装与反代下载 URL（契约锁定 app-release.yml 命名）。 */
+
+import {
+  buildLinuxPackageAssetName,
+  buildLinuxPackageDownloadUrl,
+  normalizeVersionTag,
+} from "../linuxUpdateAssets";
+
+test("asset name follows the release workflow naming (LambChat-v<tag>-Linux-<arch>.<ext>)", () => {
+  expect(buildLinuxPackageAssetName("2.10.2", "x86_64", "deb")).toBe(
+    "LambChat-v2.10.2-Linux-x86_64.deb",
+  );
+  expect(buildLinuxPackageAssetName("2.10.2", "arm64", "rpm")).toBe(
+    "LambChat-v2.10.2-Linux-arm64.rpm",
+  );
+  // 已带 v 前缀的版本不重复加
+  expect(buildLinuxPackageAssetName("v2.10.2", "x86_64", "deb")).toBe(
+    "LambChat-v2.10.2-Linux-x86_64.deb",
+  );
+});
+
+test("download url proxies through the backend and locks the release tag", () => {
+  expect(
+    buildLinuxPackageDownloadUrl(
+      "LambChat-v2.10.2-Linux-x86_64.deb",
+      "2.10.2",
+      "http://127.0.0.1:8000",
+    ),
+  ).toBe(
+    "http://127.0.0.1:8000/api/version/assets/LambChat-v2.10.2-Linux-x86_64.deb/download?tag=v2.10.2",
+  );
+  // 版本带 v 前缀时 tag 不重复加
+  expect(
+    buildLinuxPackageDownloadUrl(
+      "LambChat-v2.10.2-Linux-arm64.rpm",
+      "v2.10.2",
+      "https://lambchat.com",
+    ),
+  ).toBe(
+    "https://lambchat.com/api/version/assets/LambChat-v2.10.2-Linux-arm64.rpm/download?tag=v2.10.2",
+  );
+});
+
+test("normalizeVersionTag is idempotent", () => {
+  expect(normalizeVersionTag("2.10.2")).toBe("v2.10.2");
+  expect(normalizeVersionTag("v2.10.2")).toBe("v2.10.2");
+});

--- a/frontend/src/utils/linuxUpdateAssets.ts
+++ b/frontend/src/utils/linuxUpdateAssets.ts
@@ -1,0 +1,41 @@
+/**
+ * Linux deb/rpm 更新链路的纯函数。
+ *
+ * 资产名与 .github/workflows/app-release.yml 的收集命名一一对应
+ * （`LambChat-${RELEASE_TAG}-Linux-${arch}.deb|.rpm`，arch 取值 x86_64 | arm64），
+ * 改任一侧都要同步另一侧（scripts/e2e_linux_update.py 固化该契约）。
+ */
+
+import { buildReleaseAssetDownloadUrl } from "../services/api/version";
+
+/** 规范化 release tag：updater 上报的版本无 v 前缀，tag 一律有。 */
+export function normalizeVersionTag(version: string): string {
+  return version.startsWith("v") ? version : `v${version}`;
+}
+
+/** 拼装 deb/rpm 安装包资产名（arch 来自 Rust 侧 get_linux_install_source 上报）。 */
+export function buildLinuxPackageAssetName(
+  version: string,
+  arch: string,
+  kind: "deb" | "rpm",
+): string {
+  return `LambChat-${normalizeVersionTag(version)}-Linux-${arch}.${kind}`;
+}
+
+/**
+ * deb/rpm 安装包的同源反代下载 URL。
+ *
+ * `?tag=` 锁定版本所属 release：发新版瞬间 latest 前移时，老资产名仍能在
+ * 其所属 release 中找到（与自更新清单同款防竞态语义）。
+ */
+export function buildLinuxPackageDownloadUrl(
+  assetName: string,
+  version: string,
+  apiBase?: string,
+): string {
+  const base =
+    apiBase === undefined
+      ? buildReleaseAssetDownloadUrl(assetName)
+      : buildReleaseAssetDownloadUrl(assetName, apiBase);
+  return `${base}?tag=${encodeURIComponent(normalizeVersionTag(version))}`;
+}

--- a/scripts/generate_updater_manifest.py
+++ b/scripts/generate_updater_manifest.py
@@ -8,6 +8,9 @@ updater.endpoints）；版本取自 tag（app-release 的 preflight 已校验与
 版本文件一致）；macOS updater 走 .app.tar.gz，dmg 仅用于首装。
 缺某平台 sig 时告警并省略该条目（发布完成的判据是五桌面齐全——由调用方
 校验，本脚本只如实反映现状）。
+
+下载 URL 走 lambchat.com 自托管反代并锁 ``?tag=``：国内直连 GitHub 下载
+必挂；反代路由按 tag 查资产，发新版瞬间 latest 前移也不会 404。
 """
 
 from __future__ import annotations
@@ -18,6 +21,8 @@ import json
 import os
 import pathlib
 import sys
+
+PROXY_ASSET_BASE = "https://lambchat.com/api/version/assets"
 
 MAPPING = [
     ("windows-x86_64", "*_x64_en-US.msi.sig", "Windows.msi"),
@@ -38,7 +43,6 @@ def main() -> int:
         print(f"RELEASE_TAG 必须形如 v2.9.3，收到: {tag!r}", file=sys.stderr)
         return 1
 
-    base = f"https://github.com/Yanyutin753/LambChat/releases/download/{tag}"
     version = tag.lstrip("v")
 
     def sig(pattern: str) -> str | None:
@@ -49,9 +53,10 @@ def main() -> int:
     for key, pattern, asset_suffix in MAPPING:
         signature = sig(pattern)
         if signature:
+            asset_name = f"LambChat-{tag}-{asset_suffix}"
             platforms[key] = {
                 "signature": signature,
-                "url": f"{base}/LambChat-{tag}-{asset_suffix}",
+                "url": f"{PROXY_ASSET_BASE}/{asset_name}/download?tag={tag}",
             }
         else:
             print(f"WARN: no sig file matches {pattern}, platform {key} omitted")

--- a/src/api/routes/version.py
+++ b/src/api/routes/version.py
@@ -64,15 +64,25 @@ def _find_asset(latest_release: Any, asset_name: str) -> Optional[dict]:
 
 
 @router.get("/version/assets/{asset_name}/download")
-async def download_release_asset(asset_name: str) -> StreamingResponse:
+async def download_release_asset(
+    asset_name: str,
+    tag: Optional[str] = Query(None, description="锁定 release tag；缺省取最新"),
+) -> StreamingResponse:
     """按资产名流式代理 GitHub release 资产下载。
 
     移动端 WebView 直连 github.com 会被 CORS 拦截（release 下载端点不带
     Access-Control-Allow-Origin）；经自托管后端同源转发即可正常下载，
-    且 content-length 转发后前端进度条照常工作。
+    且 content-length 转发后前端进度条照常工作。国内用户直连 GitHub
+    不稳，桌面端自更新清单（latest.json）与下载页也走这里。
+
+    ``?tag=`` 把资产锁定到具体 release：发新版瞬间 latest 已前移时，
+    老清单里的资产名仍能在其所属 release 中找到，不因竞态 404。
     """
-    latest_release = await github_client.get_latest_release()
-    asset = _find_asset(latest_release, asset_name)
+    if tag:
+        release = await github_client.get_release_by_tag(tag)
+    else:
+        release = await github_client.get_latest_release()
+    asset = _find_asset(release, asset_name)
     if asset is None:
         raise AppError(ErrorCode.RELEASE_ASSET_NOT_FOUND, args={"name": asset_name})
 

--- a/src/infra/github_client.py
+++ b/src/infra/github_client.py
@@ -8,7 +8,9 @@ import httpx
 
 GITHUB_REPO = "Yanyutin753/LambChat"
 GITHUB_API_URL = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
+GITHUB_TAG_RELEASE_URL = f"https://api.github.com/repos/{GITHUB_REPO}/releases/tags/{{tag}}"
 CACHE_TTL_SECONDS = 3600  # 1 hour
+TAG_CACHE_MAX_ENTRIES = 8
 
 
 @dataclass
@@ -54,6 +56,7 @@ class GitHubClient:
     def __init__(self):
         self._cache: Optional[GitHubRelease] = None
         self._cache_time: Optional[datetime] = None
+        self._tag_cache: dict[str, tuple[GitHubRelease, datetime]] = {}
 
     async def get_latest_release(self, force_refresh: bool = False) -> Optional[GitHubRelease]:
         """Get latest release from GitHub, using cache if available"""
@@ -73,6 +76,27 @@ class GitHubClient:
         elapsed = datetime.now(UTC) - self._cache_time
         return elapsed < timedelta(seconds=CACHE_TTL_SECONDS)
 
+    async def get_release_by_tag(self, tag: str) -> Optional[GitHubRelease]:
+        """按 tag 查 release（下载代理把清单锁到具体版本时用）。
+
+        更新器下载端点会扇出到这里：不缓存的话 GitHub 匿名 API 限流
+        （60 次/小时/源 IP）会被瞬时打穿，故与 latest 同 TTL 做 per-tag
+        缓存，容量截断防任意 tag 撑爆内存。
+        """
+        key = tag.strip()
+        if not key:
+            return None
+        cached = self._tag_cache.get(key)
+        if cached and datetime.now(UTC) - cached[1] < timedelta(seconds=CACHE_TTL_SECONDS):
+            return cached[0]
+        release = await self._fetch_release(GITHUB_TAG_RELEASE_URL.format(tag=key))
+        if release:
+            if len(self._tag_cache) >= TAG_CACHE_MAX_ENTRIES:
+                oldest = min(self._tag_cache, key=lambda k: self._tag_cache[k][1])
+                del self._tag_cache[oldest]
+            self._tag_cache[key] = (release, datetime.now(UTC))
+        return release
+
     async def open_asset_stream(self, url: str) -> "AssetStream":
         """打开 release 资产的上游下载流（github.com 302 → 签名 blob，需跟随重定向）。
 
@@ -90,12 +114,12 @@ class GitHubClient:
             raise
         return AssetStream(client=client, response=response)
 
-    async def _fetch_release(self) -> Optional[GitHubRelease]:
-        """Fetch latest release from GitHub API"""
+    async def _fetch_release(self, url: str = GITHUB_API_URL) -> Optional[GitHubRelease]:
+        """Fetch release JSON from GitHub API (latest or by-tag endpoint)"""
         try:
             async with httpx.AsyncClient(timeout=10.0) as client:
                 response = await client.get(
-                    GITHUB_API_URL, headers={"Accept": "application/vnd.github+json"}
+                    url, headers={"Accept": "application/vnd.github+json"}
                 )
                 if response.status_code == 200:
                     data = response.json()

--- a/src/infra/github_client.py
+++ b/src/infra/github_client.py
@@ -118,9 +118,7 @@ class GitHubClient:
         """Fetch release JSON from GitHub API (latest or by-tag endpoint)"""
         try:
             async with httpx.AsyncClient(timeout=10.0) as client:
-                response = await client.get(
-                    url, headers={"Accept": "application/vnd.github+json"}
-                )
+                response = await client.get(url, headers={"Accept": "application/vnd.github+json"})
                 if response.status_code == 200:
                     data = response.json()
                     return self._parse_release(data)

--- a/tests/client/test_packaging.py
+++ b/tests/client/test_packaging.py
@@ -303,6 +303,30 @@ def test_release_workflow_guards_version_drift_and_manifest_version_from_tag() -
     )
 
 
+def test_updater_manifest_download_urls_go_through_self_hosted_proxy() -> None:
+    """国内用户直连 GitHub 下载安装包必挂：latest.json 的平台下载 URL 必须
+    走 lambchat.com 自托管反代（/api/version/assets/<name>/download）并锁
+    ``?tag=``（发新版瞬间 latest 前移不 404）。生成器与 workflow 增量合并
+    两条写入路径同一契约；检查端点反代在前、GitHub 直连兜底。"""
+    generator = _source("scripts/generate_updater_manifest.py")
+    assert "https://lambchat.com/api/version/assets" in generator
+    assert "?tag=" in generator
+    assert "https://github.com" not in generator
+
+    merge_step = next(
+        s
+        for s in _desktop_job()["steps"]
+        if s["name"] == "Merge updater platform entry into latest.json"
+    )
+    assert "https://lambchat.com/api/version/assets" in merge_step["run"]
+    assert "?tag=" in merge_step["run"]
+    assert "releases/download" not in merge_step["run"]
+
+    tauri = _source("frontend/src-tauri/tauri.conf.json")
+    endpoints = tauri.split('"endpoints"', 1)[1]
+    assert endpoints.index("lambchat.com") < endpoints.index("github.com")
+
+
 def test_release_workflow_macos_collect_requires_app_tar_gz() -> None:
     """macOS 收集步骤必须上传 .app.tar.gz updater 产物且缺失即失败：
     静默跳过会让 darwin 平台条目被略过、mac 永远收不到更新。双 mac 构建

--- a/tests/infra/test_github_client.py
+++ b/tests/infra/test_github_client.py
@@ -1,0 +1,108 @@
+"""GitHubClient 按标签取 release 的行为（下载代理按版本锁资产用）。"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from src.infra import github_client as gc_module
+from src.infra.github_client import CACHE_TTL_SECONDS, GitHubClient
+
+TAG_URL = f"{gc_module.GITHUB_API_URL.replace('/latest', '')}/tags/v2.6.0"
+
+PAYLOAD = {
+    "tag_name": "v2.6.0",
+    "html_url": "https://github.com/Yanyutin753/LambChat/releases/tag/v2.6.0",
+    "published_at": "2026-06-11T00:00:00Z",
+    "body": "notes",
+    "assets": [
+        {
+            "name": "LambChat-v2.6.0-Windows.msi",
+            "browser_download_url": "https://github.com/x/y/releases/download/v2.6.0/LambChat-v2.6.0-Windows.msi",
+            "size": 42,
+            "content_type": "application/octet-stream",
+        }
+    ],
+}
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, payload=None):
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self):
+        return self._payload
+
+
+class _FakeAsyncClient:
+    """按 URL 应答的 httpx.AsyncClient 替身；请求 URL 记到类级共享列表
+    （_fetch_release 每次调用都新建 client，单实例列表会漏记）。"""
+
+    all_requests: list[str] = []
+
+    def __init__(self, responses=None, timeout=None):
+        self._responses = responses or {}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def get(self, url, headers=None):
+        _FakeAsyncClient.all_requests.append(url)
+        return self._responses.get(url, _FakeResponse(status_code=404))
+
+
+@pytest.fixture(autouse=True)
+def _reset_requests():
+    _FakeAsyncClient.all_requests = []
+
+
+def _install(monkeypatch: pytest.MonkeyPatch, responses) -> None:
+    def _factory(*args, **kwargs):
+        return _FakeAsyncClient(responses=responses, *args, **kwargs)
+
+    monkeypatch.setattr(gc_module.httpx, "AsyncClient", _factory)
+
+
+@pytest.mark.asyncio
+async def test_get_release_by_tag_hits_tags_endpoint_and_parses_assets(monkeypatch):
+    _install(monkeypatch, {TAG_URL: _FakeResponse(payload=PAYLOAD)})
+
+    release = await GitHubClient().get_release_by_tag("v2.6.0")
+
+    assert _FakeAsyncClient.all_requests == [TAG_URL]
+    assert release is not None
+    assert release.tag_name == "v2.6.0"
+    assert release.assets[0]["url"].endswith("LambChat-v2.6.0-Windows.msi")
+
+
+@pytest.mark.asyncio
+async def test_get_release_by_tag_caches_per_tag_until_ttl(monkeypatch):
+    _install(monkeypatch, {TAG_URL: _FakeResponse(payload=PAYLOAD)})
+    client = GitHubClient()
+
+    await client.get_release_by_tag("v2.6.0")
+    await client.get_release_by_tag("v2.6.0")
+    assert _FakeAsyncClient.all_requests == [TAG_URL]  # TTL 内只打一次上游
+
+    # 老化缓存条目越过 TTL 后重新拉取
+    client._tag_cache["v2.6.0"] = (
+        client._tag_cache["v2.6.0"][0],
+        datetime.now(UTC) - timedelta(seconds=CACHE_TTL_SECONDS + 1),
+    )
+    await client.get_release_by_tag("v2.6.0")
+    assert _FakeAsyncClient.all_requests == [TAG_URL, TAG_URL]
+
+
+@pytest.mark.asyncio
+async def test_get_release_by_tag_missing_tag_returns_none(monkeypatch):
+    _install(monkeypatch, {})  # 任何 URL 都 404
+
+    release = await GitHubClient().get_release_by_tag("v9.9.9")
+
+    assert release is None
+    assert _FakeAsyncClient.all_requests == [
+        f"{gc_module.GITHUB_API_URL.replace('/latest', '')}/tags/v9.9.9"
+    ]

--- a/tests/test_version_route.py
+++ b/tests/test_version_route.py
@@ -234,9 +234,7 @@ def test_download_release_asset_with_unknown_tag_returns_404_code(client):
     with patch.object(
         GitHubClient, "get_release_by_tag", new_callable=AsyncMock, return_value=None
     ):
-        resp = client.get(
-            "/api/version/assets/whatever.apk/download", params={"tag": "v9.9.9"}
-        )
+        resp = client.get("/api/version/assets/whatever.apk/download", params={"tag": "v9.9.9"})
         assert resp.status_code == 404
         assert resp.json()["detail"]["code"] == "release_asset_not_found"
         assert resp.json()["detail"]["args"]["name"] == "whatever.apk"

--- a/tests/test_version_route.py
+++ b/tests/test_version_route.py
@@ -193,6 +193,69 @@ def test_download_release_asset_without_release_returns_404(client):
         assert resp.json()["detail"]["code"] == "release_asset_not_found"
 
 
+def test_download_release_asset_with_tag_fetches_that_release(client):
+    """带 ?tag= 时按指定 release 查资产：自更新清单把版本锁进 URL，
+    发新版瞬间（latest 已前移）老清单的下载不受竞态影响。"""
+    tagged = make_mock_release()  # v2.6.0，含目标资产
+    latest = make_mock_release(tag_name="v2.7.0", assets=[])
+    stream = FakeAssetStream(chunks=[b"PK\x03\x04"], content_length=4)
+    with (
+        patch.object(
+            GitHubClient,
+            "get_release_by_tag",
+            new_callable=AsyncMock,
+            return_value=tagged,
+        ) as by_tag,
+        patch.object(
+            GitHubClient,
+            "get_latest_release",
+            new_callable=AsyncMock,
+            return_value=latest,
+        ) as latest_mock,
+        patch.object(
+            GitHubClient,
+            "open_asset_stream",
+            new_callable=AsyncMock,
+            return_value=stream,
+        ),
+    ):
+        resp = client.get(
+            "/api/version/assets/LambChat-v2.6.0-android-signed.apk/download",
+            params={"tag": "v2.6.0"},
+        )
+        assert resp.status_code == 200
+        assert resp.content == b"PK\x03\x04"
+        by_tag.assert_awaited_once_with("v2.6.0")
+        latest_mock.assert_not_awaited()
+
+
+def test_download_release_asset_with_unknown_tag_returns_404_code(client):
+    """tag 对应的 release 不存在：404 + release_asset_not_found。"""
+    with patch.object(
+        GitHubClient, "get_release_by_tag", new_callable=AsyncMock, return_value=None
+    ):
+        resp = client.get(
+            "/api/version/assets/whatever.apk/download", params={"tag": "v9.9.9"}
+        )
+        assert resp.status_code == 404
+        assert resp.json()["detail"]["code"] == "release_asset_not_found"
+        assert resp.json()["detail"]["args"]["name"] == "whatever.apk"
+
+
+def test_download_release_asset_tag_release_lacks_asset_returns_404_code(client):
+    """tag 的 release 存在但不含该资产：404 + release_asset_not_found。"""
+    tagged = make_mock_release(assets=[])
+    with patch.object(
+        GitHubClient, "get_release_by_tag", new_callable=AsyncMock, return_value=tagged
+    ):
+        resp = client.get(
+            "/api/version/assets/LambChat-v2.6.0-android-signed.apk/download",
+            params={"tag": "v2.6.0"},
+        )
+        assert resp.status_code == 404
+        assert resp.json()["detail"]["code"] == "release_asset_not_found"
+
+
 def test_download_release_asset_upstream_failure_returns_502(client):
     """上游非 200：502 + release_asset_fetch_failed，并关闭上游连接。"""
     release = make_mock_release()


### PR DESCRIPTION
修复 Linux 桌面端更新链路：更新清单优先使用 lambchat.com 代理，资产下载按 release tag 锁定，避免 GitHub 直连失败及发布竞态导致下载/安装失败；同步更新后端代理、下载页和测试。