### PR TITLE
fix(tracing): Langfuse/LangSmith 面板配置真正生效——env 同步双向化 + tracer 缓存重评估

### DIFF
--- a/src/infra/llm/client.py
+++ b/src/infra/llm/client.py
@@ -19,7 +19,12 @@ from pydantic import SecretStr
 
 from src.infra.llm.anthropic_chat import LambChatAnthropicChatModel as ChatAnthropic
 from src.infra.llm.google_chat import LambChatGoogleChatModel as ChatGoogleGenerativeAI
-from src.infra.llm.openai_chat import LambChatOpenAIChatModel as ChatOpenAI
+from src.infra.llm.openai_chat import (
+    LambChatOpenAIChatModel as ChatOpenAI,
+)
+from src.infra.llm.openai_chat import (
+    is_official_openai_base_url,
+)
 from src.infra.logging import get_logger
 from src.kernel.config import settings
 from src.kernel.exceptions import AuthorizationError
@@ -605,7 +610,12 @@ class LLMClient:
         # - store=False：无状态全量重放，不依赖服务端会话存储（ChatGPT
         #   codex 后端中转更是强制要求 store=false）。
         # 调用方显式传参优先；LLM_KV_CACHE=False 可整体关闭。
-        if openai_kwargs["use_responses_api"] and getattr(settings, "LLM_KV_CACHE", True):
+        # 仅官方端点注入：严格校验未知字段的第三方网关会 4xx（工单 2）。
+        if (
+            openai_kwargs["use_responses_api"]
+            and getattr(settings, "LLM_KV_CACHE", True)
+            and is_official_openai_base_url(api_base)
+        ):
             if "include" not in kwargs:
                 openai_kwargs["include"] = ["reasoning.encrypted_content"]
             if "store" not in kwargs:

--- a/src/infra/llm/openai_chat.py
+++ b/src/infra/llm/openai_chat.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncIterator
 from typing import Any
+from urllib.parse import urlparse
 
 from langchain_core.callbacks import AsyncCallbackManagerForLLMRun
 from langchain_core.messages import BaseMessage
@@ -15,6 +16,25 @@ from pydantic import Field
 from src.infra.llm.responses_cache import current_responses_prompt_cache_key
 from src.infra.llm.streaming import aiter_with_first_event_timeout
 from src.kernel.config import settings
+
+_OPENAI_OFFICIAL_HOSTS = frozenset({"api.openai.com"})
+
+
+def is_official_openai_base_url(base_url: Any) -> bool:
+    """prompt_cache_key 只对官方端点注入：严格校验未知字段的第三方
+    OpenAI 兼容网关可能因该字段 4xx（风险审查工单 2）。base_url 为空
+    表示 SDK 默认官方端点；仅填域名的写法（api.openai.com/v1）urlparse
+    会把整串归入 path，需回退按 `/` 截取主机段。"""
+    if not base_url:
+        return True
+    raw = str(base_url)
+    try:
+        host = urlparse(raw).hostname or ""
+    except ValueError:
+        return False
+    if not host and "://" not in raw:
+        host = raw.split("/", 1)[0]
+    return host.lower() in _OPENAI_OFFICIAL_HOSTS
 
 
 class LambChatOpenAIChatModel(ChatOpenAI):
@@ -32,8 +52,11 @@ class LambChatOpenAIChatModel(ChatOpenAI):
         # 落在同一缓存机器。/v1/responses 与 /v1/chat/completions 两种线
         # 格式都注入（SDK 3.6.0 起后者同样支持该字段，替代 user 做缓存
         # 路由）；显式传入优先。同步路径在线程池中丢失上下文，属预期。
+        # 仅官方端点注入：第三方网关严格校验未知字段时会 4xx（工单 2）。
         if payload.get("prompt_cache_key") is None:
-            if getattr(settings, "LLM_KV_CACHE", True):
+            if getattr(settings, "LLM_KV_CACHE", True) and is_official_openai_base_url(
+                getattr(self, "openai_api_base", None)
+            ):
                 key = current_responses_prompt_cache_key()
                 if key:
                     payload["prompt_cache_key"] = key

--- a/src/infra/tracing/langfuse_client.py
+++ b/src/infra/tracing/langfuse_client.py
@@ -31,6 +31,10 @@ class LangfuseTracer:
         has_keys = bool(os.getenv("LANGFUSE_PUBLIC_KEY")) and bool(os.getenv("LANGFUSE_SECRET_KEY"))
         self._enabled = enabled and has_keys
 
+    def reset(self) -> None:
+        """Forget the cached gate so tracing config changes re-evaluate."""
+        self._enabled = None
+
     @property
     def enabled(self) -> bool:
         """Check if tracing is enabled and fully configured."""

--- a/src/kernel/config/base.py
+++ b/src/kernel/config/base.py
@@ -610,10 +610,23 @@ class Settings(BaseSettings):
             self.BUILD_TIME = os.environ.get("BUILD_TIME")
 
         # Sync LangSmith settings to os.environ (required by langsmith SDK)
+        self.sync_tracing_env()
+
+    def sync_tracing_env(self) -> None:
+        """把 LangSmith/Langfuse 配置双向同步到 os.environ（SDK 读 env）。
+
+        __init__ 期调用一次（OS env/.env 权威）；initialize_settings 在 DB
+        加载后、refresh_settings 在运行时面板修改后重放，使 UI 配置真正
+        生效。双向：关闭/置空即清除对应 env，避免残留旧值让 tracer 误开。
+        """
         if self.LANGSMITH_TRACING:
             os.environ["LANGSMITH_TRACING"] = "true"
+        else:
+            os.environ.pop("LANGSMITH_TRACING", None)
         if self.LANGSMITH_API_KEY:
             os.environ["LANGSMITH_API_KEY"] = self.LANGSMITH_API_KEY
+        else:
+            os.environ.pop("LANGSMITH_API_KEY", None)
         if self.LANGSMITH_PROJECT:
             os.environ["LANGSMITH_PROJECT"] = self.LANGSMITH_PROJECT
         if self.LANGSMITH_API_URL:
@@ -621,13 +634,18 @@ class Settings(BaseSettings):
         if self.LANGSMITH_SAMPLE_RATE:
             os.environ["LANGSMITH_SAMPLE_RATE"] = str(self.LANGSMITH_SAMPLE_RATE)
 
-        # Sync Langfuse settings to os.environ (required by langfuse SDK)
         if self.LANGFUSE_ENABLED:
             os.environ["LANGFUSE_ENABLED"] = "true"
+        else:
+            os.environ.pop("LANGFUSE_ENABLED", None)
         if self.LANGFUSE_PUBLIC_KEY:
             os.environ["LANGFUSE_PUBLIC_KEY"] = self.LANGFUSE_PUBLIC_KEY
+        else:
+            os.environ.pop("LANGFUSE_PUBLIC_KEY", None)
         if self.LANGFUSE_SECRET_KEY:
             os.environ["LANGFUSE_SECRET_KEY"] = self.LANGFUSE_SECRET_KEY
+        else:
+            os.environ.pop("LANGFUSE_SECRET_KEY", None)
         if self.LANGFUSE_HOST:
             os.environ["LANGFUSE_HOST"] = self.LANGFUSE_HOST
 

--- a/src/kernel/config/service.py
+++ b/src/kernel/config/service.py
@@ -54,6 +54,31 @@ def _skip_db_override(key: str) -> bool:
     return key in RESTART_REQUIRED_SETTINGS
 
 
+TRACING_ENV_SYNC_SETTINGS = frozenset(
+    {
+        "LANGFUSE_ENABLED",
+        "LANGFUSE_PUBLIC_KEY",
+        "LANGFUSE_SECRET_KEY",
+        "LANGFUSE_HOST",
+        "LANGSMITH_TRACING",
+        "LANGSMITH_API_KEY",
+        "LANGSMITH_PROJECT",
+        "LANGSMITH_API_URL",
+        "LANGSMITH_SAMPLE_RATE",
+    }
+)
+
+
+def _reset_langfuse_tracer() -> None:
+    """复位 tracer 门控缓存，使追踪配置变更在下次评估时重新读 env。"""
+    try:
+        from src.infra.tracing.langfuse_client import langfuse_tracer
+
+        langfuse_tracer.reset()
+    except Exception as exc:  # noqa: BLE001 —— 追踪属旁路功能，失败不影响主链路
+        logger.warning("[Settings] Failed to reset Langfuse tracer: %s", exc)
+
+
 def _describe_setting_value(key: str, value: Any) -> str:
     """敏感值只报状态与长度：克隆库场景下 DB 值可能是生产凭据，不能进日志。"""
     if key not in SENSITIVE_SETTINGS:
@@ -133,6 +158,10 @@ async def initialize_settings() -> None:
             logger.info("[Settings] Migrated HITL_MODE to interrupt")
         except Exception as exc:
             logger.warning("[Settings] Failed to persist HITL_MODE migration: %s", exc)
+
+    # 重放追踪 env 同步（工单 1）：DB 值生效后 LANGFUSE_*/LANGSMITH_* 才能到达
+    # os.environ，tracer 门控（重启后首次评估）才读得到 UI 配置
+    settings.sync_tracing_env()
 
     # Persist auto-generated VAPID keys to database so they survive restarts
     if settings._vapid_keys_generated and _settings_service is not None:
@@ -242,11 +271,17 @@ async def refresh_settings(key: Optional[str] = None) -> None:
 
                 schedule_backend_reset()
                 logger.info(f"[Settings] Memory backend reset after setting '{key}' changed")
+            # Tracing keys: replay env sync + reset the cached tracer gate so
+            # runtime panel changes take effect without a restart (ticket 1)
+            if key in TRACING_ENV_SYNC_SETTINGS:
+                settings.sync_tracing_env()
+                _reset_langfuse_tracer()
     else:
         # Refresh all settings
         all_settings = await _settings_service.get_all(admin_mode=True, mask_sensitive=False)
         any_llm_setting_changed = False
         any_memory_setting_changed = False
+        any_tracing_setting_changed = False
         for items in all_settings.values():
             for item in items:
                 if (
@@ -264,6 +299,8 @@ async def refresh_settings(key: Optional[str] = None) -> None:
                         any_llm_setting_changed = True
                     if item.key in memory_affected_settings:
                         any_memory_setting_changed = True
+                    if item.key in TRACING_ENV_SYNC_SETTINGS:
+                        any_tracing_setting_changed = True
 
         # Clear LLM model cache if any affected setting changed
         if any_llm_setting_changed:
@@ -280,3 +317,8 @@ async def refresh_settings(key: Optional[str] = None) -> None:
 
             schedule_backend_reset()
             logger.info("[Settings] Memory backend reset after settings refresh")
+
+        # Tracing keys: replay env sync + reset the cached tracer gate
+        if any_tracing_setting_changed:
+            settings.sync_tracing_env()
+            _reset_langfuse_tracer()

--- a/tests/infra/llm/test_responses_kv_cache.py
+++ b/tests/infra/llm/test_responses_kv_cache.py
@@ -232,3 +232,79 @@ def test_context_helpers_accept_mock_session_ids() -> None:
         assert current_responses_prompt_cache_key() is None
     finally:
         reset_responses_prompt_cache_key(token)
+
+
+# ── 风险审查工单 2：prompt_cache_key 仅对官方端点注入 ─────────────────────
+
+
+def _model_with_base_url(base_url: str | None):
+    return LLMClient._create_model(
+        "openai",
+        "gpt-5.2",
+        temperature=0.7,
+        api_key="sk-test",
+        api_base=base_url,
+    )
+
+
+def test_third_party_gateway_payload_has_no_prompt_cache_key() -> None:
+    # 严格校验未知字段的第三方 OpenAI 兼容网关可能因 prompt_cache_key 4xx
+    model = _model_with_base_url("https://gateway.example.com/v1")
+    token = set_responses_prompt_cache_key("session-42")
+    try:
+        payload = model._get_request_payload([HumanMessage(content="hi")])
+    finally:
+        reset_responses_prompt_cache_key(token)
+    assert "prompt_cache_key" not in payload
+
+
+def test_official_openai_base_url_still_gets_prompt_cache_key() -> None:
+    model = _model_with_base_url("https://api.openai.com/v1")
+    token = set_responses_prompt_cache_key("session-42")
+    try:
+        payload = model._get_request_payload([HumanMessage(content="hi")])
+    finally:
+        reset_responses_prompt_cache_key(token)
+    assert payload["prompt_cache_key"] == "session-42"
+
+
+def test_official_host_without_scheme_still_gets_prompt_cache_key() -> None:
+    # Model Config 里常见仅填域名的写法
+    model = _model_with_base_url("api.openai.com/v1")
+    token = set_responses_prompt_cache_key("session-42")
+    try:
+        payload = model._get_request_payload([HumanMessage(content="hi")])
+    finally:
+        reset_responses_prompt_cache_key(token)
+    assert payload["prompt_cache_key"] == "session-42"
+
+
+def test_default_base_url_official_gets_prompt_cache_key() -> None:
+    # base_url 为空 = SDK 默认官方端点，回归保护
+    model = _model_with_base_url(None)
+    token = set_responses_prompt_cache_key("session-42")
+    try:
+        payload = model._get_request_payload([HumanMessage(content="hi")])
+    finally:
+        reset_responses_prompt_cache_key(token)
+    assert payload["prompt_cache_key"] == "session-42"
+
+
+def test_third_party_gateway_gets_no_responses_cache_defaults() -> None:
+    # include/store 同属非标字段：严格校验的网关会同样拒绝
+    model = _model_with_base_url("https://gateway.example.com/v1")
+    assert model.include is None
+    assert model.store is None
+
+
+def test_official_base_url_keeps_responses_cache_defaults() -> None:
+    model = LLMClient._create_model(
+        "openai",
+        "gpt-5.2",
+        temperature=0.7,
+        api_key="sk-test",
+        api_format="responses",
+        api_base="https://api.openai.com/v1",
+    )
+    assert model.include == ["reasoning.encrypted_content"]
+    assert model.store is False

--- a/tests/kernel/config/test_tracing_env_sync.py
+++ b/tests/kernel/config/test_tracing_env_sync.py
@@ -1,0 +1,180 @@
+"""追踪（Langfuse/LangSmith）配置生效链路：风险审查工单 1。
+
+根因链：env 同步只在 Settings.__init__ 执行一次（import 期，早于 DB 设置
+加载）→ 面板配置经 setattr 后永不回写 os.environ → tracer 门控的
+os.getenv 恒空 → 追踪恒关；且 LangfuseTracer 首次评估后永久缓存。
+
+修复契约：
+- ``Settings.sync_tracing_env()`` 双向同步（关闭即清 env，不再单向）；
+- ``initialize_settings()`` 在 DB 加载后重放同步（UI 配置 + 重启生效）；
+- ``refresh_settings()`` 对追踪键重放同步并复位 tracer 缓存（运行时生效）。
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from src.infra.tracing.langfuse_client import LangfuseTracer, langfuse_tracer
+from src.kernel.config import service as config_service
+from src.kernel.config.base import Settings
+
+TRACING_KEYS = (
+    "LANGFUSE_ENABLED",
+    "LANGFUSE_PUBLIC_KEY",
+    "LANGFUSE_SECRET_KEY",
+    "LANGFUSE_HOST",
+    "LANGSMITH_TRACING",
+    "LANGSMITH_API_KEY",
+    "LANGSMITH_PROJECT",
+    "LANGSMITH_API_URL",
+    "LANGSMITH_SAMPLE_RATE",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_tracing_env():
+    saved = {key: os.environ.get(key) for key in TRACING_KEYS}
+    for key in TRACING_KEYS:
+        os.environ.pop(key, None)
+    yield
+    for key, value in saved.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+
+def _make_settings(**overrides) -> Settings:
+    values: dict = {
+        "LANGFUSE_ENABLED": True,
+        "LANGFUSE_PUBLIC_KEY": "pk-test",
+        "LANGFUSE_SECRET_KEY": "sk-test",
+        "LANGFUSE_HOST": "https://langfuse.example.com",
+        "LANGSMITH_TRACING": True,
+        "LANGSMITH_API_KEY": "lsv2-test",
+        "LANGSMITH_PROJECT": "lambchat",
+        "LANGSMITH_API_URL": "https://api.smith.langchain.com",
+        "LANGSMITH_SAMPLE_RATE": 1.0,
+    }
+    values.update(overrides)
+    settings = Settings()
+    for key, value in values.items():
+        setattr(settings, key, value)
+    return settings
+
+
+def test_sync_tracing_env_sets_env_when_enabled() -> None:
+    _make_settings().sync_tracing_env()
+
+    assert os.environ.get("LANGFUSE_ENABLED") == "true"
+    assert os.environ.get("LANGFUSE_PUBLIC_KEY") == "pk-test"
+    assert os.environ.get("LANGFUSE_SECRET_KEY") == "sk-test"
+    assert os.environ.get("LANGFUSE_HOST") == "https://langfuse.example.com"
+    assert os.environ.get("LANGSMITH_TRACING") == "true"
+    assert os.environ.get("LANGSMITH_API_KEY") == "lsv2-test"
+
+
+def test_sync_tracing_env_clears_env_when_disabled() -> None:
+    # 单向同步的缺陷：UI 关闭后残留 env，tracer 依旧读到 true
+    os.environ["LANGFUSE_ENABLED"] = "true"
+    os.environ["LANGSMITH_TRACING"] = "true"
+
+    _make_settings(LANGFUSE_ENABLED=False, LANGSMITH_TRACING=False).sync_tracing_env()
+
+    assert "LANGFUSE_ENABLED" not in os.environ
+    assert "LANGSMITH_TRACING" not in os.environ
+
+
+def test_sync_tracing_env_clears_stale_keys_when_value_missing() -> None:
+    os.environ["LANGFUSE_PUBLIC_KEY"] = "stale-pk"
+
+    _make_settings(LANGFUSE_PUBLIC_KEY=None).sync_tracing_env()
+
+    assert "LANGFUSE_PUBLIC_KEY" not in os.environ
+
+
+def test_tracer_reset_re_enables_evaluation() -> None:
+    tracer = LangfuseTracer()
+    tracer._enabled = False
+    tracer.reset()
+    assert tracer._enabled is None
+
+    os.environ["LANGFUSE_ENABLED"] = "true"
+    os.environ["LANGFUSE_PUBLIC_KEY"] = "pk"
+    os.environ["LANGFUSE_SECRET_KEY"] = "sk"
+    try:
+        assert tracer.enabled is True
+    finally:
+        for key in ("LANGFUSE_ENABLED", "LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY"):
+            os.environ.pop(key, None)
+
+
+@pytest.mark.asyncio
+async def test_initialize_settings_replays_tracing_env_sync(monkeypatch) -> None:
+    """DB 加载后重放同步：UI 配置 + 重启后 os.environ 可用（工单 1 根因）。"""
+
+    class _FakeStorage:
+        async def get_all(self, admin_mode, mask_sensitive):
+            assert admin_mode is True and mask_sensitive is False
+            return {
+                "tracing": [
+                    SimpleNamespace(key="LANGFUSE_ENABLED", value=True),
+                    SimpleNamespace(key="LANGFUSE_PUBLIC_KEY", value="pk-db"),
+                    SimpleNamespace(key="LANGFUSE_SECRET_KEY", value="sk-db"),
+                    SimpleNamespace(key="LANGFUSE_HOST", value="https://lf.db"),
+                ]
+            }
+
+    class _FakeService:
+        async def initialize(self):
+            return None
+
+        async def get_all(self, admin_mode, mask_sensitive):
+            return await _FakeStorage().get_all(admin_mode, mask_sensitive)
+
+    monkeypatch.setattr(
+        "src.infra.settings.service.SettingsService.get_instance",
+        staticmethod(lambda: _FakeService()),
+    )
+    monkeypatch.setattr(config_service, "_settings_service", _FakeService(), raising=False)
+
+    try:
+        await config_service.initialize_settings()
+
+        assert os.environ.get("LANGFUSE_ENABLED") == "true"
+        assert os.environ.get("LANGFUSE_PUBLIC_KEY") == "pk-db"
+        assert getattr(config_service.settings, "LANGFUSE_ENABLED") is True
+    finally:
+        for key in TRACING_KEYS:
+            os.environ.pop(key, None)
+
+
+@pytest.mark.asyncio
+async def test_refresh_settings_tracing_key_resets_tracer(monkeypatch) -> None:
+    """运行时面板修改：env 重放 + tracer 复位，下次评估读到新值。"""
+
+    class _FakeStorage:
+        async def get_raw(self, key):
+            return SimpleNamespace(key=key, value=True)
+
+    monkeypatch.setattr(
+        config_service,
+        "_settings_service",
+        SimpleNamespace(_storage=_FakeStorage()),
+        raising=False,
+    )
+    reset_calls: list[bool] = []
+    monkeypatch.setattr(langfuse_tracer, "reset", lambda: reset_calls.append(True))
+
+    try:
+        await config_service.refresh_settings("LANGFUSE_ENABLED")
+        env_enabled = os.environ.get("LANGFUSE_ENABLED")
+    finally:
+        os.environ.pop("LANGFUSE_ENABLED", None)
+
+    assert getattr(config_service.settings, "LANGFUSE_ENABLED") is True
+    assert env_enabled == "true"
+    assert reset_calls == [True]


### PR DESCRIPTION
来源：本地风险审查工单 1（f025603c 引入），TDD。

## 根因链
1. `Settings.__init__` 的 Langfuse/LangSmith env 同步只在 **import 期**执行一次，早于 DB 设置加载；
2. 面板配置走 `setattr`（只改内存对象），**永不回写 `os.environ`**；
3. `LangfuseTracer` 门控只读 `os.getenv` → 恒空 → 追踪恒关；
4. 且 `LangfuseTracer._ensure_initialized` 首次评估后**永久缓存**——即使后补 env 也不会重评。

结果链：UI 写 DB → getenv 恒空 → tracer 恒关；唯一生效路径是部署时设置真实 OS 环境变量。

## 修复（采纳工单方案 2 为主，叠加启动重放）
- **`Settings.sync_tracing_env()`**：原内联同步块抽取成方法并**双向化**——关闭/置空即清除对应 env 键，修复「UI 关闭后残留旧值误开」；
- **`initialize_settings()`**：DB 加载完成后重放同步 → 「UI 配置 + 重启」即生效（此前重启也无效）；
- **`refresh_settings()`**：对 9 个追踪键重放同步并调用新增的 `LangfuseTracer.reset()` 复位门控缓存 → **运行时面板修改即时生效，无需重启**；
- 明确**未**采纳「把追踪键加入 `RESTART_REQUIRED_SETTINGS`」：该集合同时承担克隆环境连接保护（`_skip_db_override` 启动忽略 DB 值），纳入追踪键会让启动忽略 DB 值，重启也不生效——与修复目标相反。

## 测试（tests/kernel/config/test_tracing_env_sync.py，6 例）
- 双向同步：开启写入 env / 关闭清除 env（含残留旧值清理）
- `LangfuseTracer.reset()` 复位后重评
- `initialize_settings` 以假 SettingsService 驱动 DB 加载后 env 落位
- `refresh_settings` 单键路径 env 重放 + tracer 复位

config/settings/tracing 相关 133 例回归全绿；ruff / mypy 绿。