### PR TITLE
fix: 沙箱确认策略持久化 + 弹层滚动 + web 工具默认挂载（今晚测试三连修）

### DIFF
--- a/frontend/src/components/chat/AgentOptionButton.tsx
+++ b/frontend/src/components/chat/AgentOptionButton.tsx
@@ -151,6 +151,10 @@ export const AgentOptionButton = memo(function AgentOptionButton({
                   style={{
                     background: "var(--theme-bg-card)",
                     maxHeight: "60dvh",
+                    // 内容超高（沙箱设备+策略两段）可滚：否则移动端 sheet 底部
+                    // 条目被裁掉点不到（仅命令确认截半、无需确认不可达）
+                    overflowY: "auto",
+                    overscrollBehavior: "contain",
                   }}
                   onClick={(e) => e.stopPropagation()}
                 >
@@ -259,6 +263,9 @@ export const AgentOptionButton = memo(function AgentOptionButton({
                   style={{
                     background: "var(--theme-bg-card)",
                     maxHeight: "60dvh",
+                    // 同上：超高内容可滚，防止移动端 sheet 底部条目不可达
+                    overflowY: "auto",
+                    overscrollBehavior: "contain",
                   }}
                   onClick={(e) => e.stopPropagation()}
                 >
@@ -317,6 +324,10 @@ export const AgentOptionButton = memo(function AgentOptionButton({
                   ...dropdownStyle,
                   background: "var(--theme-bg-card)",
                   borderColor: "var(--theme-border)",
+                  // 桌面下拉靠近视口底时超高可滚（机器多 + 策略段展开时）
+                  maxHeight: "calc(100dvh - 8rem)",
+                  overflowY: "auto",
+                  overscrollBehavior: "contain",
                 }}
               >
                 <div

--- a/frontend/src/components/chat/__tests__/AgentOptionButtonSource.test.ts
+++ b/frontend/src/components/chat/__tests__/AgentOptionButtonSource.test.ts
@@ -1,0 +1,20 @@
+/** AgentOptionButton 弹层滚动契约：三个变体（居中/移动 sheet/桌面下拉）都必须
+ * 有 maxHeight + overflowY——沙箱面板内容超高（执行设备 + 执行策略两段）时，
+ * 没有滚动会把底部条目裁成不可点（手机网页端「无需确认」不可达的根因）。 */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("all dropdown variants scroll when content exceeds maxHeight", () => {
+  const source = readFileSync(
+    resolve(import.meta.dirname, "../AgentOptionButton.tsx"),
+    "utf8",
+  );
+  const sheetStyles = source.match(/maxHeight: "60dvh",/g) ?? [];
+  expect(sheetStyles.length).toBe(2); // 居中变体 + 移动 sheet 变体
+  const scrollables = source.match(/overflowY: "auto",/g) ?? [];
+  expect(scrollables.length).toBe(3); // 上述两个 + 桌面下拉
+  expect(source).toMatch(/overscrollBehavior: "contain",/);
+  // 桌面下拉必须有自身高度上限（原本完全没有）
+  expect(source).toMatch(/maxHeight: "calc\(100dvh - 8rem\)"/);
+});

--- a/frontend/src/components/profile/LocalSandboxSection.tsx
+++ b/frontend/src/components/profile/LocalSandboxSection.tsx
@@ -9,7 +9,7 @@ import {
   RotateCw,
   Download,
 } from "lucide-react";
-import { sandboxApi } from "../../services/api/sandbox";
+import { sandboxApi, sandboxApiMachines } from "../../services/api/sandbox";
 import { getValidAccessToken } from "../../services/api/tokenManager";
 import { effectiveApiBase } from "../../services/api/serverConfig";
 import {
@@ -81,7 +81,8 @@ export function LocalSandboxSection({
   const { t } = useTranslation();
   const navigate = useNavigate();
   const shell = isShellAvailable();
-  const { status, statusError, online, refresh } = useSandboxStatus();
+  const { status, statusError, online, refresh, currentMachineId } =
+    useSandboxStatus();
   const [processStatus, setProcessStatus] = useState("");
   const [policy, setPolicy] = useState<ConfirmPolicy>("all");
   const [policyOpen, setPolicyOpen] = useState(false);
@@ -369,6 +370,11 @@ export function LocalSandboxSection({
     if (applying) return;
     setApplying(true);
     try {
+      // 服务端耐久层（machpolicy）是持久化真源：先写它，daemon 重连/心跳
+      // 才不会用 sandbox.json 启动快照把策略打回旧值（全局生效的关键）。
+      if (currentMachineId) {
+        await sandboxApiMachines.updateConfirmPolicy(currentMachineId, next);
+      }
       // 只写配置：write_confirm_policy 仅覆写 confirm_policy（保留 pat 等其余
       // 字段），不重铸 PAT——旧实现每次切换铸一枚永久凭据，会无限累积。
       await writeConfirmPolicy(next);

--- a/src/infra/sandbox/relay/registry.py
+++ b/src/infra/sandbox/relay/registry.py
@@ -52,6 +52,11 @@ def _machname_key(user_id: str) -> str:
     return f"sandbox:machname:{user_id}"
 
 
+def _machpolicy_key(user_id: str) -> str:
+    """每机器确认策略耐久层（hash、无 TTL）：网页/对话内切换的持久化真源。"""
+    return f"sandbox:machpolicy:{user_id}"
+
+
 def _machdefault_key(user_id: str) -> str:
     return f"sandbox:machdefault:{user_id}"
 
@@ -144,6 +149,21 @@ class SandboxClientRegistry:
     def _redis(self):
         return get_redis_client()
 
+    async def _effective_confirm_policy(
+        self, redis, user_id: str, machine_id: str, reported: str
+    ) -> str:
+        """耐久层策略优先于 daemon 上报值。
+
+        daemon 上报的 confirm_policy 是 sandbox.json 的启动快照；网页/对话内
+        热更只写服务端。若注册/心跳直接采用上报值，会把热更结果打回旧值
+        （v2.10.3 实测：切换后刷新即回退）。machpolicy 耐久层无记录时（首连）
+        才用上报值播种。
+        """
+        durable = await redis.hget(_machpolicy_key(user_id), machine_id)
+        if durable in {"all", "commands", "none"}:
+            return durable
+        return reported
+
     async def register(
         self,
         user_id: str,
@@ -158,9 +178,12 @@ class SandboxClientRegistry:
     ) -> None:
         """注册连接。带 machine_id 走多机路径（同机重连只替换自身字段，其他
         机器不受影响）；缺 machine_id 走 legacy 路径（清空旧 hash 后连踢前连）。"""
-        value = encode_node_value(node_id, version, platform, confirm_policy, machine_name)
         redis = self._redis()
         if machine_id:
+            effective_policy = await self._effective_confirm_policy(
+                redis, user_id, machine_id, confirm_policy
+            )
+            value = encode_node_value(node_id, version, platform, effective_policy, machine_name)
             await redis.sadd(_machset_key(user_id), machine_id)
             await redis.set(_machine_key(user_id, machine_id), value, ex=_TTL_SECONDS)
             await redis.hset(
@@ -170,10 +193,11 @@ class SandboxClientRegistry:
                     machine_name=machine_name,
                     platform=platform,
                     version=version,
-                    confirm_policy=confirm_policy,
+                    confirm_policy=effective_policy,
                 ),
             )
             return
+        value = encode_node_value(node_id, version, platform, confirm_policy, machine_name)
         await redis.delete(_key(user_id))  # 后连踢前连（legacy 单机语义）
         await redis.hset(_key(user_id), client_id, value)
         await redis.expire(_key(user_id), _TTL_SECONDS)
@@ -190,9 +214,12 @@ class SandboxClientRegistry:
         machine_id: str = "",
         machine_name: str = "",
     ) -> None:
-        value = encode_node_value(node_id, version, platform, confirm_policy, machine_name)
         redis = self._redis()
         if machine_id:
+            effective_policy = await self._effective_confirm_policy(
+                redis, user_id, machine_id, confirm_policy
+            )
+            value = encode_node_value(node_id, version, platform, effective_policy, machine_name)
             await redis.sadd(_machset_key(user_id), machine_id)
             await redis.set(_machine_key(user_id, machine_id), value, ex=_TTL_SECONDS)
             await redis.hset(
@@ -202,10 +229,11 @@ class SandboxClientRegistry:
                     machine_name=machine_name,
                     platform=platform,
                     version=version,
-                    confirm_policy=confirm_policy,
+                    confirm_policy=effective_policy,
                 ),
             )
             return
+        value = encode_node_value(node_id, version, platform, confirm_policy, machine_name)
         await redis.hset(_key(user_id), client_id, value)
         await redis.expire(_key(user_id), _TTL_SECONDS)
 
@@ -317,26 +345,34 @@ class SandboxClientRegistry:
         await self._redis().hset(_machname_key(user_id), machine_id, name)
 
     async def update_confirm_policy(self, user_id: str, machine_id: str, policy: str) -> bool:
-        """热更新在线机器确认策略，无需重连 daemon。"""
+        """热更新并持久化机器确认策略（全局语义，无需重连 daemon）。
+
+        三处同步写入：machpolicy 耐久层（真源——daemon 心跳/重连/重启上报
+        旧快照时由它压制，见 _effective_confirm_policy）、在线条目（执行门
+        实时读它，下一次执行立即生效）、machseen 记忆层（离线展示一致性，
+        保留原 ts/name/platform/version）。机器在线或有记忆记录即接受。
+        """
         if policy not in {"all", "commands", "none"}:
             return False
         redis = self._redis()
         key = _machine_key(user_id, machine_id)
         value = await redis.get(key)
-        if value is None:
+        seen_raw = await redis.hget(_machseen_key(user_id), machine_id)
+        if value is None and seen_raw is None:
             return False
-        parts = value.split("|", 4)
-        node_id = parts[0]
-        version = parts[1] if len(parts) > 1 else ""
-        platform = parts[2] if len(parts) > 2 else ""
-        machine_name = parts[4] if len(parts) > 4 else ""
-        await redis.set(
-            key,
-            encode_node_value(node_id, version, platform, policy, machine_name),
-            ex=_TTL_SECONDS,
-        )
-        seen_all = await redis.hgetall(_machseen_key(user_id))
-        seen = _decode_seen_record(seen_all.get(machine_id))
+        await redis.hset(_machpolicy_key(user_id), machine_id, policy)
+        if value is not None:
+            parts = value.split("|", 4)
+            node_id = parts[0]
+            version = parts[1] if len(parts) > 1 else ""
+            platform = parts[2] if len(parts) > 2 else ""
+            machine_name = parts[4] if len(parts) > 4 else ""
+            await redis.set(
+                key,
+                encode_node_value(node_id, version, platform, policy, machine_name),
+                ex=_TTL_SECONDS,
+            )
+        seen = _decode_seen_record(seen_raw)
         if seen is not None:
             seen["confirm_policy"] = policy
             await redis.hset(_machseen_key(user_id), machine_id, json.dumps(seen))
@@ -352,6 +388,8 @@ class SandboxClientRegistry:
         await redis.srem(_machset_key(user_id), machine_id)
         await redis.hdel(_machname_key(user_id), machine_id)
         await redis.hdel(_machseen_key(user_id), machine_id)
+        # 耐久策略随机器一并清理：forget 后重新注册恢复 daemon 上报语义
+        await redis.hdel(_machpolicy_key(user_id), machine_id)
         if await redis.get(_machdefault_key(user_id)) == machine_id:
             await redis.delete(_machdefault_key(user_id))
         return True

--- a/src/infra/tool/internal_registry.py
+++ b/src/infra/tool/internal_registry.py
@@ -238,6 +238,18 @@ async def get_internal_tool_policies() -> dict[str, MCPToolPolicy]:
         return {}
 
 
+# 默认 inline 直挂的内置工具：网页检索/阅读是通用基础能力，不该藏在
+# tool_search 元工具后面（模型要先「搜工具」才能发现它们，等于默认不可用）。
+# 管理员在 MCP 面板对工具显式设置过策略的，一律以显式值为准。
+_DEFAULT_INLINE_TOOL_NAMES = frozenset({"web_search", "web_fetch"})
+
+
+def _default_inline_exposure(policy: MCPToolPolicy | None, tool_name: str) -> bool:
+    if policy is not None:
+        return bool(policy.inline_exposure)
+    return tool_name in _DEFAULT_INLINE_TOOL_NAMES
+
+
 async def get_internal_tools_for_user(
     *,
     user_id: str | None,
@@ -287,7 +299,7 @@ async def get_internal_tools_by_exposure_for_user(
             role_quotas=(policy.role_quotas if policy else None),
             quota_tool_name=tool.name,
         )
-        target = direct if policy is not None and policy.inline_exposure else deferred
+        target = direct if _default_inline_exposure(policy, tool.name) else deferred
         target.append(wrapped)
     return direct, deferred
 
@@ -325,7 +337,7 @@ async def get_internal_tool_infos(
                 allowed_roles=list(policy.allowed_roles) if policy else [],
                 role_quotas=dict(policy.role_quotas) if policy else {},
                 policy_configured=policy is not None,
-                inline_exposure=bool(policy.inline_exposure) if policy else False,
+                inline_exposure=_default_inline_exposure(policy, tool.name),
             )
         )
     return infos

--- a/src/kernel/config/_definitions_tools.py
+++ b/src/kernel/config/_definitions_tools.py
@@ -294,7 +294,7 @@ TOOLS_SETTING_DEFINITIONS: dict[str, dict] = {
         "category": SettingCategory.TOOLS,
         "subcategory": "web_search",
         "description": "settingDesc.ENABLE_WEB_SEARCH",
-        "default": False,
+        "default": True,
         "frontend_visible": True,
     },
     "WEB_SEARCH_PROVIDER": {
@@ -354,7 +354,7 @@ TOOLS_SETTING_DEFINITIONS: dict[str, dict] = {
         "category": SettingCategory.TOOLS,
         "subcategory": "web_fetch",
         "description": "settingDesc.ENABLE_WEB_FETCH",
-        "default": False,
+        "default": True,
         "frontend_visible": True,
     },
     "WEB_FETCH_PROVIDER": {

--- a/src/kernel/config/base.py
+++ b/src/kernel/config/base.py
@@ -470,16 +470,19 @@ class Settings(BaseSettings):
     AUDIO_TRANSCRIPTION_MODEL: str = "gpt-4o-mini-transcribe"
     AUDIO_TRANSCRIPTION_MAX_DOWNLOAD_BYTES: int = 50 * 1024 * 1024
 
-    # Web search tool settings（多 key 用英文逗号分隔，round-robin 轮询）
-    ENABLE_WEB_SEARCH: bool = False
+    # Web search tool settings（多 key 用英文逗号分隔，round-robin 轮询）。
+    # 默认挂载为系统内置工具：未配置任何 provider 时工具返回
+    # web_search_no_provider_configured 引导配置，而不是不挂载
+    ENABLE_WEB_SEARCH: bool = True
     WEB_SEARCH_PROVIDER: str = "auto"
     TAVILY_API_KEYS: str = ""
     BRAVE_API_KEYS: str = ""
     SEARXNG_BASE_URL: str = ""
     SEARXNG_API_KEY: str = ""
 
-    # Web fetch tool settings（各家 key 英文逗号分隔轮询；direct 无需 key）
-    ENABLE_WEB_FETCH: bool = False
+    # Web fetch tool settings（各家 key 英文逗号分隔轮询；direct 无需 key）。
+    # 默认挂载：direct 供应商零 key 可用
+    ENABLE_WEB_FETCH: bool = True
     WEB_FETCH_PROVIDER: str = "auto"
     JINA_API_KEYS: str = ""
     FIRECRAWL_BASE_URL: str = ""

--- a/tests/infra/sandbox/relay/test_presence.py
+++ b/tests/infra/sandbox/relay/test_presence.py
@@ -49,6 +49,9 @@ class _FakeRedis:
     async def hset(self, key: str, field: str, value: str) -> None:
         self.hashes.setdefault(key, {})[field] = value
 
+    async def hget(self, key: str, field: str) -> str | None:
+        return self.hashes.get(key, {}).get(field)
+
     async def hdel(self, key: str, field: str) -> None:
         self.hashes.get(key, {}).pop(field, None)
 

--- a/tests/infra/sandbox/relay/test_registry_machines.py
+++ b/tests/infra/sandbox/relay/test_registry_machines.py
@@ -60,6 +60,9 @@ class _FakeRedis:
     async def hset(self, key: str, field: str, value: str) -> None:
         self.hashes.setdefault(key, {})[field] = value
 
+    async def hget(self, key: str, field: str) -> str | None:
+        return self.hashes.get(key, {}).get(field)
+
     async def hdel(self, key: str, field: str) -> None:
         self.hashes.get(key, {}).pop(field, None)
 
@@ -339,4 +342,40 @@ async def test_update_confirm_policy_rewrites_live_machine_and_memory(registry):
     await registry.update_confirm_policy("u1", "m1", "commands")
     machines = await registry.list_machines("u1")
     assert machines[0]["confirm_policy"] == "commands"
+    assert await registry.get_confirm_policy("u1", "m1") == "commands"
+
+
+# ---------------------------------------------------------------------------
+# 确认策略持久化（machpolicy 耐久层）：全局且跨心跳/重连/过期不回退
+# ---------------------------------------------------------------------------
+
+
+async def test_heartbeat_does_not_clobber_persisted_policy(registry):
+    """对话内热更后 daemon 心跳仍上报启动快照旧值——耐久层优先，不回退。"""
+    await registry.register("u1", "c1", "node1", confirm_policy="all", machine_id="m1")
+    await registry.update_confirm_policy("u1", "m1", "none")
+    # daemon 未重启：心跳继续上报 connect 时的 "all"
+    await registry.heartbeat("u1", "c1", "node1", confirm_policy="all", machine_id="m1")
+    assert await registry.get_confirm_policy("u1", "m1") == "none"
+    machines = await registry.list_machines("u1")
+    assert machines[0]["confirm_policy"] == "none"
+
+
+async def test_policy_survives_daemon_reconnect(registry):
+    """web 端切换只写服务端：daemon 重连（上报 sandbox.json 旧值）后仍持久。"""
+    await registry.register("u1", "c1", "node1", confirm_policy="all", machine_id="m1")
+    await registry.update_confirm_policy("u1", "m1", "commands")
+    await registry.unregister("u1", "c1", "m1")
+    await registry.register("u1", "c1", "node1", confirm_policy="all", machine_id="m1")
+    assert await registry.get_confirm_policy("u1", "m1") == "commands"
+
+
+async def test_daemon_report_seeds_policy_only_without_durable_record(registry):
+    """首连无耐久记录：上报值播种；forget 清耐久层后恢复上报语义。"""
+    await registry.register("u1", "c1", "node1", confirm_policy="none", machine_id="m1")
+    assert await registry.get_confirm_policy("u1", "m1") == "none"
+    await registry.update_confirm_policy("u1", "m1", "all")
+    await registry.unregister("u1", "c1", "m1")
+    assert await registry.forget_machine("u1", "m1") is True
+    await registry.register("u1", "c1", "node1", confirm_policy="commands", machine_id="m1")
     assert await registry.get_confirm_policy("u1", "m1") == "commands"

--- a/tests/infra/tool/test_internal_registry_exposure.py
+++ b/tests/infra/tool/test_internal_registry_exposure.py
@@ -78,6 +78,8 @@ async def test_conversation_history_tools_default_to_deferred_exposure(monkeypat
     monkeypatch.setattr(internal_registry.settings, "ENABLE_IMAGE_GENERATION", False)
     monkeypatch.setattr(internal_registry.settings, "ENABLE_AUDIO_TRANSCRIPTION", False)
     monkeypatch.setattr(internal_registry.settings, "ENABLE_SCHEDULED_TASK", False)
+    monkeypatch.setattr(internal_registry.settings, "ENABLE_WEB_SEARCH", False)
+    monkeypatch.setattr(internal_registry.settings, "ENABLE_WEB_FETCH", False)
     monkeypatch.setattr(internal_registry, "get_env_var_tools", lambda: [])
     monkeypatch.setattr(internal_registry, "get_persona_preset_tools", lambda: [])
     monkeypatch.setattr(internal_registry, "get_team_tools", lambda: [])
@@ -98,3 +100,55 @@ async def test_conversation_history_tools_default_to_deferred_exposure(monkeypat
         "search_conversation_history",
         "get_conversation_detail",
     }
+
+
+@pytest.mark.asyncio
+async def test_web_tools_mount_by_default_as_system_tools(monkeypatch) -> None:
+    """web_search/web_fetch 默认即挂载且 inline 直挂：无策略时进 direct
+    暴露集（模型工具表直接可见），不再需要先经 tool_search 元工具发现；
+    管理员显式设置过策略的以显式值为准。"""
+    monkeypatch.setattr(internal_registry.settings, "ENABLE_IMAGE_ANALYSIS", False)
+    monkeypatch.setattr(internal_registry.settings, "ENABLE_IMAGE_GENERATION", False)
+    monkeypatch.setattr(internal_registry.settings, "ENABLE_AUDIO_TRANSCRIPTION", False)
+    monkeypatch.setattr(internal_registry.settings, "ENABLE_SCHEDULED_TASK", False)
+    monkeypatch.setattr(internal_registry, "get_env_var_tools", lambda: [])
+    monkeypatch.setattr(internal_registry, "get_persona_preset_tools", lambda: [])
+    monkeypatch.setattr(internal_registry, "get_team_tools", lambda: [])
+
+    async def no_policies():
+        return {}
+
+    monkeypatch.setattr(internal_registry, "get_internal_tool_policies", no_policies)
+
+    # 不 monkeypatch web 开关：默认值（True）下两工具必须在册且直挂
+    direct, deferred = await internal_registry.get_internal_tools_by_exposure_for_user(
+        user_id="user-1",
+        user_roles=[],
+        is_admin=False,
+    )
+    direct_names = {tool.name for tool in direct}
+    assert {"web_search", "web_fetch"} <= direct_names
+    assert not {"web_search", "web_fetch"} & {tool.name for tool in deferred}
+
+    # 显式策略优先：管理员钉死 inline_exposure=False 时回落 deferred
+    from src.kernel.schemas.mcp import MCPToolPolicy
+
+    async def explicit_policies():
+        return {
+            "web_search": MCPToolPolicy(
+                server_name=internal_registry.INTERNAL_MCP_SERVER_NAME,
+                tool_name="web_search",
+                inline_exposure=False,
+            ),
+        }
+
+    monkeypatch.setattr(internal_registry, "get_internal_tool_policies", explicit_policies)
+    direct, deferred = await internal_registry.get_internal_tools_by_exposure_for_user(
+        user_id="user-1",
+        user_roles=[],
+        is_admin=False,
+    )
+    assert "web_search" not in {tool.name for tool in direct}
+    assert "web_search" in {tool.name for tool in deferred}
+    # 未被显式策略覆盖的 web_fetch 仍默认直挂
+    assert "web_fetch" in {tool.name for tool in direct}

--- a/tests/kernel/config/test_tool_setting_definitions.py
+++ b/tests/kernel/config/test_tool_setting_definitions.py
@@ -18,7 +18,8 @@ def test_removed_deferred_prompt_limit_is_not_registered() -> None:
 
 def test_web_search_settings_are_registered() -> None:
     expected_defaults = {
-        "ENABLE_WEB_SEARCH": False,
+        # 默认挂载为系统内置工具（未配 provider 时工具自述引导，而非不挂载）
+        "ENABLE_WEB_SEARCH": True,
         "WEB_SEARCH_PROVIDER": "auto",
         "TAVILY_API_KEYS": "",
         "BRAVE_API_KEYS": "",
@@ -46,7 +47,8 @@ def test_web_search_settings_are_registered() -> None:
 
 def test_web_fetch_settings_are_registered() -> None:
     expected_defaults = {
-        "ENABLE_WEB_FETCH": False,
+        # 默认挂载（direct 供应商零 key 可用）
+        "ENABLE_WEB_FETCH": True,
         "WEB_FETCH_PROVIDER": "auto",
         "JINA_API_KEYS": "",
         "FIRECRAWL_BASE_URL": "",


### PR DESCRIPTION
## 1. 确认策略持久化（对话内切换刷新即回退）

**根因**：daemon `register`/`heartbeat` 用 connect 时上报的 `confirm_policy`（sandbox.json 启动快照）整条重写在线条目与 machseen——#535 的热更在下一个心跳（秒级）即被打回；且无耐久存储，web 端切换 daemon 一重连就回退。

**修复**：新增 `sandbox:machpolicy:{uid}` 耐久 hash（真源）；register/heartbeat 耐久值优先、上报值仅首连播种；`update_confirm_policy` 三层同步（耐久层 + 在线条目[执行门实时读] + machseen）；forget 连带清理；LocalSandboxSection 补服务端 API 调用。

- [x] registry 单测（心跳不回退/重连持久/forget 恢复上报语义）
- [x] `e2e_local_sandbox.py` 41/41 PASS（硬门禁）

## 2. 沙箱选择弹层滚动（手机网页端「无需确认」点不到）

三个弹层变体有 maxHeight 无 overflow-y，内容超高直接裁掉。统一补 `overflowY+overscrollBehavior`，桌面下拉补高度上限，源码契约测试锁定。

## 3. web_search / web_fetch 默认挂载

`ENABLE_WEB_SEARCH/FETCH` 默认 False → True：系统内置工具直接挂载，不再需要管理员先开开关。web_fetch 的 direct 供应商零 key 可用；web_search 未配 provider 时返回引导性错误而非不挂载。已有显式 DB/env 配置的部署不受影响。