### PR TITLE
fix(theme): 个人信息弹窗跟随 sepia 主题

### DIFF
--- a/frontend/src/__tests__/appSafeAreaSurfaces.test.ts
+++ b/frontend/src/__tests__/appSafeAreaSurfaces.test.ts
@@ -178,7 +178,7 @@ test("profile mobile sheet relies on the portal viewport safe area only", () => 
     /className="safe-area-viewport-padding-top fixed inset-0 z-\[300\] flex items-end/,
   );
   expect(profileModal).toMatch(
-    /sm:hidden relative z-10 w-full bg-white[^"]*safe-area-bottom/,
+    /sm:hidden relative z-10 w-full bg-theme-bg-card[^"]*safe-area-bottom/,
   );
   expect(profileModal).not.toMatch(
     /renderFooter\(\s*"[^"]*\bsafe-area-bottom\b/,

--- a/frontend/src/components/common/__tests__/fullscreenOverlaysSafeAreaSource.test.ts
+++ b/frontend/src/components/common/__tests__/fullscreenOverlaysSafeAreaSource.test.ts
@@ -178,7 +178,7 @@ const bottomSheetSurfaceExpectations: OverlayExpectation[] = [
   {
     name: "ProfileModal mobile sheet carries the bottom inset itself",
     path: "../../profile/ProfileModal.tsx",
-    pattern: /sm:hidden relative z-10 w-full bg-white[^"]*safe-area-bottom/,
+    pattern: /sm:hidden relative z-10 w-full bg-theme-bg-card[^"]*safe-area-bottom/,
   },
   {
     name: "SessionPreviewDialog sheet carries the bottom inset itself",

--- a/frontend/src/components/profile/LocalSandboxSection.tsx
+++ b/frontend/src/components/profile/LocalSandboxSection.tsx
@@ -211,20 +211,20 @@ export function LocalSandboxSection({
       <div className="flex items-center gap-1.5">
         <Monitor
           size={13}
-          className="text-stone-400 dark:text-stone-500 shrink-0"
+          className="text-theme-text-tertiary dark:text-stone-500 shrink-0"
         />
-        <span className="font-medium font-serif text-14 text-stone-900 dark:text-stone-100">
+        <span className="font-medium font-serif text-14 text-theme-text dark:text-stone-100">
           {t("profile.localSandbox.title")}
         </span>
       </div>
-      <p className="text-12 text-stone-500 dark:text-stone-400 mt-1 leading-relaxed">
+      <p className="text-12 text-theme-text-secondary dark:text-stone-400 mt-1 leading-relaxed">
         {t("profile.localSandbox.desc")}
       </p>
     </>
   ) : (
     <div className="flex items-center gap-2 mb-3">
       <Monitor size={13} className="text-amber-500 dark:text-amber-400" />
-      <h3 className="text-12 font-semibold font-serif uppercase tracking-wider text-stone-400 dark:text-stone-500">
+      <h3 className="text-12 font-semibold font-serif uppercase tracking-wider text-theme-text-tertiary dark:text-stone-500">
         {t("profile.localSandbox.title")}
       </h3>
     </div>
@@ -243,21 +243,21 @@ export function LocalSandboxSection({
           ) : online ? (
             <>
               <div className="flex w-full items-center justify-between gap-2 py-3 first:pt-2 last:pb-0 text-left">
-                <span className="flex min-w-0 items-center gap-2 text-14 text-stone-700 dark:text-stone-200">
+                <span className="flex min-w-0 items-center gap-2 text-14 text-theme-text dark:text-stone-200">
                   <span
                     className="h-2 w-2 rounded-full shrink-0 bg-green-500"
                     data-sandbox-online={online}
                   />
                   {t("profile.localSandbox.statusOnline")}
                   {status?.daemon_version && (
-                    <span className="truncate text-12 text-stone-500 dark:text-stone-400">
+                    <span className="truncate text-12 text-theme-text-secondary dark:text-stone-400">
                       {t("profile.localSandbox.version", {
                         version: status.daemon_version,
                       })}
                     </span>
                   )}
                 </span>
-                <span className="shrink-0 text-12 text-stone-500 dark:text-stone-400">
+                <span className="shrink-0 text-12 text-theme-text-secondary dark:text-stone-400">
                   {t("profile.localSandbox.webManaged")}
                 </span>
               </div>
@@ -266,7 +266,7 @@ export function LocalSandboxSection({
             </>
           ) : (
             <div className="space-y-2">
-              <p className="text-12 text-stone-500 dark:text-stone-400">
+              <p className="text-12 text-theme-text-secondary dark:text-stone-400">
                 {t("profile.localSandbox.needDesktop")}
               </p>
               {/* 离线引导：跳站内下载页（桌面端/daemon 安装包 + 配对教程） */}
@@ -286,13 +286,13 @@ export function LocalSandboxSection({
     );
     if (embedded) {
       return (
-        <div className="mt-3 border-t border-stone-200/70 dark:border-stone-600/50 pt-3.5">
+        <div className="mt-3 border-t border-theme-border dark:border-stone-600/50 pt-3.5">
           {webBody}
         </div>
       );
     }
     return (
-      <div className="rounded-2xl bg-theme-bg-subtle dark:bg-stone-700/40 p-4 border border-stone-200/60 dark:border-stone-600/40">
+      <div className="rounded-2xl bg-theme-bg-subtle dark:bg-stone-700/40 p-4 border border-theme-border dark:border-stone-600/40">
         {webBody}
       </div>
     );
@@ -449,10 +449,10 @@ export function LocalSandboxSection({
           <SkeletonLine width="w-full" />
         ) : (
           <div className="flex w-full items-center justify-between gap-2 py-3 first:pt-2 last:pb-0 text-left">
-            <span className="flex min-w-0 items-center gap-2 text-14 text-stone-700 dark:text-stone-200">
+            <span className="flex min-w-0 items-center gap-2 text-14 text-theme-text dark:text-stone-200">
               <span
                 className={`h-2 w-2 rounded-full shrink-0 ${
-                  online ? "bg-green-500" : "bg-stone-400 dark:bg-stone-500"
+                  online ? "bg-green-500" : "bg-theme-text-tertiary dark:bg-stone-500"
                 }`}
                 data-sandbox-online={online}
               />
@@ -460,7 +460,7 @@ export function LocalSandboxSection({
                 ? t("profile.localSandbox.statusOnline")
                 : t("profile.localSandbox.statusOffline")}
               {status?.daemon_version && (
-                <span className="truncate text-12 text-stone-500 dark:text-stone-400">
+                <span className="truncate text-12 text-theme-text-secondary dark:text-stone-400">
                   {t("profile.localSandbox.version", {
                     version: status.daemon_version,
                   })}
@@ -471,7 +471,7 @@ export function LocalSandboxSection({
               className={`shrink-0 rounded-full px-2 py-0.5 text-10 font-medium ${
                 processStatus === "running"
                   ? "bg-green-500/10 text-green-600 dark:text-green-400"
-                  : "bg-stone-500/10 dark:bg-stone-500/20 text-stone-500 dark:text-stone-400"
+                  : "bg-stone-500/10 dark:bg-stone-500/20 text-theme-text-secondary dark:text-stone-400"
               }`}
             >
               {processStatus === "running"
@@ -483,7 +483,7 @@ export function LocalSandboxSection({
 
         {unpaired ? (
           <form onSubmit={handlePair} className="space-y-2 pt-2">
-            <p className="text-12 text-stone-500 dark:text-stone-400">
+            <p className="text-12 text-theme-text-secondary dark:text-stone-400">
               {t("profile.localSandbox.pairTitle")}
             </p>
             {/* 一键配对：当前登录账号铸 PAT（OAuth 账号唯一可用的手动路径） */}
@@ -498,7 +498,7 @@ export function LocalSandboxSection({
                 ? t("common.loading")
                 : t("profile.localSandbox.pairWithCurrent")}
             </button>
-            <p className="pt-1 text-12 text-stone-400 dark:text-stone-500">
+            <p className="pt-1 text-12 text-theme-text-tertiary dark:text-stone-500">
               {t("profile.localSandbox.pairOtherAccount")}
             </p>
             <input
@@ -507,7 +507,7 @@ export function LocalSandboxSection({
               placeholder={t("auth.usernamePlaceholder")}
               value={username}
               onChange={(e) => setUsername(e.target.value)}
-              className="w-full rounded-xl border border-stone-200 dark:border-stone-600 bg-theme-bg-card dark:bg-stone-800 px-3 py-2 text-14 text-stone-800 dark:text-stone-100 focus:outline-none focus:ring-1 focus:ring-amber-400"
+              className="w-full rounded-xl border border-theme-border dark:border-stone-600 bg-theme-bg-card dark:bg-stone-800 px-3 py-2 text-14 text-theme-text dark:text-stone-100 focus:outline-none focus:ring-1 focus:ring-amber-400"
             />
             <input
               type="password"
@@ -515,12 +515,12 @@ export function LocalSandboxSection({
               placeholder={t("auth.passwordPlaceholder")}
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className="w-full rounded-xl border border-stone-200 dark:border-stone-600 bg-theme-bg-card dark:bg-stone-800 px-3 py-2 text-14 text-stone-800 dark:text-stone-100 focus:outline-none focus:ring-1 focus:ring-amber-400"
+              className="w-full rounded-xl border border-theme-border dark:border-stone-600 bg-theme-bg-card dark:bg-stone-800 px-3 py-2 text-14 text-theme-text dark:text-stone-100 focus:outline-none focus:ring-1 focus:ring-amber-400"
             />
             <button
               type="submit"
               disabled={pairing || !username.trim() || !password}
-              className="w-full rounded-xl border border-stone-200/80 dark:border-stone-500/70 disabled:opacity-50 px-3 py-2 text-14 font-medium text-stone-600 dark:text-stone-300 transition-colors hover:border-stone-300 dark:hover:border-stone-400/70 hover:bg-white dark:hover:bg-stone-800/70"
+              className="w-full rounded-xl border border-theme-border dark:border-stone-500/70 disabled:opacity-50 px-3 py-2 text-14 font-medium text-theme-text-secondary dark:text-stone-300 transition-colors hover:border-theme-border-hover dark:hover:border-stone-400/70 hover:bg-theme-bg-card dark:hover:bg-stone-800/70"
             >
               {pairing
                 ? t("common.loading")
@@ -545,7 +545,7 @@ export function LocalSandboxSection({
               <button
                 type="button"
                 onClick={() => handleOpenLocalPath("workspaces")}
-                className="flex items-center justify-center gap-1.5 rounded-xl border border-stone-200/80 dark:border-stone-500/70 px-2 py-2 text-12 font-medium text-stone-600 dark:text-stone-300 transition-colors hover:border-stone-300 dark:hover:border-stone-400/70 hover:bg-white dark:hover:bg-stone-800/70"
+                className="flex items-center justify-center gap-1.5 rounded-xl border border-theme-border dark:border-stone-500/70 px-2 py-2 text-12 font-medium text-theme-text-secondary dark:text-stone-300 transition-colors hover:border-theme-border-hover dark:hover:border-stone-400/70 hover:bg-theme-bg-card dark:hover:bg-stone-800/70"
               >
                 <FolderOpen size={12} className="shrink-0 opacity-60" />
                 <span className="truncate">
@@ -555,7 +555,7 @@ export function LocalSandboxSection({
               <button
                 type="button"
                 onClick={() => handleOpenLocalPath("audit")}
-                className="flex items-center justify-center gap-1.5 rounded-xl border border-stone-200/80 dark:border-stone-500/70 px-2 py-2 text-12 font-medium text-stone-600 dark:text-stone-300 transition-colors hover:border-stone-300 dark:hover:border-stone-400/70 hover:bg-white dark:hover:bg-stone-800/70"
+                className="flex items-center justify-center gap-1.5 rounded-xl border border-theme-border dark:border-stone-500/70 px-2 py-2 text-12 font-medium text-theme-text-secondary dark:text-stone-300 transition-colors hover:border-theme-border-hover dark:hover:border-stone-400/70 hover:bg-theme-bg-card dark:hover:bg-stone-800/70"
               >
                 <FolderOpen size={12} className="shrink-0 opacity-60" />
                 <span className="truncate">
@@ -565,7 +565,7 @@ export function LocalSandboxSection({
               <button
                 type="button"
                 onClick={handleRestart}
-                className="flex items-center justify-center gap-1.5 rounded-xl border border-stone-200/80 dark:border-stone-500/70 px-2 py-2 text-12 font-medium text-stone-600 dark:text-stone-300 transition-colors hover:border-stone-300 dark:hover:border-stone-400/70 hover:bg-white dark:hover:bg-stone-800/70"
+                className="flex items-center justify-center gap-1.5 rounded-xl border border-theme-border dark:border-stone-500/70 px-2 py-2 text-12 font-medium text-theme-text-secondary dark:text-stone-300 transition-colors hover:border-theme-border-hover dark:hover:border-stone-400/70 hover:bg-theme-bg-card dark:hover:bg-stone-800/70"
               >
                 <RotateCw size={12} className="shrink-0 opacity-60" />
                 <span className="truncate">
@@ -581,7 +581,7 @@ export function LocalSandboxSection({
                 type="button"
                 onClick={handleUnpair}
                 disabled={unpairing}
-                className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-12 text-stone-400 dark:text-stone-500 transition-colors hover:bg-red-50 dark:hover:bg-red-950/30 hover:text-red-600 dark:hover:text-red-400 disabled:opacity-50"
+                className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-12 text-theme-text-tertiary dark:text-stone-500 transition-colors hover:bg-red-50 dark:hover:bg-red-950/30 hover:text-red-600 dark:hover:text-red-400 disabled:opacity-50"
               >
                 <Link2Off size={12} />
                 {unpairing
@@ -600,13 +600,13 @@ export function LocalSandboxSection({
 
   if (embedded) {
     return (
-      <div className="mt-3 border-t border-stone-200/70 dark:border-stone-600/50 pt-3.5">
+      <div className="mt-3 border-t border-theme-border dark:border-stone-600/50 pt-3.5">
         {body}
       </div>
     );
   }
   return (
-    <div className="rounded-2xl bg-theme-bg-subtle dark:bg-stone-700/40 p-4 border border-stone-200/60 dark:border-stone-600/40">
+    <div className="rounded-2xl bg-theme-bg-subtle dark:bg-stone-700/40 p-4 border border-theme-border dark:border-stone-600/40">
       {body}
     </div>
   );

--- a/frontend/src/components/profile/ProfileModal.tsx
+++ b/frontend/src/components/profile/ProfileModal.tsx
@@ -120,7 +120,7 @@ export function ProfileModal({
   const renderCloseButton = (className?: string) => (
     <button
       onClick={onCloseProfileModal}
-      className={`p-1.5 rounded-lg text-stone-400 hover:text-stone-600 hover:bg-stone-100 dark:text-stone-500 dark:hover:text-stone-300 dark:hover:bg-stone-700/60 transition-all ${
+      className={`p-1.5 rounded-lg text-theme-text-tertiary hover:text-theme-text-secondary hover:bg-theme-bg-subtle dark:text-stone-500 dark:hover:text-stone-300 dark:hover:bg-stone-700/60 transition-all ${
         className ?? ""
       }`}
     >
@@ -130,7 +130,7 @@ export function ProfileModal({
 
   const renderFooter = (className?: string) => (
     <div
-      className={`px-4 sm:px-5 py-2.5 sm:py-3 border-t border-stone-100 dark:border-stone-700/50 flex items-center justify-between bg-stone-50/50 dark:bg-stone-900/30 whitespace-nowrap ${
+      className={`px-4 sm:px-5 py-2.5 sm:py-3 border-t border-theme-border-subtle dark:border-stone-700/50 flex items-center justify-between bg-theme-bg-subtle dark:bg-stone-900/30 whitespace-nowrap ${
         className ?? ""
       }`}
     >
@@ -139,11 +139,11 @@ export function ProfileModal({
         target="_blank"
         rel="noopener noreferrer"
         onClick={(e) => e.stopPropagation()}
-        className="text-11 text-stone-400 dark:text-stone-500 tabular-nums hover:text-stone-600 dark:hover:text-stone-300 transition-colors flex items-center gap-1 leading-none"
+        className="text-11 text-theme-text-tertiary dark:text-stone-500 tabular-nums hover:text-theme-text-secondary dark:hover:text-stone-300 transition-colors flex items-center gap-1 leading-none"
       >
         <BrandWordmark
           decorative
-          className="inline-block h-4 w-auto text-stone-500 dark:text-stone-400"
+          className="inline-block h-4 w-auto text-theme-text-secondary dark:text-stone-400"
         />
         {/* 客户端自身版本（打包进 bundle），不是所连服务端的版本 */}
         <span className="opacity-70 font-serif leading-none">
@@ -155,7 +155,7 @@ export function ProfileModal({
         target="_blank"
         rel="noopener noreferrer"
         onClick={(e) => e.stopPropagation()}
-        className="px-1.5 sm:px-2 text-11 font-medium text-stone-400 dark:text-stone-500 hover:text-stone-600 dark:hover:text-stone-300 transition-colors py-1 rounded-md hover:bg-stone-100 dark:hover:bg-stone-700/60 shrink-0 font-serif leading-none"
+        className="px-1.5 sm:px-2 text-11 font-medium text-theme-text-tertiary dark:text-stone-500 hover:text-theme-text-secondary dark:hover:text-stone-300 transition-colors py-1 rounded-md hover:bg-theme-bg-subtle dark:hover:bg-stone-700/60 shrink-0 font-serif leading-none"
       >
         {t("common.poweredBy")}
       </a>
@@ -174,17 +174,17 @@ export function ProfileModal({
       {/* ===== Mobile: bottom sheet ===== */}
       <div
         ref={swipeRef as React.RefObject<HTMLDivElement>}
-        className="sm:hidden relative z-10 w-full bg-white dark:bg-stone-800 rounded-t-2xl shadow-2xl shadow-black/20 dark:shadow-black/50 border-x border-t border-stone-200/80 dark:border-stone-700/60 overflow-hidden max-h-[90dvh] flex flex-col animate-slide-up-sheet safe-area-bottom"
+        className="sm:hidden relative z-10 w-full bg-theme-bg-card dark:bg-stone-800 rounded-t-2xl shadow-2xl shadow-black/20 dark:shadow-black/50 border-x border-t border-theme-border dark:border-stone-700/60 overflow-hidden max-h-[90dvh] flex flex-col animate-slide-up-sheet safe-area-bottom"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Drag handle */}
         <div className="flex justify-center pt-3 pb-1">
-          <div className="w-9 h-1 bg-stone-300 dark:bg-stone-600 rounded-full" />
+          <div className="w-9 h-1 bg-theme-border-hover dark:bg-stone-600 rounded-full" />
         </div>
 
         {/* Header */}
         <div className="px-4 py-2.5 flex items-center justify-between">
-          <h3 className="text-15 font-semibold text-stone-900 dark:text-stone-100 tracking-tight font-serif">
+          <h3 className="text-15 font-semibold text-theme-text dark:text-stone-100 tracking-tight font-serif">
             {t("profile.title")}
           </h3>
           {renderCloseButton()}
@@ -209,7 +209,7 @@ export function ProfileModal({
                   className={`relative shrink-0 flex items-center gap-1.5 px-3 py-2 rounded-lg text-12 font-medium transition-all whitespace-nowrap ${
                     isActive
                       ? "bg-stone-900 text-white dark:bg-stone-100 dark:text-stone-900"
-                      : "text-stone-500 dark:text-stone-400 hover:bg-stone-100 dark:hover:bg-stone-700/50"
+                      : "text-theme-text-secondary dark:text-stone-400 hover:bg-theme-bg-subtle dark:hover:bg-stone-700/50"
                   }`}
                 >
                   {Icon && <Icon size={14} />}
@@ -241,16 +241,16 @@ export function ProfileModal({
 
       {/* ===== Desktop: centered with sidebar ===== */}
       <div
-        className="hidden sm:flex relative z-10 w-[80vw] max-w-[680px] h-[75dvh] max-h-[640px] bg-white dark:bg-stone-800 rounded-2xl shadow-2xl shadow-stone-900/10 dark:shadow-black/40 border border-stone-200/80 dark:border-stone-700/50 overflow-hidden flex-col animate-scale-in"
+        className="hidden sm:flex relative z-10 w-[80vw] max-w-[680px] h-[75dvh] max-h-[640px] bg-theme-bg-card dark:bg-stone-800 rounded-2xl shadow-2xl shadow-stone-900/10 dark:shadow-black/40 border border-theme-border dark:border-stone-700/50 overflow-hidden flex-col animate-scale-in"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="px-5 py-4 flex items-center justify-between border-b border-stone-100 dark:border-stone-700/50">
+        <div className="px-5 py-4 flex items-center justify-between border-b border-theme-border-subtle dark:border-stone-700/50">
           <div>
-            <h3 className="text-14 font-semibold font-serif text-stone-900 dark:text-stone-100 tracking-tight">
+            <h3 className="text-14 font-semibold font-serif text-theme-text dark:text-stone-100 tracking-tight">
               {t("profile.title")}
             </h3>
-            <p className="text-11 text-stone-400 dark:text-stone-500 mt-0.5">
+            <p className="text-11 text-theme-text-tertiary dark:text-stone-500 mt-0.5">
               {t("profile.title")}
             </p>
           </div>
@@ -260,7 +260,7 @@ export function ProfileModal({
         {/* Body: left sidebar tabs + right content */}
         <div className="flex flex-1 min-h-0">
           {/* Left sidebar tabs */}
-          <div className="w-[152px] shrink-0 border-r border-stone-100 dark:border-stone-700/50 py-2 px-2 space-y-0.5 bg-stone-50/50 dark:bg-stone-900/20">
+          <div className="w-[152px] shrink-0 border-r border-theme-border-subtle dark:border-stone-700/50 py-2 px-2 space-y-0.5 bg-theme-bg-subtle dark:bg-stone-900/20">
             {tabs.map((tab) => {
               const Icon = TAB_ICONS[tab.key];
               const isActive = activeTab === tab.key;
@@ -270,8 +270,8 @@ export function ProfileModal({
                   onClick={() => setActiveTab(tab.key)}
                   className={`w-full text-left flex items-center gap-2.5 px-3 py-2.5 rounded-lg text-12 font-medium transition-all ${
                     isActive
-                      ? "bg-white dark:bg-stone-800 text-stone-900 dark:text-stone-100 shadow-sm border border-stone-200/80 dark:border-stone-700/60"
-                      : "text-stone-500 dark:text-stone-400 hover:text-stone-700 dark:hover:text-stone-200 hover:bg-white/60 dark:hover:bg-stone-800/60 border border-transparent"
+                      ? "bg-theme-bg-card dark:bg-stone-800 text-theme-text dark:text-stone-100 shadow-sm border border-theme-border dark:border-stone-700/60"
+                      : "text-theme-text-secondary dark:text-stone-400 hover:text-theme-text dark:hover:text-stone-200 hover:bg-theme-bg-card dark:hover:bg-stone-800/60 border border-transparent"
                   }`}
                 >
                   {Icon && (
@@ -288,7 +288,7 @@ export function ProfileModal({
                 </button>
               );
             })}
-            <div className="!mt-3 pt-3 border-t border-stone-200/80 dark:border-stone-700/50">
+            <div className="!mt-3 pt-3 border-t border-theme-border dark:border-stone-700/50">
               <button
                 onClick={() => {
                   logout();

--- a/frontend/src/components/profile/SandboxMachinesCard.tsx
+++ b/frontend/src/components/profile/SandboxMachinesCard.tsx
@@ -93,29 +93,29 @@ export function SandboxMachinesCard() {
   };
 
   return (
-    <div className="mt-3 border-t border-stone-200/70 dark:border-stone-600/50 pt-3.5">
+    <div className="mt-3 border-t border-theme-border dark:border-stone-600/50 pt-3.5">
       <div className="flex items-center gap-1.5">
         <Laptop
           size={13}
-          className="text-stone-400 dark:text-stone-500 shrink-0"
+          className="text-theme-text-tertiary dark:text-stone-500 shrink-0"
         />
-        <span className="font-medium font-serif text-14 text-stone-900 dark:text-stone-100">
+        <span className="font-medium font-serif text-14 text-theme-text dark:text-stone-100">
           {t("profile.localSandbox.machines")}
         </span>
       </div>
-      <p className="text-12 text-stone-500 dark:text-stone-400 mt-1 leading-relaxed">
+      <p className="text-12 text-theme-text-secondary dark:text-stone-400 mt-1 leading-relaxed">
         {t("profile.localSandbox.machinesDesc")}
       </p>
 
       {/* 当前服务器：label-value 行（同设置行语言，mono 值右对齐截断）；
           运行时配置优先，构建期烘焙兜底 */}
       <div className="flex items-center justify-between gap-3 py-2.5">
-        <span className="flex shrink-0 items-center gap-1.5 text-14 text-stone-700 dark:text-stone-200">
+        <span className="flex shrink-0 items-center gap-1.5 text-14 text-theme-text dark:text-stone-200">
           <Link2 size={13} className="opacity-50" />
           {t("profile.localSandbox.currentServer")}
         </span>
         <span
-          className="min-w-0 truncate font-mono text-12 text-stone-500 dark:text-stone-400"
+          className="min-w-0 truncate font-mono text-12 text-theme-text-secondary dark:text-stone-400"
           data-sandbox-server-url
         >
           {serverUrl}
@@ -124,7 +124,7 @@ export function SandboxMachinesCard() {
 
       <div data-sandbox-machines-count={machines.length}>
         {online && machines.length === 0 && (
-          <p className="py-1.5 text-12 text-stone-400 dark:text-stone-500">
+          <p className="py-1.5 text-12 text-theme-text-tertiary dark:text-stone-500">
             {t("profile.localSandbox.machinesEmpty")}
           </p>
         )}
@@ -136,14 +136,14 @@ export function SandboxMachinesCard() {
           return (
             <div
               key={machine.machine_id}
-              className={`flex items-center gap-2 rounded-lg px-1.5 py-2 transition-colors hover:bg-stone-100/70 dark:hover:bg-stone-700/40 ${
+              className={`flex items-center gap-2 rounded-lg px-1.5 py-2 transition-colors hover:bg-theme-bg-subtle dark:hover:bg-stone-700/40 ${
                 machineOnline ? "" : "opacity-60"
               }`}
               data-sandbox-machine={machine.machine_id}
             >
               <span
                 className={`h-2 w-2 rounded-full shrink-0 ${
-                  machineOnline ? "bg-green-500" : "bg-stone-300 dark:bg-stone-600"
+                  machineOnline ? "bg-green-500" : "bg-theme-border-hover dark:bg-stone-600"
                 }`}
               />
               {renaming ? (
@@ -156,13 +156,13 @@ export function SandboxMachinesCard() {
                       if (e.key === "Enter") void submitRename();
                       if (e.key === "Escape") setRenamingId(null);
                     }}
-                    className="min-w-0 flex-1 rounded-md border border-amber-300 dark:border-amber-500/60 bg-theme-bg-card dark:bg-stone-800 px-2 py-1 text-14 text-stone-800 dark:text-stone-100 focus:outline-none focus:ring-1 focus:ring-amber-400"
+                    className="min-w-0 flex-1 rounded-md border border-amber-300 dark:border-amber-500/60 bg-theme-bg-card dark:bg-stone-800 px-2 py-1 text-14 text-theme-text dark:text-stone-100 focus:outline-none focus:ring-1 focus:ring-amber-400"
                   />
                   <button
                     type="button"
                     onClick={() => void submitRename()}
                     disabled={busy || !renameValue.trim()}
-                    className="rounded-md p-1 text-stone-500 hover:text-amber-500 disabled:opacity-40"
+                    className="rounded-md p-1 text-theme-text-secondary hover:text-amber-500 disabled:opacity-40"
                     title={t("profile.localSandbox.renameSave")}
                   >
                     <Check size={13} />
@@ -170,7 +170,7 @@ export function SandboxMachinesCard() {
                   <button
                     type="button"
                     onClick={() => setRenamingId(null)}
-                    className="rounded-md p-1 text-stone-500 hover:text-stone-700 dark:hover:text-stone-300"
+                    className="rounded-md p-1 text-theme-text-secondary hover:text-theme-text dark:hover:text-stone-300"
                     title={t("profile.localSandbox.renameCancel")}
                   >
                     <X size={13} />
@@ -178,7 +178,7 @@ export function SandboxMachinesCard() {
                 </span>
               ) : (
                 <>
-                  <span className="min-w-0 flex-1 truncate text-14 font-medium text-stone-800 dark:text-stone-100">
+                  <span className="min-w-0 flex-1 truncate text-14 font-medium text-theme-text dark:text-stone-100">
                     {machine.name}
                     {isDefault && (
                       <span className="ml-1.5 whitespace-nowrap rounded-full bg-amber-100 dark:bg-amber-500/15 px-1.5 py-0.5 text-10 font-medium text-amber-700 dark:text-amber-400">
@@ -186,17 +186,17 @@ export function SandboxMachinesCard() {
                       </span>
                     )}
                   </span>
-                  <span className="shrink-0 whitespace-nowrap text-12 text-stone-500 dark:text-stone-400">
+                  <span className="shrink-0 whitespace-nowrap text-12 text-theme-text-secondary dark:text-stone-400">
                     {machinePlatformLabel(machine.platform, t)}
                     {machine.version ? ` · v${machine.version}` : ""}
                     {!machineOnline && (
-                      <span className="ml-1.5 rounded-full bg-stone-200 dark:bg-stone-700 px-1.5 py-0.5 text-10 font-medium text-stone-500 dark:text-stone-400">
+                      <span className="ml-1.5 rounded-full bg-theme-border dark:bg-stone-700 px-1.5 py-0.5 text-10 font-medium text-theme-text-secondary dark:text-stone-400">
                         {t("profile.localSandbox.offlineBadge")}
                       </span>
                     )}
                     {!machineOnline && lastSeenKey && (
                       <span
-                        className="ml-1.5 text-11 text-stone-400 dark:text-stone-500"
+                        className="ml-1.5 text-11 text-theme-text-tertiary dark:text-stone-500"
                         data-testid={`last-seen-${machine.machine_id}`}
                       >
                         {t(`profile.localSandbox.lastSeen.${lastSeenKey}`, {
@@ -227,7 +227,7 @@ export function SandboxMachinesCard() {
                       type="button"
                       onClick={() => void handleForget(machine)}
                       disabled={busy}
-                      className="rounded-md p-1 text-stone-400 dark:text-stone-500 transition-colors hover:text-red-500 dark:hover:text-red-400 disabled:opacity-50"
+                      className="rounded-md p-1 text-theme-text-tertiary dark:text-stone-500 transition-colors hover:text-red-500 dark:hover:text-red-400 disabled:opacity-50"
                       title={t("profile.localSandbox.forgetMachine")}
                       data-testid={`forget-${machine.machine_id}`}
                     >
@@ -239,7 +239,7 @@ export function SandboxMachinesCard() {
                       type="button"
                       onClick={() => void handleSetDefault(machine.machine_id)}
                       disabled={busy}
-                      className="flex shrink-0 items-center gap-1 rounded-md px-1.5 py-1 text-12 text-stone-400 dark:text-stone-500 transition-colors hover:bg-amber-50 dark:hover:bg-amber-500/10 hover:text-amber-600 dark:hover:text-amber-400 disabled:opacity-50"
+                      className="flex shrink-0 items-center gap-1 rounded-md px-1.5 py-1 text-12 text-theme-text-tertiary dark:text-stone-500 transition-colors hover:bg-amber-50 dark:hover:bg-amber-500/10 hover:text-amber-600 dark:hover:text-amber-400 disabled:opacity-50"
                       title={t("profile.localSandbox.setDefault")}
                     >
                       <Star size={11} />
@@ -250,7 +250,7 @@ export function SandboxMachinesCard() {
                     type="button"
                     onClick={() => startRename(machine)}
                     disabled={busy}
-                    className="shrink-0 rounded-md p-1 text-stone-400 dark:text-stone-500 transition-colors hover:bg-stone-200/70 dark:hover:bg-stone-700/60 hover:text-stone-700 dark:hover:text-stone-200 disabled:opacity-50"
+                    className="shrink-0 rounded-md p-1 text-theme-text-tertiary dark:text-stone-500 transition-colors hover:bg-theme-bg-subtle dark:hover:bg-stone-700/60 hover:text-theme-text dark:hover:text-stone-200 disabled:opacity-50"
                     title={t("profile.localSandbox.rename")}
                   >
                     <Pencil size={12} className="opacity-70" />

--- a/frontend/src/components/profile/SelectRow.tsx
+++ b/frontend/src/components/profile/SelectRow.tsx
@@ -32,10 +32,10 @@ export function SelectRow<T extends string>({
         onClick={onToggle}
         className="flex w-full items-center justify-between py-3 first:pt-0 last:pb-0 text-left"
       >
-        <span className="text-14 text-stone-700 dark:text-stone-200">
+        <span className="text-14 text-theme-text dark:text-stone-200">
           {label}
         </span>
-        <span className="flex items-center gap-1 text-12 text-stone-500 dark:text-stone-400">
+        <span className="flex items-center gap-1 text-12 text-theme-text-secondary dark:text-stone-400">
           {loading ? (
             <SkeletonLine width="w-16" />
           ) : (
@@ -47,7 +47,7 @@ export function SelectRow<T extends string>({
                   : value}
             </span>
           )}
-          <ChevronRight size={14} className="shrink-0 text-stone-400" />
+          <ChevronRight size={14} className="shrink-0 text-theme-text-tertiary" />
         </span>
       </button>
       {open &&
@@ -58,11 +58,11 @@ export function SelectRow<T extends string>({
           >
             <div className="absolute inset-0 bg-black/40" />
             <div
-              className="relative z-10 w-[300px] max-h-[60dvh] rounded-2xl bg-theme-bg-card dark:bg-stone-800 border border-stone-200 dark:border-stone-700 shadow-2xl overflow-hidden animate-scale-in"
+              className="relative z-10 w-[300px] max-h-[60dvh] rounded-2xl bg-theme-bg-card dark:bg-stone-800 border border-theme-border dark:border-stone-700 shadow-2xl overflow-hidden animate-scale-in"
               onClick={(e) => e.stopPropagation()}
             >
               <div className="px-5 pt-4 pb-2">
-                <h4 className="text-14 font-semibold font-serif text-stone-900 dark:text-stone-100">
+                <h4 className="text-14 font-semibold font-serif text-theme-text dark:text-stone-100">
                   {label}
                 </h4>
               </div>
@@ -73,8 +73,8 @@ export function SelectRow<T extends string>({
                     onClick={() => onSelect(opt.key)}
                     className={`w-full text-left px-5 py-2.5 text-14 transition-colors ${
                       value === opt.key
-                        ? "bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300 font-medium"
-                        : "text-stone-700 dark:text-stone-300 hover:bg-stone-50 dark:hover:bg-stone-700/50"
+                        ? "bg-theme-accent-light dark:bg-amber-900/20 text-amber-700 dark:text-amber-300 font-medium"
+                        : "text-theme-text dark:text-stone-300 hover:bg-theme-bg-subtle dark:hover:bg-stone-700/50"
                     }`}
                   >
                     <span className="flex items-center justify-between">
@@ -86,10 +86,10 @@ export function SelectRow<T extends string>({
                   </button>
                 ))}
               </div>
-              <div className="border-t border-stone-100 dark:border-stone-700/50 px-5 py-3">
+              <div className="border-t border-theme-border-subtle dark:border-stone-700/50 px-5 py-3">
                 <button
                   onClick={onToggle}
-                  className="w-full text-center text-12 font-medium text-stone-500 dark:text-stone-400 hover:text-stone-700 dark:hover:text-stone-200 transition-colors"
+                  className="w-full text-center text-12 font-medium text-theme-text-secondary dark:text-stone-400 hover:text-theme-text dark:hover:text-stone-200 transition-colors"
                 >
                   {t("common.cancel")}
                 </button>

--- a/frontend/src/components/profile/__tests__/profileSepiaAdaptationSource.test.ts
+++ b/frontend/src/components/profile/__tests__/profileSepiaAdaptationSource.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+
+/**
+ * 个人信息弹窗家族（外壳 + 偏好设置 tab + SelectRow + 内嵌沙箱分区）的
+ * sepia 适配契约：亮色家族的中性 stone/白硬编码一律换成 theme-* token。
+ * 亮色 token 值与原 stone 值一致（tokens.css 即按 stone 调色板定义），
+ * 亮/暗渲染不变；sepia 由 .theme-sepia 的 token 覆盖层自动接管成暖色。
+ * dark: 变体是暗色家族的显式声明，不属于本契约（校验前剥离）。
+ */
+
+const FAMILY_FILES = [
+  "../ProfileModal.tsx",
+  "../SelectRow.tsx",
+  "../tabs/ProfilePreferencesTab.tsx",
+  "../LocalSandboxSection.tsx",
+  "../SandboxMachinesCard.tsx",
+] as const;
+
+/** 剥离 dark: 前缀类后，剩下的就是亮色/sepia 共享的亮色家族类 */
+function lightFamilyClasses(relativePath: string): string {
+  return readFileSync(new URL(relativePath, import.meta.url), "utf8").replace(
+    /dark:[^\s"'`}]+/g,
+    "",
+  );
+}
+
+const LIGHT_FAMILY_NEUTRAL_HARDCODES =
+  /\b(?:bg-white|bg-stone-(?:50|100|300)|border-stone-(?:100|200)|text-stone-(?:400|500|600|700|800|900))\b/g;
+
+describe.each(FAMILY_FILES)("%s", (file) => {
+  test("亮色家族不残留中性 stone/白硬编码（sepia 跟随 token）", () => {
+    const offenders =
+      lightFamilyClasses(file).match(LIGHT_FAMILY_NEUTRAL_HARDCODES) ?? [];
+    expect(offenders).toEqual([]);
+  });
+});
+
+test("弹窗外壳与下拉弹层表面走 theme token", () => {
+  const modal = readFileSync(new URL("../ProfileModal.tsx", import.meta.url), "utf8");
+  // 移动端抽屉 + 桌面弹窗两处壳，加桌面侧栏激活项，共三处同款表面
+  expect(modal.match(/bg-theme-bg-card dark:bg-stone-800/g)?.length).toBe(3);
+  // SelectRow 选中项：accent-light 亮色值即 amber-50，sepia 下暖米黄
+  const selectRow = readFileSync(
+    new URL("../SelectRow.tsx", import.meta.url),
+    "utf8",
+  );
+  expect(selectRow).toMatch(/bg-theme-accent-light dark:bg-amber-900\/20/);
+});

--- a/frontend/src/components/profile/__tests__/sandboxMachinesCard.test.tsx
+++ b/frontend/src/components/profile/__tests__/sandboxMachinesCard.test.tsx
@@ -76,7 +76,7 @@ test("online machines show green dot, offline machines greyed with last-seen and
   // 离线机：置灰点 + 离线徽标 + 相对时间
   expect(screen.getByText("Old PC")).toBeInTheDocument();
   const offlineRow = screen.getByText("Old PC").closest("div");
-  expect(offlineRow?.querySelector("span")?.className).toContain("bg-stone-300");
+  expect(offlineRow?.querySelector("span")?.className).toContain("bg-theme-border-hover");
   expect(screen.getByText(/offline/i)).toBeInTheDocument();
   expect(screen.getByTestId("last-seen-pc1").textContent).toMatch(/1h|h/);
 

--- a/frontend/src/components/profile/tabs/ProfilePreferencesTab.tsx
+++ b/frontend/src/components/profile/tabs/ProfilePreferencesTab.tsx
@@ -292,10 +292,10 @@ export function ProfilePreferencesTab() {
 
   return (
     <div className="space-y-4">
-      <div className="rounded-2xl bg-theme-bg-subtle dark:bg-stone-700/40 p-4 border border-stone-200/60 dark:border-stone-600/40">
+      <div className="rounded-2xl bg-theme-bg-subtle dark:bg-stone-700/40 p-4 border border-theme-border dark:border-stone-600/40">
         <div className="flex items-center gap-2 mb-3">
           <Settings size={13} className="text-amber-500 dark:text-amber-400" />
-          <h3 className="text-12 font-semibold font-serif uppercase tracking-wider text-stone-400 dark:text-stone-500">
+          <h3 className="text-12 font-semibold font-serif uppercase tracking-wider text-theme-text-tertiary dark:text-stone-500">
             {t("profile.preferences")}
           </h3>
         </div>
@@ -306,21 +306,21 @@ export function ProfilePreferencesTab() {
               onClick={handleMemoryToggle}
               className="flex w-full items-center justify-between py-3 first:pt-0 last:pb-0 text-left"
             >
-              <span className="text-14 text-stone-700 dark:text-stone-200">
+              <span className="text-14 text-theme-text dark:text-stone-200">
                 {t("profile.memoryToggle")}
               </span>
               <span
                 className={`relative h-5 w-9 rounded-full transition-colors ${
                   memoryEnabled
                     ? "bg-amber-500"
-                    : "bg-stone-300 dark:bg-stone-600"
+                    : "bg-theme-border-hover dark:bg-stone-600"
                 }`}
                 role="switch"
                 aria-checked={memoryEnabled}
                 aria-label={t("profile.memoryToggle")}
               >
                 <span
-                  className={`absolute top-0.5 h-4 w-4 rounded-full bg-white transition-all ${
+                  className={`absolute top-0.5 h-4 w-4 rounded-full bg-theme-toggle-knob transition-all ${
                     memoryEnabled ? "left-[1.15rem]" : "left-0.5"
                   }`}
                 />
@@ -421,10 +421,10 @@ export function ProfilePreferencesTab() {
 
       {/* 沙箱：云端 + 本地合并一张卡——平铺分区，分区之间用 hairline 分隔
           （不叠 tile 夹层）；本地分区仍懒加载（M4 T8 PWA 预算） */}
-      <div className="rounded-2xl bg-theme-bg-subtle dark:bg-stone-700/40 p-4 border border-stone-200/60 dark:border-stone-600/40">
+      <div className="rounded-2xl bg-theme-bg-subtle dark:bg-stone-700/40 p-4 border border-theme-border dark:border-stone-600/40">
         <div className="flex items-center gap-2 mb-3">
           <Container size={13} className="text-amber-500 dark:text-amber-400" />
-          <h3 className="text-12 font-semibold font-serif uppercase tracking-wider text-stone-400 dark:text-stone-500">
+          <h3 className="text-12 font-semibold font-serif uppercase tracking-wider text-theme-text-tertiary dark:text-stone-500">
             {t("profile.sandbox")}
           </h3>
         </div>
@@ -432,12 +432,12 @@ export function ProfilePreferencesTab() {
         {/* 云端沙箱：执行确认策略（用户级偏好，存 metadata） */}
         <div>
           <div className="flex items-center gap-1.5">
-            <Cloud size={13} className="text-stone-400 dark:text-stone-500" />
-            <span className="font-medium font-serif text-14 text-stone-900 dark:text-stone-100">
+            <Cloud size={13} className="text-theme-text-tertiary dark:text-stone-500" />
+            <span className="font-medium font-serif text-14 text-theme-text dark:text-stone-100">
               {t("profile.cloudSandbox")}
             </span>
           </div>
-          <p className="text-12 text-stone-500 dark:text-stone-400 mt-1 leading-relaxed">
+          <p className="text-12 text-theme-text-secondary dark:text-stone-400 mt-1 leading-relaxed">
             {t("profile.cloudSandboxDesc")}
           </p>
           <SelectRow
@@ -457,14 +457,14 @@ export function ProfilePreferencesTab() {
 
       {/* 关于：检查更新——仅原生客户端（桌面/移动）渲染；Web 随部署走刷新即更 */}
       {isNativeAppRuntime() && (
-        <div className="rounded-2xl bg-theme-bg-subtle dark:bg-stone-700/40 p-4 border border-stone-200/60 dark:border-stone-600/40">
+        <div className="rounded-2xl bg-theme-bg-subtle dark:bg-stone-700/40 p-4 border border-theme-border dark:border-stone-600/40">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <RefreshCw
                 size={13}
                 className="text-amber-500 dark:text-amber-400"
               />
-              <h3 className="text-12 font-semibold font-serif uppercase tracking-wider text-stone-400 dark:text-stone-500">
+              <h3 className="text-12 font-semibold font-serif uppercase tracking-wider text-theme-text-tertiary dark:text-stone-500">
                 {t("update.aboutTitle", "关于")}
               </h3>
             </div>
@@ -473,7 +473,7 @@ export function ProfilePreferencesTab() {
               onClick={() => {
                 window.dispatchEvent(new Event("lambchat:check-update"));
               }}
-              className="flex items-center gap-1.5 rounded-lg border border-stone-200/70 dark:border-stone-600/60 px-3 py-1.5 text-12 font-medium text-stone-600 dark:text-stone-300 hover:bg-white/60 dark:hover:bg-black/20 transition-colors"
+              className="flex items-center gap-1.5 rounded-lg border border-theme-border dark:border-stone-600/60 px-3 py-1.5 text-12 font-medium text-theme-text-secondary dark:text-stone-300 hover:bg-theme-bg-card dark:hover:bg-black/20 transition-colors"
             >
               <RefreshCw size={12} />
               {t("update.checkNow", "检查更新")}

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -176,6 +176,8 @@
   --theme-accent-hover: linear-gradient(to bottom right, #f59e0b, #ea580c);
   --theme-accent-light: #fffbeb;
   --theme-accent-glow: rgba(251, 191, 36, 0.2);
+  /* 开关旋钮：彩色轨道上的滑块，三主题恒白（dark/sepia 不覆盖） */
+  --theme-toggle-knob: #ffffff;
 
   /* ── Composed Shadows ── */
   --shadow-card: 0 1px 3px 0 rgb(0 0 0 / 0.06), 0 1px 2px -1px rgb(0 0 0 / 0.04);

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -69,6 +69,7 @@ export default {
           primary: "var(--theme-primary)",
           "primary-hover": "var(--theme-primary-hover)",
           "primary-light": "var(--theme-primary-light)",
+          "toggle-knob": "var(--theme-toggle-knob)",
         },
       },
     },


### PR DESCRIPTION
## 问题

sepia（护眼）模式下，「个人信息」弹窗整体仍是亮色 stone/白渲染：弹窗外壳 `bg-white`、左侧栏 `bg-stone-50/50`、卡片边框 `border-stone-200`、内嵌磁贴 `bg-stone-50`、下拉弹层边框/悬停/选中项等均为亮色家族硬编码——在米黄界面上形成刺眼的"白色孤岛"。

这些组件的配色只写了亮色 + `dark:` 两态，没有接入 `.theme-sepia` 的 token 覆盖层（sepia 的实现机制是 `.theme-sepia` 覆盖 `--theme-*` CSS 变量，`dark:` 变体自动回落亮色，因此亮色家族硬编码不会跟随）。

## 修复

- 弹窗家族（`ProfileModal` / `ProfilePreferencesTab` / `SelectRow` / `LocalSandboxSection` / `SandboxMachinesCard`）亮色家族硬编码统一换 `theme-*` token。**亮色 token 值与原 stone 值一致（tokens.css 本就按 stone 调色板定义），亮/暗渲染逐值不变，sepia 自动接管为暖色**；所有 `dark:` 变体原样保留
- 新增 `--theme-toggle-knob` token：开关旋钮三主题恒白（`dark`/`sepia` 不覆盖，维持现状）
- `SelectRow` 选中项 `bg-amber-50` → `bg-theme-accent-light`（亮色值相同 `#fffbeb`，sepia 下暖米黄）
- 新增守护测试 `profileSepiaAdaptationSource.test.ts`：剥离 `dark:` 前缀后断言弹窗家族不再出现亮色家族中性 stone/白硬编码，并钉住外壳与弹层 token 用法
- `sandboxMachinesCard.test.tsx` 离线机灰点断言跟随 token（`bg-stone-300` → `bg-theme-border-hover`，亮色值相同 `#d6d3d1`）

## 验证

- `profile` + 样式守护测试全部通过（含新增 6 个契约用例）
- 本地浏览器实测（1280×720，`html.theme-sepia`）：
  - sepia：弹窗外壳计算色值 `rgb(250,246,234)` = `--theme-bg-card`(#faf6ea)，侧栏/卡片 `rgb(234,226,205)` = `--theme-bg-subtle`(#eae2cd)，整体协调暖色，无白色孤岛
  - 亮色：外壳 `rgb(255,255,255)`，与修复前渲染一致，无回归
  - 经主题下拉显式切换亮色 ↔ 护眼各一次，`SelectRow` 弹层交互正常

## 说明

- 前置关联：#449（sepia 视觉补齐，已合并）。本 PR 是同一主题工作的收尾——弹窗家族当时未覆盖。
- PR 分支基于最新 `develop` 重放（上游 #494→#558 期间弹窗家族有多处演进——机器卡离线置灰/忘记机器、沙箱卡平铺化、字号 token 化——本修复已在新结构上重放并通过守护测试）。