### PR TITLE
chore(promote): develop → main——GPT-6 思考强度支持

### DIFF
--- a/src/infra/llm/client.py
+++ b/src/infra/llm/client.py
@@ -233,8 +233,9 @@ def _langchain_profile(profile: Optional[dict]) -> Optional[dict]:
 
 # OpenAI-protocol providers whose reasoning models accept reasoning_effort.
 # o1 系不发送：o1-preview/o1-mini 不支持该参数（发送即 400），o1 已退役。
+# gpt-6 系同 gpt-5 接受 reasoning_effort（-chat-latest/-non-reasoning 变体除外）。
 _REASONING_EFFORT_PREFIXES: dict[str, tuple[str, ...]] = {
-    "openai": ("gpt-5", "o3", "o4"),
+    "openai": ("gpt-5", "gpt-6", "o3", "o4"),
     "xai": ("grok-4",),
 }
 # zhipu hybrid-reasoning GLM families that accept the `thinking` request-body
@@ -289,10 +290,14 @@ def _resolve_reasoning_effort(
         return None
 
     level = str(thinking.get("level") or "medium")
-    if provider == "xai" and level == "max":
-        # grok 4.6+ 的 max 档映射到 xhigh
-        match = _GROK_VERSION_RE.search(name)
-        return "xhigh" if match and _version_tuple(match) >= (4, 6) else "high"
+    if level == "max" and provider in {"openai", "xai"}:
+        # max 档原生支持度按家族分野：gpt-6 与 grok-4.6+ 原生接受
+        # max/xhigh；gpt-5/o3/o4 只到 high（发 max 会 400），降档处理
+        if provider == "openai" and name.startswith("gpt-6"):
+            return "max"
+        if provider == "xai":
+            match = _GROK_VERSION_RE.search(name)
+            return "xhigh" if match and _version_tuple(match) >= (4, 6) else "high"
     return _EFFORT_BY_LEVEL.get(level, "medium")
 
 

--- a/tests/infra/llm/test_thinking_gating.py
+++ b/tests/infra/llm/test_thinking_gating.py
@@ -52,6 +52,19 @@ def _google_model(model_name: str, thinking: dict | None):
 # ── OpenAI provider ──────────────────────────────────────────────────────
 
 
+def test_openai_gpt6_receives_effort_per_level() -> None:
+    # gpt-6 系与 gpt-5 同为 reasoning_effort 家族（曾漏配导致强度控件隐藏）；
+    # 且原生支持 max 档（gpt-5 只到 high）——Astra 不支持 none、始终思考
+    for level, expected in [
+        ("low", "low"),
+        ("medium", "medium"),
+        ("high", "high"),
+        ("max", "max"),
+    ]:
+        model = _openai_model("openai", "gpt-6-astra", ENABLED(level))
+        assert model.reasoning_effort == expected
+
+
 def test_openai_reasoning_models_receive_effort_per_level() -> None:
     for level, expected in [
         ("low", "low"),
@@ -304,6 +317,7 @@ def test_gemini_2_5_lite_variant_supported() -> None:
 
 
 def test_model_supports_thinking_openai_families() -> None:
+    assert model_supports_thinking("openai", "gpt-6-astra") is True
     assert model_supports_thinking("openai", "gpt-5.5") is True
     assert model_supports_thinking("openai", "o3-mini") is True
     assert model_supports_thinking("openai", "o4-mini-high") is True
@@ -316,6 +330,7 @@ def test_model_supports_thinking_openai_exclusions() -> None:
     assert model_supports_thinking("openai", "gpt-4.1") is False
     assert model_supports_thinking("openai", "o1") is False
     assert model_supports_thinking("openai", "gpt-5.1-chat-latest") is False
+    assert model_supports_thinking("openai", "gpt-6-chat-latest") is False
     assert model_supports_thinking("xai", "grok-4-fast-non-reasoning") is False
     assert model_supports_thinking("xai", "grok-3") is False
 


### PR DESCRIPTION
## 晋升内容
- #550 fix(llm): GPT-6 纳入 reasoning_effort 家族（思考强度控件可见 + 原生 max 档透传）

## 前置
- [x] develop CI 全绿
- [x] 后端全量 4526 passed + MyPy 干净