### PR TITLE
docs: env 与部署文档对齐当前配置

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -116,7 +116,7 @@ MCP_ENCRYPTION_SALT=  # Optional: auto-generated if not set (recommended for con
 # ============================================
 # Sandbox Configuration
 # ============================================
-# Supported platforms: daytona, e2b
+# Supported platforms: daytona, e2b, cubesandbox
 SANDBOX_PLATFORM=daytona
 
 # 本地沙箱（daemon 中继）超时

--- a/README.md
+++ b/README.md
@@ -278,8 +278,8 @@ TASK_BACKEND=arq  # local or arq
 make format       # Format with ruff
 make lint         # Lint with ruff
 make typecheck    # Type check with mypy
-make test         # Backend tests with pytest
-make check-all    # Run lint + typecheck + tests
+make test         # Frontend (vitest) + backend (pytest) tests
+make check-all    # Run pre-commit hooks + typecheck + tests + builds
 ```
 
 ### Frontend, Mobile, and Docs

--- a/README_CN.md
+++ b/README_CN.md
@@ -278,8 +278,8 @@ TASK_BACKEND=arq  # local 或 arq
 make format       # 使用 ruff 格式化
 make lint         # 使用 ruff 检查
 make typecheck    # 使用 mypy 做类型检查
-make test         # 使用 pytest 跑后端测试
-make check-all    # 运行 lint + typecheck + test
+make test         # 运行前端（vitest）+ 后端（pytest）测试
+make check-all    # 运行 pre-commit + 类型检查 + 测试 + 构建
 ```
 
 ### 前端、移动端与文档

--- a/docs/en/deploy/docker.md
+++ b/docs/en/deploy/docker.md
@@ -11,9 +11,9 @@ orchestrator with shared MongoDB, Redis, and S3-compatible object storage.
 git clone https://github.com/Yanyutin753/LambChat.git
 cd LambChat
 
-# Copy and edit environment file
-cp deploy/.env.example .env
-# Edit .env with your configuration
+# Copy and edit environment file (Compose reads .env from deploy/)
+cp deploy/.env.example deploy/.env
+# Edit deploy/.env with your configuration
 
 # Start all services
 docker compose -f deploy/docker-compose.yml up -d
@@ -25,32 +25,36 @@ Docker Compose starts three services for a single-node stack:
 
 | Service | Image | Port | Description |
 |---------|-------|------|-------------|
-| `lambchat` | Custom build | 8000 | LambChat application (FastAPI + static frontend) |
-| `mongo` | `mongo:7` | 27017 | MongoDB database |
-| `redis` | `redis:7-alpine` | 6379 | Redis cache & pub/sub |
+| `lambchat` | `ghcr.io/yanyutin753/lambchat:latest` | 8000 | LambChat application (FastAPI + static frontend) |
+| `mongodb` | `mongo:8.2.5` | 127.0.0.1:27017 | MongoDB database |
+| `redis` | `redis:alpine` | 127.0.0.1:6379 | Redis cache & pub/sub |
+
+MongoDB and Redis ports are bound to `127.0.0.1` so they are not reachable from other hosts.
 
 ## Configuration
 
 ### Environment Variables
 
-Copy `deploy/.env.example` to `.env` and configure:
+Copy `deploy/.env.example` to `deploy/.env`. The compose file wires the following variables from it:
 
 ```bash
-# Recommended: Set a stable JWT secret (auto-generated on each restart if unset, invalidating existing sessions)
-JWT_SECRET_KEY=your-stable-secret-key
+# E2B sandbox (optional)
+E2B_API_KEY=your_e2b_api_key
+E2B_TEMPLATE=base
 
-# Recommended: Set MCP encryption salt (auto-generated on each restart if unset, invalidating saved MCP configs)
-MCP_ENCRYPTION_SALT=your-stable-encryption-salt
+# Optional tuning
+LLM_MODEL_CACHE_SIZE=50
+SESSION_MAX_EVENTS_PER_TRACE=10000
+```
 
-# Optional: Configure MongoDB connection
-MONGODB_URL=mongodb://localhost:27017
-MONGODB_DB=agent_state
-MONGODB_USERNAME=admin
-MONGODB_PASSWORD=your-mongo-password
+`REDIS_URL` and `MONGODB_URL` are preset to the in-stack Redis and MongoDB services. Other environment variables such as `JWT_SECRET_KEY` (stable JWT secret; auto-generated on each restart if unset, invalidating existing sessions) and `MCP_ENCRYPTION_SALT` (stable MCP encryption salt; auto-generated on each restart if unset, invalidating saved MCP configs) are not wired by default — add them to the `environment` section of the `lambchat` service in `deploy/docker-compose.yml`:
 
-# Optional: Configure Redis connection
-REDIS_URL=redis://localhost:6379/0
-REDIS_PASSWORD=your-redis-password
+```yaml
+    environment:
+      # Recommended: keep sessions valid across restarts
+      - JWT_SECRET_KEY=your-stable-secret-key
+      # Recommended: keep saved MCP configs decryptable across restarts
+      - MCP_ENCRYPTION_SALT=your-stable-encryption-salt
 ```
 
 ::: tip
@@ -113,17 +117,20 @@ docker compose -f deploy/docker-compose.yml down
 # Restart application (preserves data)
 docker compose -f deploy/docker-compose.yml restart lambchat
 
-# Rebuild after code changes
-docker compose -f deploy/docker-compose.yml up -d --build lambchat
+# Update to the latest published image
+docker compose -f deploy/docker-compose.yml pull lambchat
+docker compose -f deploy/docker-compose.yml up -d lambchat
 ```
 
 ## Data Persistence
 
-Docker Compose uses named volumes for data persistence:
+Docker Compose uses named volumes and bind mounts for data persistence:
 
-- `mongo_data` — MongoDB data
-- `redis_data` — Redis data
-- `uploads` — Uploaded files (local storage mode)
+- `mongodb-data` — MongoDB data
+- `redis-data` — Redis data
+- `lamb-data` — LambChat application data (`/app/data`)
+- `./workspace` — agent workspace (bind mount, resolved under `deploy/`)
+- `./uploads` — uploaded files in local storage mode (bind mount, resolved under `deploy/`)
 
 These volumes persist across container restarts and recreations.
 

--- a/docs/en/deploy/kubernetes.md
+++ b/docs/en/deploy/kubernetes.md
@@ -15,6 +15,10 @@ kubectl get pods -n lambchat
 kubectl get svc -n lambchat
 ```
 
+::: tip
+The manifest reads sensitive values (JWT secret, MCP encryption salt, database credentials, S3 keys) from the `lambchat-secrets` Secret. Copy `k8s/lambchat-secret.yaml.example` to `k8s/lambchat-secret.yaml`, fill in your values, and apply it — pods cannot start until the Secret exists.
+:::
+
 ## Architecture
 
 The K8s manifest (`k8s/lambchat.yaml`) creates:
@@ -61,11 +65,11 @@ For sensitive values, use Kubernetes Secrets:
 
 ```yaml
 env:
-  - name: LLM_API_KEY
+  - name: JWT_SECRET_KEY
     valueFrom:
       secretKeyRef:
         name: lambchat-secrets
-        key: llm-api-key
+        key: jwt-secret-key
 ```
 
 ### Ingress
@@ -99,7 +103,7 @@ spec:
               service:
                 name: lambchat
                 port:
-                  number: 8000
+                  number: 80
 ```
 
 ## Scaling

--- a/docs/en/env/frontend.md
+++ b/docs/en/env/frontend.md
@@ -4,7 +4,7 @@ Frontend display and behavior settings.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `DEFAULT_AGENT` | `default` | Default agent ID when creating new sessions. |
+| `DEFAULT_AGENT` | `fast` | Default agent ID when creating new sessions. |
 | `WELCOME_SUGGESTIONS` | _(4-item list)_ | Welcome page suggestion items. JSON array of `{icon, text}` objects. |
 | `FRONTEND_DEV_URL` | _(empty)_ | Frontend dev server URL for CORS. Only needed in development. |
 | `VITE_API_BASE` | _(empty)_ | API base URL for frontend fetch calls. Leave empty for same-origin. |
@@ -33,7 +33,7 @@ The suggestions support i18n with language keys:
 ## Example
 
 ```bash
-DEFAULT_AGENT=default
+DEFAULT_AGENT=fast
 WELCOME_SUGGESTIONS=[{"icon":"🐍","text":"Create a Python hello world script"},{"icon":"📁","text":"List files in the workspace directory"}]
 FRONTEND_DEV_URL=http://localhost:3001
 ```

--- a/docs/zh/deploy/docker.md
+++ b/docs/zh/deploy/docker.md
@@ -10,9 +10,9 @@ Kubernetes 或其他编排系统，并配置共享 MongoDB、Redis 和 S3 兼容
 git clone https://github.com/Yanyutin753/LambChat.git
 cd LambChat
 
-# 复制并编辑环境文件
-cp deploy/.env.example .env
-# 编辑 .env 填入你的配置
+# 复制并编辑环境文件（Compose 从 deploy/ 目录读取 .env）
+cp deploy/.env.example deploy/.env
+# 编辑 deploy/.env 填入你的配置
 
 # 启动所有服务
 docker compose -f deploy/docker-compose.yml up -d
@@ -24,32 +24,36 @@ Docker Compose 为单节点服务栈启动三个服务：
 
 | 服务 | 镜像 | 端口 | 说明 |
 |------|------|------|------|
-| `lambchat` | 自定义构建 | 8000 | LambChat 应用（FastAPI + 静态前端） |
-| `mongo` | `mongo:7` | 27017 | MongoDB 数据库 |
-| `redis` | `redis:7-alpine` | 6379 | Redis 缓存和发布/订阅 |
+| `lambchat` | `ghcr.io/yanyutin753/lambchat:latest` | 8000 | LambChat 应用（FastAPI + 静态前端） |
+| `mongodb` | `mongo:8.2.5` | 127.0.0.1:27017 | MongoDB 数据库 |
+| `redis` | `redis:alpine` | 127.0.0.1:6379 | Redis 缓存和发布/订阅 |
+
+MongoDB 和 Redis 端口绑定在 `127.0.0.1`，不会暴露给其他主机访问。
 
 ## 配置
 
 ### 环境变量
 
-将 `deploy/.env.example` 复制为 `.env` 并配置：
+将 `deploy/.env.example` 复制为 `deploy/.env`。Compose 文件会从其中读取以下变量：
 
 ```bash
-# 推荐：设置稳定的 JWT 密钥（不设置则每次重启自动生成，导致已登录用户失效）
-JWT_SECRET_KEY=your-stable-secret-key
+# E2B 沙箱（可选）
+E2B_API_KEY=your_e2b_api_key
+E2B_TEMPLATE=base
 
-# 推荐：设置 MCP 加密盐值（不设置则每次重启自动生成，导致已保存的 MCP 配置失效）
-MCP_ENCRYPTION_SALT=your-stable-encryption-salt
+# 可选调优项
+LLM_MODEL_CACHE_SIZE=50
+SESSION_MAX_EVENTS_PER_TRACE=10000
+```
 
-# 可选：配置 MongoDB 连接
-MONGODB_URL=mongodb://localhost:27017
-MONGODB_DB=agent_state
-MONGODB_USERNAME=admin
-MONGODB_PASSWORD=your-mongo-password
+`REDIS_URL` 和 `MONGODB_URL` 已预设为服务栈内的 Redis 和 MongoDB 服务。其他环境变量（如 `JWT_SECRET_KEY`——稳定的 JWT 密钥，不设置则每次重启自动生成，导致已登录用户失效；`MCP_ENCRYPTION_SALT`——稳定的 MCP 加密盐值，不设置则每次重启自动生成，导致已保存的 MCP 配置失效）默认未接线——需要在 `deploy/docker-compose.yml` 的 `lambchat` 服务 `environment` 段中添加：
 
-# 可选：配置 Redis 连接
-REDIS_URL=redis://localhost:6379/0
-REDIS_PASSWORD=your-redis-password
+```yaml
+    environment:
+      # 推荐：保持登录会话在重启后仍然有效
+      - JWT_SECRET_KEY=your-stable-secret-key
+      # 推荐：保持已保存 MCP 配置在重启后仍可解密
+      - MCP_ENCRYPTION_SALT=your-stable-encryption-salt
 ```
 
 ::: tip
@@ -112,17 +116,20 @@ docker compose -f deploy/docker-compose.yml down
 # 重启应用（保留数据）
 docker compose -f deploy/docker-compose.yml restart lambchat
 
-# 代码变更后重新构建
-docker compose -f deploy/docker-compose.yml up -d --build lambchat
+# 更新到最新发布的镜像
+docker compose -f deploy/docker-compose.yml pull lambchat
+docker compose -f deploy/docker-compose.yml up -d lambchat
 ```
 
 ## 数据持久化
 
-Docker Compose 使用命名卷来持久化数据：
+Docker Compose 使用命名卷和绑定挂载来持久化数据：
 
-- `mongo_data` — MongoDB 数据
-- `redis_data` — Redis 数据
-- `uploads` — 上传的文件（本地存储模式）
+- `mongodb-data` — MongoDB 数据
+- `redis-data` — Redis 数据
+- `lamb-data` — LambChat 应用数据（`/app/data`）
+- `./workspace` — Agent 工作区（绑定挂载，解析到 `deploy/` 下）
+- `./uploads` — 本地存储模式下的上传文件（绑定挂载，解析到 `deploy/` 下）
 
 这些卷在容器重启和重建时保持不变。
 

--- a/docs/zh/deploy/kubernetes.md
+++ b/docs/zh/deploy/kubernetes.md
@@ -14,6 +14,10 @@ kubectl get pods -n lambchat
 kubectl get svc -n lambchat
 ```
 
+::: tip
+清单会从 `lambchat-secrets` Secret 读取敏感值（JWT 密钥、MCP 加密盐、数据库凭据、S3 密钥）。请将 `k8s/lambchat-secret.yaml.example` 复制为 `k8s/lambchat-secret.yaml`，填入你的值并 apply——Secret 不存在时 Pod 无法启动。
+:::
+
 ## 架构
 
 K8s 清单（`k8s/lambchat.yaml`）创建以下资源：
@@ -59,11 +63,11 @@ env:
 
 ```yaml
 env:
-  - name: LLM_API_KEY
+  - name: JWT_SECRET_KEY
     valueFrom:
       secretKeyRef:
         name: lambchat-secrets
-        key: llm-api-key
+        key: jwt-secret-key
 ```
 
 ### Ingress
@@ -97,7 +101,7 @@ spec:
               service:
                 name: lambchat
                 port:
-                  number: 8000
+                  number: 80
 ```
 
 ## 扩缩容

--- a/docs/zh/env/frontend.md
+++ b/docs/zh/env/frontend.md
@@ -4,7 +4,7 @@
 
 | 变量名 | 默认值 | 说明 |
 |--------|--------|------|
-| `DEFAULT_AGENT` | `default` | 创建新会话时的默认 Agent ID。 |
+| `DEFAULT_AGENT` | `fast` | 创建新会话时的默认 Agent ID。 |
 | `WELCOME_SUGGESTIONS` | _(4 项列表)_ | 欢迎页建议项。`{icon, text}` 对象的 JSON 数组。 |
 | `FRONTEND_DEV_URL` | _(空)_ | 前端开发服务器 URL，用于 CORS。仅在开发时需要。 |
 | `VITE_API_BASE` | _(空)_ | 前端 fetch 调用的 API 基础 URL。留空表示同源。 |
@@ -33,7 +33,7 @@
 ## 示例
 
 ```bash
-DEFAULT_AGENT=default
+DEFAULT_AGENT=fast
 WELCOME_SUGGESTIONS=[{"icon":"🐍","text":"创建一个 Python Hello World 脚本"},{"icon":"📁","text":"列出工作区目录中的文件"}]
 FRONTEND_DEV_URL=http://localhost:3001
 ```

--- a/docs/zh/env/sandbox.md
+++ b/docs/zh/env/sandbox.md
@@ -1,13 +1,13 @@
 # 沙箱配置
 
-安全远程代码执行的沙箱设置。支持 Daytona 和 E2B 平台。
+安全远程代码执行的沙箱设置。支持 Daytona、E2B 和 CubeSandbox 平台。
 
 ## 通用设置
 
 | 变量名 | 默认值 | 说明 |
 |--------|--------|------|
 | `ENABLE_SANDBOX` | `false` | 启用沙箱执行。 |
-| `SANDBOX_PLATFORM` | `daytona` | 沙箱平台：`daytona` 或 `e2b`。 |
+| `SANDBOX_PLATFORM` | `daytona` | 沙箱平台：`daytona`、`e2b` 或 `cubesandbox`。 |
 | `SANDBOX_GREP_TIMEOUT` | `30` | 沙箱 grep 命令超时时间（秒）。 |
 
 ## Daytona
@@ -32,6 +32,79 @@
 | `E2B_AUTO_PAUSE` | `true` | 否 | 超时时暂停沙箱而非终止（保留状态）。 |
 | `E2B_AUTO_RESUME` | `true` | 否 | 下次活动时自动恢复暂停的沙箱。 |
 
+## CubeSandbox
+
+CubeSandbox 通过原生 CubeSandbox Python SDK 支持。LambChat 使用 CubeSandbox 元数据维持稳定的用户与沙箱绑定：每个用户应保持一个运行中的沙箱，并在所有会话之间共享。
+
+| 变量名 | 默认值 | 敏感 | 说明 |
+|--------|--------|------|------|
+| `CUBE_API_URL` | `http://127.0.0.1:3000` | 否 | CubeSandbox API 基础 URL。本地开发环境通常为 `http://127.0.0.1:13000`。 |
+| `CUBE_TEMPLATE` | _(空)_ | 否 | 创建沙箱时使用的 CubeSandbox 模板 ID。 |
+| `CUBE_TIMEOUT` | `3600` | 否 | 沙箱超时时间（秒）。 |
+| `CUBE_PROXY_NODE_IP` | _(空)_ | 否 | SDK 访问沙箱数据面服务使用的代理节点 IP。 |
+| `CUBE_PROXY_PORT_HTTP` | `80` | 否 | SDK 使用的 HTTP 代理端口。 |
+| `CUBE_SANDBOX_DOMAIN` | `cube.app` | 否 | CubeSandbox 代理路由使用的沙箱域名后缀。 |
+| `CUBE_REQUEST_TIMEOUT` | `120` | 否 | SDK 请求超时时间（秒）。值越小，对失效数据面连接失败越快；值越大，越能容忍较慢的本地启动。 |
+| `CUBE_AUTO_PAUSE` | `true` | 否 | 在运行时支持时，超时后请求 CubeSandbox 暂停而非终止。 |
+| `CUBE_AUTO_RESUME` | `true` | 否 | 在运行时支持时，请求 CubeSandbox 自动恢复已暂停的沙箱。 |
+
+### 生命周期行为
+
+当 `SANDBOX_PLATFORM=cubesandbox` 时，LambChat 对每个用户按以下顺序处理：
+
+1. 进程内缓存的沙箱仍健康时直接复用。
+2. 重连 MongoDB `user_sandbox_bindings` 记录。
+3. 绑定缺失或不健康时，按 `metadata.user_id` 匹配列出 CubeSandbox 实例并复用健康的运行中沙箱。
+4. 仅当没有可用的健康沙箱时才创建新沙箱。
+5. 清理同一用户的重复运行中沙箱，保留选中的沙箱。
+
+CubeSandbox 偶尔会在控制面将沙箱报告为 `running`，但数据面返回 `504 Gateway Time-out`。当 LambChat 无法创建会话工作目录或执行命令时，会将其视为不健康，然后回退到另一个已有沙箱或创建新沙箱。
+
+### 生产迁移
+
+LambChat 按用户和平台存储沙箱绑定。新记录使用：
+
+- `sandboxes.e2b`
+- `sandboxes.cubesandbox`
+
+较旧的生产记录可能只有 `sandbox_id`、`sandbox_state` 等顶层字段。当 `SANDBOX_PLATFORM=e2b` 时，这些旧的顶层记录会出于向后兼容被视为 E2B 绑定。下次成功复用时，LambChat 会将同一沙箱写入 `sandboxes.e2b`，因此现有 E2B 沙箱会继续使用而不会重建。
+
+将用户或部署从 `e2b` 切换到 `cubesandbox` 时，会在 `sandboxes.cubesandbox` 下创建或复用 CubeSandbox 绑定，不覆盖 `sandboxes.e2b`。切回 `e2b` 时会重新读取 E2B 槽位。
+
+应继续使用 E2B 的生产部署请保持：
+
+```bash
+SANDBOX_PLATFORM=e2b
+```
+
+除非确实希望这些用户开始使用 CubeSandbox，否则不要设置 `SANDBOX_PLATFORM=cubesandbox`。两个平台具有独立的沙箱 ID 和独立的生命周期 API。
+
+### 性能说明
+
+- 冷启动创建 CubeSandbox 的耗时取决于模板和本地运行时恢复时间。本地测试中通常约 20-30 秒。
+- 同一用户的新会话通常应复用同一沙箱，避免冷启动。
+- 重复沙箱清理不在关键缓存命中路径上执行，复用可在后台清理完成前返回。
+- `CubeSandboxBackend` 使用 `CUBE_TIMEOUT` 作为命令执行超时，并缓存重复文件写入的父目录创建。
+- 会话管理器在当前后端进程中缓存已成功准备的会话工作目录。后端重启后会重新执行 `mkdir -p`，仍然安全。
+
+### 控制台与 API 检查
+
+集成本地 CubeSandbox 开发环境时：
+
+```bash
+# CubeSandbox Web UI
+open http://127.0.0.1:12088
+
+# 从 Cube API 列出沙箱
+curl http://127.0.0.1:13000/sandboxes
+```
+
+有用的检查：
+
+- 选中的沙箱的 `metadata.user_id` 应等于 LambChat 用户 ID。
+- 一个用户通常应只有一个健康的 `running` 沙箱。
+- 如果沙箱显示为 `running` 但命令执行返回 504，请在 CubeSandbox 中终止它，或让 LambChat 在下次初始化沙箱时替换它。
+
 ## 示例
 
 ### Daytona（自托管）
@@ -54,6 +127,26 @@ E2B_TEMPLATE=base
 E2B_TIMEOUT=3600
 ```
 
+### CubeSandbox（本地开发）
+
+```bash
+ENABLE_SANDBOX=true
+SANDBOX_PLATFORM=cubesandbox
+CUBE_API_URL=http://127.0.0.1:13000
+CUBE_TEMPLATE=tpl-your-template-id
+CUBE_PROXY_NODE_IP=127.0.0.1
+CUBE_PROXY_PORT_HTTP=11080
+CUBE_SANDBOX_DOMAIN=cube.app
+CUBE_TIMEOUT=3600
+CUBE_REQUEST_TIMEOUT=120
+CUBE_AUTO_PAUSE=true
+CUBE_AUTO_RESUME=true
+```
+
 ::: info
 `DAYTONA_AUTO_*_INTERVAL` 设置控制沙箱生命周期管理以优化资源使用。沙箱会根据这些间隔自动停止、归档和最终删除。
+:::
+
+::: tip
+对于 CubeSandbox，请根据本地运行时调整 `CUBE_REQUEST_TIMEOUT`。值越小，失效沙箱失败越快；值越大，可减少本地恢复较慢时的误判失败。
 :::


### PR DESCRIPTION
文档与当前实际配置对齐（已 rebase 到最新 develop）：

- **保留并仍然成立**：deploy/.env 路径与 Compose 容器清单（ghcr 镜像、mongo:8.2.5、redis:alpine、127.0.0.1 端口绑定）、DEFAULT_AGENT 默认值 fast、make test/check-all 描述、README 双语同步
- **CubeSandbox 文档**：zh 版 sandbox.md 补齐 en 版已有的 CubeSandbox 平台章节（9 个 CUBE_* 变量与生命周期行为，已逐一核对与 src/kernel/config 一致）；.env.example 平台列表补 cubesandbox
- **冲突取舍**：llm 超时相关行（LLM_REQUEST_TIMEOUT 等）develop 已有更新版本，冲突处全部取 develop，本 PR 不覆盖