### PR TITLE
fix(frontend): chat input 切换确认策略后即时对账 status（双显同步）

### DIFF
--- a/frontend/src/components/chat/ChatInputSelectors.tsx
+++ b/frontend/src/components/chat/ChatInputSelectors.tsx
@@ -9,8 +9,11 @@ import { AgentModeSelector } from "../selectors/AgentModeSelector";
 import { PersonaPresetSelector } from "../persona/PersonaPresetSelector";
 import { TeamPickerModal } from "../team/TeamPickerModal";
 import { AgentOptionButton } from "./AgentOptionButton";
-import { useSandboxStatus } from "../../hooks/useSandboxStatus";
 import { isShellAvailable, writeConfirmPolicy } from "../../services/tauri/sandboxShell";
+import {
+  notifySandboxStatusRefresh,
+  useSandboxStatus,
+} from "../../hooks/useSandboxStatus";
 import { sandboxApiMachines } from "../../services/api/sandbox";
 import {
   SANDBOX_AGENT_OPTION_KEY,
@@ -170,6 +173,10 @@ export function ChatInputSelectors({
         await writeConfirmPolicy(policy);
       }
       setPolicyOverride(policy);
+      // 与偏好设置页同款对账：machines 走 presence 秒推，但 profile 页依赖的
+      // status（daemon_confirm_policy）要等 60s 对账轮询——不发本事件会出现
+      // 「chat input 已新、偏好设置还旧」的双显不同步
+      notifySandboxStatusRefresh();
       toast.success(t("agentOptions.sandboxPolicy.updated"));
     } catch {
       toast.error(t("agentOptions.sandboxPolicy.updateFailed"));

--- a/frontend/src/components/chat/__tests__/chatInputSelectorsSandboxSource.test.ts
+++ b/frontend/src/components/chat/__tests__/chatInputSelectorsSandboxSource.test.ts
@@ -69,3 +69,14 @@ test("popover gates sandbox status polling on its open state; the selector stays
   expect(source).toMatch(/useSandboxStatus\(\)/);
   expect(source).not.toMatch(/useSandboxStatus\(\{/);
 });
+
+test("policy change notifies the sandbox status store to resync status", () => {
+  // 双显不同步根因：machines 走 presence 秒推、profile 页依赖的 status 只有
+  // 60s 对账轮询——chat input 切换成功后必须发 SANDBOX_STATUS_REFRESH 事件
+  expect(source).toMatch(/notifySandboxStatusRefresh\(\);/);
+  const successIdx = source.indexOf("agentOptions.sandboxPolicy.updated");
+  const notifyIdx = source.indexOf("notifySandboxStatusRefresh();");
+  expect(successIdx).toBeGreaterThan(-1);
+  expect(notifyIdx).toBeGreaterThan(-1);
+  expect(notifyIdx).toBeLessThan(successIdx);
+});


### PR DESCRIPTION
## 根因

服务端三层已核一致（machpolicy 耐久层 / 在线条目 / machseen 均同值）。不同步是纯前端对账缺口：

- **chat input** 的机器列表走 presence WebSocket 秒推 → 切换后立即显示新值
- **偏好设置** 依赖 `status.daemon_confirm_policy`，WS 健康时只有 **60s 对账轮询** → 窗口期内显示旧值
- 偏好设置侧切换本来就发 `SANDBOX_STATUS_REFRESH` 事件，chat input 侧漏发——不对称

## 修复

chat input `handlePolicyChange` 成功后补发 `notifySandboxStatusRefresh()`，与偏好设置页同款对账；源码契约测试锁定「事件先于成功 toast」。

- [x] 前端全量 vitest + lint + build 全绿