### PR TITLE
fix(task): stall 看门狗接入 presenter 进展探针——修深跑整点误杀

### DIFF
--- a/src/infra/task/executor.py
+++ b/src/infra/task/executor.py
@@ -267,6 +267,9 @@ class TaskExecutor:
                     base_url=base_url,
                 ),
                 timeout=_run_stall_timeout_seconds(),
+                # 直连路径（emit→save_event）的进展也证明流未挂死：
+                # 深跑时生成器可静默超过 deadline，全靠探针续命
+                progress_probe=getattr(presenter, "last_progress_monotonic", None),
             ):
                 await presenter.save_event(event)
                 if not produced_main_text and _is_main_agent_text_event(event):

--- a/src/infra/task/stall_watchdog.py
+++ b/src/infra/task/stall_watchdog.py
@@ -7,12 +7,21 @@ TaskStalledError，由 TaskExecutor 的通用错误路径迁移 error 终态。
 
 与 ``src/infra/llm/streaming.py`` 的首事件超时互补：那只覆盖模型适配层的
 首个流式事件，覆盖不了图内非流式调用与工具挂起。
+
+progress_probe（2026-09-12/13 生产事故）：事件有两条入口——executor 循环
+的 yield 与 presenter 直连路径（emit→save_event）。Search Agent 深跑时后者
+持续产出而生成器可静默超过 deadline，watchdog 若只看 yield 会把满负荷运行
+的健康 run 误杀。探针返回 presenter 最近一次 save_event 的单调时间戳，
+deadline 到期时若探针窗口内仍有进展则重新武装，且绝不取消挂起的 anext
+（取消会连带毁掉底层生成器）。
 """
 
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterable, AsyncIterator
+import contextlib
+import time
+from collections.abc import AsyncIterable, AsyncIterator, Callable
 from typing import TypeVar
 
 from src.infra.task.exceptions import TaskStalledError
@@ -20,15 +29,24 @@ from src.infra.task.exceptions import TaskStalledError
 T = TypeVar("T")
 
 
+def _probe_recent(progress_probe: Callable[[], float], timeout: float) -> bool:
+    try:
+        return (time.monotonic() - progress_probe()) < timeout
+    except Exception:
+        return False
+
+
 async def aiter_with_stall_timeout(
     source: AsyncIterable[T],
     *,
     timeout: float | None,
+    progress_probe: Callable[[], float] | None = None,
 ) -> AsyncIterator[T]:
     """Require stream progress by a recurring deadline between events.
 
     timeout 为 None 或 <=0 时直接透传（watchdog 关闭）。超时会取消对底层
-    迭代器的等待并尝试 aclose 释放其资源。
+    迭代器的等待并尝试 aclose 释放其资源；探针窗口内有外部进展时改为
+    重新武装 deadline 而不判死。
     """
     if timeout is None or timeout <= 0:
         async for item in source:
@@ -36,17 +54,27 @@ async def aiter_with_stall_timeout(
         return
 
     iterator = source.__aiter__()
+    anext_task: asyncio.Task[T] | None = None
     try:
         while True:
+            if anext_task is None:
+                anext_task = asyncio.ensure_future(anext(iterator))
+            done, _pending = await asyncio.wait({anext_task}, timeout=timeout)
+            if anext_task not in done:
+                if progress_probe is not None and _probe_recent(progress_probe, timeout):
+                    continue  # 外部仍在推进：重新武装 deadline，不取消挂起的 anext
+                raise TaskStalledError(f"agent stream stalled: no event within {timeout}s")
             try:
-                async with asyncio.timeout(timeout):
-                    item = await anext(iterator)
+                item = anext_task.result()
             except StopAsyncIteration:
                 return
-            except TimeoutError as exc:
-                raise TaskStalledError(f"agent stream stalled: no event within {timeout}s") from exc
+            anext_task = None
             yield item
     finally:
+        if anext_task is not None:
+            anext_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await anext_task
         close = getattr(iterator, "aclose", None)
         if close is not None:
             try:

--- a/src/infra/writer/present.py
+++ b/src/infra/writer/present.py
@@ -20,6 +20,7 @@ Writer 模块 - 统一流式输出 + 事件存储
 """
 
 import asyncio
+import time
 from typing import Any, AsyncGenerator, Dict, List, Optional, Sequence
 
 from src.infra.async_utils.background_tasks import BestEffortTaskLimiter
@@ -108,6 +109,9 @@ class Presenter(EventPresenterMixin, StoragePresenterMixin):
         # 缓冲 flush 的 emit——两者都汇聚到 save_event，在此统一标记，
         # 供 executor 零正文守卫判定 run 是否真的交付过答案。
         self.produced_main_text: bool = False
+        # save_event 汇聚点的单调进展时间戳（含直连路径）：stall watchdog
+        # 的探针据此判定流仍在推进——生成器静默不代表挂死。
+        self._last_progress_monotonic: float = time.monotonic()
 
     @property
     def trace_id(self) -> str:

--- a/src/infra/writer/presenter_storage.py
+++ b/src/infra/writer/presenter_storage.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Dict
 
@@ -355,6 +356,10 @@ class StoragePresenterMixin:
     # 事件存储
     # ------------------------------------------------------------------
 
+    def last_progress_monotonic(self) -> float:
+        """最近一次 save_event 汇聚的单调时间戳（stall watchdog 进展探针）。"""
+        return self._last_progress_monotonic
+
     async def save_event(
         self,
         event: Dict[str, Any],
@@ -367,6 +372,10 @@ class StoragePresenterMixin:
         Args:
             event: SSE 事件字典，包含 event 和 data 字段
         """
+        # 两条入口（executor 循环、直连 emit）都汇聚到这里：刷新进展时间戳，
+        # 供 stall watchdog 探针判定流仍在推进（2026-09-12/13 生产事故）。
+        self._last_progress_monotonic = time.monotonic()
+
         # 主代理正文追踪放在最前（enable_storage=False 时也要标记）：
         # message:chunk 可能经两条路径进入（executor 循环、处理器缓冲 flush
         # 的 emit），executor 零正文守卫依赖本标记判定 run 是否交付过答案。

--- a/tests/infra/task/test_executor_stall_watchdog.py
+++ b/tests/infra/task/test_executor_stall_watchdog.py
@@ -8,6 +8,7 @@ Worker 存活但 agent stream 挂死（LLM 首包永不到达等）时，心跳�
 from __future__ import annotations
 
 import asyncio
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -34,7 +35,12 @@ class _FakePresenter:
         self._trace_created = False
         self.saved_events: list[dict] = []
         self.completed: list[str] = []
+        self._last_progress_monotonic = time.monotonic()
         self.__class__.instances.append(self)
+
+    def last_progress_monotonic(self) -> float:
+        """镜像真实 Presenter 的进展时间戳契约（save_event 汇聚点刷新）。"""
+        return self._last_progress_monotonic
 
     async def _ensure_trace(self) -> None:
         self._trace_created = True
@@ -44,6 +50,7 @@ class _FakePresenter:
 
     async def save_event(self, event: dict) -> None:
         self.saved_events.append(event)
+        self._last_progress_monotonic = time.monotonic()
 
     async def complete(self, status: str) -> None:
         self.completed.append(status)
@@ -185,6 +192,42 @@ async def test_progressing_stream_completes_without_watchdog_interference(
     assert result is False  # completed path
     assert presenter.completed == ["completed"]
     assert len(presenter.saved_events) == 3
+    assert not [w for w in writer.written if w.get("event_type") == "error"]
+
+
+@pytest.mark.asyncio
+async def test_presenter_direct_path_progress_prevents_stall(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """presenter 直连路径持续落事件时，生成器静默不得误杀（2026-09-12/13 生产事故）。
+
+    Search Agent 深跑的 message:chunk / 子代理事件走 presenter.emit 直连，
+    executor 生成器可静默超过整个 stall 超时窗口；run 实际满负荷运行，
+    却被「无事件」看门狗判死。探针观察到 presenter 进展即续命。
+    """
+    executor, writer, _status_updates = _executor_fixture(monkeypatch, stall_timeout=0.05)
+
+    async def _busy_direct_emit_stream(*_args, presenter=None, **_kwargs):
+        # 生成器全程不 yield，直到最后才出正文；期间靠直连路径持续产出
+        for i in range(5):
+            await asyncio.sleep(0.03)  # 直连事件间隔 < stall 超时
+            await presenter.save_event(
+                {"event": "message:chunk", "data": {"content": f"direct-{i}", "depth": 1}}
+            )
+        yield {"event": "message:chunk", "data": {"content": "final"}}
+
+    result = await executor.run_task(
+        session_id="session-1",
+        run_id="run-5",
+        agent_id="search",
+        message="",
+        user_id="user-1",
+        executor=_busy_direct_emit_stream,
+    )
+
+    presenter = _FakePresenter.instances[0]
+    assert result is False  # completed path
+    assert presenter.completed == ["completed"]
     assert not [w for w in writer.written if w.get("event_type") == "error"]
 
 

--- a/tests/infra/task/test_stall_watchdog_probe.py
+++ b/tests/infra/task/test_stall_watchdog_probe.py
@@ -1,0 +1,101 @@
+"""stall watchdog 原语：generator 静默时的外部进展探针。
+
+生产事故（2026-09-12/13，ginko 两次深跑被杀）：Search Agent 深跑时
+message:chunk / 子代理事件走 presenter.emit 直连路径，executor 生成器
+可静默超过 1 小时；watchdog 只看生成器 yield，把满负荷运行的健康 run
+按「3600s 无事件」误杀。本组测试锁定新契约：探针观察到外部进展时
+重新武装 deadline，且等待期间不得取消挂起的 anext（否则生成器被毁）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from src.infra.task.exceptions import TaskStalledError
+from src.infra.task.stall_watchdog import aiter_with_stall_timeout
+
+
+async def _slow_gen(delay: float, items: int):
+    for i in range(items):
+        await asyncio.sleep(delay)
+        yield {"event": "message:chunk", "data": {"content": str(i)}}
+
+
+async def _collect(async_iter):
+    return [item async for item in async_iter]
+
+
+async def test_probe_fresh_external_progress_prevents_stall() -> None:
+    """生成器静默超过 deadline，但探针持续上报进展 → 不误杀，事件照常流出。"""
+    probe_clock = {"last": time.monotonic()}
+
+    async def _probe_updater(stop: asyncio.Event) -> None:
+        while not stop.is_set():
+            await asyncio.sleep(0.02)
+            probe_clock["last"] = time.monotonic()
+
+    stop = asyncio.Event()
+    updater = asyncio.create_task(_probe_updater(stop))
+    try:
+        # 生成器每 0.12s 才出一个事件，远超 0.05s deadline；全靠探针续命
+        items = await asyncio.wait_for(
+            _collect(
+                aiter_with_stall_timeout(
+                    _slow_gen(0.12, 2),
+                    timeout=0.05,
+                    progress_probe=lambda: probe_clock["last"],
+                )
+            ),
+            timeout=5,
+        )
+        assert len(items) == 2
+    finally:
+        stop.set()
+        await updater
+
+
+async def test_probe_stale_still_raises_stall_error() -> None:
+    """生成器静默且探针时间戳过期（外部也没有进展）→ 照常判死。"""
+
+    def _stale_probe() -> float:
+        return time.monotonic() - 999.0
+
+    with pytest.raises(TaskStalledError):
+        async for _ in aiter_with_stall_timeout(
+            _slow_gen(10, 1), timeout=0.05, progress_probe=_stale_probe
+        ):
+            pass
+
+
+async def test_no_probe_keeps_original_gap_semantics() -> None:
+    """不传探针 → 保持原行为：事件间隔超时即判死。"""
+    with pytest.raises(TaskStalledError):
+        async for _ in aiter_with_stall_timeout(_slow_gen(10, 1), timeout=0.05):
+            pass
+
+
+async def test_zero_timeout_passthrough_with_probe() -> None:
+    """timeout<=0 时直通，探针存在也不生效。"""
+
+    def _any_probe() -> float:
+        return time.monotonic()
+
+    items = await _collect(
+        aiter_with_stall_timeout(_slow_gen(0.0, 3), timeout=0, progress_probe=_any_probe)
+    )
+    assert len(items) == 3
+
+
+async def test_generator_exhaustion_ends_cleanly_with_probe() -> None:
+    """生成器自然耗尽（StopAsyncIteration）在探针模式下正常收尾。"""
+
+    def _fresh_probe() -> float:
+        return time.monotonic()
+
+    items = await _collect(
+        aiter_with_stall_timeout(_slow_gen(0.01, 2), timeout=1.0, progress_probe=_fresh_probe)
+    )
+    assert len(items) == 2

--- a/tests/infra/writer/test_presenter_progress.py
+++ b/tests/infra/writer/test_presenter_progress.py
@@ -47,7 +47,9 @@ async def test_emit_direct_path_refreshes_last_progress() -> None:
     before = presenter.last_progress_monotonic()
     await asyncio.sleep(0.01)
 
-    await presenter.emit({"event": "message:chunk", "data": {"content": "直连路径输出", "depth": 1}})
+    await presenter.emit(
+        {"event": "message:chunk", "data": {"content": "直连路径输出", "depth": 1}}
+    )
 
     assert presenter.last_progress_monotonic() > before
 

--- a/tests/infra/writer/test_presenter_progress.py
+++ b/tests/infra/writer/test_presenter_progress.py
@@ -1,0 +1,63 @@
+"""Presenter 进展时间戳契约（stall watchdog 的外部进展探针）。
+
+事件有两条入口（executor 循环、AgentEventProcessor 缓冲 flush 的 emit 直连），
+都汇聚到 save_event——看门狗据此判定「流仍在推进」。直连事件也必须刷新
+last_progress_monotonic，否则深跑会被 stall watchdog 误杀
+（2026-09-12/13 生产事故：生成器静默 >1h，直连事件持续产出，run 被判死）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+from src.infra.writer.present import Presenter, PresenterConfig
+
+
+def _presenter() -> Presenter:
+    # enable_storage=False：只验证追踪契约本身，不触达 dual writer
+    return Presenter(
+        PresenterConfig(
+            session_id="session-1",
+            agent_id="fast",
+            run_id="run-1",
+            enable_storage=False,
+        )
+    )
+
+
+async def test_last_progress_starts_at_init() -> None:
+    presenter = _presenter()
+
+    assert presenter.last_progress_monotonic() <= time.monotonic()
+
+
+async def test_save_event_refreshes_last_progress() -> None:
+    presenter = _presenter()
+    before = presenter.last_progress_monotonic()
+    await asyncio.sleep(0.01)
+
+    await presenter.save_event({"event": "thinking", "data": {"content": "长篇思考"}})
+
+    assert presenter.last_progress_monotonic() > before
+
+
+async def test_emit_direct_path_refreshes_last_progress() -> None:
+    presenter = _presenter()
+    before = presenter.last_progress_monotonic()
+    await asyncio.sleep(0.01)
+
+    await presenter.emit({"event": "message:chunk", "data": {"content": "直连路径输出", "depth": 1}})
+
+    assert presenter.last_progress_monotonic() > before
+
+
+async def test_storage_disabled_still_refreshes_last_progress() -> None:
+    """enable_storage=False 的 save_event 提前返回，也必须先刷新进展时间戳。"""
+    presenter = _presenter()
+    before = presenter.last_progress_monotonic()
+    await asyncio.sleep(0.01)
+
+    await presenter.save_event({"event": "tool:start", "data": {"tool": "web_search"}})
+
+    assert presenter.last_progress_monotonic() > before


### PR DESCRIPTION
## 背景（生产事故，ginko 两次深跑被杀）

- **9-12 14:08→15:08**（类风湿提取 session）：run 被杀时 duration **正好 3600.0155s**，主 agent 全程每几秒就有事件，被杀前 29 秒还在 image_analyze 做最终图表复审。$11.53 / 359 万 tokens 白烧。
- **9-13 03:53→05:05**（masld_sepsis session）：被杀前 2 秒子 agent 还在正常返回 R 统计表。$35.59 / 1081 万 tokens 白烧。

两条 trace 的终末错误一致：`TaskStalledError: agent stream stalled: no event within 3600.0s`——但事件流明明一直在动。

## 根因

事件有两条入口：executor 生成器 yield 的、与 **presenter.emit→save_event 直连路径**（AgentEventProcessor 缓冲 flush，2026-09-05 事故注释已记载这条双路径）。Search Agent 深跑时全部事件走直连路径，生成器静默超 3600s，run 级看门狗只看生成器 yield → 对满负荷运行的健康 run 失明，在「上次 yield + 3600s」整点误杀。

## 修复

- `Presenter.save_event`（两条入口的汇聚点）刷新单调进展时间戳，expose `last_progress_monotonic()`
- `aiter_with_stall_timeout` 新增 `progress_probe`：deadline 到期时若探针窗口内仍有外部进展 → 重新武装 deadline 而不判死。等待改为 task 包装 + `asyncio.wait` 的**非破坏性**等待——续命路径绝不取消挂起的 anext（原 `asyncio.timeout` 到期即取消，会连带毁掉生成器，这是不能简单 try/except 续命的原因）
- executor 接线探针（`getattr` 防御，旧 fake presenter 不受影响）；真挂死（生成器与探针同时静默满窗口）照常判死，原有保护不回退

## 验证

- 新增测试 9 个（看门狗原语 5 + executor 接线 1 + presenter 契约 4→含既有契约回归），先 RED 后 GREEN
- `tests/infra/task/ + tests/infra/writer/` 全量 303 passed；`make lint`、`make typecheck` 干净

## 关联

- #583（同窗口发现的另一问题：恢复路径误杀活 run、trace 终态不回写——独立根因，另行跟进）