### PR TITLE
chore(release): 版本晋升 2.10.3

### DIFF
--- a/client/lambchat_sandbox/__init__.py
+++ b/client/lambchat_sandbox/__init__.py
@@ -11,4 +11,4 @@ self-update 与服务端最低版本拒连打底。
 2.x/0.3.x 均放行，旧 daemon 经 self-update 平滑升到对齐版本。
 """
 
-__version__ = "2.10.2"
+__version__ = "2.10.3"

--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.lambchat.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 2102
-        versionName "2.10.2"
+        versionCode 2103
+        versionName "2.10.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/frontend/ios/App/App.xcodeproj/project.pbxproj
+++ b/frontend/ios/App/App.xcodeproj/project.pbxproj
@@ -352,7 +352,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 2.10.2;
+				MARKETING_VERSION = 2.10.3;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.lambchat.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -372,7 +372,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 2.10.2;
+				MARKETING_VERSION = 2.10.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lambchat.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lambchat-frontend",
   "private": true,
-  "version": "2.10.2",
+  "version": "2.10.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "lambchat"
-version = "2.10.2"
+version = "2.10.3"
 dependencies = [
  "command-group",
  "libc",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambchat"
-version = "2.10.2"
+version = "2.10.3"
 description = "LambChat desktop app"
 authors = ["LambChat"]
 license = ""

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LambChat",
-  "version": "2.10.2",
+  "version": "2.10.3",
   "identifier": "com.lambchat.app",
   "build": {
     "frontendDist": "../dist",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lambchat"
-version = "2.10.2"
+version = "2.10.3"
 description = "Full-featured AI Agent system with FastAPI, LangGraph, and LangSmith"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
七处版本文件 bump 到 2.10.3（package.json / tauri.conf.json / **Cargo.toml** / android versionName 2103 / iOS MARKETING_VERSION / pyproject.toml / daemon __version__）+ Cargo.lock 同步。

本地已按 app-release.yml preflight 同款脚本预检：8/8 一致。

随版：#534 Linux deb/rpm 自更新分流、#535 sandbox 执行策略、#536 eager JS 预算抬档。