### PR TITLE
fix(mcp): 根路由补无尾斜杠别名——修 SPA 抢答致 MCP 列表为空

### DIFF
--- a/frontend/src/services/api/mcp.ts
+++ b/frontend/src/services/api/mcp.ts
@@ -24,7 +24,7 @@ export const mcpApi = {
    * List all visible MCP servers
    */
   async list(): Promise<MCPServersResponse> {
-    return authFetch<MCPServersResponse>(`${API_BASE}/api/mcp`);
+    return authFetch<MCPServersResponse>(`${API_BASE}/api/mcp/`);
   },
 
   /**
@@ -40,7 +40,7 @@ export const mcpApi = {
    * Create a new MCP server
    */
   async create(data: MCPServerCreate): Promise<MCPServerResponse> {
-    return authFetch<MCPServerResponse>(`${API_BASE}/api/mcp`, {
+    return authFetch<MCPServerResponse>(`${API_BASE}/api/mcp/`, {
       method: "POST",
       body: JSON.stringify(data),
     });

--- a/src/api/routes/mcp.py
+++ b/src/api/routes/mcp.py
@@ -101,6 +101,7 @@ def _has_permission_for_transport(user: TokenPayload, transport: str) -> bool:
 # ==========================================
 
 
+@router.get("", response_model=MCPServersResponse, include_in_schema=False)
 @router.get("/", response_model=MCPServersResponse)
 async def list_servers(
     skip: int = Query(0, ge=0),
@@ -124,6 +125,7 @@ async def list_servers(
     return _paginate_servers(servers, skip=skip, limit=limit, q=q)
 
 
+@router.post("", response_model=MCPServerResponse, status_code=201, include_in_schema=False)
 @router.post("/", response_model=MCPServerResponse, status_code=201)
 async def create_server(
     data: MCPServerCreate,

--- a/tests/api/test_mcp_root_path_alias.py
+++ b/tests/api/test_mcp_root_path_alias.py
@@ -1,0 +1,20 @@
+"""MCP 根路由无尾斜杠别名回归测试。
+
+背景：staging/nginx 的 SPA fallback 会抢答未被后端精确注册的 /api/mcp
+（无斜杠）返回 index.html，导致 mcpApi.list()/create() 解析失败、MCP 面板
+与角色编辑器的 MCP 绑定选择器为空。后端在根路由上同时注册 "" 与 "/"。
+"""
+
+from src.api.routes import mcp
+
+
+def test_mcp_root_routes_accept_empty_path() -> None:
+    paths = {
+        (getattr(route, "path", None), method)
+        for route in mcp.router.routes
+        for method in getattr(route, "methods", set())
+    }
+    assert ("", "GET") in paths
+    assert ("/", "GET") in paths
+    assert ("", "POST") in paths
+    assert ("/", "POST") in paths


### PR DESCRIPTION
## 现象

staging 上 MCP 面板与角色编辑器的「MCP 服务」绑定选择器为空（暂无可用的 MCP 服务），但库中 deepwiki server 正常、运行时工具装配正常。

## 根因

前端 `mcpApi.list()/create()` 请求 `/api/mcp`（无尾斜杠）；后端 mcp router 只注册了 `/`。经 nginx 时无斜杠路径未命中后端、被 SPA fallback 抢答返回 index.html → authFetch 解析失败 → catch 后空列表。`/api/mcp/`（带斜杠）一切正常。

## 修复

- 后端 `src/api/routes/mcp.py`：根 GET/POST 叠加空路径路由（`include_in_schema=False`），新旧客户端通吃
- 前端 `mcp.ts`：list/create 补尾斜杠（与 skills/persona 等既有风格一致）
- 回归测试断言 ``""`` 与 `"/"` 双注册

## 验证

- [x] `pytest tests/api/test_mcp_root_path_alias.py tests/api/test_mcp_routes.py`（12 passed）
- [x] make lint / make typecheck
- [ ] staging 部署后 `:8021` 与域名链路 `/api/mcp` 返回 JSON + 角色编辑器下拉可见 deepwiki