### PR TITLE
perf(persona): use_preset 热路径优化——早退+点查+JWT 角色透传+单例

### DIFF
--- a/frontend/src/components/persona/PersonaEditorModal.tsx
+++ b/frontend/src/components/persona/PersonaEditorModal.tsx
@@ -67,9 +67,11 @@ export function PersonaEditorModal({
     setBindingsLoading(true);
     void (async () => {
       try {
+        // 技能列表只为「缺失提示」服务：编辑的预设没有技能绑定时直接跳过请求
+        const needSkills = (editingPreset?.skill_names ?? []).length > 0;
         const [mcpList, skillList] = await Promise.all([
           mcpApi.list(),
-          skillApi.list({ limit: 100 }),
+          needSkills ? skillApi.list({ limit: 100 }) : Promise.resolve(null),
         ]);
         if (cancelled) return;
         setMcpOptions(
@@ -81,7 +83,7 @@ export function PersonaEditorModal({
             })),
         );
         setInstalledSkillNames(
-          (skillList.skills ?? []).map((skill) => skill.skill_name),
+          (skillList?.skills ?? []).map((skill) => skill.skill_name),
         );
       } catch {
         if (!cancelled) {
@@ -95,7 +97,7 @@ export function PersonaEditorModal({
     return () => {
       cancelled = true;
     };
-  }, [showModal, t]);
+  }, [showModal, t, editingPreset]);
 
   // 编辑既有预设时，绑定里当前用户不可用的部分（技能未安装 / MCP 不可见）
   const missingSkills = computeMissingBindings(

--- a/src/api/routes/chat_request_config.py
+++ b/src/api/routes/chat_request_config.py
@@ -6,7 +6,10 @@
 
 from __future__ import annotations
 
-from src.infra.persona_preset.manager import PersonaPresetManager
+from src.infra.persona_preset.manager import (
+        PersonaPresetManager,
+        get_persona_preset_manager,
+    )
 from src.kernel.schemas.agent import AgentRequest
 from src.kernel.schemas.persona_preset import PersonaPresetSnapshot
 from src.kernel.schemas.user import TokenPayload
@@ -82,11 +85,12 @@ async def resolve_persona_request(
     if not request.persona_preset_id:
         return
 
-    persona_manager = manager or PersonaPresetManager()
+    persona_manager = manager or get_persona_preset_manager()
     snapshot = await persona_manager.use_preset(
         request.persona_preset_id,
         user_id=user.sub,
         is_admin="persona_preset:admin" in (user.permissions or []),
+        user_roles=list(user.roles or []),
     )
     request.persona_snapshot = snapshot
     request.enabled_skills = _persona_enabled_skills_from_snapshot(snapshot)

--- a/src/api/routes/chat_request_config.py
+++ b/src/api/routes/chat_request_config.py
@@ -7,9 +7,9 @@
 from __future__ import annotations
 
 from src.infra.persona_preset.manager import (
-        PersonaPresetManager,
-        get_persona_preset_manager,
-    )
+    PersonaPresetManager,
+    get_persona_preset_manager,
+)
 from src.kernel.schemas.agent import AgentRequest
 from src.kernel.schemas.persona_preset import PersonaPresetSnapshot
 from src.kernel.schemas.user import TokenPayload

--- a/src/api/routes/persona_preset.py
+++ b/src/api/routes/persona_preset.py
@@ -178,6 +178,7 @@ async def use_persona_preset(
             preset_id,
             user_id=user.sub,
             is_admin=_is_admin(user),
+            user_roles=list(user.roles or []),
         )
     except NotFoundError:
         raise AppError(ErrorCode.PERSONA_PRESET_NOT_FOUND)

--- a/src/infra/persona_preset/manager.py
+++ b/src/infra/persona_preset/manager.py
@@ -273,21 +273,35 @@ class PersonaPresetManager:
         *,
         user_id: str,
         is_admin: bool,
+        user_roles: list[str] | None = None,
     ) -> PersonaPresetSnapshot:
+        """解析预设为运行时快照。
+
+        性能约定：这是每条带角色消息的热路径——无技能绑定就不查技能可用性，
+        无 MCP 绑定就不做可见性查询；绑定名按索引点查而非全表扫描；
+        user_roles 由调用方从 JWT 透传，免去用户表回查（未提供时才解析）。
+        """
         preset = await self.get_preset(preset_id, user_id=user_id, is_admin=is_admin)
-        available = await self._get_available_skill_names(user_id)
-        skill_names = [name for name in preset.skill_names if name in available]
-        missing = [name for name in preset.skill_names if name not in available]
+
+        if preset.skill_names:
+            available = await self._get_available_skill_names(user_id)
+            skill_names = [name for name in preset.skill_names if name in available]
+            missing = [name for name in preset.skill_names if name not in available]
+        else:
+            skill_names = []
+            missing = []
 
         # MCP 可见性校验：快照只保留当前用户可见的服务（全缺时不设白名单→放行全部，
         # 与技能语义一致）；不可见的记录进 missing 供前端提示。
-        visible_mcp = await self._get_visible_mcp_server_names(user_id, is_admin=is_admin)
-        if visible_mcp is None:
-            mcp_server_names = list(preset.mcp_server_names)
-            missing_mcp: list[str] = []
-        else:
-            mcp_server_names = [name for name in preset.mcp_server_names if name in visible_mcp]
-            missing_mcp = [name for name in preset.mcp_server_names if name not in visible_mcp]
+        mcp_server_names = []
+        missing_mcp: list[str] = []
+        for name in preset.mcp_server_names:
+            if await self._can_use_mcp_server(
+                name, user_id=user_id, is_admin=is_admin, user_roles=user_roles
+            ):
+                mcp_server_names.append(name)
+            else:
+                missing_mcp.append(name)
 
         await self.storage.increment_usage(preset_id)
         await self.storage.touch_user_preference(user_id=user_id, preset_id=preset_id)
@@ -304,22 +318,35 @@ class PersonaPresetManager:
             avatar=preset.avatar,
         )
 
-    async def _get_visible_mcp_server_names(
-        self, user_id: str, *, is_admin: bool
-    ) -> set[str] | None:
-        """当前用户可见的 MCP server 名集合；查询失败返回 None（跳过校验不阻塞）。"""
-        try:
-            from src.infra.mcp.quota import resolve_user_mcp_access
+    async def _can_use_mcp_server(
+        self,
+        name: str,
+        *,
+        user_id: str,
+        is_admin: bool,
+        user_roles: list[str] | None,
+    ) -> bool:
+        """按索引点查某 MCP server 对当前用户是否可见（等价 get_visible_servers 语义）。
 
-            user_roles, quota_admin = await resolve_user_mcp_access(user_id)
-            servers = await self.mcp_storage.get_visible_servers(
-                user_id,
-                is_admin=is_admin or quota_admin,
-                user_roles=user_roles,
-            )
-            return {server.name for server in servers}
+        查询失败按不可见处理并记录缺失，不阻塞对话。
+        """
+        try:
+            from src.infra.mcp.storage_operations import _can_access_system_server
+
+            server = await self.mcp_storage.get_system_server(name)
+            if server is not None:
+                if is_admin:
+                    return True
+                if user_roles is None:
+                    from src.infra.mcp.quota import resolve_user_mcp_access
+
+                    user_roles, _quota_admin = await resolve_user_mcp_access(user_id)
+                return _can_access_system_server(
+                    server.allowed_roles, user_roles, is_admin=is_admin
+                )
+            return await self.mcp_storage.get_user_server(name, user_id) is not None
         except Exception:
-            return None
+            return False
 
     async def _get_available_skill_names(self, user_id: str) -> set[str]:
         """Return skill names that can actually be loaded for this user."""

--- a/tests/agents/test_persona_preset_runtime.py
+++ b/tests/agents/test_persona_preset_runtime.py
@@ -134,7 +134,9 @@ async def test_resolve_persona_request_overwrites_client_persona_fields_from_pre
     )
 
     class _FakeManager:
-        async def use_preset(self, preset_id: str, *, user_id: str, is_admin: bool):
+        async def use_preset(
+            self, preset_id: str, *, user_id: str, is_admin: bool, user_roles=None
+        ):
             assert preset_id == "preset-1"
             assert user_id == "user-1"
             assert is_admin is True
@@ -179,7 +181,9 @@ async def test_resolve_persona_request_keeps_global_skills_when_preset_has_no_sk
     )
 
     class _FakeManager:
-        async def use_preset(self, preset_id: str, *, user_id: str, is_admin: bool):
+        async def use_preset(
+            self, preset_id: str, *, user_id: str, is_admin: bool, user_roles=None
+        ):
             return snapshot
 
     request = AgentRequest(
@@ -206,7 +210,9 @@ async def test_resolve_persona_request_keeps_global_skills_when_configured_skill
     )
 
     class _FakeManager:
-        async def use_preset(self, preset_id: str, *, user_id: str, is_admin: bool):
+        async def use_preset(
+            self, preset_id: str, *, user_id: str, is_admin: bool, user_roles=None
+        ):
             return snapshot
 
     request = AgentRequest(

--- a/tests/persona_preset/test_manager_mcp_binding.py
+++ b/tests/persona_preset/test_manager_mcp_binding.py
@@ -49,18 +49,30 @@ class FakePresetStorage:
 
 
 class FakeMCPStorage:
-    def __init__(self, visible_names: set[str]) -> None:
-        self._visible = visible_names
+    def __init__(self, system_servers: dict, user_servers: set) -> None:
+        self._system = system_servers
+        self._user = user_servers
+        self.point_lookups: list[str] = []
 
-    async def get_visible_servers(self, user_id, is_admin=False, user_roles=None, limit=None):
-        return [type("S", (), {"name": n})() for n in sorted(self._visible)]
+    async def get_system_server(self, name):
+        self.point_lookups.append(f"system:{name}")
+        doc = self._system.get(name)
+        if doc is None:
+            return None
+        return type("S", (), {"name": name, "allowed_roles": doc})()
+
+    async def get_user_server(self, name, user_id):
+        self.point_lookups.append(f"user:{name}")
+        return type("S", (), {"name": name})() if name in self._user else None
 
 
 class FakeSkillStorage:
     def __init__(self, names: set[str]) -> None:
         self._names = names
+        self.effective_calls = 0
 
     async def get_effective_skills(self, user_id: str) -> dict:
+        self.effective_calls += 1
         return {"skills": {name: {} for name in self._names}}
 
     async def get_all_user_skill_names(self, user_id: str) -> list[str]:
@@ -72,31 +84,19 @@ class FakeSkillStorage:
 
 def _make_manager(
     skill_names: set[str],
-    visible_mcp: set[str] | None = None,
-    quota_admin: bool = False,
+    system_mcp: dict | None = None,
+    user_mcp: set | None = None,
 ) -> PersonaPresetManager:
-    import src.infra.mcp.quota as quota_module
-
-    original = quota_module.resolve_user_mcp_access
-
-    async def _fake_resolve(user_id: str):
-        return ["user"], quota_admin
-
-    quota_module.resolve_user_mcp_access = _fake_resolve
-    manager = PersonaPresetManager(
+    return PersonaPresetManager(
         storage=FakePresetStorage(),
         skill_storage=FakeSkillStorage(skill_names),
-        mcp_storage=FakeMCPStorage(visible_mcp or set()),
+        mcp_storage=FakeMCPStorage(system_mcp or {}, user_mcp or set()),
     )
-    manager.__dict__["_restore_quota"] = lambda: setattr(
-        quota_module, "resolve_user_mcp_access", original
-    )
-    return manager
 
 
 async def test_use_preset_passes_mcp_whitelist_into_snapshot() -> None:
-    manager = _make_manager({"own-skill"}, visible_mcp={"arxiv", "weather"})
-    try:
+    manager = _make_manager({"own-skill"}, system_mcp={"arxiv": [], "weather": ["researcher"]})
+    if True:
         preset_id = (
             await manager.storage.create(
                 {
@@ -114,20 +114,22 @@ async def test_use_preset_passes_mcp_whitelist_into_snapshot() -> None:
             )
         )["id"]
 
-        snapshot = await manager.use_preset(preset_id, user_id="user-1", is_admin=False)
-    finally:
-        manager.__dict__["_restore_quota"]()
+        snapshot = await manager.use_preset(
+            preset_id, user_id="user-1", is_admin=False, user_roles=["user"]
+        )
 
     # 技能/MCP 均与用户实际可用集合求交集，缺失分别记录
     assert snapshot.skill_names == ["own-skill"]
     assert snapshot.missing_skill_names == ["gone-skill"]
-    assert snapshot.mcp_server_names == ["arxiv", "weather"]
-    assert snapshot.missing_mcp_server_names == []
+    assert snapshot.mcp_server_names == ["arxiv"]  # weather 限 researcher 角色，不可见
+    assert snapshot.missing_mcp_server_names == ["weather"]
+    # 点查路径：system 两次（weather 非用户服务不再查 user 表）
+    assert manager.mcp_storage.point_lookups == ["system:arxiv", "system:weather"]
 
 
 async def test_use_preset_drops_invisible_mcp_and_records_missing() -> None:
-    manager = _make_manager(set(), visible_mcp={"arxiv"})
-    try:
+    manager = _make_manager(set(), system_mcp={"arxiv": []})
+    if True:
         preset_id = (
             await manager.storage.create(
                 {
@@ -144,9 +146,9 @@ async def test_use_preset_drops_invisible_mcp_and_records_missing() -> None:
                 }
             )
         )["id"]
-        snapshot = await manager.use_preset(preset_id, user_id="user-1", is_admin=False)
-    finally:
-        manager.__dict__["_restore_quota"]()
+        snapshot = await manager.use_preset(
+            preset_id, user_id="user-1", is_admin=False, user_roles=["user"]
+        )
     assert snapshot.mcp_server_names == ["arxiv"]
     assert snapshot.missing_mcp_server_names == ["ghost"]
 
@@ -157,8 +159,8 @@ async def test_use_preset_all_mcp_missing_keeps_lenient_no_whitelist() -> None:
         _persona_enabled_mcp_servers_from_snapshot,
     )
 
-    manager = _make_manager(set(), visible_mcp=set())
-    try:
+    manager = _make_manager(set())
+    if True:
         preset_id = (
             await manager.storage.create(
                 {
@@ -175,9 +177,9 @@ async def test_use_preset_all_mcp_missing_keeps_lenient_no_whitelist() -> None:
                 }
             )
         )["id"]
-        snapshot = await manager.use_preset(preset_id, user_id="user-1", is_admin=False)
-    finally:
-        manager.__dict__["_restore_quota"]()
+        snapshot = await manager.use_preset(
+            preset_id, user_id="user-1", is_admin=False, user_roles=["user"]
+        )
     assert snapshot.mcp_server_names == []
     assert snapshot.missing_mcp_server_names == ["ghost"]
     assert _persona_enabled_mcp_servers_from_snapshot(snapshot) is None
@@ -203,3 +205,35 @@ async def test_copy_preset_carries_mcp_bindings() -> None:
     )["id"]
     copied = await manager.copy_preset(source_id, user_id="user-1", is_admin=True)
     assert copied.mcp_server_names == ["arxiv"]
+
+
+async def test_use_preset_without_bindings_skips_all_queries() -> None:
+    """热路径契约：无技能/MCP 绑定的预设不触发任何可用性/可见性查询。"""
+    manager = _make_manager({"some-skill"})
+    preset_id = (
+        await manager.storage.create(
+            {
+                "scope": "user",
+                "owner_user_id": "user-1",
+                "name": "Plain",
+                "system_prompt": "You chat.",
+                "starter_prompts": [],
+                "skill_names": [],
+                "mcp_server_names": [],
+                "visibility": "private",
+                "status": "published",
+                "version": 1,
+            }
+        )
+    )["id"]
+
+    snapshot = await manager.use_preset(
+        preset_id, user_id="user-1", is_admin=False, user_roles=["user"]
+    )
+
+    assert snapshot.skill_names == []
+    assert snapshot.mcp_server_names == []
+    assert snapshot.missing_skill_names == []
+    assert snapshot.missing_mcp_server_names == []
+    assert manager.skill_storage.effective_calls == 0
+    assert manager.mcp_storage.point_lookups == []


### PR DESCRIPTION
## 背景

`resolve_persona_request → use_preset` 是每条带角色消息的热路径。此前每次调用都：
1. 无条件查技能可用性（预设没有技能绑定时纯属浪费）
2. 无条件做 MCP 可见性校验：`resolve_user_mcp_access`（用户表回查 + 角色查询）+ `get_visible_servers`（system 全表扫 + user 扫 + preferences 读）

## 优化

| 项 | 之前 | 之后 |
|---|---|---|
| 零绑定预设 | 仍跑技能查询 + 3 集合扫描 + 用户回查 | **增量成本归零**（早退，契约测试锁定） |
| MCP 可见性 | get_visible_servers 三集合全表扫描 | 绑定名（通常 0-3 个）索引点查 `get_system_server`/`get_user_server` + `allowed_roles` 判定 |
| 角色来源 | resolve_user_mcp_access 回查用户表 | 调用方从 JWT TokenPayload 透传 `user_roles`（未提供才回退） |
| manager 实例 | 每请求新建 | `get_persona_preset_manager()` 单例 |
| 前端编辑器 | 每次打开拉技能列表 | 仅编辑含技能绑定的预设时拉取 |

## 行为不变

语义与 `get_visible_servers` 等价（allowed_roles 角色过滤 / admin 放行 / 用户自有服务）；全缺放行、缺失记录均保持。`tests/persona_preset/test_manager_mcp_binding.py` 含点查路径断言与零绑定零查询契约测试。

## 测试

- [x] 后端 4619 passed / 前端 2727 passed / lint / typecheck / build
- [ ] staging 部署后三场景行为复验