### PR TITLE
chore(promote): develop → main 晋升 v2.11.0

### DIFF
--- a/client/lambchat_sandbox/__init__.py
+++ b/client/lambchat_sandbox/__init__.py
@@ -11,4 +11,4 @@ self-update 与服务端最低版本拒连打底。
 2.x/0.3.x 均放行，旧 daemon 经 self-update 平滑升到对齐版本。
 """
 
-__version__ = "2.10.3"
+__version__ = "2.11.0"

--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.lambchat.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 2103
-        versionName "2.10.3"
+        versionCode 2110
+        versionName "2.11.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/frontend/ios/App/App.xcodeproj/project.pbxproj
+++ b/frontend/ios/App/App.xcodeproj/project.pbxproj
@@ -352,7 +352,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 2.10.3;
+				MARKETING_VERSION = 2.11.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.lambchat.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -372,7 +372,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 2.10.3;
+				MARKETING_VERSION = 2.11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lambchat.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lambchat-frontend",
   "private": true,
-  "version": "2.10.3",
+  "version": "2.11.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "lambchat"
-version = "2.10.3"
+version = "2.11.0"
 dependencies = [
  "command-group",
  "libc",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambchat"
-version = "2.10.3"
+version = "2.11.0"
 description = "LambChat desktop app"
 authors = ["LambChat"]
 license = ""

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LambChat",
-  "version": "2.10.3",
+  "version": "2.11.0",
   "identifier": "com.lambchat.app",
   "build": {
     "frontendDist": "../dist",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lambchat"
-version = "2.10.3"
+version = "2.11.0"
 description = "Full-featured AI Agent system with FastAPI, LangGraph, and LangSmith"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/infra/session/trace_attachment_cleanup.py
+++ b/src/infra/session/trace_attachment_cleanup.py
@@ -48,23 +48,23 @@ class TraceAttachmentCleanupMixin:
         """
         current = now if now is not None else utc_now()
         stale_before = current - ttl
+        # HITL 挂起（等人工输入）期间事件天然停流，updated_at 不刷新，但不是
+        # 僵尸——据 metadata.waiting_human 豁免（#583）。会话删除路径
+        # （expire_stale_running_traces）不豁免：用户删会话时删除必须赢。
+        base_query: Dict[str, Any] = {
+            "status": "running",
+            "updated_at": {"$lte": stale_before},
+            "metadata.waiting_human": {"$ne": True},
+        }
         try:
-            cursor = (
-                self.collection.find(
-                    {"status": "running", "updated_at": {"$lte": stale_before}},
-                    {"_id": 1},
-                )
-                .sort("updated_at", 1)
-                .limit(limit)
-            )
+            cursor = self.collection.find(base_query, {"_id": 1}).sort("updated_at", 1).limit(limit)
             docs = await cursor.to_list(length=limit)
             if not docs:
                 return 0
             result = await self.collection.update_many(
                 {
                     "_id": {"$in": [doc["_id"] for doc in docs]},
-                    "status": "running",
-                    "updated_at": {"$lte": stale_before},
+                    **base_query,
                 },
                 {
                     "$set": {

--- a/src/infra/session/trace_storage_writes.py
+++ b/src/infra/session/trace_storage_writes.py
@@ -396,6 +396,23 @@ class TraceStorageWriteMixin:
             logger.error(f"Failed to complete trace {trace_id}: {e}")
             return False
 
+    async def set_trace_waiting_human(self, trace_id: str, *, waiting: bool = True) -> bool:
+        """标记/清除 HITL 挂起（#583）。
+
+        等人工输入期间事件停流、updated_at 不再刷新，全局僵尸清扫
+        （expire_stale_running_traces_globally）据 metadata.waiting_human=True
+        豁免；恢复时清除。失败只返回 False，由调用方降级为日志。
+        """
+        try:
+            result = await self.collection.update_one(
+                {"trace_id": trace_id},
+                {"$set": {"metadata.waiting_human": waiting}},
+            )
+            return result.modified_count > 0
+        except Exception as e:
+            logger.warning("Failed to set waiting_human=%s on trace %s: %s", waiting, trace_id, e)
+            return False
+
     async def reopen_interrupted_trace(self, trace_id: str) -> bool:
         """Reopen an error-finalized trace so a seamless resume can append events.
 

--- a/src/infra/task/executor.py
+++ b/src/infra/task/executor.py
@@ -221,6 +221,8 @@ class TaskExecutor:
                 )
 
             if hitl_resume is not None:
+                # HITL 恢复：清除挂起标记（挂起期间它让全局僵尸清扫豁免本 trace）
+                await self._set_trace_waiting_human(presenter.trace_id, waiting=False)
                 resolved = hitl_resume.get("approval_resolved")
                 if isinstance(resolved, dict):
                     await presenter.save_event({"event": "approval_resolved", "data": resolved})
@@ -277,6 +279,9 @@ class TaskExecutor:
 
             # interrupt 模式挂起（issue #218）：保留 checkpoint，标记 WAITING_HUMAN
             if presenter is not None and getattr(presenter, "hitl_suspended", False):
+                # 等人工输入期间事件停流、updated_at 不刷新；打 waiting_human 标记
+                # 让全局僵尸清扫豁免（#583：挂起 10 分钟被误终态为 error）
+                await self._set_trace_waiting_human(presenter.trace_id, waiting=True)
                 if dual_writer is not None:
                     try:
                         await dual_writer.flush_mongo_buffer(require_empty=True)
@@ -339,6 +344,15 @@ class TaskExecutor:
             # 清除请求上下文，防止 contextvars 泄漏到后续任务
             TraceContext.clear_request_context()
             TraceContext.clear()
+
+    async def _set_trace_waiting_human(self, trace_id: str, *, waiting: bool) -> None:
+        """HITL 挂起标记（#583）：失败只降级为日志，不影响挂起/恢复主流程。"""
+        try:
+            from src.infra.session.trace_storage import get_trace_storage
+
+            await get_trace_storage().set_trace_waiting_human(trace_id, waiting=waiting)
+        except Exception as e:
+            logger.warning("Failed to mark trace %s waiting_human=%s: %s", trace_id, waiting, e)
 
     async def _handle_cancelled_error(
         self,

--- a/src/infra/task/hitl.py
+++ b/src/infra/task/hitl.py
@@ -524,6 +524,27 @@ async def submit_hitl_resume_run(
             "recommendation_input": resume_context.get("recommendation_input"),
             "auto_mode": bool(metadata.get("auto_mode", False)),
         }
+        if source_trace_id:
+            # 挂起等审批超过 10 分钟时，全局僵尸清扫会把 updated_at 过期的
+            # trace 误终态为 error（#583）。恢复前重开（error→running，幂等），
+            # 否则跑完后 complete_trace 被终态保护拒绝，trace 永远停在 error。
+            try:
+                from src.infra.session.trace_storage import get_trace_storage
+
+                reopened = await get_trace_storage().reopen_interrupted_trace(source_trace_id)
+                if reopened:
+                    logger.info(
+                        "[HITL] approval_id=%s Reopened error-finalized trace %s before resume",
+                        approval.id,
+                        source_trace_id,
+                    )
+            except Exception as e:
+                logger.warning(
+                    "[HITL] approval_id=%s Failed to reopen trace %s before resume: %s",
+                    approval.id,
+                    source_trace_id,
+                    e,
+                )
         if getattr(settings, "TASK_BACKEND", "local") == "arq":
             dispatch_id = resume_attempt_id or f"hitl-resume:{approval.id}:{uuid.uuid4().hex}"
             run_id, _ = await manager.submit_arq(

--- a/tests/infra/session/test_stale_trace_global_expiry.py
+++ b/tests/infra/session/test_stale_trace_global_expiry.py
@@ -19,20 +19,25 @@ CUTOFF = datetime(2026, 9, 5, 12, 0, tzinfo=timezone.utc)
 
 
 class _GlobalExpiryCollection:
-    """支持 find(status/updated_at 过滤 + sort + limit) 与 update_many($in) 的假集合。"""
+    """支持 find(status/updated_at/waiting_human 过滤) + sort + limit 与 update_many($in) 的假集合。"""
 
     def __init__(self, docs: list[dict]) -> None:
         self.docs = docs
         self.update_queries: list[dict] = []
 
+    @staticmethod
+    def _matches(doc: dict, query: dict) -> bool:
+        if doc.get("status") != query.get("status"):
+            return False
+        if "updated_at" in query and doc.get("updated_at") > query["updated_at"]["$lte"]:
+            return False
+        if query.get("metadata.waiting_human") == {"$ne": True}:
+            if (doc.get("metadata") or {}).get("waiting_human") is True:
+                return False
+        return True
+
     def find(self, query: dict, _projection: dict | None = None) -> "_GlobalExpiryCollection":
-        matched = [
-            doc
-            for doc in self.docs
-            if doc.get("status") == query.get("status")
-            and doc.get("updated_at") <= query["updated_at"]["$lte"]
-        ]
-        self._matched = matched
+        self._matched = [doc for doc in self.docs if self._matches(doc, query)]
         return self
 
     def sort(self, _key: str, _direction: int) -> "_GlobalExpiryCollection":
@@ -51,7 +56,7 @@ class _GlobalExpiryCollection:
         ids = set(query["_id"]["$in"])
         modified = 0
         for doc in self.docs:
-            if doc["_id"] in ids and doc.get("status") == query["status"]:
+            if doc["_id"] in ids and self._matches(doc, query):
                 doc.update(
                     status=update["$set"]["status"],
                     completed_at=update["$set"]["completed_at"],
@@ -145,3 +150,58 @@ async def test_expiry_swallows_collection_errors() -> None:
     storage._collection = _Broken()
 
     assert await storage.expire_stale_running_traces_globally(now=CUTOFF) == 0
+
+
+def _waiting_human_trace(doc_id: str, age_minutes: int) -> dict:
+    doc = _trace(doc_id, "running", age_minutes)
+    doc["metadata"] = {"waiting_human": True}
+    return doc
+
+
+@pytest.mark.asyncio
+async def test_expiry_skips_waiting_human_traces() -> None:
+    """HITL 挂起等人工输入时事件天然停流，不是僵尸（#583）——全局清扫必须豁免。"""
+    docs = [
+        _waiting_human_trace("waiting-old", age_minutes=120),
+        _trace("stale-old", "running", age_minutes=120),
+    ]
+    storage, _collection = _storage_with(docs)
+
+    count = await storage.expire_stale_running_traces_globally(now=CUTOFF)
+
+    by_id = {doc["_id"]: doc for doc in docs}
+    assert count == 1
+    assert by_id["waiting-old"]["status"] == "running"
+    assert by_id["stale-old"]["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_session_deletion_expiry_still_expires_waiting_human() -> None:
+    """会话删除路径不豁免挂起 trace：用户删会话时删除必须赢（锁定语义，防过度豁免）。"""
+    docs = [_waiting_human_trace("waiting-old", age_minutes=120)]
+    storage = TraceStorage()
+
+    class _DelCollection:
+        def __init__(self) -> None:
+            self.queries: list[dict] = []
+
+        async def update_many(self, query: dict, update: dict) -> SimpleNamespace:
+            self.queries.append(query)
+            matched = [
+                doc
+                for doc in docs
+                if doc.get("session_id") == query.get("session_id")
+                and doc.get("status") == query.get("status")
+                and doc.get("updated_at") <= query["updated_at"]["$lte"]
+            ]
+            for doc in matched:
+                doc["status"] = update["$set"]["status"]
+            return SimpleNamespace(modified_count=len(matched))
+
+    del_collection = _DelCollection()
+    storage._collection = del_collection
+
+    count = await storage.expire_stale_running_traces("session-waiting-old", now=CUTOFF)
+
+    assert count == 1
+    assert docs[0]["status"] == "error"

--- a/tests/infra/session/test_trace_waiting_human_marker.py
+++ b/tests/infra/session/test_trace_waiting_human_marker.py
@@ -1,0 +1,75 @@
+"""Trace waiting_human 标记契约（#583）。
+
+HITL 挂起等人工输入期间事件停流，trace 的 updated_at 不再刷新；全局僵尸
+清扫（expire_stale_running_traces_globally）据 metadata.waiting_human=True
+豁免，恢复时清除。标记写入失败只降级为日志，不得影响挂起/恢复主流程。
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from src.infra.session.trace_storage import TraceStorage
+
+
+class _MarkerCollection:
+    def __init__(self, docs: list[dict]) -> None:
+        self.docs = docs
+        self.updates: list[tuple[dict, dict]] = []
+
+    async def update_one(self, query: dict, update: dict) -> SimpleNamespace:
+        self.updates.append((query, update))
+        for doc in self.docs:
+            if doc.get("trace_id") == query.get("trace_id"):
+                doc.setdefault("metadata", {}).update(
+                    {"waiting_human": update["$set"]["metadata.waiting_human"]}
+                )
+                return SimpleNamespace(modified_count=1)
+        return SimpleNamespace(modified_count=0)
+
+
+def _storage_with(docs: list[dict]) -> tuple[TraceStorage, _MarkerCollection]:
+    storage = TraceStorage()
+    collection = _MarkerCollection(docs)
+    storage._collection = collection
+    return storage, collection
+
+
+async def test_set_waiting_human_marks_metadata_flag() -> None:
+    docs = [{"trace_id": "trace-1", "status": "running", "metadata": {}}]
+    storage, _collection = _storage_with(docs)
+
+    ok = await storage.set_trace_waiting_human("trace-1", waiting=True)
+
+    assert ok is True
+    assert docs[0]["metadata"]["waiting_human"] is True
+
+
+async def test_clear_waiting_human_unmarks_flag() -> None:
+    docs = [{"trace_id": "trace-1", "status": "running", "metadata": {"waiting_human": True}}]
+    storage, _collection = _storage_with(docs)
+
+    ok = await storage.set_trace_waiting_human("trace-1", waiting=False)
+
+    assert ok is True
+    assert docs[0]["metadata"]["waiting_human"] is False
+
+
+async def test_set_waiting_human_on_missing_trace_returns_false() -> None:
+    storage, _collection = _storage_with([])
+
+    ok = await storage.set_trace_waiting_human("trace-none", waiting=True)
+
+    assert ok is False
+
+
+async def test_set_waiting_human_swallows_collection_errors() -> None:
+    storage = TraceStorage()
+
+    class _Broken:
+        async def update_one(self, *_args, **_kwargs):
+            raise RuntimeError("mongo down")
+
+    storage._collection = _Broken()
+
+    assert await storage.set_trace_waiting_human("trace-1", waiting=True) is False

--- a/tests/infra/task/test_executor_hitl_trace_marker.py
+++ b/tests/infra/task/test_executor_hitl_trace_marker.py
@@ -1,0 +1,157 @@
+"""executor 对 HITL 挂起/恢复的 trace 标记（#583）。
+
+挂起（WAITING_HUMAN）时给 trace 打 metadata.waiting_human=True——等人工
+输入期间事件停流，updated_at 不再刷新，全局僵尸清扫据此豁免；恢复
+（hitl_resume）时清除标记。标记失败只降级为日志，不得影响主流程。
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import src.infra.session.trace_storage as trace_storage_mod
+from src.infra.task.executor import TaskExecutor
+from src.kernel.config import settings
+
+
+class _FakeHeartbeat:
+    async def start(self, run_id: str, *, user_id: str | None = None) -> None:
+        return None
+
+    async def stop(self, run_id: str) -> None:
+        return None
+
+
+class _FakePresenter:
+    def __init__(self, config) -> None:
+        self.trace_id = config.trace_id or "trace-1"
+        self.run_id = config.run_id
+        self.hitl_suspended: bool = False
+        self.saved_events: list[dict] = []
+        self.completed: list[str] = []
+
+    async def _ensure_trace(self) -> None:
+        return None
+
+    async def emit_user_message(self, message: str, **_kwargs) -> None:
+        return None
+
+    async def save_event(self, event: dict) -> None:
+        self.saved_events.append(event)
+
+    async def complete(self, status: str) -> None:
+        self.completed.append(status)
+
+
+class _RecordingWriter:
+    async def _flush_redis_buffer(self, **_kwargs) -> None:
+        return None
+
+    async def flush_mongo_buffer(self, **_kwargs) -> None:
+        return None
+
+    async def write_event(self, **_kwargs) -> None:
+        return None
+
+    async def expire_stream(self, *_args, **_kwargs) -> None:
+        return None
+
+
+class _FakeTraceStorage:
+    def __init__(self) -> None:
+        self.waiting_calls: list[tuple[str, bool]] = []
+
+    async def set_trace_waiting_human(self, trace_id: str, *, waiting: bool) -> bool:
+        self.waiting_calls.append((trace_id, waiting))
+        return True
+
+
+def _executor_fixture(monkeypatch: pytest.MonkeyPatch) -> tuple[TaskExecutor, _FakeTraceStorage]:
+    from src.infra.task import cancellation
+
+    monkeypatch.setattr(settings, "TASK_RUN_STALL_TIMEOUT", 0)
+    monkeypatch.setattr("src.infra.writer.present.Presenter", _FakePresenter)
+    monkeypatch.setattr("src.infra.task.executor.get_dual_writer", lambda: _RecordingWriter())
+
+    async def _no_op(*_args, **_kwargs) -> None:
+        return None
+
+    monkeypatch.setattr(cancellation.TaskCancellation, "clear_interrupt", _no_op)
+
+    trace_storage = _FakeTraceStorage()
+    monkeypatch.setattr(trace_storage_mod, "get_trace_storage", lambda: trace_storage)
+
+    async def _record_status(session_id, status, error=None, run_id=None):
+        return None
+
+    executor = TaskExecutor(
+        storage=SimpleNamespace(),  # type: ignore[arg-type]
+        run_info={},
+        heartbeat_manager=_FakeHeartbeat(),
+    )
+    monkeypatch.setattr(executor, "_update_session_status", _record_status)
+    monkeypatch.setattr(executor, "_send_task_notification", _no_op)
+    monkeypatch.setattr(executor, "_expire_terminal_stream", _no_op)
+    return executor, trace_storage
+
+
+@pytest.mark.asyncio
+async def test_hitl_suspension_marks_trace_waiting_human(monkeypatch: pytest.MonkeyPatch) -> None:
+    executor, trace_storage = _executor_fixture(monkeypatch)
+
+    async def _suspending_stream(*_args, presenter=None, **_kwargs):
+        presenter.hitl_suspended = True
+        yield {"event": "message:chunk", "data": {"content": "需要审批"}}
+
+    result = await executor.run_task(
+        session_id="session-1",
+        run_id="run-1",
+        agent_id="search",
+        message="",
+        user_id="user-1",
+        executor=_suspending_stream,
+    )
+
+    assert result is True  # WAITING_HUMAN 挂起路径
+    assert ("trace-1", True) in trace_storage.waiting_calls
+
+
+@pytest.mark.asyncio
+async def test_hitl_resume_clears_waiting_human_marker(monkeypatch: pytest.MonkeyPatch) -> None:
+    executor, trace_storage = _executor_fixture(monkeypatch)
+
+    async def _resumed_stream(*_args, **_kwargs):
+        yield {"event": "message:chunk", "data": {"content": "恢复后的回答"}}
+
+    await executor.run_task(
+        session_id="session-1",
+        run_id="run-2",
+        agent_id="search",
+        message="",
+        user_id="user-1",
+        executor=_resumed_stream,
+        hitl_resume={"approval_resolved": {"id": "approval-1"}},
+    )
+
+    assert ("trace-1", False) in trace_storage.waiting_calls
+
+
+@pytest.mark.asyncio
+async def test_normal_run_never_touches_waiting_marker(monkeypatch: pytest.MonkeyPatch) -> None:
+    executor, trace_storage = _executor_fixture(monkeypatch)
+
+    async def _normal_stream(*_args, **_kwargs):
+        yield {"event": "message:chunk", "data": {"content": "普通回答"}}
+
+    await executor.run_task(
+        session_id="session-1",
+        run_id="run-3",
+        agent_id="search",
+        message="",
+        user_id="user-1",
+        executor=_normal_stream,
+    )
+
+    assert trace_storage.waiting_calls == []

--- a/tests/infra/task/test_hitl_resume.py
+++ b/tests/infra/task/test_hitl_resume.py
@@ -572,3 +572,61 @@ async def test_submit_resume_failure_restores_waiting_session_state(fake_redis, 
             {"task_status": "waiting_human", "current_run_id": "run-1"},
         )
     ]
+
+
+@pytest.mark.asyncio
+async def test_submit_resume_reopens_error_finalized_trace(fake_redis, monkeypatch):
+    """恢复前重开被全局僵尸清扫误终态的 trace（#583）。
+
+    挂起等审批超过 10 分钟时 updated_at 心跳过期，trace 被标 error；
+    若不重开（error→running），恢复跑完后 complete_trace 被终态保护拒绝，
+    trace 永远停在 error。reopen 幂等：trace 本就 running 时为 no-op。
+    """
+    monkeypatch.setattr(hitl_mod.settings, "TASK_BACKEND", "arq", raising=False)
+
+    class _Storage:
+        async def get_by_session_id(self, _session_id):
+            return SimpleNamespace(
+                user_id="user-1",
+                name="s",
+                metadata={
+                    "task_status": "waiting_human",
+                    "current_run_id": "run-1",
+                    "executor_key": "agent_stream",
+                    "agent_id": "search",
+                },
+            )
+
+    monkeypatch.setattr("src.infra.session.storage.SessionStorage", lambda: _Storage())
+
+    async def fake_executor():
+        yield
+
+    monkeypatch.setattr(
+        "src.infra.task.concurrency.get_registered_executor", lambda _key: fake_executor
+    )
+
+    class _FakeManager:
+        async def submit_arq(self, *args, **kwargs):
+            return "run-1", "trace-source"
+
+    monkeypatch.setattr("src.infra.task.manager.get_task_manager", lambda: _FakeManager())
+
+    reopened: list[str] = []
+
+    class _FakeTraceStorage:
+        async def reopen_interrupted_trace(self, trace_id: str) -> bool:
+            reopened.append(trace_id)
+            return True
+
+    monkeypatch.setattr(
+        "src.infra.session.trace_storage.get_trace_storage", lambda: _FakeTraceStorage()
+    )
+
+    result = await submit_hitl_resume_run(
+        _approval(metadata={"mode": "interrupt", "run_id": "run-1", "trace_id": "trace-source"}),
+        {"approved": True, "values": {}},
+    )
+
+    assert result["submitted"] is True
+    assert reopened == ["trace-source"]


### PR DESCRIPTION
v2.11.0 发版晋升。自 v2.10.3 以来：#576-#582（角色 MCP 绑定体系 + 热路径优化 + 插件中心迭代与退役）、#584（stall 看门狗）、#586（HITL 挂起豁免）、#587/#588（prompt cache 跨 context P0 热修及回合）、#589（版本 bump 2.11.0 八处同步）。staging 已在 develop-20260913-094200 验证：版本 2.11.0、真实对话全链路通过；生产回归 28/28（main-20260913-090115 基础）。