### PR TITLE
chore: .gitignore 忽略本地 tickets/ 工单目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ uv.lock
 
 # GUI 走查截图（agent 生成的本地验证产物，勿提交）
 gui-test-screenshots/
+
+# 本地工单/PR 文稿（工单清单、spec、PR body 草稿，勿提交）
+tickets/


### PR DESCRIPTION
本地工单/spec/PR 文稿草稿目录按整目录忽略，避免误提交。见 AGENTS.md「本地状态目录按整目录忽略」约定。