### PR TITLE
feat(llm): DeepSeek V4 系接入 reasoning_effort（思考强度控件 + 三档映射）

### DIFF
--- a/src/infra/llm/client.py
+++ b/src/infra/llm/client.py
@@ -237,6 +237,9 @@ def _langchain_profile(profile: Optional[dict]) -> Optional[dict]:
 _REASONING_EFFORT_PREFIXES: dict[str, tuple[str, ...]] = {
     "openai": ("gpt-5", "gpt-6", "o3", "o4"),
     "xai": ("grok-4",),
+    # deepseek V4 系官方接受 reasoning_effort（low/high/max，无 medium——
+    # medium 映射到 high）；旧 V3 家族（deepseek-chat/r1/v3）不发送
+    "deepseek": ("deepseek-flash", "deepseek-v4"),
 }
 # zhipu hybrid-reasoning GLM families that accept the `thinking` request-body
 # field (via model_kwargs). glm-4.7 未核实，不发送。
@@ -290,6 +293,9 @@ def _resolve_reasoning_effort(
         return None
 
     level = str(thinking.get("level") or "medium")
+    if provider == "deepseek":
+        # 官方仅 low/high/max 三档：medium 并入 high
+        return {"low": "low", "medium": "high", "high": "high", "max": "max"}.get(level, "high")
     if level == "max" and provider in {"openai", "xai"}:
         # max 档原生支持度按家族分野：gpt-6 与 grok-4.6+ 原生接受
         # max/xhigh；gpt-5/o3/o4 只到 high（发 max 会 400），降档处理
@@ -609,8 +615,8 @@ class LLMClient:
         #   langchain-openai 会自动映射为 reasoning.effort
         # - zhipu GLM-4.5+/GLM-5 收到 `thinking` 请求体字段（经 model_kwargs，
         #   仅 chat completions 线格式；/v1/responses 不接受该字段）
-        # - 其他 OpenAI 兼容提供商 (DeepSeek、Qwen 等) 有各自的推理机制，
-        #   发送 reasoning_effort 会触发不兼容的"思考模式"导致 API 报错
+        # - deepseek V4 系官方接受 reasoning_effort（见前缀表）；
+        #   其余 OpenAI 兼容提供商（Qwen 等）不发送——会触发不兼容思考模式
         reasoning_effort: Optional[str] = None
         zhipu_thinking_body: Optional[dict[str, Any]] = None
         if thinking:

--- a/tests/infra/llm/test_thinking_gating.py
+++ b/tests/infra/llm/test_thinking_gating.py
@@ -409,3 +409,29 @@ def test_model_supports_thinking_infers_provider_when_missing() -> None:
 def test_model_supports_thinking_explicit_provider_wins() -> None:
     # 显式 provider 优先于 value 前缀：google 渠道托管的 glm 走 Gemini 门控（不匹配）
     assert model_supports_thinking("google", "zhipu/glm-4.6") is False
+
+
+def test_deepseek_v4_receives_effort_with_medium_folded_to_high() -> None:
+    # 官方 Thinking Mode：low/high/max 三档，无 medium（并入 high）
+    for level, expected in [
+        ("low", "low"),
+        ("medium", "high"),
+        ("high", "high"),
+        ("max", "max"),
+    ]:
+        model = _openai_model("deepseek", "deepseek-flash", ENABLED(level))
+        assert model.reasoning_effort == expected, level
+    model = _openai_model("deepseek", "deepseek-v4-pro", ENABLED("max"))
+    assert model.reasoning_effort == "max"
+
+
+def test_deepseek_legacy_families_receive_no_effort() -> None:
+    for name in ("deepseek-chat", "deepseek-r1", "deepseek-v3"):
+        model = _openai_model("deepseek", name, ENABLED("high"))
+        assert model.reasoning_effort is None, name
+
+
+def test_model_supports_thinking_deepseek_families() -> None:
+    assert model_supports_thinking("deepseek", "deepseek-flash") is True
+    assert model_supports_thinking("deepseek", "deepseek-v4-pro") is True
+    assert model_supports_thinking("deepseek", "deepseek-chat") is False


### PR DESCRIPTION
## 背景

生产已配 DeepSeek 4.1 Flash（`deepseek-flash`，官方直连 + Responses API），但思考强度控件不显示——deepseek 不在思考家族表。

## 修复（按[官方 Thinking Mode 文档](https://api-docs.deepseek.com/guides/thinking_mode/)）

- `deepseek: ("deepseek-flash", "deepseek-v4")` 纳入 reasoning_effort 家族：控件可见、请求带参；responses 线格式经 langchain 自动映射 `reasoning.effort`（官方 /v1/responses 已实测支持）
- 档位映射：官方仅 **low/high/max** 三档，UI 的 medium 并入 high
- 旧 V3 家族（deepseek-chat/r1/v3）维持不发送
- 测试：三档映射 + medium 折叠 + 家族/排除 + supports_thinking

## 验证
- [x] 后端全量 4546 passed / MyPy / ruff 干净
- [x] 官方端点 /v1/responses + reasoning.effort 实测 200