### PR TITLE
ci: fork 上跳过 docs pages 部署

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.repository == 'Yanyutin753/LambChat'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -40,6 +41,7 @@ jobs:
 
   deploy:
     needs: build
+    if: github.repository == 'Yanyutin753/LambChat'
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
docs.yml 增加 repository 判断：非上游仓库不部署 GitHub Pages，避免 fork 的无效 Pages 构建失败噪音。