### PR TITLE
fix(version): 资产代理缓存竞态自愈（回合 develop）

### DIFF
--- a/src/api/routes/version.py
+++ b/src/api/routes/version.py
@@ -80,9 +80,16 @@ async def download_release_asset(
     """
     if tag:
         release = await github_client.get_release_by_tag(tag)
+        asset = _find_asset(release, asset_name)
     else:
         release = await github_client.get_latest_release()
-    asset = _find_asset(release, asset_name)
+        asset = _find_asset(release, asset_name)
+        if asset is None:
+            # 缓存竞态自愈：发版后 latest.json 由 updater 工作流后上传，
+            # 进程内 1 小时缓存可能持有无该资产的旧快照（v2.11.0 发版实测：
+            # 双 pod 缓存窗口内自更新主端点 404）。找不到时强刷一次再找。
+            release = await github_client.get_latest_release(force_refresh=True)
+            asset = _find_asset(release, asset_name)
     if asset is None:
         raise AppError(ErrorCode.RELEASE_ASSET_NOT_FOUND, args={"name": asset_name})
 

--- a/tests/api/test_asset_proxy_race.py
+++ b/tests/api/test_asset_proxy_race.py
@@ -1,0 +1,105 @@
+"""资产下载代理的缓存竞态自愈回归。
+
+事故（v2.11.0 发版实测）：latest.json 由 updater 工作流在 release 发布后
+上传，服务端 latest-release 进程缓存（TTL 1h）持有无 latest.json 的旧
+资产快照 → 桌面端自更新主端点 404（备用 GitHub 端点国内不可达）。
+热修：latest 路径找不到资产时 force_refresh 一次再找。
+"""
+
+from src.api.routes.version import download_release_asset
+from src.infra.github_client import GitHubRelease
+from src.kernel.errors import AppError, ErrorCode
+
+import pytest
+
+
+def _release(assets: list[str]) -> GitHubRelease:
+    return GitHubRelease(
+        tag_name="v2.11.0",
+        html_url="https://example.com",
+        published_at="2026-09-13T10:28:39Z",
+        assets=[
+            {
+                "name": name,
+                "url": f"https://example.com/{name}",
+                "size": 1,
+                "content_type": "application/octet-stream",
+            }
+            for name in assets
+        ],
+    )
+
+
+class _Stream:
+    status_code = 200
+    content_length = 1
+
+    async def iter_chunks(self):
+        yield b"{}"
+
+    async def close(self):
+        return None
+
+
+class _FakeClient:
+    """第一次返回旧快照（无 latest.json），force_refresh 后返回新快照。"""
+
+    def __init__(self) -> None:
+        self.calls: list[bool] = []
+
+    async def get_latest_release(self, force_refresh: bool = False):
+        self.calls.append(force_refresh)
+        if not force_refresh:
+            return _release(["app.tar.gz", "deb"])
+        return _release(["app.tar.gz", "deb", "latest.json"])
+
+    async def get_release_by_tag(self, tag):
+        return _release(["latest.json"])
+
+    async def open_asset_stream(self, url):
+        return _Stream()
+
+
+async def test_latest_path_retries_with_force_refresh_on_missing_asset(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from src.api.routes import version as version_module
+
+    fake = _FakeClient()
+    monkeypatch.setattr(version_module, "github_client", fake)
+
+    response = await download_release_asset("latest.json", tag=None)
+    assert response.status_code == 200
+    assert fake.calls == [False, True]  # 缓存快照未命中 → 强刷自愈
+
+
+async def test_tag_path_does_not_force_refresh(monkeypatch: pytest.MonkeyPatch):
+    from src.api.routes import version as version_module
+
+    class _TagClient:
+        refreshed = False
+
+        async def get_release_by_tag(self, tag):
+            return _release(["latest.json"])
+
+        async def get_latest_release(self, force_refresh=False):
+            _TagClient.refreshed = True
+            return _release([])
+
+        async def open_asset_stream(self, url):
+            class _Stream:
+                status_code = 200
+                content_length = 1
+
+                async def iter_chunks(self):
+                    yield b"{}"
+
+                async def close(self):
+                    return None
+
+            return _Stream()
+
+    monkeypatch.setattr(version_module, "github_client", _TagClient())
+    response = await download_release_asset("latest.json", tag="v2.11.0")
+    assert response.status_code == 200
+    assert _TagClient.refreshed is False  # tag 锁定路径不做 latest 强刷

--- a/tests/api/test_asset_proxy_race.py
+++ b/tests/api/test_asset_proxy_race.py
@@ -6,11 +6,10 @@
 热修：latest 路径找不到资产时 force_refresh 一次再找。
 """
 
+import pytest
+
 from src.api.routes.version import download_release_asset
 from src.infra.github_client import GitHubRelease
-from src.kernel.errors import AppError, ErrorCode
-
-import pytest
 
 
 def _release(assets: list[str]) -> GitHubRelease:


### PR DESCRIPTION
P0 热修回合：main 已合 #591 并部署（main-20260913-105227，回归 28/28）。latest 路径 _find_asset 未命中时 force_refresh 重查，防发版后 latest.json 后上传的 1h 缓存窗口内自更新主端点 404。