### PR TITLE
feat(sandbox): 沙箱根 LAMBCHAT_HOME 可迁移——壳与 daemon 同变量同根

### DIFF
--- a/client/lambchat_sandbox/auth.py
+++ b/client/lambchat_sandbox/auth.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 import httpx
 
+from lambchat_sandbox import paths
+
 try:  # keyring 为可选依赖，缺失时静默使用文件后端
     import keyring
 except ImportError:  # pragma: no cover - 是否触发取决于运行环境
@@ -18,8 +20,6 @@ except ImportError:  # pragma: no cover - 是否触发取决于运行环境
 
 KEYRING_SERVICE = "lambchat-sandbox"
 KEYRING_USER = "pat"
-
-PAT_FILE = Path.home() / ".lambchat" / "pat"
 
 
 class AuthError(Exception):
@@ -38,7 +38,7 @@ def store_pat(token: str, path: Path | None = None) -> None:
             return
         except Exception:
             pass  # 静默落文件
-    p = path if path is not None else PAT_FILE
+    p = path if path is not None else paths.pat_file()
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(token, encoding="utf-8")
     os.chmod(p, 0o600)
@@ -53,7 +53,7 @@ def load_pat(path: Path | None = None) -> str | None:
                 return token
         except Exception:
             pass
-    p = path if path is not None else PAT_FILE
+    p = path if path is not None else paths.pat_file()
     try:
         token = p.read_text(encoding="utf-8").strip()
     except FileNotFoundError:
@@ -68,7 +68,7 @@ def clear_pat(path: Path | None = None) -> None:
             keyring.delete_password(KEYRING_SERVICE, KEYRING_USER)
         except Exception:
             pass
-    p = path if path is not None else PAT_FILE
+    p = path if path is not None else paths.pat_file()
     try:
         p.unlink()
     except FileNotFoundError:

--- a/client/lambchat_sandbox/config.py
+++ b/client/lambchat_sandbox/config.py
@@ -6,8 +6,10 @@ import json
 import os
 import tempfile
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
+
+from lambchat_sandbox import paths
 
 _VALID_CONFIRM_POLICIES = frozenset({"all", "commands", "none"})
 
@@ -19,7 +21,8 @@ class ConfigError(Exception):
 @dataclass
 class SandboxConfig:
     server_url: str = "http://127.0.0.1:8000"
-    data_root: Path = Path.home() / ".lambchat" / "workspaces"
+    # 调用时解析（default_factory）：LAMBCHAT_HOME 设定即生效，见 paths 模块。
+    data_root: Path = field(default_factory=paths.workspaces_root)
     confirm_policy: str = "all"  # all | commands | none
     embedded_python: bool = True  # 内嵌 PBS 运行时（false 走系统 PATH）
     # 壳侧配对回执（Rust save_pairing 落盘）：daemon 目前只回读不使用，
@@ -38,8 +41,8 @@ def new_machine_id() -> str:
 
 
 def config_path() -> Path:
-    """默认配置文件路径：~/.lambchat/sandbox.json"""
-    return Path.home() / ".lambchat" / "sandbox.json"
+    """默认配置文件路径：LAMBCHAT_HOME 优先，缺省 ~/.lambchat/sandbox.json"""
+    return paths.config_file()
 
 
 def load_config(path: Path | None = None) -> SandboxConfig:
@@ -78,7 +81,7 @@ def load_config(path: Path | None = None) -> SandboxConfig:
 
     cfg = SandboxConfig(
         server_url=str(raw.get("server_url", SandboxConfig.server_url)),
-        data_root=Path(str(raw.get("data_root", SandboxConfig.data_root))),
+        data_root=Path(str(raw.get("data_root", paths.workspaces_root()))),
         confirm_policy=str(raw.get("confirm_policy", SandboxConfig.confirm_policy)),
         embedded_python=raw_embedded,
         pat_id=raw_pat_id,

--- a/client/lambchat_sandbox/daemon.py
+++ b/client/lambchat_sandbox/daemon.py
@@ -40,7 +40,7 @@ from collections import deque
 from collections.abc import AsyncIterator, Awaitable, Callable
 from pathlib import Path
 
-from lambchat_sandbox import pbs
+from lambchat_sandbox import paths, pbs
 from lambchat_sandbox.audit import Auditor
 from lambchat_sandbox.config import SandboxConfig
 from lambchat_sandbox.executor import Executor, ExecutorError
@@ -59,7 +59,6 @@ from lambchat_sandbox.transport import (
     backoff_delay,
 )
 
-DEFAULT_AUDIT_ROOT = Path.home() / ".lambchat" / "audit"
 DEFAULT_EXEC_TIMEOUT_S = 60.0  # 帧缺失/非正 timeout 的兜底，避免 communicate(timeout=0) 立即超时
 DAEMON_AUDIT_SESSION = "daemon"  # shutdown 等进程级事件的审计会话（过 Auditor 白名单）
 
@@ -137,7 +136,7 @@ async def run_daemon(
         if executor is not None
         else Executor(cfg.data_root, extra_path=_ensure_runtime_bin(cfg))
     )
-    auditor_ = auditor if auditor is not None else Auditor(DEFAULT_AUDIT_ROOT)
+    auditor_ = auditor if auditor is not None else Auditor(paths.audit_root())
     installed = _install_sigterm_cancel()
 
     client: ChannelClient | None = None

--- a/client/lambchat_sandbox/paths.py
+++ b/client/lambchat_sandbox/paths.py
@@ -1,0 +1,56 @@
+"""沙箱数据根解析：LAMBCHAT_HOME 优先，缺省 ``~/.lambchat``。
+
+壳（Rust ``sandbox_home()``，frontend/src-tauri/src/daemon.rs）与 daemon
+（本模块）两侧读同一个 ``LAMBCHAT_HOME``——迁移沙箱根时两进程解析到同一
+目录；未设/空白一律回落 ``~/.lambchat``，既有用户行为不变。
+
+所有子路径一律**调用时**解析（不留模块级常量）：daemon 由壳 spawn 继承
+环境，用户级环境变量改动需重启壳生效，但进程内即设即读，测试注入也无
+需 import 顺序配合。
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+#: 根目录覆盖环境变量名（与 Rust sandbox_home() 同名约定）。
+HOME_ENV = "LAMBCHAT_HOME"
+
+
+def home_root() -> Path:
+    """沙箱数据根：LAMBCHAT_HOME 优先（空白视同未设），缺省 ~/.lambchat。"""
+    raw = os.environ.get(HOME_ENV, "")
+    if raw.strip():
+        return Path(raw).expanduser()
+    return Path.home() / ".lambchat"
+
+
+def pat_file() -> Path:
+    """PAT 明文回退文件（keyring 不可用时）：{root}/pat。"""
+    return home_root() / "pat"
+
+
+def config_file() -> Path:
+    """沙箱配置：{root}/sandbox.json。"""
+    return home_root() / "sandbox.json"
+
+
+def workspaces_root() -> Path:
+    """会话工作区默认根（SandboxConfig.data_root 缺省）：{root}/workspaces。"""
+    return home_root() / "workspaces"
+
+
+def audit_root() -> Path:
+    """审计 JSONL 目录：{root}/audit。"""
+    return home_root() / "audit"
+
+
+def resources_dir() -> Path:
+    """壳播种的 PBS 归档查找目录：{root}/resources/python。"""
+    return home_root() / "resources" / "python"
+
+
+def install_root() -> Path:
+    """PBS 解压根：{root}/python/<tag>。"""
+    return home_root() / "python"

--- a/client/lambchat_sandbox/pbs.py
+++ b/client/lambchat_sandbox/pbs.py
@@ -40,6 +40,7 @@ import sys
 import tarfile
 from pathlib import Path
 
+from lambchat_sandbox import paths
 from lambchat_sandbox import platform as plat
 
 #: 锁定的 python-build-standalone release tag（fetch-pbs.py 同源引用）。
@@ -53,12 +54,6 @@ TARBALL_NAME = "python.tar.gz"
 
 #: 幂等标记：install_dir 下存在即视为解压完成，不再重解压。
 EXTRACT_MARKER = ".lambchat-extracted"
-
-#: 默认归档查找目录：~/.lambchat/resources/python/python.tar.gz。
-DEFAULT_RESOURCES_DIR = Path.home() / ".lambchat" / "resources" / "python"
-
-#: 默认解压根：~/.lambchat/python/<tag>/。
-DEFAULT_INSTALL_ROOT = Path.home() / ".lambchat" / "python"
 
 
 def shim_bin_dir(install_root: Path) -> Path:
@@ -150,8 +145,8 @@ def ensure_runtime(
     调用方回退系统 PATH——绝不抛异常阻断 daemon 启动。幂等：已解压（标记
     文件在）则只补 shim。
     """
-    resources = Path(resources_dir) if resources_dir is not None else DEFAULT_RESOURCES_DIR
-    root = Path(install_root) if install_root is not None else DEFAULT_INSTALL_ROOT
+    resources = Path(resources_dir) if resources_dir is not None else paths.resources_dir()
+    root = Path(install_root) if install_root is not None else paths.install_root()
     install_dir = root / PBS_TAG
 
     if not (install_dir / EXTRACT_MARKER).exists():

--- a/frontend/src-tauri/src/daemon.rs
+++ b/frontend/src-tauri/src/daemon.rs
@@ -520,12 +520,21 @@ fn handle_exit(app: &AppHandle, generation: u64) {
 // invoke 命令（配对 / 配置 / 启停 / 开目录）
 // ---------------------------------------------------------------------------
 
-/// daemon 数据根 `~/.lambchat`（lib.rs 的 PBS 归档落位也复用）。
+/// daemon 数据根：`LAMBCHAT_HOME` 优先，缺省 `~/.lambchat`（lib.rs 的 PBS
+/// 归档落位与 append_desktop_log 均复用）。
 ///
-/// `$HOME` 优先（unix / git-bash dev）；Windows 常规进程无 `HOME`，回退
-/// `%USERPROFILE%`——与 daemon 侧 Python `Path.home()` 的 Windows 语义一致
-/// （M4 T9：恢复 Windows 打包矩阵的前置，两进程必须解析到同一目录）。
+/// `LAMBCHAT_HOME`（非空白）即数据根本身，两侧（Python `paths.home_root()`）
+/// 读同一个变量——迁移沙箱根时两进程解析到同一目录；未设时：`$HOME` 优先
+/// （unix / git-bash dev），Windows 常规进程无 `HOME` 回退 `%USERPROFILE%`，
+/// 与 daemon 侧 Python `Path.home()` 的 Windows 语义一致（M4 T9：恢复
+/// Windows 打包矩阵的前置，两进程必须解析到同一目录）。
+/// daemon 由壳 spawn 继承环境：用户级环境变量改动需重启壳生效。
 pub(crate) fn sandbox_home() -> Result<PathBuf, String> {
+    if let Some(custom) = std::env::var_os("LAMBCHAT_HOME") {
+        if !custom.to_string_lossy().trim().is_empty() {
+            return Ok(PathBuf::from(custom));
+        }
+    }
     std::env::var_os("HOME")
         .or_else(|| std::env::var_os("USERPROFILE"))
         .map(|home| PathBuf::from(home).join(".lambchat"))
@@ -1259,6 +1268,16 @@ mod tests {
         assert!(resolve_openable_path(&sandbox.join("workspaces-evil").to_string_lossy()).is_err());
         // 白名单外绝对路径拒绝。
         assert!(resolve_openable_path("/etc/passwd").is_err());
+
+        // LAMBCHAT_HOME 优先于 HOME/USERPROFILE（沙箱根可迁移；与 Python
+        // paths.home_root() 同语义）。仍在 HOME 已设的本测试函数内断言——
+        // env 竞争纪律：本模块所有 env 断言集中在此串行函数。
+        std::env::set_var("LAMBCHAT_HOME", tmp.join("custom-root"));
+        assert_eq!(sandbox_home().unwrap(), tmp.join("custom-root"));
+        // 空白值视同未设：回落 HOME 下的 .lambchat（此刻 HOME 仍指向 tmp/home）。
+        std::env::set_var("LAMBCHAT_HOME", "   ");
+        assert_eq!(sandbox_home().unwrap(), home.join(".lambchat"));
+        std::env::remove_var("LAMBCHAT_HOME");
 
         match original_home {
             Some(h) => std::env::set_var("HOME", h),

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -9,15 +9,16 @@ import pytest
 import lambchat_sandbox.auth as auth
 import lambchat_sandbox.cli as cli
 import lambchat_sandbox.config as config_mod
+from lambchat_sandbox import paths
 from lambchat_sandbox.auth import AuthError, clear_pat, load_pat, pair, store_pat
 from lambchat_sandbox.cli import main
 
 
 @pytest.fixture(autouse=True)
 def _isolate_pat_store(monkeypatch, tmp_path):
-    """默认强制文件后端 + tmp 路径，不触碰真实 keyring 与 ~/.lambchat。"""
+    """默认强制文件后端 + tmp 根（LAMBCHAT_HOME 注入），不触碰真实 keyring 与 ~/.lambchat。"""
     monkeypatch.setattr(auth, "keyring", None)
-    monkeypatch.setattr(auth, "PAT_FILE", tmp_path / "pat")
+    monkeypatch.setenv(paths.HOME_ENV, str(tmp_path))
     monkeypatch.setattr(config_mod, "config_path", lambda: tmp_path / "sandbox.json")
 
 
@@ -104,20 +105,21 @@ def test_clear_missing_pat_is_noop(tmp_path):
     clear_pat(path=tmp_path / "pat")  # 不应抛异常
 
 
-def test_store_prefers_keyring_when_available(monkeypatch):
+def test_store_prefers_keyring_when_available(monkeypatch, tmp_path):
     fake = FakeKeyring()
     monkeypatch.setattr(auth, "keyring", fake)
     store_pat("token-4")
     assert fake.store == {(auth.KEYRING_SERVICE, auth.KEYRING_USER): "token-4"}
-    assert not auth.PAT_FILE.exists()  # keyring 成功时不落文件
+    assert not (tmp_path / "pat").exists()  # keyring 成功时不落文件
     assert load_pat() == "token-4"
 
 
-def test_keyring_failure_falls_back_to_file(monkeypatch):
+def test_keyring_failure_falls_back_to_file(monkeypatch, tmp_path):
     monkeypatch.setattr(auth, "keyring", FakeKeyring(fail=True))
     store_pat("token-5")
-    assert auth.PAT_FILE.read_text(encoding="utf-8") == "token-5"
-    assert stat.S_IMODE(auth.PAT_FILE.stat().st_mode) == 0o600
+    pat_file = tmp_path / "pat"
+    assert pat_file.read_text(encoding="utf-8") == "token-5"
+    assert stat.S_IMODE(pat_file.stat().st_mode) == 0o600
     assert load_pat() == "token-5"  # keyring 读失败回退文件
 
 

--- a/tests/client/test_paths.py
+++ b/tests/client/test_paths.py
@@ -1,0 +1,67 @@
+"""paths.home_root() 与各子路径解析：LAMBCHAT_HOME 优先、缺省 ~/.lambchat。
+
+壳（Rust sandbox_home()）与 daemon（本模块）两侧读同一个 LAMBCHAT_HOME，
+迁移沙箱根时两进程必须解析到同一目录；未设/空白一律回落 ~/.lambchat，
+既有用户行为逐字节不变。
+"""
+
+from pathlib import Path
+
+from lambchat_sandbox import paths
+
+
+def test_home_root_defaults_to_home_lambchat(monkeypatch):
+    monkeypatch.delenv(paths.HOME_ENV, raising=False)
+    assert paths.home_root() == Path.home() / ".lambchat"
+
+
+def test_home_root_prefers_lambchat_home_env(monkeypatch, tmp_path):
+    monkeypatch.setenv(paths.HOME_ENV, str(tmp_path))
+    assert paths.home_root() == tmp_path
+
+
+def test_home_root_blank_env_falls_back_to_home(monkeypatch):
+    monkeypatch.setenv(paths.HOME_ENV, "   ")
+    assert paths.home_root() == Path.home() / ".lambchat"
+
+
+def test_subpath_helpers_follow_env_root(monkeypatch, tmp_path):
+    monkeypatch.setenv(paths.HOME_ENV, str(tmp_path))
+    assert paths.pat_file() == tmp_path / "pat"
+    assert paths.config_file() == tmp_path / "sandbox.json"
+    assert paths.workspaces_root() == tmp_path / "workspaces"
+    assert paths.audit_root() == tmp_path / "audit"
+    assert paths.resources_dir() == tmp_path / "resources" / "python"
+    assert paths.install_root() == tmp_path / "python"
+
+
+def test_sandbox_config_defaults_follow_env_root(monkeypatch, tmp_path):
+    """data_root 缺省与 config_path 走调用时解析——env 即设即生效。"""
+    from lambchat_sandbox.config import SandboxConfig, config_path
+
+    monkeypatch.setenv(paths.HOME_ENV, str(tmp_path))
+    assert SandboxConfig().data_root == tmp_path / "workspaces"
+    assert config_path() == tmp_path / "sandbox.json"
+
+
+def test_pbs_ensure_runtime_default_resources_follow_env_root(monkeypatch, tmp_path, capsys):
+    """未显式传参时 ensure_runtime 到 LAMBCHAT_HOME 根下找归档。"""
+    from lambchat_sandbox import pbs
+
+    monkeypatch.setenv(paths.HOME_ENV, str(tmp_path))
+    assert pbs.ensure_runtime() is None
+    err = capsys.readouterr().err
+    assert str(tmp_path / "resources" / "python" / pbs.TARBALL_NAME) in err
+
+
+def test_auth_pat_file_follows_env_root(monkeypatch, tmp_path):
+    """auth 文件后端经 paths.pat_file() 解析（env 注入即迁移）。"""
+    from lambchat_sandbox import auth
+
+    monkeypatch.setattr(auth, "keyring", None)
+    monkeypatch.setenv(paths.HOME_ENV, str(tmp_path))
+    auth.store_pat("token-x")
+    assert (tmp_path / "pat").read_text(encoding="utf-8") == "token-x"
+    assert auth.load_pat() == "token-x"
+    auth.clear_pat()
+    assert not (tmp_path / "pat").exists()

--- a/tests/client/test_pbs.py
+++ b/tests/client/test_pbs.py
@@ -27,7 +27,7 @@ import tarfile
 from collections.abc import Collection
 from pathlib import Path
 
-from lambchat_sandbox import pbs
+from lambchat_sandbox import paths, pbs
 from lambchat_sandbox import platform as plat
 
 _FAKE_PY = '#!/bin/sh\necho "argv0=$0"\n'
@@ -235,12 +235,13 @@ def test_ensure_runtime_tarball_without_interpreter_returns_none(tmp_path, capsy
     assert "python3" in capsys.readouterr().err or "python.exe" in capsys.readouterr().err
 
 
-def test_default_paths_under_lambchat_home():
+def test_default_paths_under_lambchat_home(monkeypatch):
     """默认 resources / install_root / shim 目录的 ~/.lambchat 约定锁死。"""
-    assert pbs.DEFAULT_RESOURCES_DIR == Path.home() / ".lambchat" / "resources" / "python"
-    assert pbs.DEFAULT_INSTALL_ROOT == Path.home() / ".lambchat" / "python"
+    monkeypatch.delenv(paths.HOME_ENV, raising=False)
+    assert paths.resources_dir() == Path.home() / ".lambchat" / "resources" / "python"
+    assert paths.install_root() == Path.home() / ".lambchat" / "python"
     # shim 目录由 install_root 推导：~/.lambchat/python → ~/.lambchat/bin
-    assert pbs.shim_bin_dir(pbs.DEFAULT_INSTALL_ROOT) == Path.home() / ".lambchat" / "bin"
+    assert pbs.shim_bin_dir(paths.install_root()) == Path.home() / ".lambchat" / "bin"
 
 
 def test_extract_marker_name_is_dotted():


### PR DESCRIPTION
## 概述

沙箱根目录可迁移机制（工单 1）：新增 `LAMBCHAT_HOME` 环境变量贯通桌面壳（Rust）与本地 daemon（Python），未设时行为与现状逐字节一致。

## 背景

桌面端沙箱全部落盘此前硬编码 `~/.lambchat`（PAT、sandbox.json、workspaces、audit JSONL、PBS Python 运行时数百 MB、desktop.log），用户无法迁离系统盘；且 Windows 上 `HOME` 只影响壳侧、Python `Path.home()` 不认，设 `HOME` 会导致两进程分叉，不可用作迁移手段。两侧读同一个 `LAMBCHAT_HOME`（非空白即数据根本身）天然保证配对一致性。

## 变更

- 新增 `client/lambchat_sandbox/paths.py`：`home_root()` + 六个子路径函数（pat/sandbox.json/workspaces/audit/resources/python），**全部调用时解析**——env 进程内即设即读，测试注入不依赖 import 顺序
- 六处模块级硬编码收敛到 paths：`auth.PAT_FILE`、`pbs.DEFAULT_RESOURCES_DIR/DEFAULT_INSTALL_ROOT`、`daemon.DEFAULT_AUDIT_ROOT` 常量移除；`SandboxConfig.data_root` 改 `default_factory`，`load_config` 回退同步改 `paths.workspaces_root()`
- Rust `sandbox_home()` 优先读 `LAMBCHAT_HOME`：PBS 播种、配对文件、`open_local_path` 白名单、`append_desktop_log` 复用该函数自动跟随；doc comment 写明「改用户级环境变量需重启壳生效」
- 测试：新增 `tests/client/test_paths.py`（7 例：env 优先 / 空白回退 / 六子路径 / config 缺省 / pbs 归档定位 / auth 文件后端）；`test_auth` 的 `PAT_FILE` monkeypatch 改为 `LAMBCHAT_HOME` 注入（即新机制的测试入口）；Rust env 断言并入既有串行 env 测试（遵循模块内 env 竞争纪律）

## 测试

- `tests/client` 全量失败清单与干净基线（upstream develop@cd96d7db worktree）**逐条一致**——31 例均为 Windows 环境既有问题（`.gitattributes`/POSIX 执行类，另单处理），本 PR 零新增失败；新增 7 例全绿
- `mypy`（paths/config/auth）通过；`ruff check` 干净
- **两项待补验证**：① 开发机无 cargo，Rust 侧编译与 `cargo test` 待 CI/有链环境；② E2E 门禁（`scripts/e2e_local_sandbox.py`）本机 MongoDB/Redis 未运行无法执行，合并前需在具备服务的环境补跑

## 备注

- 后续 UI（工单 2：设置页数据位置卡片与引导）依赖本机制，另行 PR
- 工单全文见仓库 `tickets/2026-09-07-desktop-install-sandbox-paths.md`
