### PR TITLE
test(frontend): 源码结构测试跨平台可移植——Windows 本地 14 个失败清零

### DIFF
--- a/frontend/src/__tests__/performanceBudget.test.ts
+++ b/frontend/src/__tests__/performanceBudget.test.ts
@@ -1,4 +1,5 @@
 import { gzipSync } from "node:zlib";
+import { resolve } from "node:path";
 import { describe, expect, test } from "vitest";
 import {
   collectRouteShellUrls,
@@ -136,15 +137,18 @@ describe("frontend performance budgets", () => {
   });
 
   test("filters to the eager graph, route shells, offline shell, and icons", async () => {
+    // distDir 必须是平台正确的绝对路径：Windows 上 resolve("/dist") 会落盘符根
+    const distDir = resolve("perf-dist-fixture");
+    const dist = (...parts: string[]) => resolve(distDir, ...parts);
     const files = new Map<string, Buffer>([
       [
-        "/dist/index.html",
+        dist("index.html"),
         Buffer.from(
           '<script type="module" src="/assets/index.js"></script><link rel="modulepreload" href="/assets/vendor.js">',
         ),
       ],
       [
-        "/dist/.vite/manifest.json",
+        dist(".vite", "manifest.json"),
         Buffer.from(
           JSON.stringify({
             "src/main.tsx": {
@@ -163,14 +167,14 @@ describe("frontend performance budgets", () => {
           }),
         ),
       ],
-      ["/dist/assets/index.js", Buffer.from("entry")],
-      ["/dist/assets/vendor.js", Buffer.from("vendor")],
-      ["/dist/assets/app.js", Buffer.from("app")],
-      ["/dist/assets/mermaid.js", Buffer.from("mermaid")],
-      ["/dist/assets/font.woff2", Buffer.from("font")],
-      ["/dist/offline.html", Buffer.from("offline")],
+      [dist("assets", "index.js"), Buffer.from("entry")],
+      [dist("assets", "vendor.js"), Buffer.from("vendor")],
+      [dist("assets", "app.js"), Buffer.from("app")],
+      [dist("assets", "mermaid.js"), Buffer.from("mermaid")],
+      [dist("assets", "font.woff2"), Buffer.from("font")],
+      [dist("offline.html"), Buffer.from("offline")],
       [
-        "/dist/manifest.json",
+        dist("manifest.json"),
         Buffer.from(
           JSON.stringify({
             icons: [{ src: "/icons/icon-192.png" }],
@@ -178,9 +182,9 @@ describe("frontend performance budgets", () => {
           }),
         ),
       ],
-      ["/dist/favicon.ico", Buffer.from("icon")],
-      ["/dist/icons/icon-192.png", Buffer.from("pwa icon")],
-      ["/dist/icons/og-image.png", Buffer.from("social image")],
+      [dist("favicon.ico"), Buffer.from("icon")],
+      [dist("icons", "icon-192.png"), Buffer.from("pwa icon")],
+      [dist("icons", "og-image.png"), Buffer.from("social image")],
     ]);
     const logs: string[] = [];
     const readBytes = (filePath: string) => {
@@ -188,15 +192,9 @@ describe("frontend performance budgets", () => {
       if (!value) throw new Error(`missing test file: ${filePath}`);
       return value;
     };
-    files.set(
-      "/dist/index.html",
-      Buffer.from(
-        '<script type="module" src="/assets/index.js"></script><link rel="modulepreload" href="/assets/vendor.js">',
-      ),
-    );
 
     const transform = createPerformanceManifestTransform({
-      distDir: "/dist",
+      distDir,
       readText: (filePath) => readBytes(filePath).toString("utf8"),
       readBytes,
       log: (message) => logs.push(message),
@@ -247,25 +245,27 @@ describe("frontend performance budgets", () => {
       }
       return value;
     };
+    const distDir = resolve("perf-dist-fixture-budget");
+    const dist = (...parts: string[]) => resolve(distDir, ...parts);
     const baseFiles = new Map<string, Buffer>([
       [
-        "/dist/index.html",
+        dist("index.html"),
         Buffer.from('<script type="module" src="/assets/index.js"></script>'),
       ],
       [
-        "/dist/.vite/manifest.json",
+        dist(".vite", "manifest.json"),
         Buffer.from(
           JSON.stringify({
             "index.html": { file: "assets/index.js", isEntry: true },
           }),
         ),
       ],
-      ["/dist/assets/index.js", Buffer.from("entry")],
-      ["/dist/manifest.json", Buffer.from('{"icons":[]}')],
+      [dist("assets", "index.js"), Buffer.from("entry")],
+      [dist("manifest.json"), Buffer.from('{"icons":[]}')],
     ]);
     const makeTransform = (readBytes: (filePath: string) => Uint8Array) =>
       createPerformanceManifestTransform({
-        distDir: "/dist",
+        distDir,
         readText: (filePath) =>
           Buffer.from(readBytes(filePath)).toString("utf8"),
         readBytes,
@@ -274,7 +274,7 @@ describe("frontend performance budgets", () => {
 
     await expect(
       makeTransform((filePath) =>
-        filePath === "/dist/assets/index.js"
+        filePath === dist("assets", "index.js")
           ? deterministicNoise(600_000)
           : baseFiles.get(filePath)!,
       )([{ url: "assets/index.js", size: 600_000 }]),
@@ -286,7 +286,7 @@ describe("frontend performance budgets", () => {
 
     await expect(
       makeTransform((filePath) =>
-        filePath === "/dist/assets/index.js"
+        filePath === dist("assets", "index.js")
           ? Buffer.alloc(5 * 1024 * 1024 + 1, 0)
           : baseFiles.get(filePath)!,
       )([{ url: "assets/index.js", size: 5 * 1024 * 1024 + 1 }]),

--- a/frontend/src/components/chat/ChatMessage/items/__tests__/filePathPillLabels.test.ts
+++ b/frontend/src/components/chat/ChatMessage/items/__tests__/filePathPillLabels.test.ts
@@ -1,6 +1,10 @@
 import { readFileSync } from "node:fs";
 function readSource(relativePath: string): string {
-  return readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  // Windows 检出为 CRLF，归一化后再做结构断言
+  return readFileSync(new URL(relativePath, import.meta.url), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
 }
 
 test("file operation pills render full file paths without path-breaking formatting", () => {
@@ -48,7 +52,7 @@ test("read file pill renders the line range in the suffix so it survives path tr
 });
 
 test("collapsible pill always truncates labels to prevent overflow", () => {
-  const source = readFileSync(
+  const source = readSource(
     new URL("../../../../common/CollapsiblePill.tsx", import.meta.url),
     "utf8",
   );
@@ -59,7 +63,7 @@ test("collapsible pill always truncates labels to prevent overflow", () => {
 });
 
 test("collapsible pill can preserve labels without path-breaking formatting", () => {
-  const source = readFileSync(
+  const source = readSource(
     new URL("../../../../common/CollapsiblePill.tsx", import.meta.url),
     "utf8",
   );
@@ -72,7 +76,7 @@ test("collapsible pill can preserve labels without path-breaking formatting", ()
 });
 
 test("collapsible pill uses a non-submit button for form-safe tool clicks", () => {
-  const source = readFileSync(
+  const source = readSource(
     new URL("../../../../common/CollapsiblePill.tsx", import.meta.url),
     "utf8",
   );

--- a/frontend/src/components/common/__tests__/markdownRendererSources.test.ts
+++ b/frontend/src/components/common/__tests__/markdownRendererSources.test.ts
@@ -13,7 +13,8 @@ function listTsxFiles(directory: string): string[] {
 const sourceRoot = fileURLToPath(new URL("../../../", import.meta.url));
 const directRenderers = listTsxFiles(sourceRoot)
   .map((path) => ({
-    path: relative(sourceRoot, path),
+    // Windows 下 relative() 产出反斜杠分隔符，统一为 / 便于断言
+    path: relative(sourceRoot, path).split("\\").join("/"),
     source: readFileSync(path, "utf8"),
   }))
   .filter(({ source }) => source.includes("<ReactMarkdown"));

--- a/frontend/src/components/documents/__tests__/documentFetchProxyCoverage.test.ts
+++ b/frontend/src/components/documents/__tests__/documentFetchProxyCoverage.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { test, expect } from "vitest";
 
 // 所有拉取上传文件内容的调用点必须走 documentFetchCache 的统一入口，
@@ -55,7 +56,7 @@ test("binary consumers download via fetchUploadFile", () => {
 });
 
 test("no source file combines buildUploadProxyUrl with a raw fetch()", () => {
-  const srcDir = new URL("../../../", import.meta.url).pathname;
+  const srcDir = fileURLToPath(new URL("../../../", import.meta.url));
   const offenders: string[] = [];
   for (const file of listSourceFiles(srcDir)) {
     const src = readFileSync(file, "utf8");

--- a/frontend/src/components/documents/__tests__/pdfPreviewBlobUrl.test.ts
+++ b/frontend/src/components/documents/__tests__/pdfPreviewBlobUrl.test.ts
@@ -2,11 +2,12 @@ import { readFileSync } from "node:fs";
 const stateSource = readFileSync(
   new URL("../useDocumentPreviewState.ts", import.meta.url),
   "utf8",
-);
+  // Windows 检出为 CRLF，归一化后再做结构断言
+).replace(/\r\n/g, "\n");
 const contentSource = readFileSync(
   new URL("../DocumentPreviewContent.tsx", import.meta.url),
   "utf8",
-);
+).replace(/\r\n/g, "\n");
 
 test("PDF preview uses a local PDF blob URL instead of embedding the download URL directly", () => {
   const pdfBranch = stateSource.match(

--- a/frontend/src/components/documents/previews/__tests__/pptPreviewLocal.test.ts
+++ b/frontend/src/components/documents/previews/__tests__/pptPreviewLocal.test.ts
@@ -2,11 +2,12 @@ import { readFileSync } from "node:fs";
 const previewSource = readFileSync(
   new URL("../PptPreview.tsx", import.meta.url),
   "utf8",
-);
+  // Windows 检出为 CRLF，归一化后再做结构断言
+).replace(/\r\n/g, "\n");
 const stateSource = readFileSync(
   new URL("../../useDocumentPreviewState.ts", import.meta.url),
   "utf8",
-);
+).replace(/\r\n/g, "\n");
 const frontendPackage = JSON.parse(
   readFileSync(new URL("../../../../../package.json", import.meta.url), "utf8"),
 );

--- a/frontend/src/components/download/__tests__/DownloadPage.test.tsx
+++ b/frontend/src/components/download/__tests__/DownloadPage.test.tsx
@@ -96,16 +96,21 @@ test("renders desktop and daemon downloads from the latest release assets", asyn
   render(<DownloadPage />);
 
   // 等待锚点必须是数据驱动内容（资产文件名）：平台卡标签（Windows/macOS）
-  // 不等 versionApi 就渲染，锚在静态标签上会在数据晚到时撞进空窗
+  // 不等 versionApi 就渲染，锚在静态标签上会在数据晚到时撞进空窗。
+  // 检测到的平台（跟随宿主 userAgent，jsdom 在 mac/win 主机不同）会把安装包
+  // 同时渲染进 hero CTA 和平台卡，因此用 AllBy 变体容忍重复。
   expect(
-    await screen.findByText("LambChat-v2.8.1-Windows.msi"),
-  ).toBeInTheDocument();
+    (await screen.findAllByText("LambChat-v2.8.1-Windows.msi")).length,
+  ).toBeGreaterThanOrEqual(1);
   expect(screen.getByText("Windows")).toBeInTheDocument();
   expect(screen.getByText("macOS")).toBeInTheDocument();
   expect(screen.getByText("Linux")).toBeInTheDocument();
 
   // 下载直链锚点：走自托管反代（国内直连 GitHub 下载不稳），跟随最新 release
-  const msi = screen.getByText("LambChat-v2.8.1-Windows.msi").closest("a");
+  const msi = screen
+    .getAllByText("LambChat-v2.8.1-Windows.msi")
+    .map((el) => el.closest("a"))
+    .find(Boolean);
   expect(msi).toHaveAttribute(
     "href",
     "/api/version/assets/LambChat-v2.8.1-Windows.msi/download",

--- a/frontend/src/components/layout/AppContent/__tests__/useMessageScrollHookSource.test.ts
+++ b/frontend/src/components/layout/AppContent/__tests__/useMessageScrollHookSource.test.ts
@@ -11,7 +11,8 @@ const hookSource = readFileSync(
     "useMessageScroll.hook.ts",
   ),
   "utf8",
-);
+  // Windows 检出为 CRLF，归一化后再做结构断言
+).replace(/\r\n/g, "\n");
 
 test("positions accepted history once before browser paint", () => {
   expect(hookSource).toMatch(

--- a/frontend/src/hooks/__tests__/useAutoUpdateSource.test.ts
+++ b/frontend/src/hooks/__tests__/useAutoUpdateSource.test.ts
@@ -10,7 +10,8 @@ function readRepoFile(path: string): string {
   if (!existsSync(url)) {
     throw new Error(`repo file not found: ${path}`);
   }
-  return readFileSync(url, "utf8");
+  // Windows 检出为 CRLF，归一化后再做结构断言
+  return readFileSync(url, "utf8").replace(/\r\n/g, "\n");
 }
 
 test("version service reports the bundled client version on update checks", () => {

--- a/frontend/src/i18n/__tests__/extractI18nScript.test.ts
+++ b/frontend/src/i18n/__tests__/extractI18nScript.test.ts
@@ -7,7 +7,9 @@ import { fileURLToPath } from "node:url";
 const currentDir = dirname(fileURLToPath(import.meta.url));
 const frontendRoot = resolve(currentDir, "../../..");
 const extractorPath = resolve(frontendRoot, "scripts/extract-i18n.ts");
-const tsxPath = resolve(frontendRoot, "node_modules/.bin/tsx");
+// Windows 下 .bin/tsx 是无扩展名 shell 脚本，execFileSync 直接 spawn 会 ENOENT；
+// 统一走 node + tsx CLI 入口，跨平台一致。
+const tsxPath = resolve(frontendRoot, "node_modules/tsx/dist/cli.mjs");
 
 test("reports each newly extracted locale key once", () => {
   const fixtureDir = mkdtempSync(resolve(tmpdir(), "lambchat-i18n-extract-"));
@@ -24,7 +26,7 @@ test("reports each newly extracted locale key once", () => {
       writeFileSync(resolve(localesDir, `${locale}.json`), "{}\n");
     }
 
-    const output = execFileSync(tsxPath, [extractorPath], {
+    const output = execFileSync(process.execPath, [tsxPath, extractorPath], {
       cwd: fixtureDir,
       encoding: "utf8",
     });
@@ -59,7 +61,7 @@ test("extracts keys from .ts hook files but skips __tests__ fixtures", () => {
       writeFileSync(resolve(localesDir, `${locale}.json`), "{}\n");
     }
 
-    const output = execFileSync(tsxPath, [extractorPath], {
+    const output = execFileSync(process.execPath, [tsxPath, extractorPath], {
       cwd: fixtureDir,
       encoding: "utf8",
     });

--- a/frontend/src/utils/__tests__/filenameCasingSource.test.ts
+++ b/frontend/src/utils/__tests__/filenameCasingSource.test.ts
@@ -1,5 +1,6 @@
 import { readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { test, expect } from "vitest";
 
 // 同目录下 basename 仅差大小写的 .ts/.tsx 文件对客户端构建是地雷：
@@ -7,7 +8,8 @@ import { test, expect } from "vitest";
 // （v2.7.0 的 RunStepsCollapse.tsx ↔ runStepsCollapse.ts 曾炸掉全部客户端构建）。
 // 新增文件若与本测试冲突，请重命名（如加 Utils 后缀）而不是加白名单。
 
-const SRC_ROOT = new URL("../..", import.meta.url).pathname;
+// .pathname 在 Windows 会产出 /D:/... 形态的坏路径，必须经 fileURLToPath 转换
+const SRC_ROOT = fileURLToPath(new URL("../..", import.meta.url));
 
 function listFiles(dir: string): string[] {
   const out: string[] = [];


### PR DESCRIPTION
修复三类 Windows-only 的本地测试失败（CI 在 LF 环境下不可见，本地 vitest 长期 14 failed，干扰 TDD 循环）：

1. **CRLF 行尾**：源码结构测试读源码后用 `\n` 正则断言，Windows 检出为 CRLF 时全数落空——8 个测试文件读入后统一 `replace(/\r\n/g, "\n")` 归一化。
2. **URL.pathname / 路径分隔符**：`new URL(...).pathname` 在 Windows 产出 `/D:/...` 形态（scandir 报 `D:\D:\...`），改 `fileURLToPath`；`relative()` 产出的反斜杠分隔符统一为 `/`。
3. **POSIX 绝对路径夹具**：performanceBudget 的 `/dist` 假路径在 Windows `resolve` 到盘符根，改为平台正确的绝对路径夹具。

另两处同类：
- `extractI18nScript` 直接 spawn `node_modules/.bin/tsx`（无扩展名 shell 脚本）在 Windows ENOENT，改 `node + tsx/dist/cli.mjs`；
- `DownloadPage` 的 `detectDesktopPlatform` 跟随宿主 userAgent——Windows/mac 主机上 hero CTA 与平台卡会重复渲染同一安装包，`findByText` 报 multiple elements，改 `findAllByText` + 取首个带链接元素。

**验证**：Windows 本机前端 vitest 全量 **2688 passed / 0 failed**（此前 14 failed）；全部为测试文件改动，不触及生产代码。