### PR TITLE
fix(llm): prompt cache key 跨 context 崩溃热修——看门狗逐事件 Task 副本兼容

### DIFF
--- a/src/agents/core/base.py
+++ b/src/agents/core/base.py
@@ -19,7 +19,6 @@ from src.agents.core.trace_finalizer import complete_owned_presenter_trace
 from src.infra.agent import AgentEventProcessor
 from src.infra.async_utils import run_blocking_io
 from src.infra.llm.responses_cache import (
-    reset_responses_prompt_cache_key,
     session_prompt_cache_key,
     set_responses_prompt_cache_key,
 )
@@ -334,12 +333,13 @@ class BaseGraphAgent(ABC):
         入口：graph 任务（ensure_future/create_task 复制当前上下文）与嵌套
         子 agent 都继承同一个 key，对齐 Codex 的会话级缓存路由语义。
         """
-        cache_key_token = set_responses_prompt_cache_key(session_id)
-        try:
-            async for event in self._stream(message, session_id, user_id=user_id, **kwargs):
-                yield event
-        finally:
-            reset_responses_prompt_cache_key(cache_key_token)
+        # 每轮事件重新绑定（而非入口 set + finally reset）：stall 看门狗会把
+        # 每个 __anext__ 包成独立 asyncio.Task（context 副本），入口 set 的值
+        # 无法跨副本可见，token 复位还会跨 context 报错。幂等 set 让每个副本
+        # 都拿到会话级 key；key 随副本消亡，无需复位。
+        async for event in self._stream(message, session_id, user_id=user_id, **kwargs):
+            set_responses_prompt_cache_key(session_id)
+            yield event
 
     async def _stream(
         self,

--- a/src/infra/llm/responses_cache.py
+++ b/src/infra/llm/responses_cache.py
@@ -47,9 +47,21 @@ def set_responses_prompt_cache_key(session_id: object) -> Token[Optional[str]]:
 
 
 def reset_responses_prompt_cache_key(token: Token[Optional[str]]) -> None:
-    """恢复 set 之前的上下文值（token 为 None 时无操作）。"""
-    if token is not None:
+    """恢复 set 之前的上下文值（token 为 None 时无操作）。
+
+    跨 context 防御：stall 看门狗（aiter_with_stall_timeout）把每个
+    ``__anext__`` 包成独立 asyncio.Task，生成器体内 set 的 token 可能落在
+    另一个 context 副本里，reset 会抛
+    ``ValueError: Token was created in a different Context``（生产事故：
+    main-20260913-081350 普通对话全挂）。此时降级为无操作——key 是会话级
+    路由提示，随所在 context 副本一起消亡，不污染外层。
+    """
+    if token is None:
+        return
+    try:
         _responses_prompt_cache_key.reset(token)
+    except ValueError:
+        pass
 
 
 def current_responses_prompt_cache_key() -> Optional[str]:

--- a/tests/infra/llm/test_responses_cache_context.py
+++ b/tests/infra/llm/test_responses_cache_context.py
@@ -1,0 +1,56 @@
+"""responses prompt cache key 的跨 context 安全性回归。
+
+生产事故（main-20260913-081350）：stall 看门狗把每个 __anext__ 包成独立
+asyncio.Task（context 副本），36072e4a 的入口 set + finally reset 组合导致
+「Token was created in a different Context」崩溃且后续事件丢失 key。
+"""
+
+import asyncio
+
+from src.infra.llm.responses_cache import (
+    current_responses_prompt_cache_key,
+    reset_responses_prompt_cache_key,
+    set_responses_prompt_cache_key,
+)
+
+
+async def test_reset_in_different_context_degrades_silently():
+    """token 在别的 context 副本里 reset 不再抛 ValueError。"""
+    import contextvars
+
+    token_holder = {}
+    ctx_a = contextvars.copy_context()
+    ctx_a.run(lambda: token_holder.setdefault("token", set_responses_prompt_cache_key("session-a")))
+
+    ctx_b = contextvars.copy_context()
+    # 事故现场：token 属于 ctx_a，在 ctx_b 里 reset 此前抛 ValueError
+    ctx_b.run(lambda: reset_responses_prompt_cache_key(token_holder["token"]))
+
+
+async def test_rebind_per_event_survives_task_copies():
+    """模拟看门狗迭代：每个 __anext__ 是独立 Task（context 副本）。"""
+
+    async def agent_like_stream(session_id):
+        for i in range(3):
+            from src.infra.llm.responses_cache import set_responses_prompt_cache_key
+
+            set_responses_prompt_cache_key(session_id)
+            yield {"i": i, "key": current_responses_prompt_cache_key()}
+
+    async def consume_like_watchdog():
+        it = agent_like_stream("session-x")
+        keys = []
+        while True:
+            task = asyncio.ensure_future(it.__anext__())
+            done, _ = await asyncio.wait({task})
+            if task.cancelled():
+                break
+            try:
+                event = task.result()
+            except StopAsyncIteration:
+                break
+            keys.append(event["key"])
+        return keys
+
+    keys = await consume_like_watchdog()
+    assert keys == ["session-x", "session-x", "session-x"]

--- a/tests/infra/llm/test_responses_kv_cache.py
+++ b/tests/infra/llm/test_responses_kv_cache.py
@@ -189,9 +189,10 @@ def test_overlong_session_id_is_truncated() -> None:
 def test_base_graph_agent_binds_session_key_around_graph_execution() -> None:
     # fast/search/team 各自重写 _stream，绑定必须放在未被重写的公共入口：
     # stream() → _stream_with_cache_key() → self._stream(...)
+    # 热修（跨 context 安全）：每轮事件幂等 set（看门狗把每个 __anext__ 包成
+    # 独立 Task/context 副本，入口 set + finally reset 会跨 context 崩溃）。
     assert "return self._stream_with_cache_key(" in AGENTS_BASE_SOURCE
     assert "set_responses_prompt_cache_key(session_id)" in AGENTS_BASE_SOURCE
-    assert "reset_responses_prompt_cache_key(cache_key_token)" in AGENTS_BASE_SOURCE
     assert "async for event in self._stream(message, session_id" in AGENTS_BASE_SOURCE
     assert "session_prompt_cache_key(session_id)" in AGENTS_BASE_SOURCE
 


### PR DESCRIPTION
P0 热修：#584 看门狗逐事件 Task（context 副本）× 36072e4a ContextVar 入口 set+finally reset 组合导致 ValueError 崩溃与 key 丢失（main-20260913-081350 普通对话全挂，已回滚止血）。修复：stream() 每轮幂等 set；reset 跨 context 降级。含事故复现回归测试。后端 4631 passed。