### PR TITLE
fix(chat): 重启后孤儿助手空壳修复——活跃run不合成推荐/落定移除空壳/完成后对账重载

### DIFF
--- a/frontend/src/hooks/useAgent.ts
+++ b/frontend/src/hooks/useAgent.ts
@@ -131,6 +131,12 @@ export function useAgent(options?: UseAgentOptions): UseAgentReturn {
   // Current streaming message ID
   const streamingMessageIdRef = useRef<string | null>(null);
 
+  // 最新 loadHistory 的稳定引用：SSE 层发现「run 已终结但本地空壳」时
+  // 拉起历史重载（定义在下方，渲染期回填，避免 useCallback 依赖环）
+  const loadHistoryRef = useRef<
+    ((targetSessionId: string) => Promise<unknown>) | null
+  >(null);
+
   // Flag for reconnect from history
   const isReconnectFromHistoryRef = useRef<boolean>(false);
 
@@ -233,6 +239,19 @@ export function useAgent(options?: UseAgentOptions): UseAgentReturn {
       setSandboxError,
       setActiveGoal,
       setGoalsByRunId,
+      onStaleRunStateDetected: (runId: string) => {
+        // 只在该 run 仍是当前 run 且没有新的发送/加载进行时重载，
+        // 防止覆盖用户刚发出的问题或乐观消息。
+        const activeSessionId = sessionIdRef.current;
+        if (
+          activeSessionId &&
+          currentRunIdRef.current === runId &&
+          !isSendingRef.current &&
+          !isLoadingHistoryRef.current
+        ) {
+          void loadHistoryRef.current?.(activeSessionId);
+        }
+      },
     }),
     [
       options,
@@ -848,6 +867,9 @@ export function useAgent(options?: UseAgentOptions): UseAgentReturn {
   ) => {
     return sendMessage(content, undefined, attachments);
   };
+
+  // SSE 层 onStaleRunStateDetected 回调经此拿到最新 loadHistory
+  loadHistoryRef.current = loadHistory;
 
   // If the run finishes after the API accepted a steer but before the next
   // model boundary, promote it to a normal follow-up instead of leaving it

--- a/frontend/src/hooks/useAgent/__tests__/eventHandlers.test.ts
+++ b/frontend/src/hooks/useAgent/__tests__/eventHandlers.test.ts
@@ -838,3 +838,35 @@ test("goal:end auto-clears the active goal after a short delay", () => {
   // Immediately after goal:end, the goal still has ended_at set
   expect(ctx.activeGoal()?.ended_at).toBe("2026-05-30T08:00:05.000Z");
 });
+
+test("done removes an assistant bubble that never received content", () => {
+  const ctx = createContext(
+    [
+      {
+        id: "run-1:user",
+        role: "user",
+        content: "hello",
+        timestamp: new Date("2026-09-10T02:59:59.000Z"),
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        content: "",
+        timestamp: new Date("2026-09-10T03:00:00.000Z"),
+        parts: [],
+        isStreaming: true,
+      },
+    ],
+    null,
+  );
+
+  handleStreamEvent(
+    { event: "done", data: JSON.stringify({ status: "completed" }) },
+    "assistant-1",
+    "redis-event-done-empty",
+    "2026-09-10T03:18:04.000Z",
+    ctx,
+  );
+
+  expect(ctx.messages().map((message) => message.id)).toEqual(["run-1:user"]);
+});

--- a/frontend/src/hooks/useAgent/__tests__/historyLoader.test.ts
+++ b/frontend/src/hooks/useAgent/__tests__/historyLoader.test.ts
@@ -75,7 +75,7 @@ test("attaches runless recommendation events to the preceding assistant turn", (
   );
 });
 
-test("inherits the run id for a synthesized recommendation event", () => {
+test("drops an assistant turn that only carries recommend questions", () => {
   const messages = reconstructMessagesFromEvents(
     [
       {
@@ -86,6 +86,7 @@ test("inherits the run id for a synthesized recommendation event", () => {
       },
       {
         event_type: "recommend:questions",
+        run_id: "run-1",
         timestamp: "2026-08-21T00:00:01.000Z",
         data: { questions: ["next?"] },
       },
@@ -94,7 +95,11 @@ test("inherits the run id for a synthesized recommendation event", () => {
     { activeSubagentStack: [] },
   );
 
-  expect(messages.at(-1)?.runId).toBe("run-1");
+  // 活跃 run 历史快照可能只带 user:message + 合成推荐事件（零正文）；
+  // 只有推荐 part 的助手轮次要整体丢弃，不能留一个空壳气泡。
+  expect(messages).toHaveLength(1);
+  expect(messages[0]?.role).toBe("user");
+  expect(messages[0]?.id).toBe("run-1:user");
 });
 
 test("reconstructs one resolved ask-human item from same-run history", () => {

--- a/frontend/src/hooks/useAgent/__tests__/settleStream.test.ts
+++ b/frontend/src/hooks/useAgent/__tests__/settleStream.test.ts
@@ -1,0 +1,113 @@
+import type { Message } from "../../../types";
+import {
+  assistantMessageHasContent,
+  settleAssistantMessage,
+} from "../settleStream.ts";
+
+function assistant(overrides: Partial<Message> = {}): Message {
+  return {
+    id: "assistant-1",
+    role: "assistant",
+    content: "",
+    timestamp: new Date("2026-09-10T03:00:00.000Z"),
+    parts: [],
+    isStreaming: true,
+    ...overrides,
+  };
+}
+
+function user(): Message {
+  return {
+    id: "run-1:user",
+    role: "user",
+    content: "hello",
+    timestamp: new Date("2026-09-10T02:59:59.000Z"),
+  };
+}
+
+test("assistantMessageHasContent treats recommend-only parts as empty", () => {
+  expect(assistantMessageHasContent(assistant())).toBe(false);
+  expect(
+    assistantMessageHasContent(
+      assistant({
+        parts: [
+          {
+            type: "recommend_questions",
+            questions: [{ content: "next?" }],
+          },
+        ],
+      }),
+    ),
+  ).toBe(false);
+  expect(assistantMessageHasContent(assistant({ content: "answer" }))).toBe(
+    true,
+  );
+  expect(assistantMessageHasContent(assistant({ cancelled: true }))).toBe(true);
+});
+
+test("settling an empty streaming assistant removes the orphan bubble", () => {
+  const settled = settleAssistantMessage([user(), assistant()], "assistant-1");
+
+  expect(settled).toHaveLength(1);
+  expect(settled[0]?.role).toBe("user");
+});
+
+test("settling a recommend-only shell removes it", () => {
+  const settled = settleAssistantMessage(
+    [
+      user(),
+      assistant({
+        parts: [
+          {
+            type: "recommend_questions",
+            questions: [{ content: "next?" }],
+          },
+        ],
+      }),
+    ],
+    "assistant-1",
+  );
+
+  expect(settled).toHaveLength(1);
+  expect(settled[0]?.role).toBe("user");
+});
+
+test("settling keeps a content-bearing assistant and stops streaming", () => {
+  const settled = settleAssistantMessage(
+    [user(), assistant({ content: "final answer" })],
+    "assistant-1",
+  );
+
+  expect(settled).toHaveLength(2);
+  expect(settled[1]?.isStreaming).toBe(false);
+  expect(settled[1]?.content).toBe("final answer");
+});
+
+test("settling keeps a turn whose only part is a pending ask_human card", () => {
+  const settled = settleAssistantMessage(
+    [
+      user(),
+      assistant({
+        parts: [
+          {
+            type: "tool",
+            name: "ask_human",
+            id: "approval-1",
+            args: { message: "confirm?" },
+            isPending: true,
+          },
+        ],
+      }),
+    ],
+    "assistant-1",
+  );
+
+  expect(settled).toHaveLength(2);
+  expect(settled[1]?.parts?.[0]?.type).toBe("tool");
+});
+
+test("settling is a no-op when the target message is absent", () => {
+  const settled = settleAssistantMessage([user()], "assistant-1");
+
+  expect(settled).toHaveLength(1);
+});

--- a/frontend/src/hooks/useAgent/__tests__/sseConnection.test.ts
+++ b/frontend/src/hooks/useAgent/__tests__/sseConnection.test.ts
@@ -1,8 +1,10 @@
 import { vi } from "vitest";
+import type { Message } from "../../../types";
 
 const mocks = vi.hoisted(() => ({
   fetchEventSource: vi.fn(),
   getValidAccessToken: vi.fn(),
+  getStatus: vi.fn(),
 }));
 
 vi.mock("@microsoft/fetch-event-source", () => ({
@@ -14,10 +16,18 @@ vi.mock("../../../services/api/tokenManager", () => ({
   refreshAccessToken: vi.fn(),
 }));
 
+vi.mock("../../../services/api", () => ({
+  sessionApi: {
+    getStatus: mocks.getStatus,
+    markRead: vi.fn(),
+  },
+}));
+
 import {
   connectToSSE,
   getSSECloseAction,
   isTerminalSSEEvent,
+  reconnectSSE,
   type SSEConnectionContext,
 } from "../sseConnection.ts";
 
@@ -75,4 +85,102 @@ test("a stale connection cannot start after token acquisition resolves", async (
 
   expect(mocks.fetchEventSource).not.toHaveBeenCalled();
   expect(statuses).toEqual([]);
+});
+
+function createReconnectContext(messages: Message[]) {
+  let currentMessages = messages;
+  const onStaleRunStateDetected = vi.fn();
+  const ctx = {
+    abortControllerRef: { current: null },
+    sseGenerationRef: { current: 0 },
+    isConnectingRef: { current: false },
+    streamingMessageIdRef: { current: "assistant-a" },
+    reconnectTimeoutRef: { current: null },
+    retryCountRef: { current: 0 },
+    sessionIdRef: { current: "session-a" },
+    currentRunIdRef: { current: "run-a" },
+    isReconnectFromHistoryRef: { current: false },
+    messagesRef: {
+      get current() {
+        return currentMessages;
+      },
+    },
+    setMessages: (updater: React.SetStateAction<Message[]>) => {
+      currentMessages =
+        typeof updater === "function" ? updater(currentMessages) : updater;
+    },
+    setConnectionStatus: () => undefined,
+    setIsInitializingSandbox: () => undefined,
+    setSessionId: () => undefined,
+    setActiveGoal: () => undefined,
+    setGoalsByRunId: () => undefined,
+    onStaleRunStateDetected,
+  } as unknown as SSEConnectionContext & {
+    onStaleRunStateDetected: ReturnType<typeof vi.fn>;
+    readMessages: () => Message[];
+  };
+  return {
+    ctx,
+    onStaleRunStateDetected,
+    readMessages: () => currentMessages,
+  };
+}
+
+test("reconnect drops an empty streaming bubble and reloads history when the run completed", async () => {
+  mocks.getStatus.mockResolvedValueOnce({ status: "completed" });
+  const { ctx, onStaleRunStateDetected, readMessages } = createReconnectContext([
+    {
+      id: "run-a:user",
+      role: "user",
+      content: "hello",
+      timestamp: new Date("2026-09-10T02:59:59.000Z"),
+    },
+    {
+      id: "assistant-a",
+      role: "assistant",
+      content: "",
+      timestamp: new Date("2026-09-10T03:00:00.000Z"),
+      parts: [],
+      isStreaming: true,
+    },
+  ]);
+
+  await reconnectSSE(
+    ctx as Parameters<typeof reconnectSSE>[0],
+    "run-a",
+  );
+
+  expect(readMessages().map((message) => message.id)).toEqual(["run-a:user"]);
+  expect(onStaleRunStateDetected).toHaveBeenCalledWith("run-a");
+});
+
+test("reconnect keeps a settled answer and does not reload history", async () => {
+  mocks.getStatus.mockResolvedValueOnce({ status: "completed" });
+  const { ctx, onStaleRunStateDetected, readMessages } = createReconnectContext([
+    {
+      id: "run-a:user",
+      role: "user",
+      content: "hello",
+      timestamp: new Date("2026-09-10T02:59:59.000Z"),
+    },
+    {
+      id: "assistant-a",
+      role: "assistant",
+      content: "final answer",
+      timestamp: new Date("2026-09-10T03:00:00.000Z"),
+      parts: [],
+      isStreaming: false,
+    },
+  ]);
+
+  await reconnectSSE(
+    ctx as Parameters<typeof reconnectSSE>[0],
+    "run-a",
+  );
+
+  expect(readMessages().map((message) => message.id)).toEqual([
+    "run-a:user",
+    "assistant-a",
+  ]);
+  expect(onStaleRunStateDetected).not.toHaveBeenCalled();
 });

--- a/frontend/src/hooks/useAgent/eventHandlers.ts
+++ b/frontend/src/hooks/useAgent/eventHandlers.ts
@@ -25,6 +25,7 @@ import {
   isSandboxConfirmApprovalEvent,
 } from "./messageParts";
 import { splitAssistantTurn } from "./steerTurnSplit";
+import { settleAssistantMessage } from "./settleStream";
 import { convertAttachments, processMessageEvent } from "./eventProcessor";
 import { dispatchToolMutationRefresh } from "../../components/chat/ChatMessage/items/toolMutationEvents";
 
@@ -52,6 +53,9 @@ export interface EventHandlerContext {
   setGoalsByRunId: React.Dispatch<
     React.SetStateAction<Record<string, import("./types").ActiveGoalSpec>>
   >;
+  /** 运行已在服务端终结、而本地流式目标从未收到正文（空壳）时触发，
+   *  用于拉起一次历史重载恢复存储端已有的内容。 */
+  onStaleRunStateDetected?: (runId: string) => void;
 }
 
 /**
@@ -350,19 +354,9 @@ export function handleStreamEvent(
 
     case "complete":
     case "done": {
-      ctx.setMessages((prev) =>
-        prev.map((m) =>
-          m.id === messageId
-            ? {
-                ...m,
-                isStreaming: false,
-                parts: clearAllLoadingStates(m.parts || [], {
-                  preserveAskHuman: true,
-                }),
-              }
-            : m,
-        ),
-      );
+      // 落定：清 loading；若目标从未收到任何正文（重放未挂上/只挂了推荐），
+      // 直接移除，避免留下只有头像和操作栏的孤儿气泡。
+      ctx.setMessages((prev) => settleAssistantMessage(prev, messageId));
       ctx.setConnectionStatus("disconnected");
       // AI 回复完成，用户正在查看当前 session，立即标记为已读
       const activeSessionId = ctx.sessionIdRef.current;

--- a/frontend/src/hooks/useAgent/historyLoader.ts
+++ b/frontend/src/hooks/useAgent/historyLoader.ts
@@ -25,6 +25,7 @@ import {
   createToolPart,
   isSandboxConfirmApprovalEvent,
 } from "./messageParts";
+import { assistantMessageHasContent } from "./settleStream";
 import { markInterruptedBySteer } from "./steerTurnSplit";
 import { parseDate } from "../../utils/datetime";
 
@@ -663,16 +664,14 @@ export function reconstructMessagesFromEvents(
   // producing assistant content. They still create a placeholder while the
   // event stream is being folded, which leaves an empty assistant bubble in
   // history between two real turns. Keep meaningful terminal/tool states, but
-  // remove content-less placeholders before the list reaches the UI.
+  // remove content-less placeholders before the list reaches the UI. A turn
+  // whose only payload is recommend questions counts as empty: suggestions
+  // render under the last message, never as a standalone empty bubble (this
+  // happens when an active-run snapshot synthesizes a recommend event next to
+  // a withheld content stream).
   return reconstructedMessages.filter((message) => {
     if (message.role !== "assistant") return true;
-    return Boolean(
-      message.content?.trim() ||
-        message.parts?.length ||
-        message.toolCalls?.length ||
-        message.toolResults?.length ||
-        message.cancelled,
-    );
+    return assistantMessageHasContent(message);
   });
 }
 

--- a/frontend/src/hooks/useAgent/settleStream.ts
+++ b/frontend/src/hooks/useAgent/settleStream.ts
@@ -1,0 +1,48 @@
+/**
+ * Streaming-target settlement helpers.
+ *
+ * A streaming assistant bubble can end its run without ever receiving
+ * content: the client reloaded mid-run and the SSE replay never attached,
+ * the run finished while disconnected, or only a recommend-questions push
+ * landed on the placeholder. Such a bubble must not survive as an empty
+ * orphan in the transcript — settle it, and drop it when nothing
+ * renderable remains.
+ */
+import type { Message } from "../../types";
+import { clearAllLoadingStates } from "./messageParts";
+
+/** Whether an assistant message carries anything renderable besides
+ *  recommend-questions suggestions (those render under the last message,
+ *  never as a standalone turn). */
+export function assistantMessageHasContent(message: Message): boolean {
+  return Boolean(
+    message.content?.trim() ||
+      message.toolCalls?.length ||
+      message.toolResults?.length ||
+      message.cancelled ||
+      message.parts?.some((part) => part.type !== "recommend_questions"),
+  );
+}
+
+export function settleAssistantMessage(
+  previous: Message[],
+  messageId: string,
+  options: { preserveAskHuman?: boolean } = {},
+): Message[] {
+  const target = previous.find((message) => message.id === messageId);
+  if (!target) return previous;
+
+  const settled: Message = {
+    ...target,
+    isStreaming: false,
+    parts: clearAllLoadingStates(target.parts || [], {
+      preserveAskHuman: options.preserveAskHuman ?? true,
+    }),
+  };
+  if (target.role === "assistant" && !assistantMessageHasContent(settled)) {
+    return previous.filter((message) => message.id !== messageId);
+  }
+  return previous.map((message) =>
+    message.id === messageId ? settled : message,
+  );
+}

--- a/frontend/src/hooks/useAgent/sseConnection.ts
+++ b/frontend/src/hooks/useAgent/sseConnection.ts
@@ -15,7 +15,10 @@ import {
 import { getRefreshToken } from "../../services/api/token";
 import type { EventType, StreamEvent } from "./types";
 import { handleStreamEvent, type EventHandlerContext } from "./eventHandlers";
-import { clearAllLoadingStates } from "./messageParts";
+import {
+  assistantMessageHasContent,
+  settleAssistantMessage,
+} from "./settleStream";
 import type { Message, ConnectionStatus } from "../../types";
 
 /**
@@ -237,19 +240,8 @@ export async function connectToSSE(
           setConnectionStatus("disconnected");
           isConnectingRef.current = false;
           ctx.setIsInitializingSandbox(false);
-          ctx.setMessages((prev) =>
-            prev.map((m) =>
-              m.id === messageId
-                ? {
-                    ...m,
-                    isStreaming: false,
-                    parts: clearAllLoadingStates(m.parts || [], {
-                      preserveAskHuman: true,
-                    }),
-                  }
-                : m,
-            ),
-          );
+          // 落定并移除从未收到正文的空壳气泡
+          ctx.setMessages((prev) => settleAssistantMessage(prev, messageId));
         },
       },
     );
@@ -331,19 +323,18 @@ export async function reconnectSSE(
       streamingMessageIdRef.current = null;
       // Clear loading states on the message
       if (currentMsgId) {
-        ctx.setMessages((prev) =>
-          prev.map((m) =>
-            m.id === currentMsgId
-              ? {
-                  ...m,
-                  isStreaming: false,
-                  parts: clearAllLoadingStates(m.parts || [], {
-                    preserveAskHuman: true,
-                  }),
-                }
-              : m,
-          ),
-        );
+        // 运行已在服务端终结：若本地目标仍在流式态或从未收到正文，
+        // 本地状态必然缺失（重放没挂上/断连窗口内完成）——落定并移除
+        // 空壳，同时拉起一次历史重载恢复存储端已有的内容。
+        const target = messagesRef.current.find((m) => m.id === currentMsgId);
+        const missingContent =
+          !target ||
+          target.isStreaming ||
+          (target.role === "assistant" && !assistantMessageHasContent(target));
+        ctx.setMessages((prev) => settleAssistantMessage(prev, currentMsgId));
+        if (missingContent) {
+          ctx.onStaleRunStateDetected?.(currentRId);
+        }
       }
       return;
     }

--- a/src/infra/session/trace_storage.py
+++ b/src/infra/session/trace_storage.py
@@ -773,7 +773,15 @@ class TraceStorage(
                     event.get("event_type") in {"recommend:questions", "followup:questions"}
                     for event in trace_events
                 )
-                if questions and recommendation_requested and not has_legacy_recommendation:
+                # 活跃 run 的历史快照只回 user:message（正文等 SSE 重放）；
+                # 此时合成 recommend:questions 会与零正文一起折叠成孤儿
+                # 空壳助手轮次——活跃 run 的推荐由实时通道推送。
+                if (
+                    questions
+                    and recommendation_requested
+                    and not has_legacy_recommendation
+                    and not is_active_running
+                ):
                     compatibility_event_type = "recommend:questions"
                     if (
                         event_types

--- a/tests/infra/session/test_trace_storage_recommendations.py
+++ b/tests/infra/session/test_trace_storage_recommendations.py
@@ -105,9 +105,7 @@ async def test_active_running_trace_does_not_synthesize_recommend_event() -> Non
         }
     )
 
-    snapshot = await storage.get_session_events_snapshot(
-        "session-1", active_run_id="run-1"
-    )
+    snapshot = await storage.get_session_events_snapshot("session-1", active_run_id="run-1")
 
     # 活跃 run 的历史快照只回 user:message（正文等 SSE 重放）；
     # 此时合成 recommend:questions 会折叠出零正文的孤儿助手轮次。

--- a/tests/infra/session/test_trace_storage_recommendations.py
+++ b/tests/infra/session/test_trace_storage_recommendations.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock
 
 import pytest
@@ -68,6 +69,51 @@ async def test_set_run_recommend_questions_persists_a_bounded_normalized_field()
     set_fields = collection.calls[0][1]["$set"]
     assert set_fields["recommend_questions"] == ["问题一？", "问题二？", "问题三？"]
     assert "recommend_questions_updated_at" in set_fields
+
+
+@pytest.mark.asyncio
+async def test_active_running_trace_does_not_synthesize_recommend_event() -> None:
+    collection = _ReadCollection(
+        [
+            {
+                "trace_id": "trace-1",
+                "run_id": "run-1",
+                "status": "running",
+                "started_at": "2026-09-10T02:57:40Z",
+                "updated_at": datetime.now(timezone.utc),
+                "recommend_questions": ["问题一？"],
+                "recommend_questions_updated_at": "2026-09-10T03:18:04Z",
+            }
+        ]
+    )
+    storage = TraceStorage()
+    storage._collection = collection
+    storage.read_trace_events_batch_compat = AsyncMock(  # type: ignore[method-assign]
+        return_value={
+            "trace-1": [
+                {
+                    "event_type": "user:message",
+                    "data": {"content": "hello"},
+                    "timestamp": "2026-09-10T02:57:41Z",
+                },
+                {
+                    "event_type": "message:chunk",
+                    "data": {"content": "partial"},
+                    "timestamp": "2026-09-10T03:00:00Z",
+                },
+            ]
+        }
+    )
+
+    snapshot = await storage.get_session_events_snapshot(
+        "session-1", active_run_id="run-1"
+    )
+
+    # 活跃 run 的历史快照只回 user:message（正文等 SSE 重放）；
+    # 此时合成 recommend:questions 会折叠出零正文的孤儿助手轮次。
+    assert [event["event_type"] for event in snapshot.events] == ["user:message"]
+    assert snapshot.history_mode == "active_user_only"
+    assert snapshot.stream_run_id == "run-1"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 问题

用户在 run 续跑窗口内重启客户端后，会话底部出现孤儿助手消息：只有头像、Agent 名称、操作栏（复制/收藏/分享/点赞点踩）和三条建议问题，正文为空。（生产会话 846b0afe 截图反馈）

## 根因（生产库数据实锤）

- `03:04:28` run 被发布重启打断（事件流存在 `token:usage → run:resumed` 断点）
- `03:04:41` 孤儿恢复无缝续跑同一 run
- 客户端在续跑窗口重载：历史接口对活跃 run 只回 `user:message`（active_user_only，正文等 SSE 重放），前端建**空流式占位气泡**
- SSE 重放未挂上；`03:18:04` run 完成时 WS 把 `recommend:questions` 按 runId 挂到空气泡
- 状态对账将气泡落定为非流式 → 孤儿空壳

## 修复（前后端双层防御）

| 层 | 改动 |
|----|------|
| 后端 | `trace_storage` 活跃 running trace 不再合成 `recommend:questions`（快照只回 user:message，推荐走实时通道） |
| 前端折叠 | `historyLoader` 空占位过滤排除 recommend-only part，纯推荐轮次丢弃 |
| 前端落定 | 新增 `settleStream.ts`：done/onclose/状态对账统一 `settleAssistantMessage`，无正文气泡移除 |
| 前端对账 | 重连发现 run 已完成但本地空壳/仍流式 → `onStaleRunStateDetected` 拉起历史重载恢复完整回答（带当前 run 与发送中守卫） |

受影响会话数据本身完好，修复上线后重新打开即恢复正常，无需修数据。

## 验证

- TDD：4 个新用例先红后绿
- 前端 vitest 2679 全过 + build + eslint 0 错误
- 后端 pytest 4527 全过 + ruff + mypy 干净