### PR TITLE
test: 补齐 hget 仿件与烘焙门控契约断言（修复 develop CI 红）

### DIFF
--- a/tests/api/routes/test_sandbox_routes.py
+++ b/tests/api/routes/test_sandbox_routes.py
@@ -88,6 +88,9 @@ class _FakeRedis:
     async def hset(self, key, field, value):
         self.hashes.setdefault(key, {})[field] = value
 
+    async def hget(self, key, field):
+        return self.hashes.get(key, {}).get(field)
+
     async def hdel(self, key, field):
         self.hashes.get(key, {}).pop(field, None)
 

--- a/tests/client/test_packaging.py
+++ b/tests/client/test_packaging.py
@@ -232,7 +232,12 @@ def test_release_workflow_publishes_assets_immediately_per_platform() -> None:
         for s in _desktop_job()["steps"]
         if s["name"] == "Merge updater platform entry into latest.json"
     )
-    assert merge_step["if"] == "matrix.updater_key != ''"
+    # 烘焙门控：即发即传的增量合并必须与汇总 job 同受
+    # DESKTOP_UPDATER_AUTO_PUBLISH 门控，否则平台 job 直传击穿烘焙态
+    # （v2.10.3 实测泄漏，#539 修复）
+    assert merge_step["if"] == (
+        "matrix.updater_key != '' && vars.DESKTOP_UPDATER_AUTO_PUBLISH == 'true'"
+    )
     # node 合并（三平台镜像都有 Node；Windows 无 python3）
     assert "node -e" in merge_step["run"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2090,7 +2090,7 @@ wheels = [
 
 [[package]]
 name = "lambchat"
-version = "2.10.2"
+version = "2.10.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
#540 的 registry 耐久层让 register/heartbeat 读 machpolicy hash，第三份 FakeRedis（test_sandbox_routes.py）没补 hget；#539 的烘焙门控改了 merge 步骤 if 但 test_packaging.py 契约断言没同步。两者致 develop push 的 Backend Tests 红、#541 晋升被堵。

本地全量 pytest：4515 passed。