### PR TITLE
chore(release): 版本晋升 2.11.0

### DIFF
--- a/client/lambchat_sandbox/__init__.py
+++ b/client/lambchat_sandbox/__init__.py
@@ -11,4 +11,4 @@ self-update 与服务端最低版本拒连打底。
 2.x/0.3.x 均放行，旧 daemon 经 self-update 平滑升到对齐版本。
 """
 
-__version__ = "2.10.3"
+__version__ = "2.11.0"

--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.lambchat.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 2103
-        versionName "2.10.3"
+        versionCode 2110
+        versionName "2.11.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/frontend/ios/App/App.xcodeproj/project.pbxproj
+++ b/frontend/ios/App/App.xcodeproj/project.pbxproj
@@ -352,7 +352,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 2.10.3;
+				MARKETING_VERSION = 2.11.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.lambchat.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -372,7 +372,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 2.10.3;
+				MARKETING_VERSION = 2.11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lambchat.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lambchat-frontend",
   "private": true,
-  "version": "2.10.3",
+  "version": "2.11.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "lambchat"
-version = "2.10.3"
+version = "2.11.0"
 dependencies = [
  "command-group",
  "libc",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambchat"
-version = "2.10.3"
+version = "2.11.0"
 description = "LambChat desktop app"
 authors = ["LambChat"]
 license = ""

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LambChat",
-  "version": "2.10.3",
+  "version": "2.11.0",
   "identifier": "com.lambchat.app",
   "build": {
     "frontendDist": "../dist",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lambchat"
-version = "2.10.3"
+version = "2.11.0"
 description = "Full-featured AI Agent system with FastAPI, LangGraph, and LangSmith"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
v2.10.3 → v2.11.0 八处版本文件同步（含 Cargo.lock lambchat 条目与 android versionCode=2110）。主要变更：角色 MCP 绑定与运行时白名单、绑定可见性加固、use_preset 热路径优化、MCP 根路由斜杠修复、看门狗×ContextVar P0 热修、stall/HITL 任务修复。