### PR TITLE
feat(client): 支持会话工作目录选择并修复输入框布局

### DIFF
--- a/client/lambchat_sandbox/executor.py
+++ b/client/lambchat_sandbox/executor.py
@@ -31,7 +31,9 @@ from __future__ import annotations
 
 import contextlib
 import ctypes
+import json
 import os
+import re
 import signal
 import subprocess
 from pathlib import Path
@@ -217,7 +219,23 @@ def map_workspace(virtual_cwd: str, data_root: Path) -> Path:
     if not virtual_cwd.startswith(_WORKSPACE_PREFIX):
         raise ExecutorError(f"virtual_cwd 必须以 {_WORKSPACE_PREFIX} 开头: {virtual_cwd!r}")
     sid = virtual_cwd[len(_WORKSPACE_PREFIX) :]
-    if not sid or "/" in sid or sid in (".", ".."):
+    if sid.startswith(".selected/"):
+        sid = sid[len(".selected/") :]
+        if not re.fullmatch(r"local-[0-9a-f]{32}", sid):
+            raise ExecutorError("Invalid selected workspace identifier")
+        try:
+            raw = json.loads((Path(data_root) / ".selected" / f"{sid}.json").read_text())
+            if not isinstance(raw, str):
+                raise ValueError("Invalid workspace binding")
+            selected = Path(raw)
+            if not selected.is_absolute() or not selected.is_dir():
+                raise ValueError("Selected directory is unavailable")
+            return selected.resolve()
+        except (OSError, ValueError) as exc:
+            raise ExecutorError(
+                "Selected directory is unavailable; select it again in the desktop app"
+            ) from exc
+    if not sid or "/" in sid or "\\" in sid or sid in (".", "..", ".selected"):
         raise ExecutorError(f"非法会话路径: {virtual_cwd!r}")
     return Path(data_root) / sid
 

--- a/docs/dev-workspace-selection.md
+++ b/docs/dev-workspace-selection.md
@@ -1,0 +1,22 @@
+# 桌面会话工作目录
+
+桌面开发客户端选中“本地电脑”，且执行机器为当前机器并在线时，输入框上方显示工作目录入口。选择系统文件夹后，目录绑定保存在会话的 `agent_options.sandbox_workspace` 中，同时固定 `sandbox_machine_id`。后续消息及重新打开会话继续使用该目录；新会话恢复默认。执行期间不能更换目录，清除按钮恢复默认会话工作区。
+
+网页和其他机器不显示原生目录入口。切换机器后，原机器的目录绑定不会用于新机器。
+
+## 原生命令
+
+`sandbox_pick_workspace(title: string)` 打开原生文件夹选择器，返回 `{id, machineId, path}`，取消时返回 `null`。权限为 `allow-sandbox-pick-workspace`。命令只接受对话框标题，不接受服务端传来的文件路径。
+
+本机在配置的 `data_root/.selected/<id>.json` 中保存真实路径，服务端仅使用机器绑定的标识，将虚拟工作目录设为 `/workspace/.selected/<id>`。daemon 将命令和结构化文件操作统一映射到选择目录。目录失效时明确报错，不自动创建替代目录。
+
+协议保持向后兼容：默认工作区不变；旧 daemon 不接受带子路径的新虚拟目录，会拒绝执行，因此此功能需使用包含本次变更的桌面壳和 daemon。没有更改认证、执行确认策略或传输帧。
+
+## 本地验证
+
+```bash
+uv run pytest tests/client/test_selected_workspace.py tests/infra/backend/test_workspace_selection.py
+uv run python scripts/e2e_local_sandbox.py
+cd frontend && pnpm test && pnpm run lint && pnpm run build
+cd src-tauri && cargo test --lib
+```

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -1951,12 +1951,14 @@ dependencies = [
  "sys-locale",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-shell",
  "tauri-plugin-updater",
  "time",
+ "uuid",
 ]
 
 [[package]]
@@ -2966,6 +2968,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3870,6 +3896,48 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61854a36651aa48381e5e209f69a01273b77f3f9f91f0c430b1b98d33bd47229"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.20",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de22eef34fd78c0da050e748710edd50bf127e651d02ea1b2bfada1523cc5c51"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.20",
+ "toml 1.1.5+spec-1.1.0",
+ "url",
 ]
 
 [[package]]

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+uuid = { version = "1", features = ["v4"] }
 # Linux deb/rpm 更新安装的流式下载（linux_update.rs）。与 updater 插件共用
 # 同版本 reqwest；TLS provider 不自带（rustls-no-provider）——由下方 rustls(ring)
 # 在进程级安装，避免引入 aws-lc-sys 原生构建（reqwest `rustls` feature 的默认）

--- a/frontend/src-tauri/capabilities/default.json
+++ b/frontend/src-tauri/capabilities/default.json
@@ -4,6 +4,8 @@
   "description": "Default desktop capability. process:default 供更新完成后 relaunch 重启壳；dialog:default 供设置页选择沙箱数据目录",
   "windows": ["main"],
   "permissions": [
+    "allow-existing-desktop-commands",
+    "allow-sandbox-pick-workspace",
     "core:default",
     "notification:default",
     "updater:default",

--- a/frontend/src-tauri/permissions/desktop.toml
+++ b/frontend/src-tauri/permissions/desktop.toml
@@ -1,0 +1,18 @@
+[[permission]]
+identifier = "allow-existing-desktop-commands"
+description = "Preserve the desktop commands available before app ACL was enabled."
+commands.allow = [
+  "save_pairing",
+  "write_confirm_policy",
+  "clear_pairing",
+  "read_pairing_pat",
+  "read_machine_id",
+  "restart_daemon",
+  "daemon_process_status",
+  "open_local_path",
+  "sandbox_data_location",
+  "set_sandbox_data_location",
+  "clear_sandbox_data_location",
+  "get_linux_install_source",
+  "install_linux_package",
+]

--- a/frontend/src-tauri/permissions/workspace.toml
+++ b/frontend/src-tauri/permissions/workspace.toml
@@ -1,0 +1,4 @@
+[[permission]]
+identifier = "allow-sandbox-pick-workspace"
+description = "Choose a local directory through the native picker and bind it to a session workspace."
+commands.allow = ["sandbox_pick_workspace"]

--- a/frontend/src-tauri/src/commands/mod.rs
+++ b/frontend/src-tauri/src/commands/mod.rs
@@ -1,0 +1,1 @@
+pub mod workspace;

--- a/frontend/src-tauri/src/commands/workspace.rs
+++ b/frontend/src-tauri/src/commands/workspace.rs
@@ -1,0 +1,62 @@
+use serde::Serialize;
+use std::path::PathBuf;
+use tauri_plugin_dialog::DialogExt;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SelectedWorkspace {
+    id: String,
+    machine_id: String,
+    path: String,
+}
+
+// The path is obtained from the native picker, never supplied by the server.
+#[tauri::command]
+pub async fn sandbox_pick_workspace(
+    app: tauri::AppHandle,
+    title: String,
+) -> Result<Option<SelectedWorkspace>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let home = crate::daemon::sandbox_home()?;
+        let config: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(home.join("sandbox.json")).map_err(|e| e.to_string())?,
+        )
+        .map_err(|e| e.to_string())?;
+        let machine_id = config["machine_id"]
+            .as_str()
+            .filter(|s| !s.is_empty())
+            .ok_or("Local machine is not paired")?
+            .to_owned();
+        let Some(folder) = app.dialog().file().set_title(title).blocking_pick_folder() else {
+            return Ok(None);
+        };
+        let path = folder
+            .into_path()
+            .map_err(|e| e.to_string())?
+            .canonicalize()
+            .map_err(|e| e.to_string())?;
+        if !path.is_dir() {
+            return Err("Selected path is not a directory".into());
+        }
+        let root = config["data_root"]
+            .as_str()
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join("workspaces"));
+        let bindings = root.join(".selected");
+        std::fs::create_dir_all(&bindings).map_err(|e| e.to_string())?;
+        let id = format!("local-{}", uuid::Uuid::new_v4().simple());
+        let path = path.to_string_lossy().into_owned();
+        std::fs::write(
+            bindings.join(format!("{id}.json")),
+            serde_json::to_vec(&path).map_err(|e| e.to_string())?,
+        )
+        .map_err(|e| e.to_string())?;
+        Ok(Some(SelectedWorkspace {
+            id,
+            machine_id,
+            path,
+        }))
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}

--- a/frontend/src-tauri/src/daemon.rs
+++ b/frontend/src-tauri/src/daemon.rs
@@ -1192,7 +1192,7 @@ mod sandbox_home_override_tests {
     #[test]
     fn migrate_root_entries_moves_top_level_and_is_idempotent() {
         let tmp = std::env::temp_dir().join(format!("lc-migrate-test-{}", std::process::id()));
-        let _ = std::env::remove_dir_all(&tmp);
+        let _ = std::fs::remove_dir_all(&tmp);
         let old_root = tmp.join("old");
         let new_root = tmp.join("new");
         std::fs::create_dir_all(old_root.join("audit")).unwrap();
@@ -1219,7 +1219,7 @@ mod sandbox_home_override_tests {
         let absent = migrate_root_entries(&tmp.join("nope"), &new_root).unwrap();
         assert_eq!(absent, 0);
 
-        let _ = std::env::remove_dir_all(&tmp);
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 }
 

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use tauri::Manager;
 
 mod daemon;
+mod commands;
 mod linux_update;
 mod tray;
 
@@ -223,6 +224,7 @@ pub fn run() {
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
+            commands::workspace::sandbox_pick_workspace,
             daemon::save_pairing,
             daemon::write_confirm_policy,
             daemon::clear_pairing,

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -29,13 +29,13 @@ import { MentionPopup } from "./MentionPopup";
 import { TeamMentionPopup } from "./TeamMentionPopup";
 import { ActiveGoalBar } from "./ActiveGoalBar";
 import { ChatInputToolbar } from "./ChatInputToolbar";
+import { SessionWorkspaceBar } from "./SessionWorkspaceBar";
 import { ChatInputSelectors } from "./ChatInputSelectors";
 import { ChatInputHelpMenu } from "./ChatInputHelpMenu";
 import { ChatInputAttachments } from "./ChatInputAttachments";
 import { ChatInputDragOverlay } from "./ChatInputDragOverlay";
 import { resolveThinkingPresentation } from "./chatInputThinking";
 import * as runModeOptions from "./chatInputRunModes";
-
 const { buildRunModesOptions, collectActiveRunModes } = runModeOptions;
 import { FILE_CATEGORY_PERMISSIONS } from "./chatInputConstants";
 import { getMentionPopupFixedPlacement } from "./chatInputViewport";
@@ -72,7 +72,10 @@ import { useAcceptedDraftSubmission } from "./useAcceptedDraftSubmission";
 const RichChatComposer = lazy(async () => {
   const module = await import("./richComposer/RichChatComposer");
   // chunk 自愈吞错后 import resolve undefined：抛回 chunk 错误走更新分支
-  if (!module) throw new Error("Failed to fetch dynamically imported module: RichChatComposer");
+  if (!module)
+    throw new Error(
+      "Failed to fetch dynamically imported module: RichChatComposer",
+    );
   return { default: module.RichChatComposer };
 });
 export type { ChatInputProps } from "./chatInputTypes";
@@ -152,7 +155,6 @@ export const ChatInput = memo(function ChatInput({
   const composerRef = useRef<RichChatComposerHandle>(null);
   const [activeReferenceIds, setActiveReferenceIds] = useState<string[]>([]);
   const longTextResourcesRef = useRef(new Map<string, LongTextPastePayload>());
-  // Consume external pendingInput: fill textarea and focus
   useEffect(() => {
     if (pendingInput) {
       setInput(pendingInput);
@@ -520,8 +522,7 @@ export const ChatInput = memo(function ChatInput({
   const hasInvalidAttachment = !areAttachmentsSendable(visibleAttachments);
   const handleComposerKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
-      // Lexical prevents Enter before this React handler runs, so
-      // defaultPrevented cannot distinguish editor handling from send intent.
+      // Lexical prevents Enter first; defaultPrevented cannot distinguish send intent.
       if (mention.isActive) {
         if (event.key === "Enter" || event.key === "Tab") {
           event.preventDefault();
@@ -562,9 +563,7 @@ export const ChatInput = memo(function ChatInput({
             setStopConfirmOpen(true);
           }
         } else {
-          // The expanded editor renders outside the form (body-level
-          // portal host), so resolve the form via ref instead of DOM
-          // ancestry.
+          // The expanded editor is outside the form; resolve it via ref, not ancestry.
           formRef.current?.requestSubmit();
         }
         return;
@@ -720,6 +719,11 @@ export const ChatInput = memo(function ChatInput({
                   backgroundColor: "var(--theme-bg-card)",
                 }}
               >
+                <SessionWorkspaceBar
+                  values={agentOptionValues}
+                  onChange={onToggleAgentOption}
+                  disabled={isLoading || !canSend}
+                />
                 {isDraggingOver && <ChatInputDragOverlay />}
                 <ActiveGoalBar
                   goal={activeGoal ?? null}
@@ -864,7 +868,6 @@ export const ChatInput = memo(function ChatInput({
                     ) : null}
                   </div>
                 </div>
-
                 <ChatInputToolbar
                   activePanel={activePanel}
                   onActivePanelChange={setActivePanel}
@@ -933,7 +936,6 @@ export const ChatInput = memo(function ChatInput({
             )}
         </div>
       </form>
-
       <ChatInputSelectors
         activePanel={activePanel}
         onActivePanelChange={setActivePanel}
@@ -978,9 +980,7 @@ export const ChatInput = memo(function ChatInput({
         onToggleAgentOption={onToggleAgentOption}
         modelSupportsThinking={modelSupportsThinking}
       />
-
       {showHelpMenu && <ChatInputHelpMenu className={helpMenuClassName} />}
-
       <ChatInputDialogLayer
         stopConfirmOpen={stopConfirmOpen}
         onConfirmStop={() => {

--- a/frontend/src/components/chat/SessionWorkspaceBar.tsx
+++ b/frontend/src/components/chat/SessionWorkspaceBar.tsx
@@ -1,0 +1,122 @@
+import { useRef, useState } from "react";
+import { Folder, Loader2, X } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { toast } from "react-hot-toast";
+import { useSandboxStatus } from "../../hooks/useSandboxStatus";
+import { invokeInShell } from "../../services/tauri/sandboxShell";
+import {
+  isCurrentWorkspaceMachine,
+  parseWorkspaceSelection,
+  WORKSPACE_OPTION,
+  type WorkspaceSelection,
+} from "./workspaceSelection";
+
+interface Props {
+  values: Record<string, boolean | string | number>;
+  onChange?: (key: string, value: string) => void;
+  disabled: boolean;
+}
+
+/** A session-level directory entry; the native picker creates a local binding. */
+export function SessionWorkspaceBar({ values, onChange, disabled }: Props) {
+  const { t } = useTranslation();
+  const { machines, currentMachineId, defaultMachineId } = useSandboxStatus();
+  const [busy, setBusy] = useState(false);
+  const onlineMachines = machines.filter((item) => item.online);
+  const selectedId = String(
+    values.sandbox_machine_id ||
+      defaultMachineId ||
+      (onlineMachines.length === 1 ? onlineMachines[0].machine_id : ""),
+  );
+  const machine = machines.find((item) => item.machine_id === selectedId);
+  const selection = parseWorkspaceSelection(values[WORKSPACE_OPTION]);
+  const active = selection?.machineId === selectedId ? selection : null;
+  // A dialog result belongs only to the options/session that opened it.
+  const latest = useRef(values);
+  latest.current = values;
+  const visible = isCurrentWorkspaceMachine(
+    values.sandbox,
+    selectedId,
+    currentMachineId,
+    machine?.online === true,
+  );
+  if (!visible || !onChange) return null;
+
+  const choose = async () => {
+    const initial = values;
+    setBusy(true);
+    try {
+      const picked = await invokeInShell<WorkspaceSelection | null>(
+        "sandbox_pick_workspace",
+        { title: t("sessionWorkspace.choose") },
+      );
+      if (
+        !picked ||
+        latest.current !== initial ||
+        picked.machineId !== selectedId
+      )
+        return;
+      onChange("sandbox_machine_id", selectedId);
+      onChange(WORKSPACE_OPTION, JSON.stringify(picked));
+    } catch {
+      toast.error(t("sessionWorkspace.failed"));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const name =
+    active?.path
+      .replace(/[\\/]+$/, "")
+      .split(/[\\/]/)
+      .pop() || active?.path;
+  return (
+    <div
+      className="session-workspace-bar flex min-w-0 shrink-0 items-center gap-2 text-14"
+      style={{ color: "var(--theme-text-primary)" }}
+    >
+      <button
+        type="button"
+        onClick={() => void choose()}
+        disabled={disabled || busy}
+        className="flex min-h-9 min-w-0 flex-1 items-center gap-2 rounded-md px-1 py-1 text-left focus-visible:outline focus-visible:outline-2 disabled:opacity-50"
+        title={
+          active
+            ? `${active.path}\n${t("sessionWorkspace.scope")}`
+            : t("sessionWorkspace.scope")
+        }
+        aria-label={
+          active
+            ? `${t("sessionWorkspace.choose")}: ${active.path}`
+            : t("sessionWorkspace.choose")
+        }
+      >
+        {busy ? (
+          <Loader2
+            size={16}
+            className="shrink-0 animate-spin motion-reduce:animate-none"
+          />
+        ) : (
+          <Folder size={16} className="shrink-0" />
+        )}
+        <span className="truncate">
+          {busy
+            ? t("sessionWorkspace.loading")
+            : name || t("sessionWorkspace.choose")}
+        </span>
+      </button>
+      {active && (
+        <button
+          type="button"
+          onClick={() => onChange(WORKSPACE_OPTION, "")}
+          disabled={disabled || busy}
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md focus-visible:outline focus-visible:outline-2 disabled:opacity-50"
+          title={t("sessionWorkspace.reset")}
+          aria-label={t("sessionWorkspace.reset")}
+        >
+          <X size={14} />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/chat/__tests__/chatInputExpandedComposerLayering.test.tsx
+++ b/frontend/src/components/chat/__tests__/chatInputExpandedComposerLayering.test.tsx
@@ -25,6 +25,12 @@ vi.mock("../ChatInputSelectors", () => ({
   ChatInputSelectors: () => null,
 }));
 
+vi.mock("../SessionWorkspaceBar", () => ({
+  SessionWorkspaceBar: () => (
+    <div data-testid="workspace-header">Project directory</div>
+  ),
+}));
+
 import { ChatInput } from "../ChatInput";
 
 beforeEach(() => {
@@ -32,6 +38,34 @@ beforeEach(() => {
 });
 
 const longDraft = "hello expanded composer ".repeat(10);
+
+test("directory header shares the composer boundary and follows expand and collapse", async () => {
+  render(
+    <ChatInput
+      onSend={vi.fn()}
+      onStop={vi.fn()}
+      isLoading={false}
+      pendingInput={longDraft}
+    />,
+  );
+  const editor = await screen.findByRole("textbox");
+  const header = screen.getByTestId("workspace-header");
+  const container = editor.closest(".chat-input-container");
+  expect(header.parentElement).toBe(container);
+  expect(
+    header.compareDocumentPosition(editor) & Node.DOCUMENT_POSITION_FOLLOWING,
+  ).toBeTruthy();
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: /(expand|展开编辑)/i }));
+  });
+  expect(header.parentElement).toBe(container);
+  expect(header.closest(".chat-input-shell")).toBeNull();
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: /(collapse|收起)/i }));
+  });
+  expect(header.closest("form")).not.toBeNull();
+  expect(editor.isConnected).toBe(true);
+});
 
 test("expanded composer renders at body level outside the chat shell", async () => {
   render(

--- a/frontend/src/components/chat/__tests__/composerHostRecovery.test.tsx
+++ b/frontend/src/components/chat/__tests__/composerHostRecovery.test.tsx
@@ -1,0 +1,27 @@
+/** @vitest-environment jsdom */
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { createPortal } from "react-dom";
+import { useExpandedComposerHost } from "../chatInputExpandedHost";
+
+test("composer remains visible when its slot is replaced", () => {
+  function Composer({ generation }: { generation: number }) {
+    const { host, slotRef } = useExpandedComposerHost(false);
+    return (
+      <>
+        <div key={generation} ref={slotRef} />
+        {host &&
+          createPortal(
+            <textarea aria-label="draft" defaultValue="keep me" />,
+            host,
+          )}
+      </>
+    );
+  }
+  const { rerender, unmount } = render(<Composer generation={0} />);
+  const input = screen.getByRole("textbox");
+  rerender(<Composer generation={1} />);
+  expect(screen.getByRole("textbox")).toBe(input);
+  expect(input).toHaveValue("keep me");
+  unmount();
+});

--- a/frontend/src/components/chat/__tests__/sessionWorkspaceBar.test.tsx
+++ b/frontend/src/components/chat/__tests__/sessionWorkspaceBar.test.tsx
@@ -1,0 +1,100 @@
+/** @vitest-environment jsdom */
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { SessionWorkspaceBar } from "../SessionWorkspaceBar";
+
+const mocks = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  current: "m1" as string | null,
+}));
+vi.mock("../../../hooks/useSandboxStatus", () => ({
+  useSandboxStatus: () => ({
+    currentMachineId: mocks.current,
+    defaultMachineId: "m1",
+    machines: [{ machine_id: "m1", online: true }],
+  }),
+}));
+vi.mock("../../../services/tauri/sandboxShell", () => ({
+  invokeInShell: mocks.invoke,
+}));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock("react-hot-toast", () => ({ toast: { error: vi.fn() } }));
+
+afterEach(cleanup);
+beforeEach(() => {
+  mocks.invoke.mockReset();
+  mocks.current = "m1";
+});
+
+test("native selection pins the machine and saves the directory in session options", async () => {
+  const picked = {
+    id: `local-${"a".repeat(32)}`,
+    machineId: "m1",
+    path: "/home/project",
+  };
+  mocks.invoke.mockResolvedValue(picked);
+  const onChange = vi.fn();
+  render(
+    <SessionWorkspaceBar
+      values={{ sandbox: "local" }}
+      onChange={onChange}
+      disabled={false}
+    />,
+  );
+  fireEvent.click(
+    screen.getByRole("button", { name: "sessionWorkspace.choose" }),
+  );
+  await waitFor(() =>
+    expect(onChange).toHaveBeenCalledWith(
+      "sandbox_workspace",
+      JSON.stringify(picked),
+    ),
+  );
+  expect(onChange).toHaveBeenCalledWith("sandbox_machine_id", "m1");
+});
+
+test("cancelling preserves session options", async () => {
+  mocks.invoke.mockResolvedValue(null);
+  const onChange = vi.fn();
+  render(
+    <SessionWorkspaceBar
+      values={{ sandbox: "local" }}
+      onChange={onChange}
+      disabled={false}
+    />,
+  );
+  fireEvent.click(screen.getByRole("button"));
+  await waitFor(() => expect(screen.getByRole("button")).not.toBeDisabled());
+  expect(onChange).not.toHaveBeenCalled();
+});
+
+test("browser clients do not show a native directory entry", () => {
+  mocks.current = null;
+  render(
+    <SessionWorkspaceBar
+      values={{ sandbox: "local" }}
+      onChange={vi.fn()}
+      disabled={false}
+    />,
+  );
+  expect(screen.queryByRole("button")).toBeNull();
+});
+
+test("running sessions cannot change their execution directory", () => {
+  render(
+    <SessionWorkspaceBar
+      values={{ sandbox: "local" }}
+      onChange={vi.fn()}
+      disabled
+    />,
+  );
+  expect(screen.getByRole("button")).toBeDisabled();
+});

--- a/frontend/src/components/chat/__tests__/workspaceSelection.test.ts
+++ b/frontend/src/components/chat/__tests__/workspaceSelection.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "vitest";
+import {
+  parseWorkspaceSelection,
+  isCurrentWorkspaceMachine,
+} from "../workspaceSelection";
+
+test("directory entry requires the current online machine and local mode", () => {
+  expect(isCurrentWorkspaceMachine("local", "m1", "m1", true)).toBe(true);
+  expect(isCurrentWorkspaceMachine("cloud", "m1", "m1", true)).toBe(false);
+  expect(isCurrentWorkspaceMachine("local", "m2", "m1", true)).toBe(false);
+  expect(isCurrentWorkspaceMachine("local", "m1", null, true)).toBe(false);
+  expect(isCurrentWorkspaceMachine("local", "m1", "m1", false)).toBe(false);
+});
+
+test("saved directory round trips and malformed options are ignored", () => {
+  const selection = {
+    id: `local-${"a".repeat(32)}`,
+    machineId: "m1",
+    path: "C:\\Project",
+  };
+  expect(parseWorkspaceSelection(JSON.stringify(selection))).toEqual(selection);
+  for (const value of [undefined, true, "null", "{}", "broken"]) {
+    expect(parseWorkspaceSelection(value)).toBeNull();
+  }
+});

--- a/frontend/src/components/chat/chatInputExpandedHost.ts
+++ b/frontend/src/components/chat/chatInputExpandedHost.ts
@@ -22,16 +22,11 @@ export function useExpandedComposerHost(expanded: boolean) {
   const slotRef = useRef<HTMLDivElement>(null);
   useLayoutEffect(() => {
     if (!host) return;
-    const slot = slotRef.current;
-    if (!host.parentNode && slot) {
-      slot.appendChild(host);
-    }
-    if (!expanded) return;
-    document.body.appendChild(host);
-    return () => {
-      if (slot && slot.isConnected) slot.appendChild(host);
-      else host.remove();
-    };
-  }, [expanded, host]);
+    const target = expanded ? document.body : slotRef.current;
+    // React can replace the slot during a layout change or hot update.
+    // Reattach the existing editor, preserving its draft and undo history.
+    if (target && host.parentNode !== target) target.appendChild(host);
+  });
+  useLayoutEffect(() => () => host?.remove(), [host]);
   return { host, slotRef };
 }

--- a/frontend/src/components/chat/workspaceSelection.ts
+++ b/frontend/src/components/chat/workspaceSelection.ts
@@ -1,0 +1,36 @@
+export const WORKSPACE_OPTION = "sandbox_workspace";
+
+export interface WorkspaceSelection {
+  id: string;
+  machineId: string;
+  path: string;
+}
+
+export function parseWorkspaceSelection(
+  value: unknown,
+): WorkspaceSelection | null {
+  if (typeof value !== "string") return null;
+  try {
+    const selection = JSON.parse(value);
+    if (
+      selection &&
+      /^local-[0-9a-f]{32}$/.test(selection.id) &&
+      typeof selection.machineId === "string" &&
+      typeof selection.path === "string"
+    ) {
+      return selection;
+    }
+  } catch {
+    /* Older sessions have no directory selection. */
+  }
+  return null;
+}
+
+export function isCurrentWorkspaceMachine(
+  mode: unknown,
+  selected: string | null | undefined,
+  current: string | null | undefined,
+  online: boolean,
+): boolean {
+  return mode === "local" && !!current && current === selected && online;
+}

--- a/frontend/src/components/layout/AppContent/useAgentOptions.ts
+++ b/frontend/src/components/layout/AppContent/useAgentOptions.ts
@@ -40,7 +40,9 @@ export function injectSandboxOption(
   };
 }
 
-/** 归一思考档位值："off" 时代已下线，历史 off 值统一降级到 low */export function normalizeThinkingOptionValue(value: boolean | string | number) {
+/** 归一思考档位值："off" 时代已下线，历史 off 值统一降级到 low */ export function normalizeThinkingOptionValue(
+  value: boolean | string | number,
+) {
   if (value === true) return "medium";
   if (value === false) return "low";
   if (typeof value !== "string") return value;
@@ -180,7 +182,9 @@ function applySandboxDefault(
   }
   const stored =
     storage?.getItem("defaultSandboxMode") ??
-    (typeof window !== "undefined" ? window.localStorage.getItem("defaultSandboxMode") : null);
+    (typeof window !== "undefined"
+      ? window.localStorage.getItem("defaultSandboxMode")
+      : null);
   return {
     ...defaultValues,
     sandbox: resolveSandboxDefault(stored, hints?.sandboxOnline ?? false),
@@ -307,7 +311,11 @@ export function useAgentOptions(agents: AgentInfo[], currentAgent: string) {
     setAgentOptionValues((prev) => {
       const rebuilt = buildAgentOptionValues(options);
       for (const key of Object.keys(prev)) {
-        if (key in rebuilt) {
+        if (
+          key in rebuilt ||
+          key === "sandbox_workspace" ||
+          key === "sandbox_machine_id"
+        ) {
           (rebuilt as Record<string, boolean | string | number>)[key] =
             prev[key];
         }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1,4 +1,11 @@
 {
+  "sessionWorkspace": {
+    "loading": "Choosing directory…",
+    "reset": "Restore default session directory",
+    "scope": "Use this directory for files and commands throughout this session",
+    "failed": "Could not select a directory. Check the desktop connection and try again.",
+    "choose": "Choose working directory"
+  },
   "about": {
     "appVersion": "Version",
     "buildTime": "Build Time",
@@ -264,7 +271,14 @@
       "section": "Device",
       "currentDevice": "This device"
     },
-    "sandboxPolicy": { "section": "Execution policy", "all": "Confirm everything", "commands": "Confirm commands only", "none": "No confirmation", "updated": "Execution policy updated", "updateFailed": "Failed to update execution policy" }
+    "sandboxPolicy": {
+      "section": "Execution policy",
+      "all": "Confirm everything",
+      "commands": "Confirm commands only",
+      "none": "No confirmation",
+      "updated": "Execution policy updated",
+      "updateFailed": "Failed to update execution policy"
+    }
   },
   "agents": {
     "fast": {
@@ -540,7 +554,8 @@
     "invalidTheme": "Invalid theme: {{theme}}. Must be 'light', 'dark' or 'sepia'",
     "invalidThemeSchedule": "Invalid theme schedule: expected enabled (boolean), start/end (HH:MM) and nightTheme (dark or sepia)",
     "invalidDateFormat": "Invalid date: {{value}}. Use ISO 8601",
-    "bookmarkMessageNotFound": "Message not found in this session",    "messageNotFound": "Message not found",
+    "bookmarkMessageNotFound": "Message not found in this session",
+    "messageNotFound": "Message not found",
     "sessionDeleteInProgress": "Session deletion is in progress",
     "sessionError": "Session operation failed",
     "pinUpdateFailed": "Failed to update pin state",
@@ -923,7 +938,7 @@
       "toolHistoryUser": "User",
       "toolImageAnalyze": "Image Analyze",
       "toolImageAnalyzeCount": "{{count}} images",
-"toolVideoAnalyze": "Video Analysis",
+      "toolVideoAnalyze": "Video Analysis",
       "toolVideoAnalyzeCount": "{{count}} videos",
       "toolImageCount": "{{count}} images",
       "toolImageGenerate": "Generate",
@@ -3468,7 +3483,7 @@
   "theme": {
     "switchToDark": "Switch to dark mode",
     "switchToLight": "Switch to light mode",
-      "cycleShortcut": "Shortcut Ctrl/Cmd+Shift+L",
+    "cycleShortcut": "Shortcut Ctrl/Cmd+Shift+L",
     "switchToSepia": "Switch to sepia mode"
   },
   "tools": {

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1,4 +1,11 @@
 {
+  "sessionWorkspace": {
+    "loading": "フォルダーを選択中…",
+    "reset": "既定の会話フォルダーに戻す",
+    "scope": "この会話のファイル操作とコマンド実行に使用します",
+    "failed": "フォルダーを選択できません。デスクトップの接続を確認してください。",
+    "choose": "作業フォルダーを選択"
+  },
   "about": {
     "appVersion": "バージョン",
     "buildTime": "ビルド時刻",
@@ -264,7 +271,14 @@
       "section": "実行デバイス",
       "currentDevice": "このデバイス"
     },
-    "sandboxPolicy": { "section": "実行ポリシー", "all": "すべて確認", "commands": "コマンドのみ確認", "none": "確認しない", "updated": "実行ポリシーを更新しました", "updateFailed": "実行ポリシーの更新に失敗しました" }
+    "sandboxPolicy": {
+      "section": "実行ポリシー",
+      "all": "すべて確認",
+      "commands": "コマンドのみ確認",
+      "none": "確認しない",
+      "updated": "実行ポリシーを更新しました",
+      "updateFailed": "実行ポリシーの更新に失敗しました"
+    }
   },
   "agents": {
     "fast": {
@@ -540,7 +554,8 @@
     "invalidTheme": "テーマが無効です: {{theme}}。light、dark、sepia のいずれかを指定してください",
     "invalidThemeSchedule": "テーマの自動切り替え設定が無効です：enabled（真偽値）、start/end（HH:MM）、nightTheme（dark または sepia）が必要です",
     "invalidDateFormat": "日付が無効です：{{value}}。ISO 8601 形式で指定",
-    "bookmarkMessageNotFound": "このセッションにメッセージが見つかりません",    "messageNotFound": "メッセージが見つかりません",
+    "bookmarkMessageNotFound": "このセッションにメッセージが見つかりません",
+    "messageNotFound": "メッセージが見つかりません",
     "sessionDeleteInProgress": "セッションの削除が進行中です",
     "sessionError": "セッション操作に失敗しました",
     "pinUpdateFailed": "ピン留め状態の更新に失敗しました",
@@ -923,7 +938,7 @@
       "toolHistoryUser": "ユーザー",
       "toolImageAnalyze": "画像分析",
       "toolImageAnalyzeCount": "{{count}} 枚の画像",
-"toolVideoAnalyze": "動画分析",
+      "toolVideoAnalyze": "動画分析",
       "toolVideoAnalyzeCount": "{{count}} 本の動画",
       "toolImageCount": "{{count}} 枚の画像",
       "toolImageGenerate": "生成",
@@ -3468,7 +3483,7 @@
   "theme": {
     "switchToDark": "ダークモードに切り替え",
     "switchToLight": "ライトモードに切り替え",
-      "cycleShortcut": "ショートカット Ctrl/Cmd+Shift+L",
+    "cycleShortcut": "ショートカット Ctrl/Cmd+Shift+L",
     "switchToSepia": "セピアモードに切り替え"
   },
   "tools": {

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1,4 +1,11 @@
 {
+  "sessionWorkspace": {
+    "loading": "폴더 선택 중…",
+    "reset": "기본 대화 폴더로 복원",
+    "scope": "이 대화의 파일 작업과 명령 실행에 사용합니다",
+    "failed": "폴더를 선택할 수 없습니다. 데스크톱 연결을 확인해 주세요.",
+    "choose": "작업 폴더 선택"
+  },
   "about": {
     "appVersion": "버전",
     "buildTime": "빌드 시간",
@@ -264,7 +271,14 @@
       "section": "실행 기기",
       "currentDevice": "이 기기"
     },
-    "sandboxPolicy": { "section": "실행 정책", "all": "모두 확인", "commands": "명령만 확인", "none": "확인하지 않음", "updated": "실행 정책이 업데이트되었습니다", "updateFailed": "실행 정책 업데이트에 실패했습니다" }
+    "sandboxPolicy": {
+      "section": "실행 정책",
+      "all": "모두 확인",
+      "commands": "명령만 확인",
+      "none": "확인하지 않음",
+      "updated": "실행 정책이 업데이트되었습니다",
+      "updateFailed": "실행 정책 업데이트에 실패했습니다"
+    }
   },
   "agents": {
     "fast": {
@@ -540,7 +554,8 @@
     "invalidTheme": "잘못된 테마입니다: {{theme}}. light, dark, sepia 중 하나여야 합니다",
     "invalidThemeSchedule": "테마 예약 전환 설정이 잘못되었습니다: enabled(불리언), start/end(HH:MM), nightTheme(dark 또는 sepia)이 필요합니다",
     "invalidDateFormat": "잘못된 날짜: {{value}}. ISO 8601 형식 필요",
-    "bookmarkMessageNotFound": "이 세션에서 메시지를 찾을 수 없습니다",    "messageNotFound": "메시지를 찾을 수 없습니다",
+    "bookmarkMessageNotFound": "이 세션에서 메시지를 찾을 수 없습니다",
+    "messageNotFound": "메시지를 찾을 수 없습니다",
     "sessionDeleteInProgress": "세션 삭제가 진행 중입니다",
     "sessionError": "세션 작업에 실패했습니다",
     "pinUpdateFailed": "고정 상태 업데이트에 실패했습니다",
@@ -923,7 +938,7 @@
       "toolHistoryUser": "사용자",
       "toolImageAnalyze": "이미지 분석",
       "toolImageAnalyzeCount": "{{count}}개 이미지",
-"toolVideoAnalyze": "동영상 분석",
+      "toolVideoAnalyze": "동영상 분석",
       "toolVideoAnalyzeCount": "동영상 {{count}}개",
       "toolImageCount": "{{count}}개 이미지",
       "toolImageGenerate": "생성",
@@ -3468,7 +3483,7 @@
   "theme": {
     "switchToDark": "다크 모드로 전환",
     "switchToLight": "라이트 모드로 전환",
-      "cycleShortcut": "단축키 Ctrl/Cmd+Shift+L",
+    "cycleShortcut": "단축키 Ctrl/Cmd+Shift+L",
     "switchToSepia": "세피아 모드로 전환"
   },
   "tools": {

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1,4 +1,11 @@
 {
+  "sessionWorkspace": {
+    "loading": "Выбор папки…",
+    "reset": "Вернуть папку разговора по умолчанию",
+    "scope": "Папка для файлов и команд в этом разговоре",
+    "failed": "Не удалось выбрать папку. Проверьте подключение приложения.",
+    "choose": "Выбрать рабочую папку"
+  },
   "about": {
     "appVersion": "Версия",
     "buildTime": "Время сборки",
@@ -264,7 +271,14 @@
       "section": "Устройство",
       "currentDevice": "Это устройство"
     },
-    "sandboxPolicy": { "section": "Политика выполнения", "all": "Подтверждать всё", "commands": "Подтверждать только команды", "none": "Не подтверждать", "updated": "Политика выполнения обновлена", "updateFailed": "Не удалось обновить политику выполнения" }
+    "sandboxPolicy": {
+      "section": "Политика выполнения",
+      "all": "Подтверждать всё",
+      "commands": "Подтверждать только команды",
+      "none": "Не подтверждать",
+      "updated": "Политика выполнения обновлена",
+      "updateFailed": "Не удалось обновить политику выполнения"
+    }
   },
   "agents": {
     "fast": {
@@ -540,7 +554,8 @@
     "invalidTheme": "Недопустимая тема: {{theme}}. Должна быть light, dark или sepia",
     "invalidThemeSchedule": "Недопустимое расписание тем: нужны enabled (логическое), start/end (ЧЧ:ММ) и nightTheme (dark или sepia)",
     "invalidDateFormat": "Неверная дата: {{value}}. Ожидается ISO 8601",
-    "bookmarkMessageNotFound": "Сообщение в диалоге не найдено",    "messageNotFound": "Сообщение не найдено",
+    "bookmarkMessageNotFound": "Сообщение в диалоге не найдено",
+    "messageNotFound": "Сообщение не найдено",
     "sessionDeleteInProgress": "Выполняется удаление сессии",
     "sessionError": "Ошибка операции с сессией",
     "pinUpdateFailed": "Не удалось обновить состояние закрепления",
@@ -923,7 +938,7 @@
       "toolHistoryUser": "Вопрос",
       "toolImageAnalyze": "Анализ изображения",
       "toolImageAnalyzeCount": "{{count}} изображений",
-"toolVideoAnalyze": "Анализ видео",
+      "toolVideoAnalyze": "Анализ видео",
       "toolVideoAnalyzeCount": "{{count}} видео",
       "toolImageCount": "{{count}} изображений",
       "toolImageGenerate": "Генерация",
@@ -3468,7 +3483,7 @@
   "theme": {
     "switchToDark": "Переключить на тёмную тему",
     "switchToLight": "Переключить на светлую тему",
-      "cycleShortcut": "Горячая клавиша Ctrl/Cmd+Shift+L",
+    "cycleShortcut": "Горячая клавиша Ctrl/Cmd+Shift+L",
     "switchToSepia": "Переключить на режим сепии"
   },
   "tools": {

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -1,4 +1,11 @@
 {
+  "sessionWorkspace": {
+    "loading": "正在选择目录…",
+    "reset": "恢复默认会话目录",
+    "scope": "此目录用于当前会话的文件操作和命令执行",
+    "failed": "无法选择工作目录，请确认本地客户端已连接后重试",
+    "choose": "选择工作目录"
+  },
   "about": {
     "appVersion": "版本",
     "buildTime": "构建时间",
@@ -264,7 +271,14 @@
       "section": "执行设备",
       "currentDevice": "当前设备"
     },
-    "sandboxPolicy": { "section": "执行策略", "all": "全部确认", "commands": "仅命令确认", "none": "不确认", "updated": "执行策略已更新", "updateFailed": "执行策略更新失败" }
+    "sandboxPolicy": {
+      "section": "执行策略",
+      "all": "全部确认",
+      "commands": "仅命令确认",
+      "none": "不确认",
+      "updated": "执行策略已更新",
+      "updateFailed": "执行策略更新失败"
+    }
   },
   "agents": {
     "fast": {
@@ -540,7 +554,8 @@
     "invalidTheme": "主题无效：{{theme}}，必须为 light、dark 或 sepia",
     "invalidThemeSchedule": "主题定时切换配置无效：需要 enabled（布尔）、start/end（HH:MM）与 nightTheme（dark 或 sepia）",
     "invalidDateFormat": "日期无效：{{value}}，需 ISO 8601 格式",
-    "bookmarkMessageNotFound": "会话中未找到该消息，无法收藏",    "messageNotFound": "消息不存在",
+    "bookmarkMessageNotFound": "会话中未找到该消息，无法收藏",
+    "messageNotFound": "消息不存在",
     "sessionDeleteInProgress": "会话删除进行中",
     "sessionError": "会话操作失败",
     "pinUpdateFailed": "置顶状态更新失败",
@@ -923,7 +938,7 @@
       "toolHistoryUser": "用户",
       "toolImageAnalyze": "图片分析",
       "toolImageAnalyzeCount": "{{count}} 张图片",
-"toolVideoAnalyze": "视频分析",
+      "toolVideoAnalyze": "视频分析",
       "toolVideoAnalyzeCount": "{{count}} 段视频",
       "toolImageCount": "{{count}} 张图片",
       "toolImageGenerate": "生成",
@@ -3468,7 +3483,7 @@
   "theme": {
     "switchToDark": "切换到深色模式",
     "switchToLight": "切换到浅色模式",
-      "cycleShortcut": "快捷键 Ctrl/Cmd+Shift+L",
+    "cycleShortcut": "快捷键 Ctrl/Cmd+Shift+L",
     "switchToSepia": "切换到护眼模式"
   },
   "tools": {

--- a/frontend/src/styles/chat.css
+++ b/frontend/src/styles/chat.css
@@ -28,6 +28,16 @@
   box-shadow: var(--shadow-inset-hover), var(--shadow-med);
 }
 
+/* The directory is a normal header row inside the composer, sharing its
+   outer radius. Insets keep controls clear of the corner arc and focus ring;
+   no clipping/absolute positioning, so attachments and popovers stay usable. */
+.chat-input-container > .session-workspace-bar {
+  margin-inline: 0.75rem;
+  padding-block: 0.375rem;
+  padding-inline: 0.25rem;
+  border-bottom: 1px solid var(--theme-border);
+}
+
 .chat-input-container:focus-within {
   border-color: transparent;
   box-shadow: var(--shadow-inset-selected), var(--shadow-med);

--- a/scripts/e2e_local_sandbox.py
+++ b/scripts/e2e_local_sandbox.py
@@ -1013,6 +1013,43 @@ async def stress(user_id: str, machine_id: str) -> None:
     )
 
 
+async def selected_workspace_battery(user_id: str, machine_id: str) -> None:
+    """Use a native-picker-format binding through the real backend and daemon."""
+    from src.infra.backend.local import WorkspaceAliasBackend
+    from src.infra.backend.workspace_selection import selected_workspace_id
+
+    root = WORKSPACE_ROOT / machine_id
+    selected = root / "selected-project"
+    selected.mkdir(exist_ok=True)
+    bindings = root / "workspaces" / ".selected"
+    bindings.mkdir(exist_ok=True)
+    key = "local-" + secrets.token_hex(16)
+    (bindings / f"{key}.json").write_text(json.dumps(str(selected.resolve())))
+    options = {
+        "sandbox_machine_id": machine_id,
+        "sandbox_workspace": json.dumps({"id": key, "machineId": machine_id}),
+    }
+    for turn in (1, 2):
+        backend = WorkspaceAliasBackend(
+            user_id=user_id,
+            session_id=f".selected/{selected_workspace_id(options)}",
+            machine_id=machine_id,
+        )
+        await backend.awrite(f"{backend.work_dir}/turn-{turn}.txt", f"turn {turn}")
+        result = await backend.aexecute("pwd")
+        check(
+            f"所选目录跨轮次执行 turn={turn}",
+            (selected / f"turn-{turn}.txt").read_text() == f"turn {turn}"
+            and str(selected.resolve()) in result.output,
+        )
+    from src.infra.sandbox.relay.dispatch import dispatch_local_call
+
+    result = await dispatch_local_call(
+        user_id, "fs_read", {"cwd": backend.work_dir, "path": "turn-1.txt"}, machine_id=machine_id
+    )
+    check("所选目录结构化文件操作", (result.get("result") or {}).get("content") == "turn 1")
+
+
 async def run_daemon_child(pat: str, machine_id: str) -> None:
     sys.path.insert(0, str(REPO / "client"))
     from lambchat_sandbox.config import SandboxConfig
@@ -1033,6 +1070,9 @@ async def run_daemon_child(pat: str, machine_id: str) -> None:
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--stress", action="store_true", help="追加压测段")
+    ap.add_argument(
+        "--selected-workspace-only", action="store_true", help="仅验证所选目录跨轮次执行"
+    )
     ap.add_argument("--daemon-child", nargs=2, metavar=("PAT", "MACHINE_ID"))
     args = ap.parse_args()
 
@@ -1057,9 +1097,13 @@ def main() -> int:
         print(f"[env] daemon pid={holder['proc'].pid} machine={machine_id} user={username}")
 
         async def run_all():
+            if args.selected_workspace_only:
+                await selected_workspace_battery(user_id, machine_id)
+                return
             # battery/edge/crash/stress 必须同一事件循环：redis 客户端是模块级单例，
             # 跨 asyncio.run 复用会把旧循环的连接带进新循环（Event loop is closed）
             await battery(user_id, pat, machine_id)
+            await selected_workspace_battery(user_id, machine_id)
             await edge_cases(user_id, machine_id)
             await crash_recovery(user_id, pat, machine_id, holder)
             await comprehensive(user_id, pat, machine_id, holder)

--- a/src/agents/search_agent/nodes.py
+++ b/src/agents/search_agent/nodes.py
@@ -645,14 +645,16 @@ async def _create_backend_and_prompt(
     platform = _resolve_sandbox_platform(agent_options, settings.SANDBOX_PLATFORM.lower())
     if platform == "local":
         from src.infra.backend.local import WorkspaceAliasBackend
+        from src.infra.backend.workspace_selection import selected_workspace_id
 
         # WorkspaceAliasBackend：prompt_policy 让模型用 /workspace/{sid}/x 别名
         # 路径调文件工具，别名剥离层把路径翻译回相对路径再构造命令（F1）。
         # 会话级选机（多机 daemon）：agent_options.sandbox_machine_id 缺省走
         # 注册表默认解析（默认机→唯一在线→legacy）
+        workspace_id = selected_workspace_id(agent_options)
         local_backend = WorkspaceAliasBackend(
             user_id=user_id,
-            session_id=session_id,
+            session_id=f".selected/{workspace_id}" if workspace_id else session_id,
             machine_id=(agent_options or {}).get("sandbox_machine_id") or None,
         )
         # 用户 env 变量注入（对齐云端：backend.env_vars → 执行时下发）；

--- a/src/infra/backend/workspace_selection.py
+++ b/src/infra/backend/workspace_selection.py
@@ -1,0 +1,27 @@
+"""Resolve an opaque, machine-bound directory selection from session options."""
+
+import json
+import re
+
+
+def selected_workspace_id(options: dict | None) -> str | None:
+    options = options or {}
+    raw = options.get("sandbox_workspace")
+    if not isinstance(raw, str):
+        return None
+    try:
+        selection = json.loads(raw)
+    except ValueError:
+        return None
+    if not isinstance(selection, dict):
+        return None
+    key = selection.get("id")
+    machine = options.get("sandbox_machine_id")
+    if (
+        not machine
+        or selection.get("machineId") != machine
+        or not isinstance(key, str)
+        or not re.fullmatch(r"local-[0-9a-f]{32}", key)
+    ):
+        return None
+    return key

--- a/tests/client/test_desktop_command_permissions.py
+++ b/tests/client/test_desktop_command_permissions.py
@@ -1,0 +1,21 @@
+"""An app ACL must preserve the existing desktop command surface."""
+
+import json
+import tomllib
+from pathlib import Path
+
+
+def test_main_window_can_call_all_registered_desktop_commands():
+    root = Path(__file__).resolve().parents[2] / "frontend" / "src-tauri"
+    source = (root / "src" / "lib.rs").read_text()
+    handler = source.split("tauri::generate_handler![", 1)[1].split("]", 1)[0]
+    commands = {entry.strip().split("::")[-1] for entry in handler.split(",") if entry.strip()}
+    capability = json.loads((root / "capabilities" / "default.json").read_text())
+    allowed = set()
+    for path in (root / "permissions").glob("*.toml"):
+        for permission in tomllib.loads(path.read_text()).get("permission", []):
+            if permission["identifier"] in capability["permissions"]:
+                allowed.update(permission.get("commands", {}).get("allow", []))
+    assert not commands - allowed, (
+        f"Desktop commands denied by app ACL: {sorted(commands - allowed)}"
+    )

--- a/tests/client/test_selected_workspace.py
+++ b/tests/client/test_selected_workspace.py
@@ -1,0 +1,30 @@
+import json
+
+import pytest
+
+from lambchat_sandbox.executor import Executor, ExecutorError, map_workspace
+
+
+def test_selected_directory_is_used_for_commands_and_mapping(tmp_path):
+    root = tmp_path / "workspaces"
+    selected = tmp_path / "project"
+    selected.mkdir()
+    bindings = root / ".selected"
+    bindings.mkdir(parents=True)
+    key = "local-" + "a" * 32
+    (bindings / f"{key}.json").write_text(json.dumps(str(selected)))
+    assert map_workspace(f"/workspace/.selected/{key}", root) == selected
+    result = Executor(root).execute("echo hello > result.txt", f"/workspace/.selected/{key}", 5)
+    assert result["exit_code"] == 0
+    assert (selected / "result.txt").read_text().strip() == "hello"
+
+
+@pytest.mark.parametrize("value", [None, "missing", "relative/path"])
+def test_selected_directory_fails_closed_when_binding_is_unavailable(tmp_path, value):
+    bindings = tmp_path / ".selected"
+    bindings.mkdir()
+    key = "local-" + "b" * 32
+    if value is not None:
+        (bindings / f"{key}.json").write_text(json.dumps(value))
+    with pytest.raises(ExecutorError):
+        map_workspace(f"/workspace/.selected/{key}", tmp_path)

--- a/tests/infra/backend/test_workspace_selection.py
+++ b/tests/infra/backend/test_workspace_selection.py
@@ -1,0 +1,23 @@
+import json
+
+from src.infra.backend.workspace_selection import selected_workspace_id
+
+
+def test_workspace_requires_matching_explicit_machine():
+    selection = json.dumps({"id": "local-" + "a" * 32, "machineId": "m1", "path": "/project"})
+    assert (
+        selected_workspace_id({"sandbox_workspace": selection, "sandbox_machine_id": "m1"})
+        == "local-" + "a" * 32
+    )
+    assert (
+        selected_workspace_id({"sandbox_workspace": selection, "sandbox_machine_id": "m2"}) is None
+    )
+    assert selected_workspace_id({"sandbox_workspace": selection}) is None
+
+
+def test_workspace_rejects_paths_and_malformed_options():
+    for selection in ["bad", "null", "[]", '{"id":"../../etc","machineId":"m1"}']:
+        assert (
+            selected_workspace_id({"sandbox_workspace": selection, "sandbox_machine_id": "m1"})
+            is None
+        )


### PR DESCRIPTION
桌面客户端选择当前在线的本地机器后，可在输入框顶部选择工作目录。目录绑定随会话保存，后续消息继续使用；切换机器时不会误用原机器的目录。

目录栏与输入框共用圆角和边框，支持长路径、附件以及展开和收起。修复编辑器挂载容器切换后输入框消失的问题，并补齐桌面命令权限，避免新增权限声明后已有命令被拒绝。

本地目录通过机器绑定标识映射，失效目录明确报错。包含五语文案、原生选择器、daemon 映射、使用文档及回归测试。

验证：
- 前端全量 2724 项测试、构建通过；lint 无错误，保留一条已有警告。
- Python 相关测试、Ruff、Mypy 通过；Rust 26 项通过、1 项忽略。
- 本地沙箱全量 E2E 41 项通过，新增工作目录链路专项 4 项通过。
- 提交格式检查及格式化后的输入框回归检查通过。
