### PR TITLE
feat(persona): 绑定可见性加固——MCP 求交+缺失记录+编辑器提示

### DIFF
--- a/frontend/scripts/performanceBudget.ts
+++ b/frontend/scripts/performanceBudget.ts
@@ -158,7 +158,7 @@ export function combinePrecacheBudgetEntries(
 // 528KB：#563 沙箱数据位置卡片（五语 13 键，顶到 525.1KB）与 #565
 // 定时主题（调度状态机 + themeDom 解析助手 + 五语文案，再 +1.2KB）叠加
 // 把 eager JS 顶到约 526.8KB，沿 2KB 阶梯惯例累加抬档。
-export const EAGER_JAVASCRIPT_BUDGET_BYTES = 528 * 1024;
+export const EAGER_JAVASCRIPT_BUDGET_BYTES = 530 * 1024;
 export const PRECACHE_BUDGET_BYTES = 5 * 1024 * 1024;
 export const PRECACHE_ADDITIONAL_ENTRIES: PrecacheEntry[] = [];
 

--- a/frontend/src/components/persona/PersonaEditorModal.tsx
+++ b/frontend/src/components/persona/PersonaEditorModal.tsx
@@ -1,13 +1,15 @@
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { GlassSelect } from "../common/GlassSelect";
-import { Plus, Pencil, Sparkles, Tag, Save, MessageSquare, Server } from "lucide-react";
+import { Plus, Pencil, Sparkles, Tag, Save, MessageSquare, Server, TriangleAlert } from "lucide-react";
 import { LoadingSpinner } from "../common/LoadingSpinner";
 import { EditorSidebar } from "../common/EditorSidebar";
 import toast from "react-hot-toast";
 import { mcpApi } from "../../services/api/mcp";
+import { skillApi } from "../../services/api/skill";
 import {
   buildPersonaPresetPayload,
+  computeMissingBindings,
   draftRowsToStarterPrompts,
   starterPromptsToDraftRows,
 } from "./personaPresetEditor";
@@ -56,6 +58,7 @@ export function PersonaEditorModal({
   const [skillDropdownOpen, setSkillDropdownOpen] = useState(false);
   const [mcpDropdownOpen, setMcpDropdownOpen] = useState(false);
   const [mcpOptions, setMcpOptions] = useState<BindingOption[]>([]);
+  const [installedSkillNames, setInstalledSkillNames] = useState<string[]>([]);
   const [bindingsLoading, setBindingsLoading] = useState(false);
 
   useEffect(() => {
@@ -64,7 +67,10 @@ export function PersonaEditorModal({
     setBindingsLoading(true);
     void (async () => {
       try {
-        const mcpList = await mcpApi.list();
+        const [mcpList, skillList] = await Promise.all([
+          mcpApi.list(),
+          skillApi.list({ limit: 100 }),
+        ]);
         if (cancelled) return;
         setMcpOptions(
           (mcpList.servers ?? [])
@@ -74,9 +80,13 @@ export function PersonaEditorModal({
               description: null,
             })),
         );
+        setInstalledSkillNames(
+          (skillList.skills ?? []).map((skill) => skill.skill_name),
+        );
       } catch {
         if (!cancelled) {
           setMcpOptions([]);
+          setInstalledSkillNames([]);
         }
       } finally {
         if (!cancelled) setBindingsLoading(false);
@@ -86,6 +96,16 @@ export function PersonaEditorModal({
       cancelled = true;
     };
   }, [showModal, t]);
+
+  // 编辑既有预设时，绑定里当前用户不可用的部分（技能未安装 / MCP 不可见）
+  const missingSkills = computeMissingBindings(
+    editingPreset?.skill_names,
+    installedSkillNames,
+  );
+  const missingMcpServers = computeMissingBindings(
+    editingPreset?.mcp_server_names,
+    mcpOptions.map((option) => option.name),
+  );
 
   useEffect(() => {
     if (showModal) {
@@ -399,6 +419,14 @@ export function PersonaEditorModal({
               open={skillDropdownOpen}
               onOpenChange={setSkillDropdownOpen}
             />
+            {!bindingsLoading && missingSkills.length > 0 && (
+              <p className="mt-1.5 flex items-start gap-1 text-11 leading-relaxed text-amber-600/90 dark:text-amber-400/90">
+                <TriangleAlert size={11} className="mt-0.5 shrink-0 opacity-80" />
+                {t("personaPresets.missingSkillsHint", {
+                  names: missingSkills.join("、"),
+                })}
+              </p>
+            )}
           </div>
 
           <div className="ppe-field">
@@ -424,6 +452,14 @@ export function PersonaEditorModal({
               emptyKey="personaPresets.noMcpServers"
               loading={bindingsLoading}
             />
+            {!bindingsLoading && missingMcpServers.length > 0 && (
+              <p className="mt-1.5 flex items-start gap-1 text-11 leading-relaxed text-amber-600/90 dark:text-amber-400/90">
+                <TriangleAlert size={11} className="mt-0.5 shrink-0 opacity-80" />
+                {t("personaPresets.missingMcpHint", {
+                  names: missingMcpServers.join("、"),
+                })}
+              </p>
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/components/persona/__tests__/personaMissingBindings.test.ts
+++ b/frontend/src/components/persona/__tests__/personaMissingBindings.test.ts
@@ -1,0 +1,16 @@
+import { computeMissingBindings } from "../personaPresetEditor";
+
+test("returns empty when nothing is declared", () => {
+  expect(computeMissingBindings(undefined, ["a"])).toEqual([]);
+  expect(computeMissingBindings([], ["a"])).toEqual([]);
+});
+
+test("returns declared names missing from the available set", () => {
+  expect(
+    computeMissingBindings(["source-triage", "deepwiki-skill"], ["deepwiki-skill", "other"]),
+  ).toEqual(["source-triage"]);
+});
+
+test("returns everything when the user has none available", () => {
+  expect(computeMissingBindings(["a", "b"], [])).toEqual(["a", "b"]);
+});

--- a/frontend/src/components/persona/personaPresetEditor.ts
+++ b/frontend/src/components/persona/personaPresetEditor.ts
@@ -6,6 +6,21 @@ import type {
   PersonaPresetUpdate,
 } from "../../types";
 
+/**
+ * 计算「预设声明的绑定」里当前用户不可用的部分（技能未安装 / MCP 不可见），
+ * 供编辑器展示缺失提示；全缺时由运行时回落为放行全部，这里只做可视化。
+ */
+export function computeMissingBindings(
+  declared: string[] | null | undefined,
+  available: string[],
+): string[] {
+  if (!declared || declared.length === 0) {
+    return [];
+  }
+  const available_set = new Set(available);
+  return declared.filter((name) => !available_set.has(name));
+}
+
 export interface StarterPromptDraftRow {
   icon: string;
   text: string;

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -2142,6 +2142,8 @@
     "skillsCount": "skills",
     "skillsInput": "Skills",
     "mcpServersInput": "MCP Servers",
+    "missingSkillsHint": "Bound skills not installed: {{names}} (inactive in chat)",
+    "missingMcpHint": "MCP servers not visible to you: {{names}} (inactive in chat)",
     "mcpServerCount": "{{count}} MCP servers bound",
     "mcpServersInputPlaceholder": "Restrict usable MCP servers (empty = all)...",
     "mcpSearchPlaceholder": "Search MCP servers...",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -2142,6 +2142,8 @@
     "skillsCount": "スキル",
     "skillsInput": "スキル",
     "mcpServersInput": "MCP サーバー",
+    "missingSkillsHint": "未インストールのバインドスキル：{{names}}（会話では無効）",
+    "missingMcpHint": "現在表示できない MCP サーバー：{{names}}（会話では無効）",
     "mcpServerCount": "MCP サーバー {{count}} 件をバインド",
     "mcpServersInputPlaceholder": "使用する MCP サーバーを限定（空欄で無制限）...",
     "mcpSearchPlaceholder": "MCP サーバーを検索...",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -2142,6 +2142,8 @@
     "skillsCount": "스킬",
     "skillsInput": "스킬",
     "mcpServersInput": "MCP 서버",
+    "missingSkillsHint": "설치되지 않은 바인딩 스킬: {{names}} (대화에서 적용되지 않음)",
+    "missingMcpHint": "현재 보이지 않는 MCP 서버: {{names}} (대화에서 적용되지 않음)",
     "mcpServerCount": "MCP 서버 {{count}}개 바인딩됨",
     "mcpServersInputPlaceholder": "사용할 MCP 서버 제한(비워두면 전부)...",
     "mcpSearchPlaceholder": "MCP 서버 검색...",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -2142,6 +2142,8 @@
     "skillsCount": "навыков",
     "skillsInput": "Навыки",
     "mcpServersInput": "MCP-серверы",
+    "missingSkillsHint": "Привязанные навыки не установлены: {{names}} (не действуют в чате)",
+    "missingMcpHint": "Недоступные вам MCP-серверы: {{names}} (не действуют в чате)",
     "mcpServerCount": "Привязано MCP-серверов: {{count}}",
     "mcpServersInputPlaceholder": "Ограничить MCP-серверы (пусто = все)...",
     "mcpSearchPlaceholder": "Поиск MCP-серверов...",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -2142,6 +2142,8 @@
     "skillsCount": "个技能",
     "skillsInput": "技能",
     "mcpServersInput": "MCP 服务",
+    "missingSkillsHint": "未安装的绑定技能：{{names}}（对话中不会生效）",
+    "missingMcpHint": "当前不可见的 MCP 服务：{{names}}（对话中不会生效）",
     "mcpServerCount": "{{count}} 个 MCP 服务已绑定",
     "mcpServersInputPlaceholder": "限定可用的 MCP 服务（留空不限制）...",
     "mcpSearchPlaceholder": "搜索 MCP 服务...",

--- a/frontend/src/styles/persona.css
+++ b/frontend/src/styles/persona.css
@@ -1485,3 +1485,4 @@
   opacity: 0.72;
   cursor: wait;
 }
+

--- a/frontend/src/types/personaPreset.ts
+++ b/frontend/src/types/personaPreset.ts
@@ -76,6 +76,7 @@ export interface PersonaPresetSnapshot {
   skill_names: string[];
   missing_skill_names: string[];
   mcp_server_names: string[];
+  missing_mcp_server_names?: string[];
   version: number;
   avatar?: string | null;
 }

--- a/src/infra/persona_preset/manager.py
+++ b/src/infra/persona_preset/manager.py
@@ -286,12 +286,8 @@ class PersonaPresetManager:
             mcp_server_names = list(preset.mcp_server_names)
             missing_mcp: list[str] = []
         else:
-            mcp_server_names = [
-                name for name in preset.mcp_server_names if name in visible_mcp
-            ]
-            missing_mcp = [
-                name for name in preset.mcp_server_names if name not in visible_mcp
-            ]
+            mcp_server_names = [name for name in preset.mcp_server_names if name in visible_mcp]
+            missing_mcp = [name for name in preset.mcp_server_names if name not in visible_mcp]
 
         await self.storage.increment_usage(preset_id)
         await self.storage.touch_user_preference(user_id=user_id, preset_id=preset_id)

--- a/src/infra/persona_preset/manager.py
+++ b/src/infra/persona_preset/manager.py
@@ -2,6 +2,7 @@
 
 from typing import Optional
 
+from src.infra.mcp.storage import MCPStorage
 from src.infra.persona_preset.storage import PersonaPresetStorage
 from src.infra.skill.storage import SkillStorage
 from src.infra.utils.datetime import utc_now
@@ -24,9 +25,11 @@ class PersonaPresetManager:
         self,
         storage: PersonaPresetStorage | None = None,
         skill_storage: SkillStorage | None = None,
+        mcp_storage: MCPStorage | None = None,
     ) -> None:
         self.storage = storage or PersonaPresetStorage()
         self.skill_storage = skill_storage or SkillStorage()
+        self.mcp_storage = mcp_storage or MCPStorage()
 
     @staticmethod
     def _can_view(doc: dict, *, user_id: str, is_admin: bool) -> bool:
@@ -275,7 +278,20 @@ class PersonaPresetManager:
         available = await self._get_available_skill_names(user_id)
         skill_names = [name for name in preset.skill_names if name in available]
         missing = [name for name in preset.skill_names if name not in available]
-        mcp_server_names = list(preset.mcp_server_names)
+
+        # MCP 可见性校验：快照只保留当前用户可见的服务（全缺时不设白名单→放行全部，
+        # 与技能语义一致）；不可见的记录进 missing 供前端提示。
+        visible_mcp = await self._get_visible_mcp_server_names(user_id, is_admin=is_admin)
+        if visible_mcp is None:
+            mcp_server_names = list(preset.mcp_server_names)
+            missing_mcp: list[str] = []
+        else:
+            mcp_server_names = [
+                name for name in preset.mcp_server_names if name in visible_mcp
+            ]
+            missing_mcp = [
+                name for name in preset.mcp_server_names if name not in visible_mcp
+            ]
 
         await self.storage.increment_usage(preset_id)
         await self.storage.touch_user_preference(user_id=user_id, preset_id=preset_id)
@@ -287,9 +303,27 @@ class PersonaPresetManager:
             skill_names=skill_names,
             missing_skill_names=missing,
             mcp_server_names=mcp_server_names,
+            missing_mcp_server_names=missing_mcp,
             version=preset.version,
             avatar=preset.avatar,
         )
+
+    async def _get_visible_mcp_server_names(
+        self, user_id: str, *, is_admin: bool
+    ) -> set[str] | None:
+        """当前用户可见的 MCP server 名集合；查询失败返回 None（跳过校验不阻塞）。"""
+        try:
+            from src.infra.mcp.quota import resolve_user_mcp_access
+
+            user_roles, quota_admin = await resolve_user_mcp_access(user_id)
+            servers = await self.mcp_storage.get_visible_servers(
+                user_id,
+                is_admin=is_admin or quota_admin,
+                user_roles=user_roles,
+            )
+            return {server.name for server in servers}
+        except Exception:
+            return None
 
     async def _get_available_skill_names(self, user_id: str) -> set[str]:
         """Return skill names that can actually be loaded for this user."""

--- a/src/kernel/schemas/persona_preset.py
+++ b/src/kernel/schemas/persona_preset.py
@@ -169,6 +169,7 @@ class PersonaPresetSnapshot(BaseModel):
     skill_names: list[str] = Field(default_factory=list)
     missing_skill_names: list[str] = Field(default_factory=list)
     mcp_server_names: list[str] = Field(default_factory=list)
+    missing_mcp_server_names: list[str] = Field(default_factory=list)
     version: int = 1
     avatar: Optional[str] = None
 

--- a/tests/persona_preset/test_manager_mcp_binding.py
+++ b/tests/persona_preset/test_manager_mcp_binding.py
@@ -48,6 +48,14 @@ class FakePresetStorage:
         return None
 
 
+class FakeMCPStorage:
+    def __init__(self, visible_names: set[str]) -> None:
+        self._visible = visible_names
+
+    async def get_visible_servers(self, user_id, is_admin=False, user_roles=None, limit=None):
+        return [type("S", (), {"name": n})() for n in sorted(self._visible)]
+
+
 class FakeSkillStorage:
     def __init__(self, names: set[str]) -> None:
         self._names = names
@@ -62,38 +70,117 @@ class FakeSkillStorage:
         return None
 
 
-def _make_manager(skill_names: set[str]) -> PersonaPresetManager:
-    return PersonaPresetManager(
+def _make_manager(
+    skill_names: set[str],
+    visible_mcp: set[str] | None = None,
+    quota_admin: bool = False,
+) -> PersonaPresetManager:
+    import src.infra.mcp.quota as quota_module
+
+    original = quota_module.resolve_user_mcp_access
+
+    async def _fake_resolve(user_id: str):
+        return ["user"], quota_admin
+
+    quota_module.resolve_user_mcp_access = _fake_resolve
+    manager = PersonaPresetManager(
         storage=FakePresetStorage(),
         skill_storage=FakeSkillStorage(skill_names),
+        mcp_storage=FakeMCPStorage(visible_mcp or set()),
     )
+    manager.__dict__["_restore_quota"] = lambda: setattr(
+        quota_module, "resolve_user_mcp_access", original
+    )
+    return manager
 
 
 async def test_use_preset_passes_mcp_whitelist_into_snapshot() -> None:
-    manager = _make_manager({"own-skill"})
-    preset_id = (
-        await manager.storage.create(
-            {
-                "scope": "user",
-                "owner_user_id": "user-1",
-                "name": "Researcher",
-                "system_prompt": "You research.",
-                "starter_prompts": [],
-                "skill_names": ["own-skill", "gone-skill"],
-                "mcp_server_names": ["arxiv", "weather"],
-                "visibility": "private",
-                "status": "published",
-                "version": 1,
-            }
-        )
-    )["id"]
+    manager = _make_manager({"own-skill"}, visible_mcp={"arxiv", "weather"})
+    try:
+        preset_id = (
+            await manager.storage.create(
+                {
+                    "scope": "user",
+                    "owner_user_id": "user-1",
+                    "name": "Researcher",
+                    "system_prompt": "You research.",
+                    "starter_prompts": [],
+                    "skill_names": ["own-skill", "gone-skill"],
+                    "mcp_server_names": ["arxiv", "weather"],
+                    "visibility": "private",
+                    "status": "published",
+                    "version": 1,
+                }
+            )
+        )["id"]
 
-    snapshot = await manager.use_preset(preset_id, user_id="user-1", is_admin=False)
+        snapshot = await manager.use_preset(preset_id, user_id="user-1", is_admin=False)
+    finally:
+        manager.__dict__["_restore_quota"]()
 
-    # 技能与用户实际可用技能求交集（缺失记录）；MCP 白名单原样透传给运行时
+    # 技能/MCP 均与用户实际可用集合求交集，缺失分别记录
     assert snapshot.skill_names == ["own-skill"]
     assert snapshot.missing_skill_names == ["gone-skill"]
     assert snapshot.mcp_server_names == ["arxiv", "weather"]
+    assert snapshot.missing_mcp_server_names == []
+
+
+async def test_use_preset_drops_invisible_mcp_and_records_missing() -> None:
+    manager = _make_manager(set(), visible_mcp={"arxiv"})
+    try:
+        preset_id = (
+            await manager.storage.create(
+                {
+                    "scope": "user",
+                    "owner_user_id": "user-1",
+                    "name": "Partial",
+                    "system_prompt": "You chat.",
+                    "starter_prompts": [],
+                    "skill_names": [],
+                    "mcp_server_names": ["arxiv", "ghost"],
+                    "visibility": "private",
+                    "status": "published",
+                    "version": 1,
+                }
+            )
+        )["id"]
+        snapshot = await manager.use_preset(preset_id, user_id="user-1", is_admin=False)
+    finally:
+        manager.__dict__["_restore_quota"]()
+    assert snapshot.mcp_server_names == ["arxiv"]
+    assert snapshot.missing_mcp_server_names == ["ghost"]
+
+
+async def test_use_preset_all_mcp_missing_keeps_lenient_no_whitelist() -> None:
+    """全缺放行：绑定的 MCP 一个都不可见时快照白名单为空（请求侧回落为不限制）。"""
+    from src.api.routes.chat_request_config import (
+        _persona_enabled_mcp_servers_from_snapshot,
+    )
+
+    manager = _make_manager(set(), visible_mcp=set())
+    try:
+        preset_id = (
+            await manager.storage.create(
+                {
+                    "scope": "user",
+                    "owner_user_id": "user-1",
+                    "name": "Ghost",
+                    "system_prompt": "You chat.",
+                    "starter_prompts": [],
+                    "skill_names": [],
+                    "mcp_server_names": ["ghost"],
+                    "visibility": "private",
+                    "status": "published",
+                    "version": 1,
+                }
+            )
+        )["id"]
+        snapshot = await manager.use_preset(preset_id, user_id="user-1", is_admin=False)
+    finally:
+        manager.__dict__["_restore_quota"]()
+    assert snapshot.mcp_server_names == []
+    assert snapshot.missing_mcp_server_names == ["ghost"]
+    assert _persona_enabled_mcp_servers_from_snapshot(snapshot) is None
 
 
 async def test_copy_preset_carries_mcp_bindings() -> None:


### PR DESCRIPTION
## 背景

角色绑定（skill_names / mcp_server_names）是「引用」而非「交付」：其他用户没有对应技能或看不到对应 MCP 时，此前是**静默降级**——缺的技能被丢弃、MCP 白名单匹配不到等于没有，用户全程无感知，且 `missing_skill_names` 后端有数据但前端零展示。

按用户决策：**技能/MCP 全缺时保持「放行全部」宽松语义不变**，其余全部加固。

## 变更

**后端**
- `use_preset` 对 `mcp_server_names` 与用户可见服务求交（`resolve_user_mcp_access` + `get_visible_servers`）：快照只保留可见服务，不可见记入新增的 `missing_mcp_server_names`；查询失败返回 None 跳过校验，不阻塞对话提交
- 全缺时快照白名单为空 → `_persona_enabled_mcp_servers_from_snapshot` 回落 None → 放行用户全部 MCP（与技能语义完全一致）

**前端**
- persona 编辑器：编辑既有预设时，绑定技能未安装 / MCP 服务不可见，在对应选择器下方展示 amber 警告（`computeMissingBindings` 纯函数 + 五语文案）
- 快照类型补 `missing_mcp_server_names`

## 测试

- [x] `tests/persona_preset/test_manager_mcp_binding.py`：部分可见求交、全缺放行回落、copy 跟随
- [x] 前端 `personaMissingBindings.test.ts` 纯函数
- [x] 后端 4618 passed / 前端 2727 passed / lint / typecheck / build（预算沿阶梯抬至 530KB）
- [ ] staging 全新用户复验