### PR TITLE
feat(filetree): 文件树支持下载子文件夹为 ZIP

### DIFF
--- a/frontend/src/components/chat/ChatMessage/items/FileTreeView.tsx
+++ b/frontend/src/components/chat/ChatMessage/items/FileTreeView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from "react";
-import { Download, ChevronRight, Copy, Check } from "lucide-react";
+import { Download, ChevronRight, Copy, Check, Loader2 } from "lucide-react";
 import clsx from "clsx";
 import { useTranslation } from "react-i18next";
 import { getFileTypeInfo, isImageFile } from "../../../documents/utils";
@@ -220,7 +220,11 @@ function FileTreeNode({
                 isDownloading && "opacity-50 pointer-events-none",
               )}
             >
-              <Download size={18} />
+              {isDownloading ? (
+                <Loader2 size={18} className="animate-spin" />
+              ) : (
+                <Download size={18} />
+              )}
             </span>
           )}
           <ChevronRight

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -2311,6 +2311,7 @@
     "exitFullscreen": "Exit fullscreen",
     "expand": "Expand",
     "exportZip": "Export ZIP",
+    "downloadFolder": "Download folder as ZIP",
     "fileCount": "{{count}} files",
     "fullscreen": "Fullscreen",
     "fullscreenHint": "Press Esc to exit fullscreen",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -2311,6 +2311,7 @@
     "exitFullscreen": "全画面を終了",
     "expand": "展開",
     "exportZip": "ZIPエクスポート",
+    "downloadFolder": "フォルダを ZIP でダウンロード",
     "fileCount": "{{count}}ファイル",
     "fullscreen": "全画面",
     "fullscreenHint": "Esc を押して全画面を終了",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -2311,6 +2311,7 @@
     "exitFullscreen": "전체 화면 종료",
     "expand": "펼치기",
     "exportZip": "ZIP 내보내기",
+    "downloadFolder": "폴더를 ZIP으로 다운로드",
     "fileCount": "{{count}}개 파일",
     "fullscreen": "전체 화면",
     "fullscreenHint": "Esc를 눌러 전체 화면 종료",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -2311,6 +2311,7 @@
     "exitFullscreen": "Выйти из полноэкранного режима",
     "expand": "Развернуть",
     "exportZip": "Экспорт ZIP",
+    "downloadFolder": "Скачать папку как ZIP",
     "fileCount": "{{count}} файлов",
     "fullscreen": "Полный экран",
     "fullscreenHint": "Нажмите Esc для выхода из полноэкранного режима",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -2311,6 +2311,7 @@
     "exitFullscreen": "退出全屏",
     "expand": "展开",
     "exportZip": "导出 ZIP",
+    "downloadFolder": "下载此文件夹为 ZIP",
     "fileCount": "{{count}} 个文件",
     "fullscreen": "全屏",
     "fullscreenHint": "按 Esc 退出全屏",


### PR DESCRIPTION
文件树目录节点的 hover 下载按钮从「仅装饰」变为可用：点击将该子文件夹整体导出为 ZIP（文本文件内容 + 二进制文件一并打包），下载中显示 Loader2 旋转占位，防重复点击。

- 复用既有 `exportProjectZip` 导出管线，目录内子树收集逻辑与根目录导出一致
- 已 rebase 到最新 develop，并合入同期落地的复制按钮 / aria-expanded / 侧栏快照 key 改动
- `project.downloadFolder` 文案 zh/en/ja/ko/ru 五语同步
- 相关测试本地通过（仅既有 Windows 环境失败项，与本改动无关）