### PR TITLE
ci(release): 修复烘焙门控被平台 job 直传击穿

### DIFF
--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -465,8 +465,11 @@ jobs:
       # latest.json（下载-合并-上传）。并发读合写的丢条目竞态由汇总 job 的
       # 权威重生成兜底。node 合并：三平台镜像都装了 Node，规避 Windows 无
       # python3 的可执行名差异。
+      # 烘焙门控：本步骤直传 Release，必须与汇总 job 同受
+      # DESKTOP_UPDATER_AUTO_PUBLISH 门控——v2.10.3 实测平台 job 无条件
+      # 直传击穿烘焙态（汇总 job 的 rm 只挡自己那份），真机抽检防线失守。
       - name: Merge updater platform entry into latest.json
-        if: matrix.updater_key != ''
+        if: matrix.updater_key != '' && vars.DESKTOP_UPDATER_AUTO_PUBLISH == 'true'
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## 问题

v2.10.3 发版实测：每个桌面平台 job 的「Merge updater platform entry into latest.json」步骤无条件执行 `gh release upload latest.json --clobber`，latest.json（version 2.10.3、五平台条目齐全）在构建完成瞬间即对桌面端自更新可见。

汇总 job 的烘焙门控（`rm -f release-assets/latest.json`）只能阻止汇总 job 自己上传，删不掉平台 job 已直传的资产——**烘焙态被击穿**，真机抽检（mac+windows）这道 v2.9.x 教训设立的防线失守。

## 修复

平台 job 的合并步骤补上与汇总 job 相同的 `vars.DESKTOP_UPDATER_AUTO_PUBLISH == 'true'` 门控；烘焙态下 latest.json 完全不产出，真机抽检后由手动 Desktop Updater Publish 权威重生成上传。

## 处置

- v2.10.3 已泄漏的 latest.json 资产已手动删除，烘焙态已恢复（发版后约 15 分钟内可见，窗口极小）
- 六端构建产物与其余资产不受影响