### PR TITLE
fix(llm): KV 缓存字段仅对官方 OpenAI 端点注入——第三方网关兼容加固

### DIFF
--- a/src/infra/llm/client.py
+++ b/src/infra/llm/client.py
@@ -19,7 +19,12 @@ from pydantic import SecretStr
 
 from src.infra.llm.anthropic_chat import LambChatAnthropicChatModel as ChatAnthropic
 from src.infra.llm.google_chat import LambChatGoogleChatModel as ChatGoogleGenerativeAI
-from src.infra.llm.openai_chat import LambChatOpenAIChatModel as ChatOpenAI
+from src.infra.llm.openai_chat import (
+    LambChatOpenAIChatModel as ChatOpenAI,
+)
+from src.infra.llm.openai_chat import (
+    is_official_openai_base_url,
+)
 from src.infra.logging import get_logger
 from src.kernel.config import settings
 from src.kernel.exceptions import AuthorizationError
@@ -605,7 +610,12 @@ class LLMClient:
         # - store=False：无状态全量重放，不依赖服务端会话存储（ChatGPT
         #   codex 后端中转更是强制要求 store=false）。
         # 调用方显式传参优先；LLM_KV_CACHE=False 可整体关闭。
-        if openai_kwargs["use_responses_api"] and getattr(settings, "LLM_KV_CACHE", True):
+        # 仅官方端点注入：严格校验未知字段的第三方网关会 4xx（工单 2）。
+        if (
+            openai_kwargs["use_responses_api"]
+            and getattr(settings, "LLM_KV_CACHE", True)
+            and is_official_openai_base_url(api_base)
+        ):
             if "include" not in kwargs:
                 openai_kwargs["include"] = ["reasoning.encrypted_content"]
             if "store" not in kwargs:

--- a/src/infra/llm/openai_chat.py
+++ b/src/infra/llm/openai_chat.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncIterator
 from typing import Any
+from urllib.parse import urlparse
 
 from langchain_core.callbacks import AsyncCallbackManagerForLLMRun
 from langchain_core.messages import BaseMessage
@@ -15,6 +16,25 @@ from pydantic import Field
 from src.infra.llm.responses_cache import current_responses_prompt_cache_key
 from src.infra.llm.streaming import aiter_with_first_event_timeout
 from src.kernel.config import settings
+
+_OPENAI_OFFICIAL_HOSTS = frozenset({"api.openai.com"})
+
+
+def is_official_openai_base_url(base_url: Any) -> bool:
+    """prompt_cache_key 只对官方端点注入：严格校验未知字段的第三方
+    OpenAI 兼容网关可能因该字段 4xx（风险审查工单 2）。base_url 为空
+    表示 SDK 默认官方端点；仅填域名的写法（api.openai.com/v1）urlparse
+    会把整串归入 path，需回退按 `/` 截取主机段。"""
+    if not base_url:
+        return True
+    raw = str(base_url)
+    try:
+        host = urlparse(raw).hostname or ""
+    except ValueError:
+        return False
+    if not host and "://" not in raw:
+        host = raw.split("/", 1)[0]
+    return host.lower() in _OPENAI_OFFICIAL_HOSTS
 
 
 class LambChatOpenAIChatModel(ChatOpenAI):
@@ -32,8 +52,11 @@ class LambChatOpenAIChatModel(ChatOpenAI):
         # 落在同一缓存机器。/v1/responses 与 /v1/chat/completions 两种线
         # 格式都注入（SDK 3.6.0 起后者同样支持该字段，替代 user 做缓存
         # 路由）；显式传入优先。同步路径在线程池中丢失上下文，属预期。
+        # 仅官方端点注入：第三方网关严格校验未知字段时会 4xx（工单 2）。
         if payload.get("prompt_cache_key") is None:
-            if getattr(settings, "LLM_KV_CACHE", True):
+            if getattr(settings, "LLM_KV_CACHE", True) and is_official_openai_base_url(
+                getattr(self, "openai_api_base", None)
+            ):
                 key = current_responses_prompt_cache_key()
                 if key:
                     payload["prompt_cache_key"] = key

--- a/tests/infra/llm/test_responses_kv_cache.py
+++ b/tests/infra/llm/test_responses_kv_cache.py
@@ -232,3 +232,79 @@ def test_context_helpers_accept_mock_session_ids() -> None:
         assert current_responses_prompt_cache_key() is None
     finally:
         reset_responses_prompt_cache_key(token)
+
+
+# ── 风险审查工单 2：prompt_cache_key 仅对官方端点注入 ─────────────────────
+
+
+def _model_with_base_url(base_url: str | None):
+    return LLMClient._create_model(
+        "openai",
+        "gpt-5.2",
+        temperature=0.7,
+        api_key="sk-test",
+        api_base=base_url,
+    )
+
+
+def test_third_party_gateway_payload_has_no_prompt_cache_key() -> None:
+    # 严格校验未知字段的第三方 OpenAI 兼容网关可能因 prompt_cache_key 4xx
+    model = _model_with_base_url("https://gateway.example.com/v1")
+    token = set_responses_prompt_cache_key("session-42")
+    try:
+        payload = model._get_request_payload([HumanMessage(content="hi")])
+    finally:
+        reset_responses_prompt_cache_key(token)
+    assert "prompt_cache_key" not in payload
+
+
+def test_official_openai_base_url_still_gets_prompt_cache_key() -> None:
+    model = _model_with_base_url("https://api.openai.com/v1")
+    token = set_responses_prompt_cache_key("session-42")
+    try:
+        payload = model._get_request_payload([HumanMessage(content="hi")])
+    finally:
+        reset_responses_prompt_cache_key(token)
+    assert payload["prompt_cache_key"] == "session-42"
+
+
+def test_official_host_without_scheme_still_gets_prompt_cache_key() -> None:
+    # Model Config 里常见仅填域名的写法
+    model = _model_with_base_url("api.openai.com/v1")
+    token = set_responses_prompt_cache_key("session-42")
+    try:
+        payload = model._get_request_payload([HumanMessage(content="hi")])
+    finally:
+        reset_responses_prompt_cache_key(token)
+    assert payload["prompt_cache_key"] == "session-42"
+
+
+def test_default_base_url_official_gets_prompt_cache_key() -> None:
+    # base_url 为空 = SDK 默认官方端点，回归保护
+    model = _model_with_base_url(None)
+    token = set_responses_prompt_cache_key("session-42")
+    try:
+        payload = model._get_request_payload([HumanMessage(content="hi")])
+    finally:
+        reset_responses_prompt_cache_key(token)
+    assert payload["prompt_cache_key"] == "session-42"
+
+
+def test_third_party_gateway_gets_no_responses_cache_defaults() -> None:
+    # include/store 同属非标字段：严格校验的网关会同样拒绝
+    model = _model_with_base_url("https://gateway.example.com/v1")
+    assert model.include is None
+    assert model.store is None
+
+
+def test_official_base_url_keeps_responses_cache_defaults() -> None:
+    model = LLMClient._create_model(
+        "openai",
+        "gpt-5.2",
+        temperature=0.7,
+        api_key="sk-test",
+        api_format="responses",
+        api_base="https://api.openai.com/v1",
+    )
+    assert model.include == ["reasoning.encrypted_content"]
+    assert model.store is False


### PR DESCRIPTION
来源：本地风险审查工单 2（预防性加固），TDD。

## 问题
36072e4a 起会话级 `prompt_cache_key` 无差别注入所有 openai 协议模型的请求体（`/v1/responses` 与 `/v1/chat/completions` 双线格式）；`/v1/responses` 模型还默认携带 `include: ["reasoning.encrypted_content"]` 与 `store: false`。对**严格校验未知字段的第三方 OpenAI 兼容网关**，这些非标字段可能触发 4xx。OpenAI 官方两个端点已验证支持，无风险。

## 修复
- 新增 `is_official_openai_base_url()`：base_url 为空（SDK 默认）或主机为 `api.openai.com` 视为官方端点；仅填域名的写法（`api.openai.com/v1`）经 path 回退截取主机段识别。
- `prompt_cache_key` 的 payload 注入与 `include`/`store` 的模型默认值统一走该门控；`LLM_KV_CACHE` 总开关与调用方显式传参优先级不变。
- 官方端点行为零变化；第三方网关请求体不再含上述字段（缓存路由本就不适用于第三方）。

## 测试
新增 6 例：第三方网关 payload 无 prompt_cache_key、官方 URL/无 scheme/默认 base_url 仍注入、第三方网关无 include/store、官方保留默认值。既有 22 例全数回归通过（含显式传参优先、kill switch、ContextVar 语义），ruff/mypy 绿。